### PR TITLE
feat: wire app shell runtime with generated components

### DIFF
--- a/.claude/agents/developer-1.md
+++ b/.claude/agents/developer-1.md
@@ -24,6 +24,7 @@ model: inherit
 <what_i_never_do>
 - Review code (that's the reviewer's job)
 - Deploy or merge to main
+- Commit or work directly on the main branch — ALWAYS work on a feature branch in a worktree
 - Skip writing tests before delivery
 - Work outside my assigned worktree
 </what_i_never_do>

--- a/.claude/agents/developer-2.md
+++ b/.claude/agents/developer-2.md
@@ -24,6 +24,7 @@ model: inherit
 <what_i_never_do>
 - Review code (that's the reviewer's job)
 - Deploy or merge to main
+- Commit or work directly on the main branch — ALWAYS work on a feature branch in a worktree
 - Skip writing tests before delivery
 - Work outside my assigned worktree
 </what_i_never_do>

--- a/.claude/agents/developer-3.md
+++ b/.claude/agents/developer-3.md
@@ -24,6 +24,7 @@ model: inherit
 <what_i_never_do>
 - Review code (that's the reviewer's job)
 - Deploy or merge to main
+- Commit or work directly on the main branch — ALWAYS work on a feature branch in a worktree
 - Skip writing tests before delivery
 - Work outside my assigned worktree
 </what_i_never_do>

--- a/.claude/agents/developer-4.md
+++ b/.claude/agents/developer-4.md
@@ -24,6 +24,7 @@ model: inherit
 <what_i_never_do>
 - Review code (that's the reviewer's job)
 - Deploy or merge to main
+- Commit or work directly on the main branch — ALWAYS work on a feature branch in a worktree
 - Skip writing tests before delivery
 - Work outside my assigned worktree
 </what_i_never_do>

--- a/.claude/agents/documentarian.md
+++ b/.claude/agents/documentarian.md
@@ -25,6 +25,7 @@ model: inherit
 - Write or modify code
 - Over-document the obvious (getters/setters, etc.)
 - Create documentation that diverges from implementation
+- Commit or work directly on the main branch — ALWAYS work on a feature branch in a worktree
 - Work outside my assigned worktree
 </what_i_never_do>
 

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -25,6 +25,7 @@ model: inherit
 - Fix bugs directly (only report them)
 - Skip running existing tests
 - Approve without running the full test suite
+- Commit or work directly on the main branch — ALWAYS work on a feature branch in a worktree
 - Work outside my assigned worktree
 </what_i_never_do>
 

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -25,6 +25,7 @@ model: inherit
 - Fix code directly (only report issues)
 - Approve without checking build
 - Block on pure style preferences
+- Commit or work directly on the main branch — ALWAYS work on a feature branch in a worktree
 - Work outside my assigned worktree
 </what_i_never_do>
 

--- a/.claude/skills/generate-ui.md
+++ b/.claude/skills/generate-ui.md
@@ -1,32 +1,44 @@
 ---
 name: generate-ui
-description: Generate React UI components from curated schema via conversational AI
+description: Generate or customize React UI components from curated schema using Shadcn/ui + Tailwind
 ---
 
-Read the curated schema and process definitions:
-- `artifacts/{window}/schema-curated.json`
-- `artifacts/{window}/rules-curated.json`
-- `artifacts/{window}/processes.json`
+## Automatic Generation (start here)
 
-SCHEMA CONSTRAINTS (INVIOLABLE):
+Run the generator first to produce the base components:
+
+```bash
+node cli/src/generate-frontend.js artifacts/{window}/contract.json
+```
+
+This produces Table, Form, Page, and index components at:
+`artifacts/{window}/generated/web/{window}/`
+
+## Customization (conversational)
+
+After running the generator, ask the user what they want to customize:
+- Layout changes (column order, field grouping, responsive breakpoints)
+- Custom logic (conditional field rendering, computed displays)
+- Visual tweaks (status badges, color coding, icons)
+
+Read the generated files and modify them based on user requests.
+
+## SCHEMA CONSTRAINTS (INVIOLABLE)
+
 - Only render fields with visibility: editable or readOnly
 - System fields NEVER appear in UI
-- ReadOnly fields render as non-editable
+- ReadOnly fields render as non-editable (readOnly or disabled inputs with bg-muted)
 - Computed fields are never editable
 - Only searchable fields can be used as filters/search
 - CascadeFrom relationships must be respected (cascading dropdowns)
 - Never invent fields not in schema
 
-GENERATION RULES:
-- Inline styles + base React (no external UI library)
-- Self-contained default export per component
-- Components target the versioned API endpoints from the contract
-- Mock data generated from schema for preview mode
+## UI LIBRARY RULES
 
-Ask the user what kind of UI they want (e.g., "Order list with filters and detail form").
-Generate React components and write them to `artifacts/{window}/generated/web/{window}/`.
-
-After generating, tell the user to run `cd tools/ui-preview && npm run dev` to preview.
+- Use Shadcn/ui components from `@/components/ui/` (button, input, card, table, badge, label, select, dialog, separator)
+- Use Tailwind CSS for layout and spacing -- NO inline styles
+- Use `cn()` from `@/lib/utils` for conditional classes
+- Use `lucide-react` for icons
 
 ## Component Props Contract
 
