### PR TITLE
feat: F8 live preview with Babel standalone iframe

### DIFF
--- a/tools/app-shell/public/preview.html
+++ b/tools/app-shell/public/preview.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Preview Sandbox</title>
+
+  <!-- Tailwind CSS -->
+  <script src="https://cdn.tailwindcss.com"></script>
+
+  <!-- React 18 (development UMD) -->
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+
+  <!-- Babel standalone for JSX transformation -->
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    }
+    .preview-waiting {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      color: #6b7280;
+      font-size: 0.875rem;
+    }
+    .preview-error {
+      margin: 1rem;
+      padding: 1rem;
+      border-radius: 0.5rem;
+      background-color: #fef2f2;
+      border: 1px solid #fecaca;
+      color: #dc2626;
+      font-family: monospace;
+      font-size: 0.8rem;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+  </style>
+</head>
+<body>
+  <div id="root">
+    <div class="preview-waiting">Waiting for component code...</div>
+  </div>
+
+  <script>
+    // ----------------------------------------------------------------
+    // Shadcn/ui stub components (render plain HTML + Tailwind classes)
+    // ----------------------------------------------------------------
+    const e = React.createElement;
+
+    const Table = React.forwardRef(function Table(props, ref) {
+      const { className = '', children, ...rest } = props;
+      return e('div', { className: 'relative w-full overflow-auto' },
+        e('table', { ref, className: 'w-full caption-bottom text-sm ' + className, ...rest }, children)
+      );
+    });
+
+    const TableHeader = React.forwardRef(function TableHeader(props, ref) {
+      const { className = '', children, ...rest } = props;
+      return e('thead', { ref, className: '[&_tr]:border-b ' + className, ...rest }, children);
+    });
+
+    const TableBody = React.forwardRef(function TableBody(props, ref) {
+      const { className = '', children, ...rest } = props;
+      return e('tbody', { ref, className: '[&_tr:last-child]:border-0 ' + className, ...rest }, children);
+    });
+
+    const TableRow = React.forwardRef(function TableRow(props, ref) {
+      const { className = '', children, ...rest } = props;
+      return e('tr', {
+        ref,
+        className: 'border-b transition-colors hover:bg-gray-50 data-[state=selected]:bg-gray-100 ' + className,
+        ...rest
+      }, children);
+    });
+
+    const TableHead = React.forwardRef(function TableHead(props, ref) {
+      const { className = '', children, ...rest } = props;
+      return e('th', {
+        ref,
+        className: 'h-10 px-2 text-left align-middle font-medium text-gray-500 [&:has([role=checkbox])]:pr-0 ' + className,
+        ...rest
+      }, children);
+    });
+
+    const TableCell = React.forwardRef(function TableCell(props, ref) {
+      const { className = '', children, ...rest } = props;
+      return e('td', {
+        ref,
+        className: 'p-2 align-middle [&:has([role=checkbox])]:pr-0 ' + className,
+        ...rest
+      }, children);
+    });
+
+    const Input = React.forwardRef(function Input(props, ref) {
+      const { className = '', ...rest } = props;
+      return e('input', {
+        ref,
+        className: 'flex h-9 w-full rounded-md border border-gray-300 bg-transparent px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-gray-400 focus:outline-none focus:ring-1 focus:ring-gray-400 disabled:cursor-not-allowed disabled:opacity-50 ' + className,
+        ...rest
+      });
+    });
+
+    const Button = React.forwardRef(function Button(props, ref) {
+      const { className = '', variant = 'default', size = 'default', children, ...rest } = props;
+      const variants = {
+        default: 'bg-gray-900 text-white hover:bg-gray-800',
+        destructive: 'bg-red-500 text-white hover:bg-red-600',
+        outline: 'border border-gray-300 bg-white hover:bg-gray-50',
+        secondary: 'bg-gray-100 text-gray-900 hover:bg-gray-200',
+        ghost: 'hover:bg-gray-100',
+        link: 'text-gray-900 underline-offset-4 hover:underline',
+      };
+      const sizes = {
+        default: 'h-9 px-4 py-2',
+        sm: 'h-8 rounded-md px-3 text-xs',
+        lg: 'h-10 rounded-md px-8',
+        icon: 'h-9 w-9',
+      };
+      return e('button', {
+        ref,
+        className: 'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-1 focus:ring-gray-400 disabled:pointer-events-none disabled:opacity-50 ' +
+          (variants[variant] || variants.default) + ' ' +
+          (sizes[size] || sizes.default) + ' ' +
+          className,
+        ...rest
+      }, children);
+    });
+
+    const Label = React.forwardRef(function Label(props, ref) {
+      const { className = '', children, ...rest } = props;
+      return e('label', {
+        ref,
+        className: 'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 ' + className,
+        ...rest
+      }, children);
+    });
+
+    const Badge = React.forwardRef(function Badge(props, ref) {
+      const { className = '', variant = 'default', children, ...rest } = props;
+      const variants = {
+        default: 'bg-gray-900 text-white',
+        secondary: 'bg-gray-100 text-gray-900',
+        destructive: 'bg-red-500 text-white',
+        outline: 'border border-gray-300 text-gray-700',
+      };
+      return e('span', {
+        ref,
+        className: 'inline-flex items-center rounded-md px-2.5 py-0.5 text-xs font-semibold transition-colors ' +
+          (variants[variant] || variants.default) + ' ' +
+          className,
+        ...rest
+      }, children);
+    });
+
+    const Separator = React.forwardRef(function Separator(props, ref) {
+      const { className = '', orientation = 'horizontal', ...rest } = props;
+      const isHorizontal = orientation === 'horizontal';
+      return e('div', {
+        ref,
+        role: 'separator',
+        'aria-orientation': orientation,
+        className: (isHorizontal ? 'h-px w-full' : 'h-full w-px') + ' shrink-0 bg-gray-200 ' + className,
+        ...rest
+      });
+    });
+
+    // Collect all stubs into an object for injection
+    const UI_STUBS = {
+      Table, TableHeader, TableBody, TableRow, TableHead, TableCell,
+      Input, Button, Label, Badge, Separator,
+    };
+
+    // ----------------------------------------------------------------
+    // Mock fetch — intercepts network requests using mockData
+    // ----------------------------------------------------------------
+    let _currentMockData = {};
+
+    const _originalFetch = window.fetch.bind(window);
+
+    window.fetch = function mockFetch(url, options) {
+      const method = (options && options.method || 'GET').toUpperCase();
+      const urlStr = typeof url === 'string' ? url : url.toString();
+
+      if (method === 'GET') {
+        // Try to extract entity name from URL path segments
+        // e.g. /api/v1/orders -> "orders", /etendo/api/Order -> "Order"
+        const segments = urlStr.replace(/\/$/, '').split('/').filter(Boolean);
+        const entityName = segments[segments.length - 1];
+
+        // Look for matching key in mockData (case-insensitive)
+        const mockKeys = Object.keys(_currentMockData);
+        const matchKey = mockKeys.find(function (k) {
+          return k.toLowerCase() === entityName.toLowerCase();
+        });
+
+        if (matchKey) {
+          const payload = _currentMockData[matchKey];
+          const body = Array.isArray(payload) ? payload : [payload];
+          return Promise.resolve(new Response(JSON.stringify(body), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          }));
+        }
+
+        // If no match, return the full mockData as a fallback
+        return Promise.resolve(new Response(JSON.stringify(_currentMockData), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }));
+      }
+
+      // POST / PUT / PATCH / DELETE — return generic success
+      return Promise.resolve(new Response(JSON.stringify({ success: true }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }));
+    };
+
+    // ----------------------------------------------------------------
+    // Message listener — receives code + mockData from parent
+    // ----------------------------------------------------------------
+    let _root = null;
+
+    window.addEventListener('message', function (event) {
+      var data = event.data;
+      if (!data || data.type !== 'preview-render') return;
+
+      var code = data.code || '';
+      var mockData = data.mockData || {};
+
+      // Update mock data for fetch interceptor
+      _currentMockData = mockData;
+
+      var rootEl = document.getElementById('root');
+      if (!_root) {
+        _root = ReactDOM.createRoot(rootEl);
+      }
+
+      try {
+        // Transform JSX to JS using Babel
+        var transformed = Babel.transform(code, {
+          presets: ['react'],
+          filename: 'preview.jsx',
+        }).code;
+
+        // Build a scoped execution function
+        // The code is expected to assign exports.default = function Component(...)
+        var exports = {};
+
+        var scopedFn = new Function(
+          'React',
+          'useState',
+          'useEffect',
+          'useCallback',
+          'useMemo',
+          'useRef',
+          'Table',
+          'TableHeader',
+          'TableBody',
+          'TableRow',
+          'TableHead',
+          'TableCell',
+          'Input',
+          'Button',
+          'Label',
+          'Badge',
+          'Separator',
+          'exports',
+          'mockData',
+          transformed
+        );
+
+        scopedFn(
+          React,
+          React.useState,
+          React.useEffect,
+          React.useCallback,
+          React.useMemo,
+          React.useRef,
+          Table,
+          TableHeader,
+          TableBody,
+          TableRow,
+          TableHead,
+          TableCell,
+          Input,
+          Button,
+          Label,
+          Badge,
+          Separator,
+          exports,
+          mockData
+        );
+
+        if (typeof exports.default !== 'function') {
+          throw new Error('Component code did not export a default function. Expected: exports.default = function ...');
+        }
+
+        // Render the component with props: token, apiBaseUrl, data
+        var Component = exports.default;
+        var appElement = React.createElement(Component, {
+          token: 'preview-token',
+          apiBaseUrl: '/api',
+          data: mockData,
+        });
+
+        _root.render(appElement);
+      } catch (err) {
+        // Show error in styled div
+        _root.render(
+          React.createElement('div', { className: 'preview-error' },
+            'Error rendering component:\n\n' + (err.message || String(err)) +
+            (err.stack ? '\n\n' + err.stack : '')
+          )
+        );
+      }
+    });
+  </script>
+</body>
+</html>

