### PR TITLE
feat: add auth context with JWT login and API wrapper

### DIFF
--- a/tools/app-shell/src/auth/AuthContext.jsx
+++ b/tools/app-shell/src/auth/AuthContext.jsx
@@ -1,0 +1,45 @@
+import { createContext, useContext, useState, useCallback, useMemo } from 'react';
+import { login as apiLogin } from './api.js';
+
+const AuthContext = createContext(null);
+
+const STORAGE_KEY = 'sf_auth_token';
+const USERNAME_KEY = 'sf_auth_user';
+
+export function AuthProvider({ children, baseUrl }) {
+  const [token, setToken] = useState(() => localStorage.getItem(STORAGE_KEY));
+  const [username, setUsername] = useState(() => localStorage.getItem(USERNAME_KEY));
+
+  const login = useCallback(async (user, password) => {
+    const data = await apiLogin(baseUrl, user, password);
+    const jwt = data.token;
+    setToken(jwt);
+    setUsername(user);
+    localStorage.setItem(STORAGE_KEY, jwt);
+    localStorage.setItem(USERNAME_KEY, user);
+    return jwt;
+  }, [baseUrl]);
+
+  const logout = useCallback(() => {
+    setToken(null);
+    setUsername(null);
+    localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(USERNAME_KEY);
+  }, []);
+
+  const value = useMemo(() => ({
+    token,
+    username,
+    isAuthenticated: !!token,
+    login,
+    logout,
+  }), [token, username, login, logout]);
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/tools/app-shell/src/auth/__tests__/api.test.js
+++ b/tools/app-shell/src/auth/__tests__/api.test.js
@@ -1,0 +1,36 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { buildHeaders, isTokenExpired } from '../api.js';
+
+describe('buildHeaders', () => {
+  it('includes Authorization header when token provided', () => {
+    const headers = buildHeaders('my-jwt-token');
+    assert.equal(headers['Authorization'], 'Bearer my-jwt-token');
+    assert.equal(headers['Content-Type'], 'application/json');
+  });
+
+  it('omits Authorization when no token', () => {
+    const headers = buildHeaders(null);
+    assert.ok(!headers['Authorization']);
+    assert.equal(headers['Content-Type'], 'application/json');
+  });
+
+  it('omits Authorization for empty string', () => {
+    const headers = buildHeaders('');
+    assert.ok(!headers['Authorization']);
+  });
+});
+
+describe('isTokenExpired', () => {
+  it('returns true for null token', () => {
+    assert.equal(isTokenExpired(null), true);
+  });
+
+  it('returns true for empty string', () => {
+    assert.equal(isTokenExpired(''), true);
+  });
+
+  it('returns false for non-empty token', () => {
+    assert.equal(isTokenExpired('some-token'), false);
+  });
+});

--- a/tools/app-shell/src/auth/api.js
+++ b/tools/app-shell/src/auth/api.js
@@ -1,0 +1,44 @@
+const DEFAULT_BASE_URL = '/etendo';
+
+export function buildHeaders(token) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+export function isTokenExpired(token) {
+  return !token;
+}
+
+export async function login(baseUrl, username, password) {
+  const res = await fetch(`${baseUrl || DEFAULT_BASE_URL}/sws/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user: username, password }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(body || `Login failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+export function createApiFetch(baseUrl, getToken, onUnauthorized) {
+  return async function apiFetch(path, options = {}) {
+    const token = getToken();
+    const res = await fetch(`${baseUrl || DEFAULT_BASE_URL}${path}`, {
+      ...options,
+      headers: {
+        ...buildHeaders(token),
+        ...options.headers,
+      },
+    });
+    if (res.status === 401) {
+      onUnauthorized();
+      throw new Error('Unauthorized');
+    }
+    return res;
+  };
+}


### PR DESCRIPTION
## Summary
- Add `api.js` with JWT-based auth utilities: `buildHeaders`, `isTokenExpired`, `login`, and `createApiFetch`
- Add `AuthContext.jsx` with React context provider for auth state (token persistence in localStorage, login/logout)
- Add unit tests for `buildHeaders` and `isTokenExpired` (6 tests, all passing)

## Test plan
- [x] `node --test tools/app-shell/src/auth/__tests__/api.test.js` — 6/6 pass
- [x] `node --test 'cli/test/*.test.js'` — 234/234 pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)