### PR TITLE
feat: contract fixture and Shadcn UI components

### DIFF
--- a/artifacts/sales-order/contract.json
+++ b/artifacts/sales-order/contract.json
@@ -1,0 +1,97 @@
+{
+  "version": "0.1.0",
+  "generatedAt": "2026-03-05T00:00:00.000Z",
+  "checksum": "fixture-dev-only",
+  "frontendContract": {
+    "window": { "id": "143", "name": "Sales Order", "primaryEntity": "order", "category": "sales" },
+    "entities": {
+      "order": {
+        "fields": [
+          { "name": "documentNo", "column": "DocumentNo", "type": "string", "tsType": "string", "visibility": "readOnly", "required": true, "grid": true, "form": true },
+          { "name": "businessPartner", "column": "C_BPartner_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "orderDate", "column": "DateOrdered", "type": "date", "tsType": "string", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "warehouse", "column": "M_Warehouse_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": true, "grid": false, "form": true },
+          { "name": "currency", "column": "C_Currency_ID", "type": "string", "tsType": "string", "visibility": "readOnly", "required": true, "grid": true, "form": true },
+          { "name": "paymentTerms", "column": "C_PaymentTerm_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true },
+          { "name": "description", "column": "Description", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true },
+          { "name": "totalLines", "column": "TotalLines", "type": "amount", "tsType": "number", "visibility": "readOnly", "required": false, "grid": true, "form": true },
+          { "name": "grandTotal", "column": "GrandTotal", "type": "amount", "tsType": "number", "visibility": "readOnly", "required": false, "grid": true, "form": true },
+          { "name": "docStatus", "column": "DocStatus", "type": "string", "tsType": "string", "visibility": "readOnly", "required": true, "grid": true, "form": true },
+          { "name": "deliveryLocation", "column": "DeliveryLocation", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true },
+          { "name": "invoiceAddress", "column": "BillTo_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true }
+        ],
+        "searchableFields": ["documentNo", "businessPartner", "docStatus"],
+        "computedFields": []
+      },
+      "orderLine": {
+        "fields": [
+          { "name": "lineNo", "column": "Line", "type": "integer", "tsType": "number", "visibility": "readOnly", "required": true, "grid": true, "form": true },
+          { "name": "product", "column": "M_Product_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "quantity", "column": "QtyOrdered", "type": "number", "tsType": "number", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "unitPrice", "column": "PriceActual", "type": "amount", "tsType": "number", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "discount", "column": "Discount", "type": "number", "tsType": "number", "visibility": "editable", "required": false, "grid": true, "form": true },
+          { "name": "lineNetAmount", "column": "LineNetAmt", "type": "amount", "tsType": "number", "visibility": "readOnly", "required": false, "grid": true, "form": true },
+          { "name": "tax", "column": "C_Tax_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": true, "form": true },
+          { "name": "description", "column": "Description", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true }
+        ],
+        "searchableFields": ["product"],
+        "computedFields": []
+      }
+    }
+  },
+  "backendContract": {
+    "window": { "id": "143", "name": "Sales Order", "primaryEntity": "order", "category": "sales" },
+    "entities": {
+      "order": {
+        "fields": [
+          { "name": "documentNo", "column": "DocumentNo", "type": "string", "visibility": "readOnly", "required": true },
+          { "name": "businessPartner", "column": "C_BPartner_ID", "type": "string", "visibility": "editable", "required": true },
+          { "name": "orderDate", "column": "DateOrdered", "type": "date", "visibility": "editable", "required": true },
+          { "name": "warehouse", "column": "M_Warehouse_ID", "type": "string", "visibility": "editable", "required": true },
+          { "name": "currency", "column": "C_Currency_ID", "type": "string", "visibility": "readOnly", "required": true },
+          { "name": "paymentTerms", "column": "C_PaymentTerm_ID", "type": "string", "visibility": "editable", "required": false },
+          { "name": "description", "column": "Description", "type": "string", "visibility": "editable", "required": false },
+          { "name": "totalLines", "column": "TotalLines", "type": "amount", "visibility": "readOnly", "required": false },
+          { "name": "grandTotal", "column": "GrandTotal", "type": "amount", "visibility": "readOnly", "required": false },
+          { "name": "docStatus", "column": "DocStatus", "type": "string", "visibility": "readOnly", "required": true },
+          { "name": "deliveryLocation", "column": "DeliveryLocation", "type": "string", "visibility": "editable", "required": false },
+          { "name": "invoiceAddress", "column": "BillTo_ID", "type": "string", "visibility": "editable", "required": false },
+          { "name": "adClientId", "column": "AD_Client_ID", "type": "id", "visibility": "system", "required": true },
+          { "name": "adOrgId", "column": "AD_Org_ID", "type": "id", "visibility": "system", "required": true },
+          { "name": "created", "column": "Created", "type": "datetime", "visibility": "system", "required": true },
+          { "name": "updated", "column": "Updated", "type": "datetime", "visibility": "system", "required": true }
+        ]
+      },
+      "orderLine": {
+        "fields": [
+          { "name": "lineNo", "column": "Line", "type": "integer", "visibility": "readOnly", "required": true },
+          { "name": "product", "column": "M_Product_ID", "type": "string", "visibility": "editable", "required": true },
+          { "name": "quantity", "column": "QtyOrdered", "type": "number", "visibility": "editable", "required": true },
+          { "name": "unitPrice", "column": "PriceActual", "type": "amount", "visibility": "editable", "required": true },
+          { "name": "discount", "column": "Discount", "type": "number", "visibility": "editable", "required": false },
+          { "name": "lineNetAmount", "column": "LineNetAmt", "type": "amount", "visibility": "readOnly", "required": false },
+          { "name": "tax", "column": "C_Tax_ID", "type": "string", "visibility": "editable", "required": false },
+          { "name": "description", "column": "Description", "type": "string", "visibility": "editable", "required": false },
+          { "name": "adClientId", "column": "AD_Client_ID", "type": "id", "visibility": "system", "required": true },
+          { "name": "adOrgId", "column": "AD_Org_ID", "type": "id", "visibility": "system", "required": true }
+        ]
+      }
+    },
+    "endpoints": [
+      { "method": "GET", "path": "/order", "entity": "order", "supportedFilters": ["documentNo", "businessPartner", "docStatus"] },
+      { "method": "GET", "path": "/order/:id", "entity": "order", "supportedFilters": [] },
+      { "method": "POST", "path": "/order", "entity": "order", "supportedFilters": [] },
+      { "method": "PUT", "path": "/order/:id", "entity": "order", "supportedFilters": [] },
+      { "method": "DELETE", "path": "/order/:id", "entity": "order", "supportedFilters": [] },
+      { "method": "GET", "path": "/orderLine", "entity": "orderLine", "supportedFilters": ["product"] },
+      { "method": "GET", "path": "/orderLine/:id", "entity": "orderLine", "supportedFilters": [] },
+      { "method": "POST", "path": "/orderLine", "entity": "orderLine", "supportedFilters": [] },
+      { "method": "PUT", "path": "/orderLine/:id", "entity": "orderLine", "supportedFilters": [] },
+      { "method": "DELETE", "path": "/orderLine/:id", "entity": "orderLine", "supportedFilters": [] }
+    ],
+    "processEndpoints": [
+      { "name": "completeOrder", "method": "POST", "path": "/process/completeOrder", "entity": "order", "preconditions": ["Order must have at least one line", "Order status must be DR or IP"], "steps": 6 },
+      { "name": "voidOrder", "method": "POST", "path": "/process/voidOrder", "entity": "order", "preconditions": ["Order status must be CO"], "steps": 4 }
+    ]
+  }
+}

--- a/tools/app-shell/src/components/ui/badge.jsx
+++ b/tools/app-shell/src/components/ui/badge.jsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive: 'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: { variant: 'default' },
+  }
+);
+
+function Badge({ className, variant, ...props }) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/tools/app-shell/src/components/ui/dialog.jsx
+++ b/tools/app-shell/src/components/ui/dialog.jsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+function Dialog({ open, onOpenChange, children }) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/80" onClick={() => onOpenChange?.(false)} />
+      <div className="relative z-50">{children}</div>
+    </div>
+  );
+}
+
+const DialogContent = React.forwardRef(({ className, children, ...props }, ref) => (
+  <div ref={ref} className={cn('w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg', className)} {...props}>
+    {children}
+  </div>
+));
+DialogContent.displayName = 'DialogContent';
+
+function DialogHeader({ className, ...props }) {
+  return <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />;
+}
+
+function DialogTitle({ className, ...props }) {
+  return <h2 className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />;
+}
+
+function DialogFooter({ className, ...props }) {
+  return <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />;
+}
+
+export { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter };

--- a/tools/app-shell/src/components/ui/label.jsx
+++ b/tools/app-shell/src/components/ui/label.jsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Label = React.forwardRef(({ className, ...props }, ref) => (
+  <label ref={ref} className={cn('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)} {...props} />
+));
+Label.displayName = 'Label';
+
+export { Label };

--- a/tools/app-shell/src/components/ui/select.jsx
+++ b/tools/app-shell/src/components/ui/select.jsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Select = React.forwardRef(({ className, children, ...props }, ref) => (
+  <select ref={ref} className={cn('flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50', className)} {...props}>
+    {children}
+  </select>
+));
+Select.displayName = 'Select';
+
+export { Select };

--- a/tools/app-shell/src/components/ui/separator.jsx
+++ b/tools/app-shell/src/components/ui/separator.jsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Separator = React.forwardRef(({ className, orientation = 'horizontal', ...props }, ref) => (
+  <div ref={ref} role="separator" className={cn('shrink-0 bg-border', orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]', className)} {...props} />
+));
+Separator.displayName = 'Separator';
+
+export { Separator };

--- a/tools/app-shell/src/components/ui/table.jsx
+++ b/tools/app-shell/src/components/ui/table.jsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Table = React.forwardRef(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+  </div>
+));
+Table.displayName = 'Table';
+
+const TableHeader = React.forwardRef(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+));
+TableHeader.displayName = 'TableHeader';
+
+const TableBody = React.forwardRef(({ className, ...props }, ref) => (
+  <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+));
+TableBody.displayName = 'TableBody';
+
+const TableRow = React.forwardRef(({ className, ...props }, ref) => (
+  <tr ref={ref} className={cn('border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted', className)} {...props} />
+));
+TableRow.displayName = 'TableRow';
+
+const TableHead = React.forwardRef(({ className, ...props }, ref) => (
+  <th ref={ref} className={cn('h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]', className)} {...props} />
+));
+TableHead.displayName = 'TableHead';
+
+const TableCell = React.forwardRef(({ className, ...props }, ref) => (
+  <td ref={ref} className={cn('p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]', className)} {...props} />
+));
+TableCell.displayName = 'TableCell';
+
+export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell };


### PR DESCRIPTION
## Summary
- Add `artifacts/sales-order/contract.json` fixture with full frontend and backend contract for Sales Order window (2 entities, 10 CRUD endpoints, 2 process endpoints)
- Add 6 Shadcn UI components to app-shell: table, badge, label, separator, select, dialog

## Test plan
- [x] contract.json validates as valid JSON
- [x] app-shell builds successfully with new components (vite build passes)

Generated with [Claude Code](https://claude.com/claude-code)