--- a/tools/app-shell/src/App.jsx
+++ b/tools/app-shell/src/App.jsx
@@ -4,6 +4,7 @@ import { AuthProvider, useAuth } from './auth/AuthContext.jsx';
 import LoginPage from './auth/LoginPage.jsx';
 import AppLayout from './layout/AppLayout.jsx';
 import WindowLoader from './windows/WindowLoader.jsx';
+import PreviewPage from './preview/PreviewPage.jsx';
 import { buildMenuFromContract, buildWindowMap } from './windows/registry.js';
 import { createMockFetch } from './lib/mockFetch.js';
 
@@ -51,6 +52,7 @@ function AppRoutes({ menuItems, windowMap }) {
         }
       >
         <Route index element={<Navigate to={`/${menuItems[0].name}`} replace />} />
+        <Route path="preview" element={<PreviewPage />} />
         <Route
           path=":windowName"
           element={<WindowLoader windowMap={windowMap} apiBaseUrl={API_BASE_URL} />}

--- a/tools/app-shell/src/layout/Sidebar.jsx
+++ b/tools/app-shell/src/layout/Sidebar.jsx
@@ -1,6 +1,6 @@
 import { NavLink } from 'react-router-dom';
 import { cn } from '@/lib/utils';
-import { LayoutDashboard } from 'lucide-react';
+import { LayoutDashboard, Eye } from 'lucide-react';
 
 export default function Sidebar({ menuItems }) {
   return (
@@ -25,6 +25,20 @@ export default function Sidebar({ menuItems }) {
           </NavLink>
         ))}
       </nav>