@@ -48,3 +60,10 @@ const res = await fetch(`${apiBaseUrl}/v1/${window.name}`, {
 ```
 
 NEVER hardcode API URLs or tokens. Always use the props.
+
+## Output Location
+
+Write generated/modified components to:
+`artifacts/{window}/generated/web/{window}/`
+
+After generating, tell the user to preview with: `cd tools/app-shell && npm run dev`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ After DEV completes, the coordinator creates a PR:
 - Make product decisions without the user
 - Approve work that skipped pipeline phases
 - Let agents work outside their assigned worktree
+- Commit, merge, or work directly on the main branch — ALL work happens on feature branches via PRs
 </what_i_never_do>
 
 <communication>

--- a/artifacts/sales-order/contract.json
+++ b/artifacts/sales-order/contract.json
@@ -1,0 +1,97 @@
+{
+  "version": "0.1.0",
+  "generatedAt": "2026-03-05T00:00:00.000Z",
+  "checksum": "fixture-dev-only",
+  "frontendContract": {
+    "window": { "id": "143", "name": "Sales Order", "primaryEntity": "order", "category": "sales" },
+    "entities": {
+      "order": {
+        "fields": [
+          { "name": "documentNo", "column": "DocumentNo", "type": "string", "tsType": "string", "visibility": "readOnly", "required": true, "grid": true, "form": true },
+          { "name": "businessPartner", "column": "C_BPartner_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "orderDate", "column": "DateOrdered", "type": "date", "tsType": "string", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "warehouse", "column": "M_Warehouse_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": true, "grid": false, "form": true },
+          { "name": "currency", "column": "C_Currency_ID", "type": "string", "tsType": "string", "visibility": "readOnly", "required": true, "grid": true, "form": true },
+          { "name": "paymentTerms", "column": "C_PaymentTerm_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true },
+          { "name": "description", "column": "Description", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true },
+          { "name": "totalLines", "column": "TotalLines", "type": "amount", "tsType": "number", "visibility": "readOnly", "required": false, "grid": true, "form": true },
+          { "name": "grandTotal", "column": "GrandTotal", "type": "amount", "tsType": "number", "visibility": "readOnly", "required": false, "grid": true, "form": true },
+          { "name": "docStatus", "column": "DocStatus", "type": "string", "tsType": "string", "visibility": "readOnly", "required": true, "grid": true, "form": true },
+          { "name": "deliveryLocation", "column": "DeliveryLocation", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true },
+          { "name": "invoiceAddress", "column": "BillTo_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true }
+        ],
+        "searchableFields": ["documentNo", "businessPartner", "docStatus"],
+        "computedFields": []
+      },
+      "orderLine": {
+        "fields": [
+          { "name": "lineNo", "column": "Line", "type": "integer", "tsType": "number", "visibility": "readOnly", "required": true, "grid": true, "form": true },
+          { "name": "product", "column": "M_Product_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "quantity", "column": "QtyOrdered", "type": "number", "tsType": "number", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "unitPrice", "column": "PriceActual", "type": "amount", "tsType": "number", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "discount", "column": "Discount", "type": "number", "tsType": "number", "visibility": "editable", "required": false, "grid": true, "form": true },
+          { "name": "lineNetAmount", "column": "LineNetAmt", "type": "amount", "tsType": "number", "visibility": "readOnly", "required": false, "grid": true, "form": true },
+          { "name": "tax", "column": "C_Tax_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": true, "form": true },
+          { "name": "description", "column": "Description", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true }
+        ],
+        "searchableFields": ["product"],
+        "computedFields": []
+      }
+    }
+  },
+  "backendContract": {
+    "window": { "id": "143", "name": "Sales Order", "primaryEntity": "order", "category": "sales" },
+    "entities": {
+      "order": {
+        "fields": [
+          { "name": "documentNo", "column": "DocumentNo", "type": "string", "visibility": "readOnly", "required": true },
+          { "name": "businessPartner", "column": "C_BPartner_ID", "type": "string", "visibility": "editable", "required": true },
+          { "name": "orderDate", "column": "DateOrdered", "type": "date", "visibility": "editable", "required": true },
+          { "name": "warehouse", "column": "M_Warehouse_ID", "type": "string", "visibility": "editable", "required": true },
+          { "name": "currency", "column": "C_Currency_ID", "type": "string", "visibility": "readOnly", "required": true },
+          { "name": "paymentTerms", "column": "C_PaymentTerm_ID", "type": "string", "visibility": "editable", "required": false },
+          { "name": "description", "column": "Description", "type": "string", "visibility": "editable", "required": false },
+          { "name": "totalLines", "column": "TotalLines", "type": "amount", "visibility": "readOnly", "required": false },
+          { "name": "grandTotal", "column": "GrandTotal", "type": "amount", "visibility": "readOnly", "required": false },
+          { "name": "docStatus", "column": "DocStatus", "type": "string", "visibility": "readOnly", "required": true },
+          { "name": "deliveryLocation", "column": "DeliveryLocation", "type": "string", "visibility": "editable", "required": false },
+          { "name": "invoiceAddress", "column": "BillTo_ID", "type": "string", "visibility": "editable", "required": false },
+          { "name": "adClientId", "column": "AD_Client_ID", "type": "id", "visibility": "system", "required": true },
+          { "name": "adOrgId", "column": "AD_Org_ID", "type": "id", "visibility": "system", "required": true },
+          { "name": "created", "column": "Created", "type": "datetime", "visibility": "system", "required": true },
+          { "name": "updated", "column": "Updated", "type": "datetime", "visibility": "system", "required": true }
+        ]
+      },
+      "orderLine": {
+        "fields": [
+          { "name": "lineNo", "column": "Line", "type": "integer", "visibility": "readOnly", "required": true },
+          { "name": "product", "column": "M_Product_ID", "type": "string", "visibility": "editable", "required": true },
+          { "name": "quantity", "column": "QtyOrdered", "type": "number", "visibility": "editable", "required": true },
+          { "name": "unitPrice", "column": "PriceActual", "type": "amount", "visibility": "editable", "required": true },
+          { "name": "discount", "column": "Discount", "type": "number", "visibility": "editable", "required": false },
+          { "name": "lineNetAmount", "column": "LineNetAmt", "type": "amount", "visibility": "readOnly", "required": false },
+          { "name": "tax", "column": "C_Tax_ID", "type": "string", "visibility": "editable", "required": false },
+          { "name": "description", "column": "Description", "type": "string", "visibility": "editable", "required": false },
+          { "name": "adClientId", "column": "AD_Client_ID", "type": "id", "visibility": "system", "required": true },
+          { "name": "adOrgId", "column": "AD_Org_ID", "type": "id", "visibility": "system", "required": true }
+        ]
+      }
+    },
+    "endpoints": [
+      { "method": "GET", "path": "/order", "entity": "order", "supportedFilters": ["documentNo", "businessPartner", "docStatus"] },
+      { "method": "GET", "path": "/order/:id", "entity": "order", "supportedFilters": [] },
+      { "method": "POST", "path": "/order", "entity": "order", "supportedFilters": [] },
+      { "method": "PUT", "path": "/order/:id", "entity": "order", "supportedFilters": [] },
+      { "method": "DELETE", "path": "/order/:id", "entity": "order", "supportedFilters": [] },
+      { "method": "GET", "path": "/orderLine", "entity": "orderLine", "supportedFilters": ["product"] },
+      { "method": "GET", "path": "/orderLine/:id", "entity": "orderLine", "supportedFilters": [] },
+      { "method": "POST", "path": "/orderLine", "entity": "orderLine", "supportedFilters": [] },
+      { "method": "PUT", "path": "/orderLine/:id", "entity": "orderLine", "supportedFilters": [] },
+      { "method": "DELETE", "path": "/orderLine/:id", "entity": "orderLine", "supportedFilters": [] }
+    ],
+    "processEndpoints": [
+      { "name": "completeOrder", "method": "POST", "path": "/process/completeOrder", "entity": "order", "preconditions": ["Order must have at least one line", "Order status must be DR or IP"], "steps": 6 },
+      { "name": "voidOrder", "method": "POST", "path": "/process/voidOrder", "entity": "order", "preconditions": ["Order status must be CO"], "steps": 4 }
+    ]
+  }
+}

--- a/artifacts/sales-order/generated/web/sales-order/OrderForm.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderForm.jsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+
+export default function OrderForm({ data, onChange, onSave, onProcess }) {
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); onSave?.(data); }} className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="documentNo">Document No *</Label>
+          <Input
+            id="documentNo"
+            name="documentNo"
+            type="text"
+            value={data?.documentNo ?? ''}
+            onChange={(e) => onChange?.('documentNo', e.target.value)} disabled readOnly className="bg-muted" required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="businessPartner">Business Partner *</Label>
+          <Input
+            id="businessPartner"
+            name="businessPartner"
+            type="text"
+            value={data?.businessPartner ?? ''}
+            onChange={(e) => onChange?.('businessPartner', e.target.value)} required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="orderDate">Order Date *</Label>
+          <Input
+            id="orderDate"
+            name="orderDate"
+            type="text"
+            value={data?.orderDate ?? ''}
+            onChange={(e) => onChange?.('orderDate', e.target.value)} required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="warehouse">Warehouse *</Label>
+          <Input
+            id="warehouse"
+            name="warehouse"
+            type="text"
+            value={data?.warehouse ?? ''}
+            onChange={(e) => onChange?.('warehouse', e.target.value)} required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="currency">Currency *</Label>
+          <Input
+            id="currency"
+            name="currency"
+            type="text"
+            value={data?.currency ?? ''}
+            onChange={(e) => onChange?.('currency', e.target.value)} disabled readOnly className="bg-muted" required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="paymentTerms">Payment Terms</Label>
+          <Input
+            id="paymentTerms"
+            name="paymentTerms"
+            type="text"
+            value={data?.paymentTerms ?? ''}
+            onChange={(e) => onChange?.('paymentTerms', e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="description">Description</Label>
+          <Input
+            id="description"
+            name="description"
+            type="text"
+            value={data?.description ?? ''}
+            onChange={(e) => onChange?.('description', e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="totalLines">Total Lines</Label>
+          <Input
+            id="totalLines"
+            name="totalLines"
+            type="number"
+            value={data?.totalLines ?? ''}
+            onChange={(e) => onChange?.('totalLines', e.target.value)} disabled readOnly className="bg-muted"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="grandTotal">Grand Total</Label>
+          <Input
+            id="grandTotal"
+            name="grandTotal"
+            type="number"
+            value={data?.grandTotal ?? ''}
+            onChange={(e) => onChange?.('grandTotal', e.target.value)} disabled readOnly className="bg-muted"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="docStatus">Doc Status *</Label>
+          <Input
+            id="docStatus"
+            name="docStatus"
+            type="text"
+            value={data?.docStatus ?? ''}
+            onChange={(e) => onChange?.('docStatus', e.target.value)} disabled readOnly className="bg-muted" required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="deliveryLocation">Delivery Location</Label>
+          <Input
+            id="deliveryLocation"
+            name="deliveryLocation"
+            type="text"
+            value={data?.deliveryLocation ?? ''}
+            onChange={(e) => onChange?.('deliveryLocation', e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="invoiceAddress">Invoice Address</Label>
+          <Input
+            id="invoiceAddress"
+            name="invoiceAddress"
+            type="text"
+            value={data?.invoiceAddress ?? ''}
+            onChange={(e) => onChange?.('invoiceAddress', e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <Button type="submit">Save</Button>
+      </div>
+      <Separator />
+      <div className="flex gap-2">
+          <Button variant="outline" onClick={() => onProcess?.('completeOrder')}>
+            Complete Order
+          </Button>
+          <Button variant="outline" onClick={() => onProcess?.('voidOrder')}>
+            Void Order
+          </Button>
+      </div>
+    </form>
+  );
+}

--- a/artifacts/sales-order/generated/web/sales-order/OrderLineForm.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderLineForm.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+
+export default function OrderLineForm({ data, onChange, onSave, onProcess }) {
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); onSave?.(data); }} className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="lineNo">Line No *</Label>
+          <Input
+            id="lineNo"
+            name="lineNo"
+            type="number"
+            value={data?.lineNo ?? ''}
+            onChange={(e) => onChange?.('lineNo', e.target.value)} disabled readOnly className="bg-muted" required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="product">Product *</Label>
+          <Input
+            id="product"
+            name="product"
+            type="text"
+            value={data?.product ?? ''}
+            onChange={(e) => onChange?.('product', e.target.value)} required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="quantity">Quantity *</Label>
+          <Input
+            id="quantity"
+            name="quantity"
+            type="number"
+            value={data?.quantity ?? ''}
+            onChange={(e) => onChange?.('quantity', e.target.value)} required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="unitPrice">Unit Price *</Label>
+          <Input
+            id="unitPrice"
+            name="unitPrice"
+            type="number"
+            value={data?.unitPrice ?? ''}
+            onChange={(e) => onChange?.('unitPrice', e.target.value)} required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="discount">Discount</Label>
+          <Input
+            id="discount"
+            name="discount"
+            type="number"
+            value={data?.discount ?? ''}
+            onChange={(e) => onChange?.('discount', e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="lineNetAmount">Line Net Amount</Label>
+          <Input
+            id="lineNetAmount"
+            name="lineNetAmount"
+            type="number"
+            value={data?.lineNetAmount ?? ''}
+            onChange={(e) => onChange?.('lineNetAmount', e.target.value)} disabled readOnly className="bg-muted"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="tax">Tax</Label>
+          <Input
+            id="tax"
+            name="tax"
+            type="text"
+            value={data?.tax ?? ''}
+            onChange={(e) => onChange?.('tax', e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="description">Description</Label>
+          <Input
+            id="description"
+            name="description"
+            type="text"
+            value={data?.description ?? ''}
+            onChange={(e) => onChange?.('description', e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="flex gap-2">
+        <Button type="submit">Save</Button>
+      </div>
+    </form>
+  );
+}

--- a/artifacts/sales-order/generated/web/sales-order/OrderLineTable.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderLineTable.jsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+export default function OrderLineTable({ data = [], onRowSelect }) {
+  const [filterProduct, setFilterProduct] = useState('');
+
+  const filteredData = data.filter(row => {
+    if (filterProduct && !String(row.product ?? '').toLowerCase().includes(filterProduct.toLowerCase())) return false;
+    return true;
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        <Input
+          placeholder="Filter Product..."
+          value={filterProduct}
+          onChange={(e) => setFilterProduct(e.target.value)}
+          className="max-w-xs"
+        />
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Line No</TableHead>
+            <TableHead>Product</TableHead>
+            <TableHead>Quantity</TableHead>
+            <TableHead>Unit Price</TableHead>
+            <TableHead>Discount</TableHead>
+            <TableHead>Line Net Amount</TableHead>
+            <TableHead>Tax</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {filteredData.map((row, idx) => (
+            <TableRow key={row.id ?? idx} onClick={() => onRowSelect?.(row)} className="cursor-pointer">
+            <TableCell>{row.lineNo}</TableCell>
+            <TableCell>{row.product}</TableCell>
+            <TableCell>{row.quantity}</TableCell>
+            <TableCell>{row.unitPrice?.toLocaleString()}</TableCell>
+            <TableCell>{row.discount}</TableCell>
+            <TableCell>{row.lineNetAmount?.toLocaleString()}</TableCell>
+            <TableCell>{row.tax}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
@@ -1,0 +1,58 @@
+import React, { useState, useEffect } from 'react';
+import { Separator } from '@/components/ui/separator';
+import OrderTable from './OrderTable';
+import OrderForm from './OrderForm';
+import OrderLineTable from './OrderLineTable';
+
+export default function OrderPage({ token, apiBaseUrl }) {
+  const [items, setItems] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [details, setDetails] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const headers = {
+    'Authorization': `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(`${apiBaseUrl}/order`, { headers })
+      .then(res => res.json())
+      .then(data => { setItems(data); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, [apiBaseUrl, token]);
+
+  useEffect(() => {
+    if (!selected?.id) { setDetails([]); return; }
+    fetch(`${apiBaseUrl}/order/${selected.id}/orderLine`, { headers })
+      .then(res => res.json())
+      .then(setDetails)
+      .catch(() => setDetails([]));
+  }, [selected]);
+
+  const handleProcess = async (processName) => {
+    if (!selected?.id) return;
+    await fetch(`${apiBaseUrl}/process/${processName}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ id: selected.id }),
+    });
+  };
+
+  return (
+    <div className="space-y-6 p-4">
+      <h2 className="text-xl font-semibold">Order</h2>
+      <OrderTable data={items} onRowSelect={setSelected} />
+      {selected && (
+        <>
+          <Separator />
+          <OrderForm data={selected} onProcess={handleProcess} />
+          <Separator />
+          <h3 className="text-lg font-medium">Order Line</h3>
+          <OrderLineTable data={details} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
@@ -1,12 +1,20 @@
 import React, { useState, useEffect } from 'react';
 import { Separator } from '@/components/ui/separator';
+import { Button } from '@/components/ui/button';
 import OrderTable from './OrderTable';
 import OrderForm from './OrderForm';
 import OrderLineTable from './OrderLineTable';
 
+const EMPTY_ORDER = {
+  documentNo: '', businessPartner: '', orderDate: '', warehouse: '',
+  currency: '', paymentTerms: '', description: '', totalLines: '',
+  grandTotal: '', docStatus: 'DR', deliveryLocation: '', invoiceAddress: '',
+};
+
 export default function OrderPage({ token, apiBaseUrl }) {
   const [items, setItems] = useState([]);
   const [selected, setSelected] = useState(null);
+  const [editing, setEditing] = useState(null);
   const [details, setDetails] = useState([]);
   const [loading, setLoading] = useState(false);
 
@@ -15,13 +23,15 @@ export default function OrderPage({ token, apiBaseUrl }) {
     'Content-Type': 'application/json',
   };
 
-  useEffect(() => {
+  const fetchItems = () => {
     setLoading(true);
     fetch(`${apiBaseUrl}/order`, { headers })
       .then(res => res.json())
       .then(data => { setItems(data); setLoading(false); })
       .catch(() => setLoading(false));
-  }, [apiBaseUrl, token]);
+  };
+
+  useEffect(() => { fetchItems(); }, [apiBaseUrl, token]);
 
   useEffect(() => {
     if (!selected?.id) { setDetails([]); return; }
@@ -31,6 +41,35 @@ export default function OrderPage({ token, apiBaseUrl }) {
       .catch(() => setDetails([]));
   }, [selected]);
 
+  const handleSelect = (row) => {
+    setSelected(row);
+    setEditing({ ...row });
+  };
+
+  const handleNew = () => {
+    setSelected(null);
+    setEditing({ ...EMPTY_ORDER });
+  };
+
+  const handleChange = (field, value) => {
+    setEditing(prev => ({ ...prev, [field]: value }));
+  };
+
+  const handleSave = async (data) => {
+    const isNew = !data.id;
+    const url = isNew ? `${apiBaseUrl}/order` : `${apiBaseUrl}/order/${data.id}`;
+    const method = isNew ? 'POST' : 'PUT';
+    try {
+      const res = await fetch(url, { method, headers, body: JSON.stringify(data) });
+      if (res.ok) {
+        const saved = await res.json();
+        setSelected(saved);
+        setEditing({ ...saved });
+        fetchItems();
+      }
+    } catch { /* handled by UI */ }
+  };
+
   const handleProcess = async (processName) => {
     if (!selected?.id) return;
     await fetch(`${apiBaseUrl}/process/${processName}`, {
@@ -38,16 +77,20 @@ export default function OrderPage({ token, apiBaseUrl }) {
       headers,
       body: JSON.stringify({ id: selected.id }),
     });
+    fetchItems();
   };
 
   return (
     <div className="space-y-6 p-4">
-      <h2 className="text-xl font-semibold">Order</h2>
-      <OrderTable data={items} onRowSelect={setSelected} />
-      {selected && (
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold">Order</h2>
+        <Button onClick={handleNew}>New</Button>
+      </div>
+      <OrderTable data={items} onRowSelect={handleSelect} />
+      {editing && (
         <>
           <Separator />
-          <OrderForm data={selected} onProcess={handleProcess} />
+          <OrderForm data={editing} onChange={handleChange} onSave={handleSave} onProcess={handleProcess} />
           <Separator />
           <h3 className="text-lg font-medium">Order Line</h3>
           <OrderLineTable data={details} />

--- a/artifacts/sales-order/generated/web/sales-order/OrderTable.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderTable.jsx
@@ -1,0 +1,69 @@
+import React, { useState } from 'react';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+
+export default function OrderTable({ data = [], onRowSelect }) {
+  const [filterDocumentNo, setFilterDocumentNo] = useState('');
+  const [filterBusinessPartner, setFilterBusinessPartner] = useState('');
+  const [filterDocStatus, setFilterDocStatus] = useState('');
+
+  const filteredData = data.filter(row => {
+    if (filterDocumentNo && !String(row.documentNo ?? '').toLowerCase().includes(filterDocumentNo.toLowerCase())) return false;
+    if (filterBusinessPartner && !String(row.businessPartner ?? '').toLowerCase().includes(filterBusinessPartner.toLowerCase())) return false;
+    if (filterDocStatus && !String(row.docStatus ?? '').toLowerCase().includes(filterDocStatus.toLowerCase())) return false;
+    return true;
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+        <Input
+          placeholder="Filter Document No..."
+          value={filterDocumentNo}
+          onChange={(e) => setFilterDocumentNo(e.target.value)}
+          className="max-w-xs"
+        />
+        <Input
+          placeholder="Filter Business Partner..."
+          value={filterBusinessPartner}
+          onChange={(e) => setFilterBusinessPartner(e.target.value)}
+          className="max-w-xs"
+        />
+        <Input
+          placeholder="Filter Doc Status..."
+          value={filterDocStatus}
+          onChange={(e) => setFilterDocStatus(e.target.value)}
+          className="max-w-xs"
+        />
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Document No</TableHead>
+            <TableHead>Business Partner</TableHead>
+            <TableHead>Order Date</TableHead>
+            <TableHead>Currency</TableHead>
+            <TableHead>Total Lines</TableHead>
+            <TableHead>Grand Total</TableHead>
+            <TableHead>Doc Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {filteredData.map((row, idx) => (
+            <TableRow key={row.id ?? idx} onClick={() => onRowSelect?.(row)} className="cursor-pointer">
+            <TableCell>{row.documentNo}</TableCell>
+            <TableCell>{row.businessPartner}</TableCell>
+            <TableCell>{row.orderDate}</TableCell>
+            <TableCell>{row.currency}</TableCell>
+            <TableCell>{row.totalLines?.toLocaleString()}</TableCell>
+            <TableCell>{row.grandTotal?.toLocaleString()}</TableCell>
+            <TableCell>{row.docStatus}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/artifacts/sales-order/generated/web/sales-order/index.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/index.jsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import OrderPage from './OrderPage';
+
+export default function App({ token, apiBaseUrl, window }) {
+  return <OrderPage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+}

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -1,0 +1,338 @@
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+
+/**
+ * Capitalize the first letter of a string.
+ */
+export function capitalize(s) {
+  if (!s) return '';
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+/**
+ * Convert camelCase name to "Title Case" label.
+ * e.g., 'orderLine' -> 'Order Line'
+ */
+export function toLabel(name) {
+  if (!name) return '';
+  const words = name.replace(/([A-Z])/g, ' $1').trim();
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/**
+ * Get process endpoints that match a given entity.
+ */
+export function getProcessesForEntity(contract, entityName) {
+  const endpoints = contract.backendContract?.processEndpoints ?? [];
+  return endpoints.filter(p => p.entity === entityName);
+}
+
+/**
+ * Generate a data table component for an entity.
+ * Renders grid:true fields as columns, searchableFields as filter inputs.
+ */
+export function generateTableComponent(entityName, contract) {
+  const entity = contract.frontendContract.entities[entityName];
+  const gridFields = entity.fields.filter(f => f.grid);
+  const searchableFields = entity.searchableFields ?? [];
+  const compName = `${capitalize(entityName)}Table`;
+
+  const imports = [
+    `import React, { useState } from 'react';`,
+    `import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';`,
+    `import { Input } from '@/components/ui/input';`,
+    `import { Badge } from '@/components/ui/badge';`,
+    `import { Button } from '@/components/ui/button';`,
+  ];
+
+  const filterState = searchableFields
+    .map(f => `  const [filter${capitalize(f)}, setFilter${capitalize(f)}] = useState('');`)
+    .join('\n');
+
+  const filterInputs = searchableFields
+    .map(f => `        <Input
+          placeholder="Filter ${toLabel(f)}..."
+          value={filter${capitalize(f)}}
+          onChange={(e) => setFilter${capitalize(f)}(e.target.value)}
+          className="max-w-xs"
+        />`)
+    .join('\n');
+
+  const headerCells = gridFields
+    .map(f => `            <TableHead>${toLabel(f.name)}</TableHead>`)
+    .join('\n');
+
+  const bodyCells = gridFields
+    .map(f => {
+      if (f.type === 'amount') {
+        return `            <TableCell>{row.${f.name}?.toLocaleString()}</TableCell>`;
+      }
+      return `            <TableCell>{row.${f.name}}</TableCell>`;
+    })
+    .join('\n');
+
+  return `${imports.join('\n')}
+
+export default function ${compName}({ data = [], onRowSelect }) {
+${filterState}
+
+  const filteredData = data.filter(row => {
+${searchableFields.map(f => `    if (filter${capitalize(f)} && !String(row.${f} ?? '').toLowerCase().includes(filter${capitalize(f)}.toLowerCase())) return false;`).join('\n')}
+    return true;
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2">
+${filterInputs}
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+${headerCells}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {filteredData.map((row, idx) => (
+            <TableRow key={row.id ?? idx} onClick={() => onRowSelect?.(row)} className="cursor-pointer">
+${bodyCells}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+`;
+}
+
+/**
+ * Generate a detail/edit form component for an entity.
+ * Renders form:true fields, editable as inputs, readOnly as disabled.
+ * Includes process action buttons for matching entity.
+ */
+export function generateFormComponent(entityName, contract) {
+  const entity = contract.frontendContract.entities[entityName];
+  const formFields = entity.fields.filter(f => f.form);
+  const processes = getProcessesForEntity(contract, entityName);
+  const compName = `${capitalize(entityName)}Form`;
+
+  const imports = [
+    `import React from 'react';`,
+    `import { Input } from '@/components/ui/input';`,
+    `import { Label } from '@/components/ui/label';`,
+    `import { Button } from '@/components/ui/button';`,
+    `import { Separator } from '@/components/ui/separator';`,
+  ];
+
+  const fieldElements = formFields.map(f => {
+    const label = toLabel(f.name);
+    const isReadOnly = f.visibility === 'readOnly';
+    const inputType = f.tsType === 'number' ? 'number' : 'text';
+    const disabledAttr = isReadOnly ? ' disabled readOnly className="bg-muted"' : '';
+    const requiredAttr = f.required ? ' required' : '';
+
+    return `        <div className="space-y-2">
+          <Label htmlFor="${f.name}">${label}${f.required ? ' *' : ''}</Label>
+          <Input
+            id="${f.name}"
+            name="${f.name}"
+            type="${inputType}"
+            value={data?.${f.name} ?? ''}
+            onChange={(e) => onChange?.('${f.name}', e.target.value)}${disabledAttr}${requiredAttr}
+          />
+        </div>`;
+  }).join('\n');
+
+  const processButtons = processes.map(p => {
+    const label = toLabel(p.name);
+    return `          <Button variant="outline" onClick={() => onProcess?.('${p.name}')}>
+            ${label}
+          </Button>`;
+  }).join('\n');
+
+  const processSection = processes.length > 0
+    ? `\n      <Separator />\n      <div className="flex gap-2">\n${processButtons}\n      </div>`
+    : '';
+
+  return `${imports.join('\n')}
+
+export default function ${compName}({ data, onChange, onSave, onProcess }) {
+  return (
+    <form onSubmit={(e) => { e.preventDefault(); onSave?.(data); }} className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+${fieldElements}
+      </div>
+      <div className="flex gap-2">
+        <Button type="submit">Save</Button>
+      </div>${processSection}
+    </form>
+  );
+}
+`;
+}
+
+/**
+ * Generate a header-detail page component.
+ * Shows header table, header form, and detail table.
+ * Includes API fetch logic using token/apiBaseUrl props.
+ */
+export function generatePageComponent(headerEntity, detailEntity, contract) {
+  const headerName = capitalize(headerEntity);
+  const detailName = capitalize(detailEntity);
+  const compName = `${headerName}Page`;
+
+  return `import React, { useState, useEffect } from 'react';
+import { Separator } from '@/components/ui/separator';
+import ${headerName}Table from './${headerName}Table';
+import ${headerName}Form from './${headerName}Form';
+import ${detailName}Table from './${detailName}Table';
+
+export default function ${compName}({ token, apiBaseUrl }) {
+  const [items, setItems] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [details, setDetails] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const headers = {
+    'Authorization': \`Bearer \${token}\`,
+    'Content-Type': 'application/json',
+  };
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(\`\${apiBaseUrl}/${headerEntity}\`, { headers })
+      .then(res => res.json())
+      .then(data => { setItems(data); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, [apiBaseUrl, token]);
+
+  useEffect(() => {
+    if (!selected?.id) { setDetails([]); return; }
+    fetch(\`\${apiBaseUrl}/${headerEntity}/\${selected.id}/${detailEntity}\`, { headers })
+      .then(res => res.json())
+      .then(setDetails)
+      .catch(() => setDetails([]));
+  }, [selected]);
+
+  const handleProcess = async (processName) => {
+    if (!selected?.id) return;
+    await fetch(\`\${apiBaseUrl}/process/\${processName}\`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({ id: selected.id }),
+    });
+  };
+
+  return (
+    <div className="space-y-6 p-4">
+      <h2 className="text-xl font-semibold">${toLabel(headerEntity)}</h2>
+      <${headerName}Table data={items} onRowSelect={setSelected} />
+      {selected && (
+        <>
+          <Separator />
+          <${headerName}Form data={selected} onProcess={handleProcess} />
+          <Separator />
+          <h3 className="text-lg font-medium">${toLabel(detailEntity)}</h3>
+          <${detailName}Table data={details} />
+        </>
+      )}
+    </div>
+  );
+}
+`;
+}
+
+/**
+ * Generate the entry point / index component.
+ * Accepts { token, apiBaseUrl, window } props.
+ */
+export function generateIndexComponent(headerEntity, detailEntity) {
+  const headerName = capitalize(headerEntity);
+
+  if (detailEntity) {
+    return `import React from 'react';
+import ${headerName}Page from './${headerName}Page';
+
+export default function App({ token, apiBaseUrl, window }) {
+  return <${headerName}Page token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+}
+`;
+  }
+
+  return `import React from 'react';
+import ${headerName}Table from './${headerName}Table';
+import ${headerName}Form from './${headerName}Form';
+
+export default function App({ token, apiBaseUrl, window }) {
+  const [selected, setSelected] = React.useState(null);
+
+  return (
+    <div className="space-y-6 p-4">
+      <${headerName}Table data={[]} onRowSelect={setSelected} />
+      {selected && <${headerName}Form data={selected} />}
+    </div>
+  );
+}
+`;
+}
+
+/**
+ * Generate all frontend components from a contract.
+ * Returns a map of { filename: code }.
+ */
+export function generateAll(contract) {
+  const { frontendContract } = contract;
+  const { window: win, entities } = frontendContract;
+  const primaryEntity = win.primaryEntity;
+  const entityNames = Object.keys(entities);
+  const detailEntity = entityNames.find(name => name !== primaryEntity);
+
+  const files = {};
+
+  // Generate Table + Form for each entity
+  for (const entityName of entityNames) {
+    const capName = capitalize(entityName);
+    files[`${capName}Table.jsx`] = generateTableComponent(entityName, contract);
+    files[`${capName}Form.jsx`] = generateFormComponent(entityName, contract);
+  }
+
+  // Generate Page if there is a detail entity
+  if (detailEntity) {
+    files[`${capitalize(primaryEntity)}Page.jsx`] = generatePageComponent(primaryEntity, detailEntity, contract);
+  }
+
+  // Always generate index
+  files['index.jsx'] = generateIndexComponent(primaryEntity, detailEntity);
+
+  return files;
+}
+
+// CLI entry point -- only runs when executed directly
+const isDirectRun = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/.*\//, ''));
+if (isDirectRun) {
+  const contractPath = process.argv[2];
+  if (!contractPath) {
+    console.error('Usage: node cli/src/generate-frontend.js <contract-path>');
+    process.exit(1);
+  }
+
+  const contractJson = readFileSync(resolve(contractPath), 'utf-8');
+  const contract = JSON.parse(contractJson);
+  const files = generateAll(contract);
+
+  const windowName = contract.frontendContract.window.name
+    .toLowerCase()
+    .replace(/\s+/g, '-');
+
+  const outDir = resolve(`artifacts/${windowName}/generated/web/${windowName}`);
+  mkdirSync(outDir, { recursive: true });
+
+  for (const [filename, code] of Object.entries(files)) {
+    const filePath = resolve(outDir, filename);
+    writeFileSync(filePath, code, 'utf-8');
+    console.log(`  wrote ${filePath}`);
+  }
+
+  console.log(`\nGenerated ${Object.keys(files).length} files in ${outDir}`);
+}

--- a/cli/test/generate-frontend.test.js
+++ b/cli/test/generate-frontend.test.js
@@ -1,0 +1,141 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import {
+  generateTableComponent,
+  generateFormComponent,
+  generatePageComponent,
+  generateIndexComponent,
+  generateAll,
+} from '../src/generate-frontend.js';
+
+const sampleContract = {
+  frontendContract: {
+    window: { id: '143', name: 'Sales Order', primaryEntity: 'order', category: 'sales' },
+    entities: {
+      order: {
+        fields: [
+          { name: 'documentNo', type: 'string', tsType: 'string', visibility: 'readOnly', required: true, grid: true, form: true },
+          { name: 'businessPartner', type: 'string', tsType: 'string', visibility: 'editable', required: true, grid: true, form: true },
+          { name: 'grandTotal', type: 'amount', tsType: 'number', visibility: 'readOnly', required: false, grid: true, form: true },
+          { name: 'docStatus', type: 'string', tsType: 'string', visibility: 'readOnly', required: true, grid: true, form: true },
+        ],
+        searchableFields: ['documentNo', 'businessPartner', 'docStatus'],
+        computedFields: [],
+      },
+      orderLine: {
+        fields: [
+          { name: 'product', type: 'string', tsType: 'string', visibility: 'editable', required: true, grid: true, form: true },
+          { name: 'quantity', type: 'number', tsType: 'number', visibility: 'editable', required: true, grid: true, form: true },
+          { name: 'lineNetAmount', type: 'amount', tsType: 'number', visibility: 'readOnly', required: false, grid: true, form: true },
+        ],
+        searchableFields: ['product'],
+        computedFields: [],
+      },
+    },
+  },
+  backendContract: {
+    processEndpoints: [
+      { name: 'completeOrder', method: 'POST', path: '/process/completeOrder', entity: 'order', preconditions: [], steps: 6 },
+      { name: 'voidOrder', method: 'POST', path: '/process/voidOrder', entity: 'order', preconditions: [], steps: 4 },
+    ],
+  },
+};
+
+describe('generateTableComponent', () => {
+  it('generates valid JSX string with imports', () => {
+    const code = generateTableComponent('order', sampleContract);
+    assert.ok(code.includes('import'), 'should have imports');
+    assert.ok(code.includes('export default function OrderTable'), 'should export OrderTable');
+  });
+
+  it('includes grid columns from contract fields', () => {
+    const code = generateTableComponent('order', sampleContract);
+    assert.ok(code.includes('documentNo'), 'should include documentNo column');
+    assert.ok(code.includes('businessPartner'), 'should include businessPartner column');
+    assert.ok(code.includes('grandTotal'), 'should include grandTotal column');
+  });
+
+  it('includes search filters for searchable fields', () => {
+    const code = generateTableComponent('order', sampleContract);
+    assert.ok(code.includes('Filter'), 'should have filter inputs');
+  });
+});
+
+describe('generateFormComponent', () => {
+  it('generates valid JSX string', () => {
+    const code = generateFormComponent('order', sampleContract);
+    assert.ok(code.includes('export default function OrderForm'), 'should export OrderForm');
+  });
+
+  it('renders editable fields as inputs', () => {
+    const code = generateFormComponent('order', sampleContract);
+    assert.ok(code.includes('businessPartner'), 'should include editable businessPartner');
+  });
+
+  it('renders readOnly fields as disabled', () => {
+    const code = generateFormComponent('order', sampleContract);
+    assert.ok(code.includes('readOnly') || code.includes('disabled'), 'should mark readOnly fields');
+  });
+
+  it('includes process action buttons for matching entity', () => {
+    const code = generateFormComponent('order', sampleContract);
+    assert.ok(code.includes('completeOrder') || code.includes('Complete Order'), 'should include completeOrder button');
+    assert.ok(code.includes('voidOrder') || code.includes('Void Order'), 'should include voidOrder button');
+  });
+
+  it('does not include process buttons for non-matching entity', () => {
+    const code = generateFormComponent('orderLine', sampleContract);
+    assert.ok(!code.includes('completeOrder'), 'should not include order processes in orderLine form');
+  });
+});
+
+describe('generatePageComponent', () => {
+  it('generates header-detail layout', () => {
+    const code = generatePageComponent('order', 'orderLine', sampleContract);
+    assert.ok(code.includes('export default function OrderPage'), 'should export OrderPage');
+    assert.ok(code.includes('OrderTable'), 'should include header table');
+    assert.ok(code.includes('OrderForm'), 'should include header form');
+    assert.ok(code.includes('OrderLineTable'), 'should include detail table');
+  });
+});
+
+describe('generateIndexComponent', () => {
+  it('generates entry point with standard props', () => {
+    const code = generateIndexComponent('order', 'orderLine');
+    assert.ok(code.includes('token'), 'should accept token prop');
+    assert.ok(code.includes('apiBaseUrl'), 'should accept apiBaseUrl prop');
+    assert.ok(code.includes('window'), 'should accept window prop');
+    assert.ok(code.includes('export default'), 'should have default export');
+  });
+});
+
+describe('generateAll', () => {
+  it('returns map of filename to code', () => {
+    const files = generateAll(sampleContract);
+    assert.ok(files['OrderTable.jsx'], 'should produce OrderTable.jsx');
+    assert.ok(files['OrderForm.jsx'], 'should produce OrderForm.jsx');
+    assert.ok(files['OrderLineTable.jsx'], 'should produce OrderLineTable.jsx');
+    assert.ok(files['OrderPage.jsx'], 'should produce OrderPage.jsx');
+    assert.ok(files['index.jsx'], 'should produce index.jsx');
+  });
+
+  it('handles single-entity contract without detail', () => {
+    const singleEntity = {
+      frontendContract: {
+        window: { id: '1', name: 'Simple', primaryEntity: 'item', category: 'test' },
+        entities: {
+          item: {
+            fields: [{ name: 'name', type: 'string', tsType: 'string', visibility: 'editable', required: true, grid: true, form: true }],
+            searchableFields: ['name'],
+            computedFields: [],
+          },
+        },
+      },
+      backendContract: { processEndpoints: [] },
+    };
+    const files = generateAll(singleEntity);
+    assert.ok(files['ItemTable.jsx'], 'should produce ItemTable.jsx');
+    assert.ok(files['ItemForm.jsx'], 'should produce ItemForm.jsx');
+    assert.ok(files['index.jsx'], 'should produce index.jsx');
+  });
+});

--- a/docs/plans/2026-03-05-frontend-generator-design.md
+++ b/docs/plans/2026-03-05-frontend-generator-design.md
@@ -1,0 +1,101 @@
+# Frontend Code Generator — Design
+
+> Approved design for automatic React component generation from contract.json
+
+## What
+
+A CLI tool (`cli/src/generate-frontend.js`) that reads a `contract.json` and produces React components that mount in the app shell. Complemented by an updated `generate-ui` skill for conversational customization with Shadcn/ui.
+
+## Architecture
+
+```
+contract.json --> generate-frontend.js --> artifacts/{window}/generated/web/{window}/
+                                              ├── OrderTable.jsx        (list + filters)
+                                              ├── OrderForm.jsx         (detail/edit)
+                                              ├── OrderLineTable.jsx    (child table)
+                                              ├── OrderPage.jsx         (header-detail orchestrator)
+                                              └── index.jsx             (entry point with props)
+```
+
+## Generated Components Per Entity
+
+| Component | What it does |
+|---|---|
+| `{Entity}Table.jsx` | Table with columns from contract, filters by `searchableFields`, pagination |
+| `{Entity}Form.jsx` | Form with fields by visibility (editable -> input, readOnly -> display). Process action buttons in toolbar |
+| `{Entity}Page.jsx` | Orchestrator: table on top (header), form + child table below (detail). Manages record selection |
+| `index.jsx` | Entry point receiving `{ token, apiBaseUrl, window }` from shell |
+
+## Header-Detail Layout
+
+```
++----------------------------------+
+| OrderTable (filters + list)      |  <-- click row
++----------------------------------+
+| OrderForm (order detail)         |
+| [Complete Order] [Void Order]    |  <-- process action buttons
++----------------------------------+
+| OrderLineTable (lines)           |  <-- inline child table
++----------------------------------+
+```
+
+## Process Actions
+
+Process buttons render in the form toolbar. Each button:
+- Maps to a process from `contract.backendContract.processEndpoints`
+- Calls `POST /process/{processName}` with the current record ID
+- Shows loading state during execution
+- Refreshes the record after completion
+
+## Shadcn Components Added to Shell
+
+New files in `tools/app-shell/src/components/ui/`:
+- `table.jsx` — Table, TableHeader, TableBody, TableRow, TableHead, TableCell
+- `dialog.jsx` — Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter
+- `badge.jsx` — Badge (for status: Draft, Completed, Void)
+- `select.jsx` — Select for dropdown filters
+- `label.jsx` — Label for form fields
+- `separator.jsx` — Separator
+
+## Contract Fixture
+
+Create `artifacts/sales-order/contract.json` with:
+- **Window**: Sales Order
+- **Order entity**: ~12 fields (documentNo, businessPartner, orderDate, warehouse, totalLines, grandTotal, docStatus, currency, paymentTerms, description, deliveryLocation, invoiceAddress)
+- **OrderLine entity**: ~8 fields (product, quantity, unitPrice, lineNetAmount, tax, description, discount, deliveredQuantity)
+- 2 processes: Complete Order, Void Order (from existing processes.json)
+- Searchable fields, visibility model, computed fields
+- Backend contract with endpoints
+
+## Generator CLI
+
+```bash
+node cli/src/generate-frontend.js artifacts/sales-order/contract.json
+```
+
+1. Reads contract.json
+2. For each entity: generates Table, Form
+3. Detects parent-child relationships -> generates Page with header-detail
+4. Generates index.jsx as entry point
+5. Outputs to `artifacts/{window}/generated/web/{window}/`
+
+## Shell Integration
+
+The shell's `registry.js` already loads components by entity. The generator produces `index.jsx` with the standard `{ token, apiBaseUrl, window }` signature — the shell mounts it without changes.
+
+## Updated generate-ui Skill
+
+- Changes "inline styles" to Shadcn/ui + Tailwind
+- References shell base components (`@/components/ui/*`)
+- Used after the automatic generator for customization: layout changes, custom logic, design tweaks
+
+## YAGNI — Not Included
+
+- Drag & drop columns
+- Export to Excel/CSV
+- Inline editing in table
+- Undo/redo
+- Complex client-side validation (only required)
+- i18n for labels
+- Token refresh
+- Optimistic updates

--- a/docs/plans/2026-03-05-frontend-generator-plan.md
+++ b/docs/plans/2026-03-05-frontend-generator-plan.md
@@ -1,0 +1,1036 @@
+# Frontend Code Generator Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Build a CLI tool that reads a contract.json and generates React components (table, form, header-detail page) that mount in the app shell, plus Shadcn UI components the generated code depends on.
+
+**Architecture:** `generate-frontend.js` reads the contract's `frontendContract` and `backendContract`, then produces per-entity Table, Form, and Page components using Shadcn/ui + Tailwind. A fixture `contract.json` for Sales Order enables development without a real Etendo instance. The app shell gets new Shadcn components (table, dialog, badge, select, label, separator) that generated code imports.
+
+**Tech Stack:** Node.js 22 ESM, React 18, Shadcn/ui, Tailwind CSS, node:test, node:assert
+
+---
+
+## Task 1: Create Sales Order Contract Fixture
+
+**Files:**
+- Create: `artifacts/sales-order/contract.json`
+
+**Step 1: Create the fixture**
+
+```json
+{
+  "version": "0.1.0",
+  "generatedAt": "2026-03-05T00:00:00.000Z",
+  "checksum": "fixture-dev-only",
+  "frontendContract": {
+    "window": { "id": "143", "name": "Sales Order", "primaryEntity": "order", "category": "sales" },
+    "entities": {
+      "order": {
+        "fields": [
+          { "name": "documentNo", "column": "DocumentNo", "type": "string", "tsType": "string", "visibility": "readOnly", "required": true, "grid": true, "form": true },
+          { "name": "businessPartner", "column": "C_BPartner_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "orderDate", "column": "DateOrdered", "type": "date", "tsType": "string", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "warehouse", "column": "M_Warehouse_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": true, "grid": false, "form": true },
+          { "name": "currency", "column": "C_Currency_ID", "type": "string", "tsType": "string", "visibility": "readOnly", "required": true, "grid": true, "form": true },
+          { "name": "paymentTerms", "column": "C_PaymentTerm_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true },
+          { "name": "description", "column": "Description", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true },
+          { "name": "totalLines", "column": "TotalLines", "type": "amount", "tsType": "number", "visibility": "readOnly", "required": false, "grid": true, "form": true },
+          { "name": "grandTotal", "column": "GrandTotal", "type": "amount", "tsType": "number", "visibility": "readOnly", "required": false, "grid": true, "form": true },
+          { "name": "docStatus", "column": "DocStatus", "type": "string", "tsType": "string", "visibility": "readOnly", "required": true, "grid": true, "form": true },
+          { "name": "deliveryLocation", "column": "DeliveryLocation", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true },
+          { "name": "invoiceAddress", "column": "BillTo_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true }
+        ],
+        "searchableFields": ["documentNo", "businessPartner", "docStatus"],
+        "computedFields": []
+      },
+      "orderLine": {
+        "fields": [
+          { "name": "lineNo", "column": "Line", "type": "integer", "tsType": "number", "visibility": "readOnly", "required": true, "grid": true, "form": true },
+          { "name": "product", "column": "M_Product_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "quantity", "column": "QtyOrdered", "type": "number", "tsType": "number", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "unitPrice", "column": "PriceActual", "type": "amount", "tsType": "number", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "discount", "column": "Discount", "type": "number", "tsType": "number", "visibility": "editable", "required": false, "grid": true, "form": true },
+          { "name": "lineNetAmount", "column": "LineNetAmt", "type": "amount", "tsType": "number", "visibility": "readOnly", "required": false, "grid": true, "form": true },
+          { "name": "tax", "column": "C_Tax_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": true, "form": true },
+          { "name": "description", "column": "Description", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true }
+        ],
+        "searchableFields": ["product"],
+        "computedFields": []
+      }
+    }
+  },
+  "backendContract": {
+    "window": { "id": "143", "name": "Sales Order", "primaryEntity": "order", "category": "sales" },
+    "entities": {
+      "order": {
+        "fields": [
+          { "name": "documentNo", "column": "DocumentNo", "type": "string", "visibility": "readOnly", "required": true },
+          { "name": "businessPartner", "column": "C_BPartner_ID", "type": "string", "visibility": "editable", "required": true },
+          { "name": "orderDate", "column": "DateOrdered", "type": "date", "visibility": "editable", "required": true },
+          { "name": "warehouse", "column": "M_Warehouse_ID", "type": "string", "visibility": "editable", "required": true },
+          { "name": "currency", "column": "C_Currency_ID", "type": "string", "visibility": "readOnly", "required": true },
+          { "name": "paymentTerms", "column": "C_PaymentTerm_ID", "type": "string", "visibility": "editable", "required": false },
+          { "name": "description", "column": "Description", "type": "string", "visibility": "editable", "required": false },
+          { "name": "totalLines", "column": "TotalLines", "type": "amount", "visibility": "readOnly", "required": false },
+          { "name": "grandTotal", "column": "GrandTotal", "type": "amount", "visibility": "readOnly", "required": false },
+          { "name": "docStatus", "column": "DocStatus", "type": "string", "visibility": "readOnly", "required": true },
+          { "name": "deliveryLocation", "column": "DeliveryLocation", "type": "string", "visibility": "editable", "required": false },
+          { "name": "invoiceAddress", "column": "BillTo_ID", "type": "string", "visibility": "editable", "required": false },
+          { "name": "adClientId", "column": "AD_Client_ID", "type": "id", "visibility": "system", "required": true },
+          { "name": "adOrgId", "column": "AD_Org_ID", "type": "id", "visibility": "system", "required": true },
+          { "name": "created", "column": "Created", "type": "datetime", "visibility": "system", "required": true },
+          { "name": "updated", "column": "Updated", "type": "datetime", "visibility": "system", "required": true }
+        ]
+      },
+      "orderLine": {
+        "fields": [
+          { "name": "lineNo", "column": "Line", "type": "integer", "visibility": "readOnly", "required": true },
+          { "name": "product", "column": "M_Product_ID", "type": "string", "visibility": "editable", "required": true },
+          { "name": "quantity", "column": "QtyOrdered", "type": "number", "visibility": "editable", "required": true },
+          { "name": "unitPrice", "column": "PriceActual", "type": "amount", "visibility": "editable", "required": true },
+          { "name": "discount", "column": "Discount", "type": "number", "visibility": "editable", "required": false },
+          { "name": "lineNetAmount", "column": "LineNetAmt", "type": "amount", "visibility": "readOnly", "required": false },
+          { "name": "tax", "column": "C_Tax_ID", "type": "string", "visibility": "editable", "required": false },
+          { "name": "description", "column": "Description", "type": "string", "visibility": "editable", "required": false },
+          { "name": "adClientId", "column": "AD_Client_ID", "type": "id", "visibility": "system", "required": true },
+          { "name": "adOrgId", "column": "AD_Org_ID", "type": "id", "visibility": "system", "required": true }
+        ]
+      }
+    },
+    "endpoints": [
+      { "method": "GET", "path": "/order", "entity": "order", "supportedFilters": ["documentNo", "businessPartner", "docStatus"] },
+      { "method": "GET", "path": "/order/:id", "entity": "order", "supportedFilters": [] },
+      { "method": "POST", "path": "/order", "entity": "order", "supportedFilters": [] },
+      { "method": "PUT", "path": "/order/:id", "entity": "order", "supportedFilters": [] },
+      { "method": "DELETE", "path": "/order/:id", "entity": "order", "supportedFilters": [] },
+      { "method": "GET", "path": "/orderLine", "entity": "orderLine", "supportedFilters": ["product"] },
+      { "method": "GET", "path": "/orderLine/:id", "entity": "orderLine", "supportedFilters": [] },
+      { "method": "POST", "path": "/orderLine", "entity": "orderLine", "supportedFilters": [] },
+      { "method": "PUT", "path": "/orderLine/:id", "entity": "orderLine", "supportedFilters": [] },
+      { "method": "DELETE", "path": "/orderLine/:id", "entity": "orderLine", "supportedFilters": [] }
+    ],
+    "processEndpoints": [
+      { "name": "completeOrder", "method": "POST", "path": "/process/completeOrder", "entity": "order", "preconditions": ["Order must have at least one line", "Order status must be DR or IP"], "steps": 6 },
+      { "name": "voidOrder", "method": "POST", "path": "/process/voidOrder", "entity": "order", "preconditions": ["Order status must be CO"], "steps": 4 }
+    ]
+  }
+}
+```
+
+**Step 2: Verify JSON is valid**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('artifacts/sales-order/contract.json', 'utf8')); console.log('Valid JSON')"`
+Expected: `Valid JSON`
+
+**Step 3: Commit**
+
+```bash
+git add artifacts/sales-order/contract.json
+git commit -m "feat: add sales order contract fixture for frontend generator development"
+```
+
+---
+
+## Task 2: Add Shadcn UI Components to App Shell
+
+**Files:**
+- Create: `tools/app-shell/src/components/ui/table.jsx`
+- Create: `tools/app-shell/src/components/ui/badge.jsx`
+- Create: `tools/app-shell/src/components/ui/label.jsx`
+- Create: `tools/app-shell/src/components/ui/separator.jsx`
+- Create: `tools/app-shell/src/components/ui/select.jsx`
+- Create: `tools/app-shell/src/components/ui/dialog.jsx`
+
+**Step 1: Create table.jsx**
+
+```jsx
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Table = React.forwardRef(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+  </div>
+));
+Table.displayName = 'Table';
+
+const TableHeader = React.forwardRef(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+));
+TableHeader.displayName = 'TableHeader';
+
+const TableBody = React.forwardRef(({ className, ...props }, ref) => (
+  <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+));
+TableBody.displayName = 'TableBody';
+
+const TableRow = React.forwardRef(({ className, ...props }, ref) => (
+  <tr ref={ref} className={cn('border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted', className)} {...props} />
+));
+TableRow.displayName = 'TableRow';
+
+const TableHead = React.forwardRef(({ className, ...props }, ref) => (
+  <th ref={ref} className={cn('h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]', className)} {...props} />
+));
+TableHead.displayName = 'TableHead';
+
+const TableCell = React.forwardRef(({ className, ...props }, ref) => (
+  <td ref={ref} className={cn('p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]', className)} {...props} />
+));
+TableCell.displayName = 'TableCell';
+
+export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell };
+```
+
+**Step 2: Create badge.jsx**
+
+```jsx
+import * as React from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive: 'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: { variant: 'default' },
+  }
+);
+
+function Badge({ className, variant, ...props }) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };
+```
+
+**Step 3: Create label.jsx**
+
+```jsx
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Label = React.forwardRef(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)}
+    {...props}
+  />
+));
+Label.displayName = 'Label';
+
+export { Label };
+```
+
+**Step 4: Create separator.jsx**
+
+```jsx
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Separator = React.forwardRef(({ className, orientation = 'horizontal', ...props }, ref) => (
+  <div
+    ref={ref}
+    role="separator"
+    className={cn(
+      'shrink-0 bg-border',
+      orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
+      className
+    )}
+    {...props}
+  />
+));
+Separator.displayName = 'Separator';
+
+export { Separator };
+```
+
+**Step 5: Create select.jsx**
+
+```jsx
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Select = React.forwardRef(({ className, children, ...props }, ref) => (
+  <select
+    ref={ref}
+    className={cn(
+      'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </select>
+));
+Select.displayName = 'Select';
+
+export { Select };
+```
+
+**Step 6: Create dialog.jsx**
+
+```jsx
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+function Dialog({ open, onOpenChange, children }) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/80" onClick={() => onOpenChange?.(false)} />
+      <div className="relative z-50">{children}</div>
+    </div>
+  );
+}
+
+const DialogContent = React.forwardRef(({ className, children, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg',
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </div>
+));
+DialogContent.displayName = 'DialogContent';
+
+function DialogHeader({ className, ...props }) {
+  return <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />;
+}
+
+function DialogTitle({ className, ...props }) {
+  return <h2 className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />;
+}
+
+function DialogFooter({ className, ...props }) {
+  return <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />;
+}
+
+export { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter };
+```
+
+**Step 7: Verify build**
+
+Run: `cd tools/app-shell && npm run build`
+Expected: PASS
+
+**Step 8: Commit**
+
+```bash
+git add tools/app-shell/src/components/ui/
+git commit -m "feat: add Shadcn table, badge, label, separator, select, dialog components"
+```
+
+---
+
+## Task 3: Generate-Frontend CLI — Core Generator with Tests
+
+**Files:**
+- Create: `cli/src/generate-frontend.js`
+- Create: `cli/test/generate-frontend.test.js`
+
+**Step 1: Write the failing test**
+
+```javascript
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import {
+  generateTableComponent,
+  generateFormComponent,
+  generatePageComponent,
+  generateIndexComponent,
+  generateAll,
+} from '../src/generate-frontend.js';
+
+const sampleContract = {
+  frontendContract: {
+    window: { id: '143', name: 'Sales Order', primaryEntity: 'order', category: 'sales' },
+    entities: {
+      order: {
+        fields: [
+          { name: 'documentNo', type: 'string', tsType: 'string', visibility: 'readOnly', required: true, grid: true, form: true },
+          { name: 'businessPartner', type: 'string', tsType: 'string', visibility: 'editable', required: true, grid: true, form: true },
+          { name: 'grandTotal', type: 'amount', tsType: 'number', visibility: 'readOnly', required: false, grid: true, form: true },
+          { name: 'docStatus', type: 'string', tsType: 'string', visibility: 'readOnly', required: true, grid: true, form: true },
+        ],
+        searchableFields: ['documentNo', 'businessPartner', 'docStatus'],
+        computedFields: [],
+      },
+      orderLine: {
+        fields: [
+          { name: 'product', type: 'string', tsType: 'string', visibility: 'editable', required: true, grid: true, form: true },
+          { name: 'quantity', type: 'number', tsType: 'number', visibility: 'editable', required: true, grid: true, form: true },
+          { name: 'lineNetAmount', type: 'amount', tsType: 'number', visibility: 'readOnly', required: false, grid: true, form: true },
+        ],
+        searchableFields: ['product'],
+        computedFields: [],
+      },
+    },
+  },
+  backendContract: {
+    processEndpoints: [
+      { name: 'completeOrder', method: 'POST', path: '/process/completeOrder', entity: 'order', preconditions: [], steps: 6 },
+      { name: 'voidOrder', method: 'POST', path: '/process/voidOrder', entity: 'order', preconditions: [], steps: 4 },
+    ],
+  },
+};
+
+describe('generateTableComponent', () => {
+  it('generates valid JSX string with imports', () => {
+    const code = generateTableComponent('order', sampleContract);
+    assert.ok(code.includes('import'), 'should have imports');
+    assert.ok(code.includes('export default function OrderTable'), 'should export OrderTable');
+  });
+
+  it('includes grid columns from contract fields', () => {
+    const code = generateTableComponent('order', sampleContract);
+    assert.ok(code.includes('documentNo'), 'should include documentNo column');
+    assert.ok(code.includes('businessPartner'), 'should include businessPartner column');
+    assert.ok(code.includes('grandTotal'), 'should include grandTotal column');
+  });
+
+  it('includes search filters for searchable fields', () => {
+    const code = generateTableComponent('order', sampleContract);
+    assert.ok(code.includes('documentNo'), 'should filter by documentNo');
+    assert.ok(code.includes('businessPartner'), 'should filter by businessPartner');
+  });
+
+  it('skips fields not marked for grid', () => {
+    const contract = {
+      ...sampleContract,
+      frontendContract: {
+        ...sampleContract.frontendContract,
+        entities: {
+          test: {
+            fields: [
+              { name: 'shown', type: 'string', tsType: 'string', visibility: 'editable', required: false, grid: true, form: true },
+              { name: 'hidden', type: 'string', tsType: 'string', visibility: 'editable', required: false, grid: false, form: true },
+            ],
+            searchableFields: [],
+            computedFields: [],
+          },
+        },
+      },
+    };
+    const code = generateTableComponent('test', contract);
+    assert.ok(code.includes('shown'), 'should include grid:true field');
+    // The table header should reference 'shown' but not 'hidden' as a column header
+    const headerSection = code.split('TableHead').join('');
+    // hidden should not appear as a table column
+  });
+});
+
+describe('generateFormComponent', () => {
+  it('generates valid JSX string', () => {
+    const code = generateFormComponent('order', sampleContract);
+    assert.ok(code.includes('export default function OrderForm'), 'should export OrderForm');
+  });
+
+  it('renders editable fields as inputs', () => {
+    const code = generateFormComponent('order', sampleContract);
+    assert.ok(code.includes('businessPartner'), 'should include editable businessPartner');
+  });
+
+  it('renders readOnly fields as disabled or display', () => {
+    const code = generateFormComponent('order', sampleContract);
+    assert.ok(code.includes('documentNo'), 'should include readOnly documentNo');
+    assert.ok(code.includes('readOnly') || code.includes('disabled'), 'should mark readOnly fields');
+  });
+
+  it('includes process action buttons for matching entity', () => {
+    const code = generateFormComponent('order', sampleContract);
+    assert.ok(code.includes('completeOrder') || code.includes('Complete Order'), 'should include completeOrder button');
+    assert.ok(code.includes('voidOrder') || code.includes('Void Order'), 'should include voidOrder button');
+  });
+
+  it('does not include process buttons for non-matching entity', () => {
+    const code = generateFormComponent('orderLine', sampleContract);
+    assert.ok(!code.includes('completeOrder'), 'should not include order processes in orderLine form');
+  });
+});
+
+describe('generatePageComponent', () => {
+  it('generates header-detail layout', () => {
+    const code = generatePageComponent('order', 'orderLine', sampleContract);
+    assert.ok(code.includes('export default function OrderPage'), 'should export OrderPage');
+    assert.ok(code.includes('OrderTable'), 'should include header table');
+    assert.ok(code.includes('OrderForm'), 'should include header form');
+    assert.ok(code.includes('OrderLineTable'), 'should include detail table');
+  });
+});
+
+describe('generateIndexComponent', () => {
+  it('generates entry point with standard props', () => {
+    const code = generateIndexComponent('order', 'orderLine');
+    assert.ok(code.includes('token'), 'should accept token prop');
+    assert.ok(code.includes('apiBaseUrl'), 'should accept apiBaseUrl prop');
+    assert.ok(code.includes('window'), 'should accept window prop');
+    assert.ok(code.includes('export default'), 'should have default export');
+  });
+});
+
+describe('generateAll', () => {
+  it('returns map of filename to code', () => {
+    const files = generateAll(sampleContract);
+    assert.ok(files['OrderTable.jsx'], 'should produce OrderTable.jsx');
+    assert.ok(files['OrderForm.jsx'], 'should produce OrderForm.jsx');
+    assert.ok(files['OrderLineTable.jsx'], 'should produce OrderLineTable.jsx');
+    assert.ok(files['OrderPage.jsx'], 'should produce OrderPage.jsx');
+    assert.ok(files['index.jsx'], 'should produce index.jsx');
+  });
+
+  it('handles single-entity contract without detail', () => {
+    const singleEntity = {
+      frontendContract: {
+        window: { id: '1', name: 'Simple', primaryEntity: 'item', category: 'test' },
+        entities: {
+          item: {
+            fields: [{ name: 'name', type: 'string', tsType: 'string', visibility: 'editable', required: true, grid: true, form: true }],
+            searchableFields: ['name'],
+            computedFields: [],
+          },
+        },
+      },
+      backendContract: { processEndpoints: [] },
+    };
+    const files = generateAll(singleEntity);
+    assert.ok(files['ItemTable.jsx'], 'should produce ItemTable.jsx');
+    assert.ok(files['ItemForm.jsx'], 'should produce ItemForm.jsx');
+    assert.ok(files['index.jsx'], 'should produce index.jsx');
+    // No Page component for single entity — index just renders table + form
+  });
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `node --test cli/test/generate-frontend.test.js`
+Expected: FAIL — module not found
+
+**Step 3: Implement generate-frontend.js**
+
+```javascript
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+
+function capitalize(s) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function toLabel(name) {
+  return name.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase()).trim();
+}
+
+function getProcessesForEntity(contract, entityName) {
+  return (contract.backendContract?.processEndpoints || [])
+    .filter(p => p.entity === entityName);
+}
+
+export function generateTableComponent(entityName, contract) {
+  const entity = contract.frontendContract.entities[entityName];
+  const gridFields = entity.fields.filter(f => f.grid);
+  const searchFields = entity.searchableFields || [];
+  const name = capitalize(entityName);
+
+  return `import { useState } from 'react';
+import { Table, TableHeader, TableBody, TableRow, TableHead, TableCell } from '@/components/ui/table.jsx';
+import { Input } from '@/components/ui/input.jsx';
+import { Badge } from '@/components/ui/badge.jsx';
+import { Button } from '@/components/ui/button.jsx';
+
+export default function ${name}Table({ data = [], onSelect, onRefresh, loading }) {
+  const [filters, setFilters] = useState({${searchFields.map(f => ` ${f}: ''`).join(',')} });
+
+  const filtered = data.filter(row => {
+${searchFields.map(f => `    if (filters.${f} && !String(row.${f} ?? '').toLowerCase().includes(filters.${f}.toLowerCase())) return false;`).join('\n')}
+    return true;
+  });
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+${searchFields.map(f => `        <Input
+          placeholder="Filter ${toLabel(f)}..."
+          value={filters.${f}}
+          onChange={e => setFilters(prev => ({ ...prev, ${f}: e.target.value }))}
+          className="max-w-xs"
+        />`).join('\n')}
+        {onRefresh && (
+          <Button variant="outline" size="sm" onClick={onRefresh} disabled={loading}>
+            {loading ? 'Loading...' : 'Refresh'}
+          </Button>
+        )}
+      </div>
+      <Table>
+        <TableHeader>
+          <TableRow>
+${gridFields.map(f => `            <TableHead>${toLabel(f.name)}</TableHead>`).join('\n')}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {filtered.map((row, i) => (
+            <TableRow key={row.id || i} onClick={() => onSelect?.(row)} className="cursor-pointer">
+${gridFields.map(f => {
+    if (f.name === 'docStatus') {
+      return `              <TableCell><Badge variant={row.docStatus === 'CO' ? 'default' : row.docStatus === 'VO' ? 'destructive' : 'secondary'}>{row.docStatus}</Badge></TableCell>`;
+    }
+    if (f.tsType === 'number') {
+      return `              <TableCell className="text-right">{row.${f.name}}</TableCell>`;
+    }
+    return `              <TableCell>{row.${f.name}}</TableCell>`;
+  }).join('\n')}
+            </TableRow>
+          ))}
+          {filtered.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={${gridFields.length}} className="text-center text-muted-foreground py-8">
+                {loading ? 'Loading...' : 'No records found'}
+              </TableCell>
+            </TableRow>
+          )}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+`;
+}
+
+export function generateFormComponent(entityName, contract) {
+  const entity = contract.frontendContract.entities[entityName];
+  const formFields = entity.fields.filter(f => f.form);
+  const processes = getProcessesForEntity(contract, entityName);
+  const name = capitalize(entityName);
+
+  return `import { useState, useEffect } from 'react';
+import { Input } from '@/components/ui/input.jsx';
+import { Label } from '@/components/ui/label.jsx';
+import { Button } from '@/components/ui/button.jsx';
+import { Separator } from '@/components/ui/separator.jsx';
+import { Badge } from '@/components/ui/badge.jsx';
+
+export default function ${name}Form({ record, onSave, onProcessAction, loading }) {
+  const [form, setForm] = useState({});
+
+  useEffect(() => {
+    if (record) setForm({ ...record });
+  }, [record]);
+
+  function handleChange(field, value) {
+    setForm(prev => ({ ...prev, [field]: value }));
+  }
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    onSave?.(form);
+  }
+
+  if (!record) {
+    return <div className="text-muted-foreground py-8 text-center">Select a record to view details</div>;
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+${processes.length > 0 ? `      <div className="flex items-center gap-2">
+${processes.map(p => `        <Button type="button" variant="outline" size="sm" onClick={() => onProcessAction?.('${p.name}', record)} disabled={loading}>
+          ${toLabel(p.name)}
+        </Button>`).join('\n')}
+      </div>
+      <Separator />` : ''}
+      <div className="grid grid-cols-2 gap-4">
+${formFields.map(f => {
+    const readOnly = f.visibility === 'readOnly';
+    return `        <div className="space-y-2">
+          <Label htmlFor="${f.name}">${toLabel(f.name)}${f.required ? ' *' : ''}</Label>
+          <Input
+            id="${f.name}"
+            value={form.${f.name} ?? ''}
+            onChange={e => handleChange('${f.name}', e.target.value)}
+            ${readOnly ? 'readOnly' : ''}
+            ${f.required ? 'required' : ''}
+            ${readOnly ? 'className="bg-muted"' : ''}
+          />
+        </div>`;
+  }).join('\n')}
+      </div>
+      <div className="flex justify-end gap-2">
+        <Button type="submit" disabled={loading}>
+          {loading ? 'Saving...' : 'Save'}
+        </Button>
+      </div>
+    </form>
+  );
+}
+`;
+}
+
+export function generatePageComponent(headerEntity, detailEntity, contract) {
+  const headerName = capitalize(headerEntity);
+  const detailName = capitalize(detailEntity);
+
+  return `import { useState, useCallback } from 'react';
+import ${headerName}Table from './${headerName}Table.jsx';
+import ${headerName}Form from './${headerName}Form.jsx';
+import ${detailName}Table from './${detailName}Table.jsx';
+import { Separator } from '@/components/ui/separator.jsx';
+
+export default function ${headerName}Page({ token, apiBaseUrl, window: windowConfig }) {
+  const [records, setRecords] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [detailRecords, setDetailRecords] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  const headers = { 'Authorization': \`Bearer \${token}\`, 'Content-Type': 'application/json' };
+
+  const fetchRecords = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(\`\${apiBaseUrl}/v1/${headerEntity}\`, { headers });
+      if (res.ok) setRecords(await res.json());
+    } catch (err) {
+      console.error('Failed to fetch ${headerEntity}:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [apiBaseUrl, token]);
+
+  const fetchDetail = useCallback(async (parentId) => {
+    try {
+      const res = await fetch(\`\${apiBaseUrl}/v1/${detailEntity}?parentId=\${parentId}\`, { headers });
+      if (res.ok) setDetailRecords(await res.json());
+    } catch (err) {
+      console.error('Failed to fetch ${detailEntity}:', err);
+    }
+  }, [apiBaseUrl, token]);
+
+  function handleSelect(record) {
+    setSelected(record);
+    if (record?.id) fetchDetail(record.id);
+  }
+
+  async function handleSave(data) {
+    setLoading(true);
+    try {
+      const method = data.id ? 'PUT' : 'POST';
+      const path = data.id ? \`\${apiBaseUrl}/v1/${headerEntity}/\${data.id}\` : \`\${apiBaseUrl}/v1/${headerEntity}\`;
+      const res = await fetch(path, { method, headers, body: JSON.stringify(data) });
+      if (res.ok) {
+        await fetchRecords();
+        const saved = await res.json();
+        setSelected(saved);
+      }
+    } catch (err) {
+      console.error('Failed to save:', err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleProcessAction(processName, record) {
+    setLoading(true);
+    try {
+      const res = await fetch(\`\${apiBaseUrl}/v1/process/\${processName}\`, {
+        method: 'POST', headers, body: JSON.stringify({ id: record.id }),
+      });
+      if (res.ok) {
+        await fetchRecords();
+        const updated = await fetch(\`\${apiBaseUrl}/v1/${headerEntity}/\${record.id}\`, { headers });
+        if (updated.ok) setSelected(await updated.json());
+      }
+    } catch (err) {
+      console.error(\`Process \${processName} failed:\`, err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <${headerName}Table data={records} onSelect={handleSelect} onRefresh={fetchRecords} loading={loading} />
+      <Separator />
+      <${headerName}Form record={selected} onSave={handleSave} onProcessAction={handleProcessAction} loading={loading} />
+      {selected && (
+        <>
+          <Separator />
+          <h3 className="text-sm font-medium text-muted-foreground">${detailName} Lines</h3>
+          <${detailName}Table data={detailRecords} loading={loading} />
+        </>
+      )}
+    </div>
+  );
+}
+`;
+}
+
+export function generateIndexComponent(headerEntity, detailEntity) {
+  const headerName = capitalize(headerEntity);
+
+  if (detailEntity) {
+    return `import ${headerName}Page from './${headerName}Page.jsx';
+
+export default function SalesOrderWindow({ token, apiBaseUrl, window }) {
+  return <${headerName}Page token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+}
+`;
+  }
+
+  return `import { useState, useCallback } from 'react';
+import ${headerName}Table from './${headerName}Table.jsx';
+import ${headerName}Form from './${headerName}Form.jsx';
+import { Separator } from '@/components/ui/separator.jsx';
+
+export default function ${headerName}Window({ token, apiBaseUrl, window: windowConfig }) {
+  const [records, setRecords] = useState([]);
+  const [selected, setSelected] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const headers = { 'Authorization': \`Bearer \${token}\`, 'Content-Type': 'application/json' };
+
+  const fetchRecords = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(\`\${apiBaseUrl}/v1/${headerEntity}\`, { headers });
+      if (res.ok) setRecords(await res.json());
+    } catch (err) {
+      console.error('Failed to fetch:', err);
+    } finally {
+      setLoading(false);
+    }
+  }, [apiBaseUrl, token]);
+
+  return (
+    <div className="space-y-6">
+      <${headerName}Table data={records} onSelect={setSelected} onRefresh={fetchRecords} loading={loading} />
+      <Separator />
+      <${headerName}Form record={selected} loading={loading} />
+    </div>
+  );
+}
+`;
+}
+
+export function generateAll(contract) {
+  const fc = contract.frontendContract;
+  const entityNames = Object.keys(fc.entities);
+  const files = {};
+
+  // Determine header and detail entities
+  const primaryEntity = fc.window.primaryEntity || entityNames[0];
+  const detailEntity = entityNames.find(e => e !== primaryEntity);
+
+  // Generate table + form for each entity
+  for (const name of entityNames) {
+    const capName = capitalize(name);
+    files[\`\${capName}Table.jsx\`] = generateTableComponent(name, contract);
+    files[\`\${capName}Form.jsx\`] = generateFormComponent(name, contract);
+  }
+
+  // Generate page if header-detail pattern exists
+  if (detailEntity) {
+    files[\`\${capitalize(primaryEntity)}Page.jsx\`] = generatePageComponent(primaryEntity, detailEntity, contract);
+  }
+
+  // Generate index entry point
+  files['index.jsx'] = generateIndexComponent(primaryEntity, detailEntity);
+
+  return files;
+}
+
+// CLI entry point
+const contractPath = process.argv[2];
+if (contractPath) {
+  const contract = JSON.parse(readFileSync(contractPath, 'utf8'));
+  const windowName = contract.frontendContract.window.name.toLowerCase().replace(/\s+/g, '-');
+  const outDir = join(dirname(contractPath), 'generated', 'web', windowName);
+  mkdirSync(outDir, { recursive: true });
+
+  const files = generateAll(contract);
+  for (const [filename, code] of Object.entries(files)) {
+    writeFileSync(join(outDir, filename), code);
+  }
+  console.log(\`Generated \${Object.keys(files).length} files in \${outDir}\`);
+}
+```
+
+**Step 4: Run tests**
+
+Run: `node --test cli/test/generate-frontend.test.js`
+Expected: All PASS
+
+**Step 5: Commit**
+
+```bash
+git add cli/src/generate-frontend.js cli/test/generate-frontend.test.js
+git commit -m "feat: add frontend code generator with table, form, page, and index components"
+```
+
+---
+
+## Task 4: Run Generator Against Contract Fixture
+
+**Step 1: Generate components**
+
+Run: `node cli/src/generate-frontend.js artifacts/sales-order/contract.json`
+Expected: `Generated 5 files in artifacts/sales-order/generated/web/sales-order`
+
+**Step 2: Verify output files exist**
+
+Run: `ls artifacts/sales-order/generated/web/sales-order/`
+Expected:
+```
+OrderTable.jsx
+OrderForm.jsx
+OrderLineTable.jsx
+OrderPage.jsx
+index.jsx
+```
+
+**Step 3: Verify generated code is valid JSX (build test)**
+
+Run: `cd tools/app-shell && npm run build`
+Expected: PASS (generated files are outside the app-shell src, so this just confirms shell still builds)
+
+**Step 4: Commit generated output**
+
+```bash
+git add artifacts/sales-order/generated/
+git commit -m "feat: generate Sales Order frontend components from contract fixture"
+```
+
+---
+
+## Task 5: Update generate-ui Skill for Shadcn/Tailwind
+
+**Files:**
+- Modify: `.claude/skills/generate-ui.md`
+
+**Step 1: Rewrite the skill**
+
+Replace the full content of `.claude/skills/generate-ui.md` with:
+
+```markdown
+---
+name: generate-ui
+description: Generate or customize React UI components from curated schema using Shadcn/ui + Tailwind
+---
+
+## Automatic Generation (start here)
+
+Run the generator first to produce the base components:
+
+\`\`\`bash
+node cli/src/generate-frontend.js artifacts/{window}/contract.json
+\`\`\`
+
+This produces Table, Form, Page, and index components at:
+`artifacts/{window}/generated/web/{window}/`
+
+## Customization (conversational)
+
+After running the generator, ask the user what they want to customize:
+- Layout changes (column order, field grouping, responsive breakpoints)
+- Custom logic (conditional field rendering, computed displays)
+- Visual tweaks (status badges, color coding, icons)
+
+Read the generated files and modify them based on user requests.
+
+## SCHEMA CONSTRAINTS (INVIOLABLE)
+
+- Only render fields with visibility: editable or readOnly
+- System fields NEVER appear in UI
+- ReadOnly fields render as non-editable (readOnly or disabled inputs with bg-muted)
+- Computed fields are never editable
+- Only searchable fields can be used as filters/search
+- CascadeFrom relationships must be respected (cascading dropdowns)
+- Never invent fields not in schema
+
+## UI LIBRARY RULES
+
+- Use Shadcn/ui components from `@/components/ui/` (button, input, card, table, badge, label, select, dialog, separator)
+- Use Tailwind CSS for layout and spacing — NO inline styles
+- Use `cn()` from `@/lib/utils` for conditional classes
+- Use `lucide-react` for icons
+
+## Component Props Contract
+
+Generated components MUST accept these props from the app shell:
+
+\`\`\`jsx
+export default function WindowName({ token, apiBaseUrl, window }) {
+  // token: JWT string for Authorization header
+  // apiBaseUrl: base URL for API calls (e.g., '/etendo/api')
+  // window: { name, label, entityConfig } from contract
+}
+\`\`\`
+
+When making API calls, use:
+\`\`\`javascript
+const res = await fetch(\`\${apiBaseUrl}/v1/\${window.name}\`, {
+  headers: { 'Authorization': \`Bearer \${token}\` },
+});
+\`\`\`
+
+NEVER hardcode API URLs or tokens. Always use the props.
+
+## Output Location
+
+Write generated/modified components to:
+`artifacts/{window}/generated/web/{window}/`
+
+After generating, tell the user to preview with: `cd tools/app-shell && npm run dev`
+```
+
+**Step 2: Commit**
+
+```bash
+git add .claude/skills/generate-ui.md
+git commit -m "feat: update generate-ui skill for Shadcn/Tailwind and auto-generator integration"
+```
+
+---
+
+## Task 6: Run All Tests — Full Regression
+
+**Step 1: Run CLI tests**
+
+Run: `node --test 'cli/test/*.test.js'`
+Expected: All PASS (234+ tests)
+
+**Step 2: Run app shell tests**
+
+Run: `node --test 'tools/app-shell/src/**/__tests__/*.test.js'`
+Expected: All PASS (11 tests)
+
+**Step 3: Run frontend generator tests**
+
+Run: `node --test cli/test/generate-frontend.test.js`
+Expected: All PASS
+
+**Step 4: Build app shell**
+
+Run: `cd tools/app-shell && npm run build`
+Expected: PASS
+
+---
+
+## Summary
+
+| Task | What | Files | Tests |
+|------|------|-------|-------|
+| 1 | Contract fixture | 1 JSON | — |
+| 2 | Shadcn components | 6 JSX | build check |
+| 3 | Generator CLI + tests | 2 JS | ~15 tests |
+| 4 | Run generator | 5 generated JSX | build check |
+| 5 | Update generate-ui skill | 1 MD | — |
+| 6 | Full regression | — | 250+ tests |

--- a/tools/app-shell/public/contract.json
+++ b/tools/app-shell/public/contract.json
@@ -1,0 +1,97 @@
+{
+  "version": "0.1.0",
+  "generatedAt": "2026-03-05T00:00:00.000Z",
+  "checksum": "fixture-dev-only",
+  "frontendContract": {
+    "window": { "id": "143", "name": "Sales Order", "primaryEntity": "order", "category": "sales" },
+    "entities": {
+      "order": {
+        "fields": [
+          { "name": "documentNo", "column": "DocumentNo", "type": "string", "tsType": "string", "visibility": "readOnly", "required": true, "grid": true, "form": true },
+          { "name": "businessPartner", "column": "C_BPartner_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "orderDate", "column": "DateOrdered", "type": "date", "tsType": "string", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "warehouse", "column": "M_Warehouse_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": true, "grid": false, "form": true },
+          { "name": "currency", "column": "C_Currency_ID", "type": "string", "tsType": "string", "visibility": "readOnly", "required": true, "grid": true, "form": true },
+          { "name": "paymentTerms", "column": "C_PaymentTerm_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true },
+          { "name": "description", "column": "Description", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true },
+          { "name": "totalLines", "column": "TotalLines", "type": "amount", "tsType": "number", "visibility": "readOnly", "required": false, "grid": true, "form": true },
+          { "name": "grandTotal", "column": "GrandTotal", "type": "amount", "tsType": "number", "visibility": "readOnly", "required": false, "grid": true, "form": true },
+          { "name": "docStatus", "column": "DocStatus", "type": "string", "tsType": "string", "visibility": "readOnly", "required": true, "grid": true, "form": true },
+          { "name": "deliveryLocation", "column": "DeliveryLocation", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true },
+          { "name": "invoiceAddress", "column": "BillTo_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true }
+        ],
+        "searchableFields": ["documentNo", "businessPartner", "docStatus"],
+        "computedFields": []
+      },
+      "orderLine": {
+        "fields": [
+          { "name": "lineNo", "column": "Line", "type": "integer", "tsType": "number", "visibility": "readOnly", "required": true, "grid": true, "form": true },
+          { "name": "product", "column": "M_Product_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "quantity", "column": "QtyOrdered", "type": "number", "tsType": "number", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "unitPrice", "column": "PriceActual", "type": "amount", "tsType": "number", "visibility": "editable", "required": true, "grid": true, "form": true },
+          { "name": "discount", "column": "Discount", "type": "number", "tsType": "number", "visibility": "editable", "required": false, "grid": true, "form": true },
+          { "name": "lineNetAmount", "column": "LineNetAmt", "type": "amount", "tsType": "number", "visibility": "readOnly", "required": false, "grid": true, "form": true },
+          { "name": "tax", "column": "C_Tax_ID", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": true, "form": true },
+          { "name": "description", "column": "Description", "type": "string", "tsType": "string", "visibility": "editable", "required": false, "grid": false, "form": true }
+        ],
+        "searchableFields": ["product"],
+        "computedFields": []
+      }
+    }
+  },
+  "backendContract": {
+    "window": { "id": "143", "name": "Sales Order", "primaryEntity": "order", "category": "sales" },
+    "entities": {
+      "order": {
+        "fields": [
+          { "name": "documentNo", "column": "DocumentNo", "type": "string", "visibility": "readOnly", "required": true },
+          { "name": "businessPartner", "column": "C_BPartner_ID", "type": "string", "visibility": "editable", "required": true },
+          { "name": "orderDate", "column": "DateOrdered", "type": "date", "visibility": "editable", "required": true },
+          { "name": "warehouse", "column": "M_Warehouse_ID", "type": "string", "visibility": "editable", "required": true },
+          { "name": "currency", "column": "C_Currency_ID", "type": "string", "visibility": "readOnly", "required": true },
+          { "name": "paymentTerms", "column": "C_PaymentTerm_ID", "type": "string", "visibility": "editable", "required": false },
+          { "name": "description", "column": "Description", "type": "string", "visibility": "editable", "required": false },
+          { "name": "totalLines", "column": "TotalLines", "type": "amount", "visibility": "readOnly", "required": false },
+          { "name": "grandTotal", "column": "GrandTotal", "type": "amount", "visibility": "readOnly", "required": false },
+          { "name": "docStatus", "column": "DocStatus", "type": "string", "visibility": "readOnly", "required": true },
+          { "name": "deliveryLocation", "column": "DeliveryLocation", "type": "string", "visibility": "editable", "required": false },
+          { "name": "invoiceAddress", "column": "BillTo_ID", "type": "string", "visibility": "editable", "required": false },
+          { "name": "adClientId", "column": "AD_Client_ID", "type": "id", "visibility": "system", "required": true },
+          { "name": "adOrgId", "column": "AD_Org_ID", "type": "id", "visibility": "system", "required": true },
+          { "name": "created", "column": "Created", "type": "datetime", "visibility": "system", "required": true },
+          { "name": "updated", "column": "Updated", "type": "datetime", "visibility": "system", "required": true }
+        ]
+      },
+      "orderLine": {
+        "fields": [
+          { "name": "lineNo", "column": "Line", "type": "integer", "visibility": "readOnly", "required": true },
+          { "name": "product", "column": "M_Product_ID", "type": "string", "visibility": "editable", "required": true },
+          { "name": "quantity", "column": "QtyOrdered", "type": "number", "visibility": "editable", "required": true },
+          { "name": "unitPrice", "column": "PriceActual", "type": "amount", "visibility": "editable", "required": true },
+          { "name": "discount", "column": "Discount", "type": "number", "visibility": "editable", "required": false },
+          { "name": "lineNetAmount", "column": "LineNetAmt", "type": "amount", "visibility": "readOnly", "required": false },
+          { "name": "tax", "column": "C_Tax_ID", "type": "string", "visibility": "editable", "required": false },
+          { "name": "description", "column": "Description", "type": "string", "visibility": "editable", "required": false },
+          { "name": "adClientId", "column": "AD_Client_ID", "type": "id", "visibility": "system", "required": true },
+          { "name": "adOrgId", "column": "AD_Org_ID", "type": "id", "visibility": "system", "required": true }
+        ]
+      }
+    },
+    "endpoints": [
+      { "method": "GET", "path": "/order", "entity": "order", "supportedFilters": ["documentNo", "businessPartner", "docStatus"] },
+      { "method": "GET", "path": "/order/:id", "entity": "order", "supportedFilters": [] },
+      { "method": "POST", "path": "/order", "entity": "order", "supportedFilters": [] },
+      { "method": "PUT", "path": "/order/:id", "entity": "order", "supportedFilters": [] },
+      { "method": "DELETE", "path": "/order/:id", "entity": "order", "supportedFilters": [] },
+      { "method": "GET", "path": "/orderLine", "entity": "orderLine", "supportedFilters": ["product"] },
+      { "method": "GET", "path": "/orderLine/:id", "entity": "orderLine", "supportedFilters": [] },
+      { "method": "POST", "path": "/orderLine", "entity": "orderLine", "supportedFilters": [] },
+      { "method": "PUT", "path": "/orderLine/:id", "entity": "orderLine", "supportedFilters": [] },
+      { "method": "DELETE", "path": "/orderLine/:id", "entity": "orderLine", "supportedFilters": [] }
+    ],
+    "processEndpoints": [
+      { "name": "completeOrder", "method": "POST", "path": "/process/completeOrder", "entity": "order", "preconditions": ["Order must have at least one line", "Order status must be DR or IP"], "steps": 6 },
+      { "name": "voidOrder", "method": "POST", "path": "/process/voidOrder", "entity": "order", "preconditions": ["Order status must be CO"], "steps": 4 }
+    ]
+  }
+}

--- a/tools/app-shell/src/App.jsx
+++ b/tools/app-shell/src/App.jsx
@@ -6,7 +6,7 @@ import AppLayout from './layout/AppLayout.jsx';
 import WindowLoader from './windows/WindowLoader.jsx';
 import { buildMenuFromContract, buildWindowMap } from './windows/registry.js';
 
-const API_BASE_URL = '/etendo/api';
+const API_BASE_URL = '/etendo_sf/api';
 
 async function loadContract() {
   try {

--- a/tools/app-shell/src/auth/api.js
+++ b/tools/app-shell/src/auth/api.js
@@ -1,4 +1,4 @@
-const DEFAULT_BASE_URL = '/etendo';
+const DEFAULT_BASE_URL = '/etendo_sf';
 
 export function buildHeaders(token) {
   const headers = { 'Content-Type': 'application/json' };
@@ -16,7 +16,7 @@ export async function login(baseUrl, username, password) {
   const res = await fetch(`${baseUrl || DEFAULT_BASE_URL}/sws/login`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ user: username, password }),
+    body: JSON.stringify({ username, password }),
   });
   if (!res.ok) {
     const body = await res.text().catch(() => '');

--- a/tools/app-shell/src/components/ui/badge.jsx
+++ b/tools/app-shell/src/components/ui/badge.jsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import { cva } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive: 'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: { variant: 'default' },
+  }
+);
+
+function Badge({ className, variant, ...props }) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+export { Badge, badgeVariants };

--- a/tools/app-shell/src/components/ui/dialog.jsx
+++ b/tools/app-shell/src/components/ui/dialog.jsx
@@ -1,0 +1,33 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+function Dialog({ open, onOpenChange, children }) {
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      <div className="fixed inset-0 bg-black/80" onClick={() => onOpenChange?.(false)} />
+      <div className="relative z-50">{children}</div>
+    </div>
+  );
+}
+
+const DialogContent = React.forwardRef(({ className, children, ...props }, ref) => (
+  <div ref={ref} className={cn('w-full max-w-lg rounded-lg border bg-background p-6 shadow-lg', className)} {...props}>
+    {children}
+  </div>
+));
+DialogContent.displayName = 'DialogContent';
+
+function DialogHeader({ className, ...props }) {
+  return <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />;
+}
+
+function DialogTitle({ className, ...props }) {
+  return <h2 className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />;
+}
+
+function DialogFooter({ className, ...props }) {
+  return <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props} />;
+}
+
+export { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter };

--- a/tools/app-shell/src/components/ui/label.jsx
+++ b/tools/app-shell/src/components/ui/label.jsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Label = React.forwardRef(({ className, ...props }, ref) => (
+  <label ref={ref} className={cn('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)} {...props} />
+));
+Label.displayName = 'Label';
+
+export { Label };

--- a/tools/app-shell/src/components/ui/select.jsx
+++ b/tools/app-shell/src/components/ui/select.jsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Select = React.forwardRef(({ className, children, ...props }, ref) => (
+  <select ref={ref} className={cn('flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50', className)} {...props}>
+    {children}
+  </select>
+));
+Select.displayName = 'Select';
+
+export { Select };

--- a/tools/app-shell/src/components/ui/separator.jsx
+++ b/tools/app-shell/src/components/ui/separator.jsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Separator = React.forwardRef(({ className, orientation = 'horizontal', ...props }, ref) => (
+  <div ref={ref} role="separator" className={cn('shrink-0 bg-border', orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]', className)} {...props} />
+));
+Separator.displayName = 'Separator';
+
+export { Separator };

--- a/tools/app-shell/src/components/ui/table.jsx
+++ b/tools/app-shell/src/components/ui/table.jsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+const Table = React.forwardRef(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+  </div>
+));
+Table.displayName = 'Table';
+
+const TableHeader = React.forwardRef(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+));
+TableHeader.displayName = 'TableHeader';
+
+const TableBody = React.forwardRef(({ className, ...props }, ref) => (
+  <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+));
+TableBody.displayName = 'TableBody';
+
+const TableRow = React.forwardRef(({ className, ...props }, ref) => (
+  <tr ref={ref} className={cn('border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted', className)} {...props} />
+));
+TableRow.displayName = 'TableRow';
+
+const TableHead = React.forwardRef(({ className, ...props }, ref) => (
+  <th ref={ref} className={cn('h-10 px-2 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]', className)} {...props} />
+));
+TableHead.displayName = 'TableHead';
+
+const TableCell = React.forwardRef(({ className, ...props }, ref) => (
+  <td ref={ref} className={cn('p-2 align-middle [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]', className)} {...props} />
+));
+TableCell.displayName = 'TableCell';
+
+export { Table, TableHeader, TableBody, TableRow, TableHead, TableCell };

--- a/tools/app-shell/src/windows/__tests__/registry.test.js
+++ b/tools/app-shell/src/windows/__tests__/registry.test.js
@@ -23,17 +23,11 @@ const sampleContract = {
 };
 
 describe('buildMenuFromContract', () => {
-  it('creates menu items from contract entities', () => {
+  it('creates one menu item per window', () => {
     const items = buildMenuFromContract(sampleContract);
-    assert.equal(items.length, 2);
-    assert.equal(items[0].name, 'order');
-    assert.equal(items[1].name, 'orderLine');
-  });
-
-  it('generates labels from entity names', () => {
-    const items = buildMenuFromContract(sampleContract);
-    assert.equal(items[0].label, 'Order');
-    assert.equal(items[1].label, 'Order Line');
+    assert.equal(items.length, 1);
+    assert.equal(items[0].name, 'sales-order');
+    assert.equal(items[0].label, 'Sales Order');
   });
 
   it('returns empty array for empty contract', () => {
@@ -43,17 +37,21 @@ describe('buildMenuFromContract', () => {
 });
 
 describe('buildWindowMap', () => {
-  it('creates window map with loaders', () => {
-    const loaders = { order: () => Promise.resolve({ default: () => null }) };
-    const map = buildWindowMap(sampleContract, loaders);
-    assert.ok(map.order);
-    assert.ok(map.order.loader);
-    assert.equal(map.order.name, 'order');
+  it('creates window map keyed by slug', () => {
+    const map = buildWindowMap(sampleContract);
+    assert.ok(map['sales-order']);
+    assert.equal(map['sales-order'].name, 'sales-order');
+    assert.equal(map['sales-order'].label, 'Sales Order');
+    assert.ok(map['sales-order'].loader);
   });
 
-  it('uses placeholder loader when no loader provided', () => {
-    const map = buildWindowMap(sampleContract, {});
-    assert.ok(map.order);
-    assert.ok(map.order.loader);
+  it('passes the full frontend contract', () => {
+    const map = buildWindowMap(sampleContract);
+    assert.deepEqual(map['sales-order'].contract, sampleContract.frontendContract);
+  });
+
+  it('returns empty object for empty contract', () => {
+    const map = buildWindowMap({});
+    assert.deepEqual(map, {});
   });
 });

--- a/tools/app-shell/src/windows/registry.js
+++ b/tools/app-shell/src/windows/registry.js
@@ -1,46 +1,49 @@
 /**
- * Convert camelCase entity name to display label.
- * 'orderLine' → 'Order Line'
+ * Convert a window name to a URL-safe slug.
+ * 'Sales Order' → 'sales-order'
  */
-function toLabel(name) {
-  return name
-    .replace(/([A-Z])/g, ' $1')
-    .replace(/^./, s => s.toUpperCase())
-    .trim();
+function toSlug(name) {
+  return name.toLowerCase().replace(/\s+/g, '-');
 }
 
 /**
- * Build menu items from a contract.json frontendContract.
+ * Known window loaders — maps slug to dynamic import.
+ * Add new entries here when generating new windows.
+ */
+const windowLoaders = {
+  'sales-order': () => import('@generated/web/sales-order/index.jsx'),
+};
+
+/**
+ * Build menu items from a contract.json — one item per window.
  */
 export function buildMenuFromContract(contract) {
-  const entities = contract?.frontendContract?.entities;
-  if (!entities) return [];
+  const window = contract?.frontendContract?.window;
+  if (!window) return [];
 
-  return Object.keys(entities).map(name => ({
-    name,
-    label: toLabel(name),
-  }));
+  return [{
+    name: toSlug(window.name),
+    label: window.name,
+  }];
 }
 
 /**
- * Build window map with loaders for each entity.
- * loaders: { entityName: () => import('...') }
- * Falls back to a placeholder component if no loader is provided.
+ * Build window map with a loader for the window's generated component.
  */
-export function buildWindowMap(contract, loaders = {}) {
-  const entities = contract?.frontendContract?.entities;
-  if (!entities) return {};
+export function buildWindowMap(contract) {
+  const fc = contract?.frontendContract;
+  if (!fc?.window) return {};
 
-  const map = {};
-  for (const name of Object.keys(entities)) {
-    map[name] = {
-      name,
-      label: toLabel(name),
-      entityConfig: entities[name],
-      loader: loaders[name] || (() =>
+  const slug = toSlug(fc.window.name);
+
+  return {
+    [slug]: {
+      name: slug,
+      label: fc.window.name,
+      contract: fc,
+      loader: windowLoaders[slug] || (() =>
         import('./PlaceholderWindow.jsx')
       ),
-    };
-  }
-  return map;
+    },
+  };
 }

--- a/tools/app-shell/vite.config.js
+++ b/tools/app-shell/vite.config.js
@@ -7,12 +7,13 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),
+      '@generated': resolve(__dirname, '../../artifacts/sales-order/generated'),
     },
   },
   server: {
     port: 3100,
     proxy: {
-      '/etendo': {
+      '/etendo_sf': {
         target: 'http://localhost:8080',
         changeOrigin: true,
       },


### PR DESCRIPTION
## Summary
- Serve `contract.json` from `public/` so the app shell loads real contract data instead of showing "Loading contract..."
- Rewrite `registry.js` to build window-level menu items (one "Sales Order" entry) with static import of generated components via `@generated` Vite alias
- Fix login: SWS API expects `username` field, not `user`; update base URL from `/etendo` to `/etendo_sf`
- Add "New" button to OrderPage with full create/edit/save flow (POST for new, PUT for existing)
- Enforce pipeline rule across all agent files: never work directly on main branch
- Include frontend generator design doc and implementation plan

## Test plan
- [ ] Run `npm run dev` in `tools/app-shell` — app loads Sales Order window instead of "Loading contract..."
- [ ] Login with admin/admin — should get a valid token
- [ ] Click "New" — empty form appears for creating an order
- [ ] Select a row — form populates with record data
- [ ] Run `node --test tools/app-shell/src/windows/__tests__/registry.test.js` — 5/5 pass
- [ ] Run `npx vite build` in `tools/app-shell` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)