### PR TITLE
feat: add frontend code generator CLI tool

### DIFF
--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -1,0 +1,338 @@
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+
+/**
+ * Capitalize the first letter of a string.
+ */
+export function capitalize(s) {
+  if (!s) return '';
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+/**
+ * Convert camelCase name to "Title Case" label.
+ * e.g., 'orderLine' -> 'Order Line'
+ */
+export function toLabel(name) {
+  if (!name) return '';
+  const words = name.replace(/([A-Z])/g, ' $1').trim();
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/**
+ * Get process endpoints that match a given entity.
+ */
+export function getProcessesForEntity(contract, entityName) {
+  const endpoints = contract.backendContract?.processEndpoints ?? [];
+  return endpoints.filter(p => p.entity === entityName);
+}
+
+/**
+ * Generate a data table component for an entity.
+ * Renders grid:true fields as columns, searchableFields as filter inputs.
+ */
+export function generateTableComponent(entityName, contract) {
+  const entity = contract.frontendContract.entities[entityName];
+  const gridFields = entity.fields.filter(f => f.grid);
+  const searchableFields = entity.searchableFields ?? [];
+  const compName = `${capitalize(entityName)}Table`;
+
+  const imports = [
+    `import React, { useState } from 'react';`,
+    `import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';`,
+    `import { Input } from '@/components/ui/input';`,
+    `import { Badge } from '@/components/ui/badge';`,
+    `import { Button } from '@/components/ui/button';`,
+  ];
+
+  const filterState = searchableFields
+    .map(f => `  const [filter${capitalize(f)}, setFilter${capitalize(f)}] = useState('');`)
+    .join('\n');
+
+  const filterInputs = searchableFields
+    .map(f => `        <Input
+          placeholder="Filter ${toLabel(f)}..."
+          value={filter${capitalize(f)}}
+          onChange={(e) => setFilter${capitalize(f)}(e.target.value)}
+          className="max-w-xs"
+        />`)
+    .join('\n');
+
+  const headerCells = gridFields
+    .map(f => `            <TableHead>${toLabel(f.name)}</TableHead>`)
+    .join('\n');
+
+  const bodyCells = gridFields
+    .map(f => {
+      if (f.type === 'amount') {
+        return `            <TableCell>{row.${f.name}?.toLocaleString()}</TableCell>`;
+      }
+      return `            <TableCell>{row.${f.name}}</TableCell>`;
+    })
+    .join('\n');
+
+  return `${imports.join('\n')}
+
+export default function ${compName}({ data = [], onRowSelect }) {
+${filterState}
+
+  const filteredData = data.filter(row => {
+${searchableFields.map(f => `    if (filter${capitalize(f)} && !String(row.${f} ?? '').toLowerCase().includes(filter${capitalize(f)}.toLowerCase())) return false;`).join('\n')}
+    return true;
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+${filterInputs}
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+${headerCells}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {filteredData.map((row, idx) => (
+            <TableRow key={row.id ?? idx} onClick={() => onRowSelect?.(row)} className="cursor-pointer">
+${bodyCells}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+`;
+}
+
+/**
+ * Generate a detail/edit form component for an entity.
+ * Renders form:true fields, editable as inputs, readOnly as disabled.
+ * Includes process action buttons for matching entity.
+ */
+export function generateFormComponent(entityName, contract) {
+  const entity = contract.frontendContract.entities[entityName];
+  const formFields = entity.fields.filter(f => f.form);
+  const processes = getProcessesForEntity(contract, entityName);
+  const compName = `${capitalize(entityName)}Form`;
+
+  const imports = [
+    `import React from 'react';`,
+    `import { Input } from '@/components/ui/input';`,
+    `import { Label } from '@/components/ui/label';`,
+    `import { Button } from '@/components/ui/button';`,
+    `import { Separator } from '@/components/ui/separator';`,
+  ];
+
+  const fieldElements = formFields.map(f => {
+    const label = toLabel(f.name);
+    const isReadOnly = f.visibility === 'readOnly';
+    const inputType = f.tsType === 'number' ? 'number' : 'text';
+    const disabledAttr = isReadOnly ? ' disabled readOnly className="bg-muted"' : '';
+    const requiredAttr = f.required ? ' required' : '';
+
+    return `        <div className="space-y-2">
+          <Label htmlFor="${f.name}">${label}${f.required ? ' *' : ''}</Label>
+          <Input
+            id="${f.name}"
+            name="${f.name}"
+            type="${inputType}"
+            value={data?.${f.name} ?? ''}
+            onChange={(e) => onChange?.('${f.name}', e.target.value)}${disabledAttr}${requiredAttr}
+          />
+        </div>`;
+  }).join('\n');
+
+  const processButtons = processes.map(p => {
+    const label = toLabel(p.name);
+    return `          <Button variant="outline" onClick={() => onProcess?.('${p.name}')}>
+            ${label}
+          </Button>`;
+  }).join('\n');
+
+  const processSection = processes.length > 0
+    ? `\n      <Separator />\n      <div className="flex gap-2">\n${processButtons}\n      </div>`
+    : '';
+
+  return `${imports.join('\n')}
+
+export default function ${compName}({ data, onChange, onSave, onProcess }) {
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); onSave?.(data); }} className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+${fieldElements}
+      </div>
+      <div className="flex gap-2">
+        <Button type="submit">Save</Button>
+      </div>${processSection}
+    </form>
+  );
+}
+`;
+}
+
+/**
+ * Generate a header-detail page component.
+ * Shows header table, header form, and detail table.
+ * Includes API fetch logic using token/apiBaseUrl props.
+ */
+export function generatePageComponent(headerEntity, detailEntity, contract) {
+  const headerName = capitalize(headerEntity);
+  const detailName = capitalize(detailEntity);
+  const compName = `${headerName}Page`;
+
+  return `import React, { useState, useEffect } from 'react';
+import { Separator } from '@/components/ui/separator';
+import ${headerName}Table from './${headerName}Table';
+import ${headerName}Form from './${headerName}Form';
+import ${detailName}Table from './${detailName}Table';
+
+export default function ${compName}({ token, apiBaseUrl }) {
+  const [items, setItems] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [details, setDetails] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const headers = {
+    'Authorization': \`Bearer \${token}\`,
+    'Content-Type': 'application/json',
+  };
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(\`\${apiBaseUrl}/${headerEntity}\`, { headers })
+      .then(res => res.json())
+      .then(data => { setItems(data); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, [apiBaseUrl, token]);
+
+  useEffect(() => {
+    if (!selected?.id) { setDetails([]); return; }
+    fetch(\`\${apiBaseUrl}/${headerEntity}/\${selected.id}/${detailEntity}\`, { headers })
+      .then(res => res.json())
+      .then(setDetails)
+      .catch(() => setDetails([]));
+  }, [selected]);
+
+  const handleProcess = async (processName) => {
+    if (!selected?.id) return;
+    await fetch(\`\${apiBaseUrl}/process/\${processName}\`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ id: selected.id }),
+    });
+  };
+
+  return (
+    <div className="space-y-6 p-4">
+      <h2 className="text-xl font-semibold">${toLabel(headerEntity)}</h2>
+      <${headerName}Table data={items} onRowSelect={setSelected} />
+      {selected && (
+        <>
+          <Separator />
+          <${headerName}Form data={selected} onProcess={handleProcess} />
+          <Separator />
+          <h3 className="text-lg font-medium">${toLabel(detailEntity)}</h3>
+          <${detailName}Table data={details} />
+        </>
+      )}
+    </div>
+  );
+}
+`;
+}
+
+/**
+ * Generate the entry point / index component.
+ * Accepts { token, apiBaseUrl, window } props.
+ */
+export function generateIndexComponent(headerEntity, detailEntity) {
+  const headerName = capitalize(headerEntity);
+
+  if (detailEntity) {
+    return `import React from 'react';
+import ${headerName}Page from './${headerName}Page';
+
+export default function App({ token, apiBaseUrl, window }) {
+  return <${headerName}Page token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+}
+`;
+  }
+
+  return `import React from 'react';
+import ${headerName}Table from './${headerName}Table';
+import ${headerName}Form from './${headerName}Form';
+
+export default function App({ token, apiBaseUrl, window }) {
+  const [selected, setSelected] = React.useState(null);
+
+  return (
+    <div className="space-y-6 p-4">
+      <${headerName}Table data={[]} onRowSelect={setSelected} />
+      {selected && <${headerName}Form data={selected} />}
+    </div>
+  );
+}
+`;
+}
+
+/**
+ * Generate all frontend components from a contract.
+ * Returns a map of { filename: code }.
+ */
+export function generateAll(contract) {
+  const { frontendContract } = contract;
+  const { window: win, entities } = frontendContract;
+  const primaryEntity = win.primaryEntity;
+  const entityNames = Object.keys(entities);
+  const detailEntity = entityNames.find(name => name !== primaryEntity);
+
+  const files = {};
+
+  // Generate Table + Form for each entity
+  for (const entityName of entityNames) {
+    const capName = capitalize(entityName);
+    files[`${capName}Table.jsx`] = generateTableComponent(entityName, contract);
+    files[`${capName}Form.jsx`] = generateFormComponent(entityName, contract);
+  }
+
+  // Generate Page if there is a detail entity
+  if (detailEntity) {
+    files[`${capitalize(primaryEntity)}Page.jsx`] = generatePageComponent(primaryEntity, detailEntity, contract);
+  }
+
+  // Always generate index
+  files['index.jsx'] = generateIndexComponent(primaryEntity, detailEntity);
+
+  return files;
+}
+
+// CLI entry point -- only runs when executed directly
+const isDirectRun = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/.*\//, ''));
+if (isDirectRun) {
+  const contractPath = process.argv[2];
+  if (!contractPath) {
+    console.error('Usage: node cli/src/generate-frontend.js <contract-path>');
+    process.exit(1);
+  }
+
+  const contractJson = readFileSync(resolve(contractPath), 'utf-8');
+  const contract = JSON.parse(contractJson);
+  const files = generateAll(contract);
+
+  const windowName = contract.frontendContract.window.name
+    .toLowerCase()
+    .replace(/\s+/g, '-');
+
+  const outDir = resolve(`artifacts/${windowName}/generated/web/${windowName}`);
+  mkdirSync(outDir, { recursive: true });
+
+  for (const [filename, code] of Object.entries(files)) {
+    const filePath = resolve(outDir, filename);
+    writeFileSync(filePath, code, 'utf-8');
+    console.log(`  wrote ${filePath}`);
+  }
+
+  console.log(`\nGenerated ${Object.keys(files).length} files in ${outDir}`);
+}

--- a/cli/test/generate-frontend.test.js
+++ b/cli/test/generate-frontend.test.js
@@ -1,0 +1,141 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import {
+  generateTableComponent,
+  generateFormComponent,
+  generatePageComponent,
+  generateIndexComponent,
+  generateAll,
+} from '../src/generate-frontend.js';
+
+const sampleContract = {
+  frontendContract: {
+    window: { id: '143', name: 'Sales Order', primaryEntity: 'order', category: 'sales' },
+    entities: {
+      order: {
+        fields: [
+          { name: 'documentNo', type: 'string', tsType: 'string', visibility: 'readOnly', required: true, grid: true, form: true },
+          { name: 'businessPartner', type: 'string', tsType: 'string', visibility: 'editable', required: true, grid: true, form: true },
+          { name: 'grandTotal', type: 'amount', tsType: 'number', visibility: 'readOnly', required: false, grid: true, form: true },
+          { name: 'docStatus', type: 'string', tsType: 'string', visibility: 'readOnly', required: true, grid: true, form: true },
+        ],
+        searchableFields: ['documentNo', 'businessPartner', 'docStatus'],
+        computedFields: [],
+      },
+      orderLine: {
+        fields: [
+          { name: 'product', type: 'string', tsType: 'string', visibility: 'editable', required: true, grid: true, form: true },
+          { name: 'quantity', type: 'number', tsType: 'number', visibility: 'editable', required: true, grid: true, form: true },
+          { name: 'lineNetAmount', type: 'amount', tsType: 'number', visibility: 'readOnly', required: false, grid: true, form: true },
+        ],
+        searchableFields: ['product'],
+        computedFields: [],
+      },
+    },
+  },
+  backendContract: {
+    processEndpoints: [
+      { name: 'completeOrder', method: 'POST', path: '/process/completeOrder', entity: 'order', preconditions: [], steps: 6 },
+      { name: 'voidOrder', method: 'POST', path: '/process/voidOrder', entity: 'order', preconditions: [], steps: 4 },
+    ],
+  },
+};
+
+describe('generateTableComponent', () => {
+  it('generates valid JSX string with imports', () => {
+    const code = generateTableComponent('order', sampleContract);
+    assert.ok(code.includes('import'), 'should have imports');
+    assert.ok(code.includes('export default function OrderTable'), 'should export OrderTable');
+  });
+
+  it('includes grid columns from contract fields', () => {
+    const code = generateTableComponent('order', sampleContract);
+    assert.ok(code.includes('documentNo'), 'should include documentNo column');
+    assert.ok(code.includes('businessPartner'), 'should include businessPartner column');
+    assert.ok(code.includes('grandTotal'), 'should include grandTotal column');
+  });
+
+  it('includes search filters for searchable fields', () => {
+    const code = generateTableComponent('order', sampleContract);
+    assert.ok(code.includes('Filter'), 'should have filter inputs');
+  });
+});
+
+describe('generateFormComponent', () => {
+  it('generates valid JSX string', () => {
+    const code = generateFormComponent('order', sampleContract);
+    assert.ok(code.includes('export default function OrderForm'), 'should export OrderForm');
+  });
+
+  it('renders editable fields as inputs', () => {
+    const code = generateFormComponent('order', sampleContract);
+    assert.ok(code.includes('businessPartner'), 'should include editable businessPartner');
+  });
+
+  it('renders readOnly fields as disabled', () => {
+    const code = generateFormComponent('order', sampleContract);
+    assert.ok(code.includes('readOnly') || code.includes('disabled'), 'should mark readOnly fields');
+  });
+
+  it('includes process action buttons for matching entity', () => {
+    const code = generateFormComponent('order', sampleContract);
+    assert.ok(code.includes('completeOrder') || code.includes('Complete Order'), 'should include completeOrder button');
+    assert.ok(code.includes('voidOrder') || code.includes('Void Order'), 'should include voidOrder button');
+  });
+
+  it('does not include process buttons for non-matching entity', () => {
+    const code = generateFormComponent('orderLine', sampleContract);
+    assert.ok(!code.includes('completeOrder'), 'should not include order processes in orderLine form');
+  });
+});
+
+describe('generatePageComponent', () => {
+  it('generates header-detail layout', () => {
+    const code = generatePageComponent('order', 'orderLine', sampleContract);
+    assert.ok(code.includes('export default function OrderPage'), 'should export OrderPage');
+    assert.ok(code.includes('OrderTable'), 'should include header table');
+    assert.ok(code.includes('OrderForm'), 'should include header form');
+    assert.ok(code.includes('OrderLineTable'), 'should include detail table');
+  });
+});
+
+describe('generateIndexComponent', () => {
+  it('generates entry point with standard props', () => {
+    const code = generateIndexComponent('order', 'orderLine');
+    assert.ok(code.includes('token'), 'should accept token prop');
+    assert.ok(code.includes('apiBaseUrl'), 'should accept apiBaseUrl prop');
+    assert.ok(code.includes('window'), 'should accept window prop');
+    assert.ok(code.includes('export default'), 'should have default export');
+  });
+});
+
+describe('generateAll', () => {
+  it('returns map of filename to code', () => {
+    const files = generateAll(sampleContract);
+    assert.ok(files['OrderTable.jsx'], 'should produce OrderTable.jsx');
+    assert.ok(files['OrderForm.jsx'], 'should produce OrderForm.jsx');
+    assert.ok(files['OrderLineTable.jsx'], 'should produce OrderLineTable.jsx');
+    assert.ok(files['OrderPage.jsx'], 'should produce OrderPage.jsx');
+    assert.ok(files['index.jsx'], 'should produce index.jsx');
+  });
+
+  it('handles single-entity contract without detail', () => {
+    const singleEntity = {
+      frontendContract: {
+        window: { id: '1', name: 'Simple', primaryEntity: 'item', category: 'test' },
+        entities: {
+          item: {
+            fields: [{ name: 'name', type: 'string', tsType: 'string', visibility: 'editable', required: true, grid: true, form: true }],
+            searchableFields: ['name'],
+            computedFields: [],
+          },
+        },
+      },
+      backendContract: { processEndpoints: [] },
+    };
+    const files = generateAll(singleEntity);
+    assert.ok(files['ItemTable.jsx'], 'should produce ItemTable.jsx');
+    assert.ok(files['ItemForm.jsx'], 'should produce ItemForm.jsx');
+    assert.ok(files['index.jsx'], 'should produce index.jsx');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `cli/src/generate-frontend.js` with 5 exported generators: `generateTableComponent`, `generateFormComponent`, `generatePageComponent`, `generateIndexComponent`, `generateAll`
- Adds `cli/test/generate-frontend.test.js` with 12 tests across 5 suites
- CLI entry point reads contract JSON and writes JSX files to `artifacts/{window}/generated/web/{window-name}/`

## Details
- Table component renders grid:true fields as columns with searchable filter inputs
- Form component renders form:true fields (editable as inputs, readOnly as disabled with bg-muted), includes process action buttons from backendContract.processEndpoints
- Page component provides header-detail layout with API fetch logic using token/apiBaseUrl
- Index component serves as entry point with { token, apiBaseUrl, window } props
- generateAll determines primary/detail entities and produces complete file map

## Test plan
- [x] All 12 new tests pass
- [x] Full suite: 246 tests, 0 failures across 43 suites
- [x] CLI guard prevents execution when imported as module

Generated with [Claude Code](https://claude.com/claude-code)