+      <div className="border-t p-2">
+        <NavLink
+          to="/preview"
+          className={({ isActive }) =>
+            cn(
+              'flex items-center gap-3 rounded-md px-3 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground',
+              isActive && 'bg-accent text-accent-foreground'
+            )
+          }
+        >
+          <Eye className="h-3.5 w-3.5" />
+          Preview
+        </NavLink>
+      </div>
     </aside>
   );
 }

--- a/tools/app-shell/src/preview/PreviewPage.jsx
+++ b/tools/app-shell/src/preview/PreviewPage.jsx
@@ -1,0 +1,109 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+
+import orderPageSource from '@generated/web/sales-order/OrderPage.jsx?raw';
+import orderTableSource from '@generated/web/sales-order/OrderTable.jsx?raw';
+import orderFormSource from '@generated/web/sales-order/OrderForm.jsx?raw';
+import orderLineTableSource from '@generated/web/sales-order/OrderLineTable.jsx?raw';
+
+import * as mockDataModule from '@generated/web/sales-order/mockData.js';
+
+const COMPONENTS = [
+  { name: 'OrderPage', source: orderPageSource },
+  { name: 'OrderTable', source: orderTableSource },
+  { name: 'OrderForm', source: orderFormSource },
+  { name: 'OrderLineTable', source: orderLineTableSource },
+];
+
+/**
+ * Strip ES module imports and convert exports so the code can run
+ * inside a plain script context (Babel standalone in the iframe).
+ */
+function prepareCodeForIframe(source) {
+  return source
+    .split('\n')
+    .filter((line) => !line.match(/^\s*import\s+.*\s+from\s+['"]/))
+    .join('\n')
+    .replace(
+      /export\s+default\s+function\s+(\w+)\s*\(/g,
+      'exports.default = function $1(',
+    )
+    .replace(/\bexport\s+/g, '');
+}
+
+/**
+ * Join multiple prepared source files into a single code string
+ * that can be sent to the preview iframe.
+ */
+function buildPreviewCode(sources) {
+  return sources.map(prepareCodeForIframe).join('\n\n');
+}
+
+export default function PreviewPage() {
+  const [activeComponent, setActiveComponent] = useState('OrderPage');
+  const iframeRef = useRef(null);
+  const [iframeReady, setIframeReady] = useState(false);
+
+  const sendToIframe = useCallback(() => {
+    const iframe = iframeRef.current;
+    if (!iframe || !iframeReady) return;
+
+    const selected = COMPONENTS.find((c) => c.name === activeComponent);
+    if (!selected) return;
+
+    const code = buildPreviewCode([selected]);
+
+    iframe.contentWindow.postMessage(
+      {
+        type: 'preview-render',
+        code,
+        mockData: JSON.parse(JSON.stringify(mockDataModule)),
+      },
+      '*',
+    );
+  }, [activeComponent, iframeReady]);
+
+  useEffect(() => {
+    sendToIframe();
+  }, [sendToIframe]);
+
+  const handleIframeLoad = useCallback(() => {
+    setIframeReady(true);
+  }, []);
+
+  // When iframeReady flips to true, send the initial payload
+  useEffect(() => {
+    if (iframeReady) {
+      sendToIframe();
+    }
+  }, [iframeReady, sendToIframe]);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-2 p-2 border-b bg-background">
+        {COMPONENTS.map((comp) => (
+          <Button
+            key={comp.name}
+            variant={activeComponent === comp.name ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setActiveComponent(comp.name)}
+          >
+            {comp.name}
+          </Button>
+        ))}
+        <div className="flex-1" />
+        <Button variant="outline" size="sm" onClick={sendToIframe}>
+          Refresh
+        </Button>
+      </div>
+      <iframe
+        ref={iframeRef}
+        src="/preview.html"
+        sandbox="allow-scripts"
+        title="Component Preview"
+        className="flex-1 w-full border-0"
+        onLoad={handleIframeLoad}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `preview.html` sandbox with React 18 + Babel standalone + Tailwind from CDN, Shadcn/ui stub components, and mock fetch override
- Add `PreviewPage.jsx` that reads generated JSX as raw text, strips imports/exports, and sends code + mock data to iframe via postMessage
- Add `/preview` route in authenticated layout with sidebar link
- Component selector toolbar (OrderPage, OrderTable, OrderForm, OrderLineTable) + Refresh button

## Test plan
- [ ] Run `cd tools/app-shell && npx vite build` — builds successfully
- [ ] Run `npm run dev` with VITE_MOCK=true — navigate to `/preview`, see OrderPage rendered with mock data in iframe
- [ ] Click component buttons — switches between OrderPage/OrderTable/OrderForm/OrderLineTable
- [ ] Click Refresh — re-renders current component
- [ ] Sidebar shows "Preview" link with eye icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)