### PR TITLE
refactor: declarative config + generic components for frontend generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+.PHONY: test test-frontend generate dev build install clean help
+
+# --- Testing ---
+
+test: ## Run all CLI tests
+	cd cli && node --test 'test/*.test.js'
+
+test-frontend: ## Run only frontend generator tests
+	cd cli && node --test 'test/generate-frontend.test.js'
+
+# --- Code Generation ---
+
+generate: ## Generate frontend from Sales Order contract
+	node cli/src/generate-frontend.js artifacts/sales-order/contract.json
+
+# --- Dev Server ---
+
+dev: ## Start app-shell dev server (http://localhost:3100)
+	cd tools/app-shell && npm run dev
+
+build: ## Build app-shell for production
+	cd tools/app-shell && npm run build
+
+# --- Setup ---
+
+install: ## Install all workspace dependencies
+	npm install
+
+# --- Cleanup ---
+
+clean: ## Remove generated artifacts and build output
+	rm -rf tools/app-shell/dist
+
+# --- Help ---
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-18s\033[0m %s\n", $$1, $$2}'
+
+.DEFAULT_GOAL := help

--- a/artifacts/sales-order/generated/web/sales-order/OrderForm.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderForm.jsx
@@ -1,80 +1,15 @@
-import React from 'react';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
+import { EntityForm } from '@/components/contract-ui';
 
-export default function OrderForm({ data, onChange }) {
-  return (
-    <div className="grid grid-cols-2 gap-3">
-        <div className="space-y-1.5">
-          <Label htmlFor="businessPartner" className="text-sm text-foreground font-medium">Business Partner *</Label>
-          <Input
-            id="businessPartner"
-            name="businessPartner"
-            type="text"
-            value={data?.businessPartner ?? ''}
-            onChange={(e) => onChange?.('businessPartner', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none" required
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="orderDate" className="text-sm text-foreground font-medium">Order Date *</Label>
-          <Input
-            id="orderDate"
-            name="orderDate"
-            type="text"
-            value={data?.orderDate ?? ''}
-            onChange={(e) => onChange?.('orderDate', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none" required
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="warehouse" className="text-sm text-foreground font-medium">Warehouse *</Label>
-          <Input
-            id="warehouse"
-            name="warehouse"
-            type="text"
-            value={data?.warehouse ?? ''}
-            onChange={(e) => onChange?.('warehouse', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none" required
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="paymentTerms" className="text-sm text-foreground font-medium">Payment Terms</Label>
-          <Input
-            id="paymentTerms"
-            name="paymentTerms"
-            type="text"
-            value={data?.paymentTerms ?? ''}
-            onChange={(e) => onChange?.('paymentTerms', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="description" className="text-sm text-foreground font-medium">Description</Label>
-          <Input
-            id="description"
-            name="description"
-            type="text"
-            value={data?.description ?? ''}
-            onChange={(e) => onChange?.('description', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="deliveryLocation" className="text-sm text-foreground font-medium">Delivery Location</Label>
-          <Input
-            id="deliveryLocation"
-            name="deliveryLocation"
-            type="text"
-            value={data?.deliveryLocation ?? ''}
-            onChange={(e) => onChange?.('deliveryLocation', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="invoiceAddress" className="text-sm text-foreground font-medium">Invoice Address</Label>
-          <Input
-            id="invoiceAddress"
-            name="invoiceAddress"
-            type="text"
-            value={data?.invoiceAddress ?? ''}
-            onChange={(e) => onChange?.('invoiceAddress', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"
-          />
-        </div>
-    </div>
-  );
+const fields = [
+  { key: 'businessPartner', label: 'Business Partner', type: 'text', required: true },
+  { key: 'orderDate', label: 'Order Date', type: 'date', required: true },
+  { key: 'warehouse', label: 'Warehouse', type: 'text', required: true },
+  { key: 'paymentTerms', label: 'Payment Terms', type: 'text' },
+  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'deliveryLocation', label: 'Delivery Location', type: 'text' },
+  { key: 'invoiceAddress', label: 'Invoice Address', type: 'text' },
+];
+
+export default function OrderForm(props) {
+  return <EntityForm fields={fields} {...props} />;
 }

--- a/artifacts/sales-order/generated/web/sales-order/OrderForm.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderForm.jsx
@@ -6,142 +6,146 @@ import { Separator } from '@/components/ui/separator';
 
 export default function OrderForm({ data, onChange, onSave, onDelete, onProcess }) {
   return (
-    <form onSubmit={(e) => { e.preventDefault(); onSave?.(data); }} className="space-y-3">
-      <div className="space-y-3">
+    <form onSubmit={(e) => { e.preventDefault(); onSave?.(data); }} className="space-y-4">
+      <div className="space-y-3 rounded-lg border p-4 bg-muted/20">
         <div className="space-y-1.5">
-          <Label htmlFor="documentNo" className="text-sm text-gray-600">Document No *</Label>
-          <Input
-            id="documentNo"
-            name="documentNo"
-            type="text"
-            value={data?.documentNo ?? ''}
-            onChange={(e) => onChange?.('documentNo', e.target.value)} disabled readOnly className="bg-gray-50 text-gray-500" required
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="businessPartner" className="text-sm text-gray-600">Business Partner *</Label>
+          <Label htmlFor="businessPartner" className="text-sm text-foreground font-medium">Business Partner *</Label>
           <Input
             id="businessPartner"
             name="businessPartner"
             type="text"
             value={data?.businessPartner ?? ''}
-            onChange={(e) => onChange?.('businessPartner', e.target.value)} required
+            onChange={(e) => onChange?.('businessPartner', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none" required
           />
         </div>
         <div className="space-y-1.5">
-          <Label htmlFor="orderDate" className="text-sm text-gray-600">Order Date *</Label>
+          <Label htmlFor="orderDate" className="text-sm text-foreground font-medium">Order Date *</Label>
           <Input
             id="orderDate"
             name="orderDate"
             type="text"
             value={data?.orderDate ?? ''}
-            onChange={(e) => onChange?.('orderDate', e.target.value)} required
+            onChange={(e) => onChange?.('orderDate', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none" required
           />
         </div>
         <div className="space-y-1.5">
-          <Label htmlFor="warehouse" className="text-sm text-gray-600">Warehouse *</Label>
+          <Label htmlFor="warehouse" className="text-sm text-foreground font-medium">Warehouse *</Label>
           <Input
             id="warehouse"
             name="warehouse"
             type="text"
             value={data?.warehouse ?? ''}
-            onChange={(e) => onChange?.('warehouse', e.target.value)} required
+            onChange={(e) => onChange?.('warehouse', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none" required
           />
         </div>
         <div className="space-y-1.5">
-          <Label htmlFor="currency" className="text-sm text-gray-600">Currency *</Label>
-          <Input
-            id="currency"
-            name="currency"
-            type="text"
-            value={data?.currency ?? ''}
-            onChange={(e) => onChange?.('currency', e.target.value)} disabled readOnly className="bg-gray-50 text-gray-500" required
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="paymentTerms" className="text-sm text-gray-600">Payment Terms</Label>
+          <Label htmlFor="paymentTerms" className="text-sm text-foreground font-medium">Payment Terms</Label>
           <Input
             id="paymentTerms"
             name="paymentTerms"
             type="text"
             value={data?.paymentTerms ?? ''}
-            onChange={(e) => onChange?.('paymentTerms', e.target.value)}
+            onChange={(e) => onChange?.('paymentTerms', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"
           />
         </div>
         <div className="space-y-1.5">
-          <Label htmlFor="description" className="text-sm text-gray-600">Description</Label>
+          <Label htmlFor="description" className="text-sm text-foreground font-medium">Description</Label>
           <Input
             id="description"
             name="description"
             type="text"
             value={data?.description ?? ''}
-            onChange={(e) => onChange?.('description', e.target.value)}
+            onChange={(e) => onChange?.('description', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"
           />
         </div>
         <div className="space-y-1.5">
-          <Label htmlFor="totalLines" className="text-sm text-gray-600">Total Lines</Label>
-          <Input
-            id="totalLines"
-            name="totalLines"
-            type="number"
-            value={data?.totalLines ?? ''}
-            onChange={(e) => onChange?.('totalLines', e.target.value)} disabled readOnly className="bg-gray-50 text-gray-500"
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="grandTotal" className="text-sm text-gray-600">Grand Total</Label>
-          <Input
-            id="grandTotal"
-            name="grandTotal"
-            type="number"
-            value={data?.grandTotal ?? ''}
-            onChange={(e) => onChange?.('grandTotal', e.target.value)} disabled readOnly className="bg-gray-50 text-gray-500"
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="docStatus" className="text-sm text-gray-600">Doc Status *</Label>
-          <Input
-            id="docStatus"
-            name="docStatus"
-            type="text"
-            value={data?.docStatus ?? ''}
-            onChange={(e) => onChange?.('docStatus', e.target.value)} disabled readOnly className="bg-gray-50 text-gray-500" required
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="deliveryLocation" className="text-sm text-gray-600">Delivery Location</Label>
+          <Label htmlFor="deliveryLocation" className="text-sm text-foreground font-medium">Delivery Location</Label>
           <Input
             id="deliveryLocation"
             name="deliveryLocation"
             type="text"
             value={data?.deliveryLocation ?? ''}
-            onChange={(e) => onChange?.('deliveryLocation', e.target.value)}
+            onChange={(e) => onChange?.('deliveryLocation', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"
           />
         </div>
         <div className="space-y-1.5">
-          <Label htmlFor="invoiceAddress" className="text-sm text-gray-600">Invoice Address</Label>
+          <Label htmlFor="invoiceAddress" className="text-sm text-foreground font-medium">Invoice Address</Label>
           <Input
             id="invoiceAddress"
             name="invoiceAddress"
             type="text"
             value={data?.invoiceAddress ?? ''}
-            onChange={(e) => onChange?.('invoiceAddress', e.target.value)}
+            onChange={(e) => onChange?.('invoiceAddress', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"
           />
         </div>
       </div>
-      <Separator className="my-4" />
-      <div className="flex gap-2">
-        <Button type="submit" size="sm">Save</Button>
-        {onDelete && <Button variant="outline" size="sm" onClick={(e) => { e.preventDefault(); onDelete(); }}>Delete</Button>}
+      <div className="space-y-3 rounded-lg border border-dashed p-4 bg-muted/10">
+        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">System Fields</p>
+        <div className="space-y-1.5">
+          <Label htmlFor="documentNo" className="text-sm text-muted-foreground">Document No *</Label>
+          <Input
+            id="documentNo"
+            name="documentNo"
+            type="text"
+            value={data?.documentNo ?? ''}
+            onChange={(e) => onChange?.('documentNo', e.target.value)} disabled readOnly className="bg-muted/50 text-muted-foreground border-dashed cursor-not-allowed" required
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="currency" className="text-sm text-muted-foreground">Currency *</Label>
+          <Input
+            id="currency"
+            name="currency"
+            type="text"
+            value={data?.currency ?? ''}
+            onChange={(e) => onChange?.('currency', e.target.value)} disabled readOnly className="bg-muted/50 text-muted-foreground border-dashed cursor-not-allowed" required
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="totalLines" className="text-sm text-muted-foreground">Total Lines</Label>
+          <Input
+            id="totalLines"
+            name="totalLines"
+            type="number"
+            value={data?.totalLines ?? ''}
+            onChange={(e) => onChange?.('totalLines', e.target.value)} disabled readOnly className="bg-muted/50 text-muted-foreground border-dashed cursor-not-allowed"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="grandTotal" className="text-sm text-muted-foreground">Grand Total</Label>
+          <Input
+            id="grandTotal"
+            name="grandTotal"
+            type="number"
+            value={data?.grandTotal ?? ''}
+            onChange={(e) => onChange?.('grandTotal', e.target.value)} disabled readOnly className="bg-muted/50 text-muted-foreground border-dashed cursor-not-allowed"
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="docStatus" className="text-sm text-muted-foreground">Doc Status *</Label>
+          <Input
+            id="docStatus"
+            name="docStatus"
+            type="text"
+            value={data?.docStatus ?? ''}
+            onChange={(e) => onChange?.('docStatus', e.target.value)} disabled readOnly className="bg-muted/50 text-muted-foreground border-dashed cursor-not-allowed" required
+          />
+        </div>
       </div>
-      <Separator className="my-4" />
-      <div className="flex gap-2">
-          <Button variant="outline" size="sm" onClick={() => onProcess?.('completeOrder')}>
+      <div className="flex items-center gap-2 pt-2">
+        <Button type="submit" size="sm">Save</Button>
+        {onDelete && <Button variant="destructive" size="sm" onClick={(e) => { e.preventDefault(); onDelete(); }}>Delete</Button>}
+      </div>
+      <div className="rounded-lg border p-4 bg-muted/10 space-y-2">
+        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Actions</p>
+        <div className="flex gap-2">
+          <Button variant="secondary" size="sm" onClick={() => onProcess?.('completeOrder')}>
             Complete Order
           </Button>
-          <Button variant="outline" size="sm" onClick={() => onProcess?.('voidOrder')}>
+          <Button variant="secondary" size="sm" onClick={() => onProcess?.('voidOrder')}>
             Void Order
           </Button>
+        </div>
       </div>
     </form>
   );

--- a/artifacts/sales-order/generated/web/sales-order/OrderForm.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderForm.jsx
@@ -7,7 +7,7 @@ import { Separator } from '@/components/ui/separator';
 export default function OrderForm({ data, onChange, onSave, onDelete, onProcess }) {
   return (
     <form onSubmit={(e) => { e.preventDefault(); onSave?.(data); }} className="space-y-4">
-      <div className="space-y-3 rounded-lg border p-4 bg-muted/20">
+      <div className="grid grid-cols-2 gap-3 rounded-lg border p-4 bg-muted/20">
         <div className="space-y-1.5">
           <Label htmlFor="businessPartner" className="text-sm text-foreground font-medium">Business Partner *</Label>
           <Input

--- a/artifacts/sales-order/generated/web/sales-order/OrderForm.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderForm.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Button } from '@/components/ui/button';
-import { Separator } from '@/components/ui/separator';
 
-export default function OrderForm({ data, onChange, onSave, onDelete, onProcess }) {
+export default function OrderForm({ data, onChange }) {
   return (
-    <form onSubmit={(e) => { e.preventDefault(); onSave?.(data); }} className="space-y-4">
-      <div className="grid grid-cols-2 gap-3 rounded-lg border p-4 bg-muted/20">
+    <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1.5">
           <Label htmlFor="businessPartner" className="text-sm text-foreground font-medium">Business Partner *</Label>
           <Input
@@ -78,75 +75,6 @@ export default function OrderForm({ data, onChange, onSave, onDelete, onProcess 
             onChange={(e) => onChange?.('invoiceAddress', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"
           />
         </div>
-      </div>
-      <div className="space-y-3 rounded-lg border border-dashed p-4 bg-muted/10">
-        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">System Fields</p>
-        <div className="space-y-1.5">
-          <Label htmlFor="documentNo" className="text-sm text-muted-foreground">Document No *</Label>
-          <Input
-            id="documentNo"
-            name="documentNo"
-            type="text"
-            value={data?.documentNo ?? ''}
-            onChange={(e) => onChange?.('documentNo', e.target.value)} disabled readOnly className="bg-muted/50 text-muted-foreground border-dashed cursor-not-allowed" required
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="currency" className="text-sm text-muted-foreground">Currency *</Label>
-          <Input
-            id="currency"
-            name="currency"
-            type="text"
-            value={data?.currency ?? ''}
-            onChange={(e) => onChange?.('currency', e.target.value)} disabled readOnly className="bg-muted/50 text-muted-foreground border-dashed cursor-not-allowed" required
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="totalLines" className="text-sm text-muted-foreground">Total Lines</Label>
-          <Input
-            id="totalLines"
-            name="totalLines"
-            type="number"
-            value={data?.totalLines ?? ''}
-            onChange={(e) => onChange?.('totalLines', e.target.value)} disabled readOnly className="bg-muted/50 text-muted-foreground border-dashed cursor-not-allowed"
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="grandTotal" className="text-sm text-muted-foreground">Grand Total</Label>
-          <Input
-            id="grandTotal"
-            name="grandTotal"
-            type="number"
-            value={data?.grandTotal ?? ''}
-            onChange={(e) => onChange?.('grandTotal', e.target.value)} disabled readOnly className="bg-muted/50 text-muted-foreground border-dashed cursor-not-allowed"
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="docStatus" className="text-sm text-muted-foreground">Doc Status *</Label>
-          <Input
-            id="docStatus"
-            name="docStatus"
-            type="text"
-            value={data?.docStatus ?? ''}
-            onChange={(e) => onChange?.('docStatus', e.target.value)} disabled readOnly className="bg-muted/50 text-muted-foreground border-dashed cursor-not-allowed" required
-          />
-        </div>
-      </div>
-      <div className="flex items-center gap-2 pt-2">
-        <Button type="submit" size="sm">Save</Button>
-        {onDelete && <Button variant="destructive" size="sm" onClick={(e) => { e.preventDefault(); onDelete(); }}>Delete</Button>}
-      </div>
-      <div className="rounded-lg border p-4 bg-muted/10 space-y-2">
-        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Actions</p>
-        <div className="flex gap-2">
-          <Button variant="secondary" size="sm" onClick={() => onProcess?.('completeOrder')}>
-            Complete Order
-          </Button>
-          <Button variant="secondary" size="sm" onClick={() => onProcess?.('voidOrder')}>
-            Void Order
-          </Button>
-        </div>
-      </div>
-    </form>
+    </div>
   );
 }

--- a/artifacts/sales-order/generated/web/sales-order/OrderLineForm.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderLineForm.jsx
@@ -7,7 +7,7 @@ import { Separator } from '@/components/ui/separator';
 export default function OrderLineForm({ data, onChange, onSave, onDelete, onProcess }) {
   return (
     <form onSubmit={(e) => { e.preventDefault(); onSave?.(data); }} className="space-y-4">
-      <div className="space-y-3 rounded-lg border p-4 bg-muted/20">
+      <div className="grid grid-cols-2 gap-3 rounded-lg border p-4 bg-muted/20">
         <div className="space-y-1.5">
           <Label htmlFor="product" className="text-sm text-foreground font-medium">Product *</Label>
           <Input

--- a/artifacts/sales-order/generated/web/sales-order/OrderLineForm.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderLineForm.jsx
@@ -6,93 +6,95 @@ import { Separator } from '@/components/ui/separator';
 
 export default function OrderLineForm({ data, onChange, onSave, onDelete, onProcess }) {
   return (
-    <form onSubmit={(e) => { e.preventDefault(); onSave?.(data); }} className="space-y-3">
-      <div className="space-y-3">
+    <form onSubmit={(e) => { e.preventDefault(); onSave?.(data); }} className="space-y-4">
+      <div className="space-y-3 rounded-lg border p-4 bg-muted/20">
         <div className="space-y-1.5">
-          <Label htmlFor="lineNo" className="text-sm text-gray-600">Line No *</Label>
-          <Input
-            id="lineNo"
-            name="lineNo"
-            type="number"
-            value={data?.lineNo ?? ''}
-            onChange={(e) => onChange?.('lineNo', e.target.value)} disabled readOnly className="bg-gray-50 text-gray-500" required
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="product" className="text-sm text-gray-600">Product *</Label>
+          <Label htmlFor="product" className="text-sm text-foreground font-medium">Product *</Label>
           <Input
             id="product"
             name="product"
             type="text"
             value={data?.product ?? ''}
-            onChange={(e) => onChange?.('product', e.target.value)} required
+            onChange={(e) => onChange?.('product', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none" required
           />
         </div>
         <div className="space-y-1.5">
-          <Label htmlFor="quantity" className="text-sm text-gray-600">Quantity *</Label>
+          <Label htmlFor="quantity" className="text-sm text-foreground font-medium">Quantity *</Label>
           <Input
             id="quantity"
             name="quantity"
             type="number"
             value={data?.quantity ?? ''}
-            onChange={(e) => onChange?.('quantity', e.target.value)} required
+            onChange={(e) => onChange?.('quantity', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none" required
           />
         </div>
         <div className="space-y-1.5">
-          <Label htmlFor="unitPrice" className="text-sm text-gray-600">Unit Price *</Label>
+          <Label htmlFor="unitPrice" className="text-sm text-foreground font-medium">Unit Price *</Label>
           <Input
             id="unitPrice"
             name="unitPrice"
             type="number"
             value={data?.unitPrice ?? ''}
-            onChange={(e) => onChange?.('unitPrice', e.target.value)} required
+            onChange={(e) => onChange?.('unitPrice', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none" required
           />
         </div>
         <div className="space-y-1.5">
-          <Label htmlFor="discount" className="text-sm text-gray-600">Discount</Label>
+          <Label htmlFor="discount" className="text-sm text-foreground font-medium">Discount</Label>
           <Input
             id="discount"
             name="discount"
             type="number"
             value={data?.discount ?? ''}
-            onChange={(e) => onChange?.('discount', e.target.value)}
+            onChange={(e) => onChange?.('discount', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"
           />
         </div>
         <div className="space-y-1.5">
-          <Label htmlFor="lineNetAmount" className="text-sm text-gray-600">Line Net Amount</Label>
-          <Input
-            id="lineNetAmount"
-            name="lineNetAmount"
-            type="number"
-            value={data?.lineNetAmount ?? ''}
-            onChange={(e) => onChange?.('lineNetAmount', e.target.value)} disabled readOnly className="bg-gray-50 text-gray-500"
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="tax" className="text-sm text-gray-600">Tax</Label>
+          <Label htmlFor="tax" className="text-sm text-foreground font-medium">Tax</Label>
           <Input
             id="tax"
             name="tax"
             type="text"
             value={data?.tax ?? ''}
-            onChange={(e) => onChange?.('tax', e.target.value)}
+            onChange={(e) => onChange?.('tax', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"
           />
         </div>
         <div className="space-y-1.5">
-          <Label htmlFor="description" className="text-sm text-gray-600">Description</Label>
+          <Label htmlFor="description" className="text-sm text-foreground font-medium">Description</Label>
           <Input
             id="description"
             name="description"
             type="text"
             value={data?.description ?? ''}
-            onChange={(e) => onChange?.('description', e.target.value)}
+            onChange={(e) => onChange?.('description', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"
           />
         </div>
       </div>
-      <Separator className="my-4" />
-      <div className="flex gap-2">
+      <div className="space-y-3 rounded-lg border border-dashed p-4 bg-muted/10">
+        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">System Fields</p>
+        <div className="space-y-1.5">
+          <Label htmlFor="lineNo" className="text-sm text-muted-foreground">Line No *</Label>
+          <Input
+            id="lineNo"
+            name="lineNo"
+            type="number"
+            value={data?.lineNo ?? ''}
+            onChange={(e) => onChange?.('lineNo', e.target.value)} disabled readOnly className="bg-muted/50 text-muted-foreground border-dashed cursor-not-allowed" required
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="lineNetAmount" className="text-sm text-muted-foreground">Line Net Amount</Label>
+          <Input
+            id="lineNetAmount"
+            name="lineNetAmount"
+            type="number"
+            value={data?.lineNetAmount ?? ''}
+            onChange={(e) => onChange?.('lineNetAmount', e.target.value)} disabled readOnly className="bg-muted/50 text-muted-foreground border-dashed cursor-not-allowed"
+          />
+        </div>
+      </div>
+      <div className="flex items-center gap-2 pt-2">
         <Button type="submit" size="sm">Save</Button>
-        {onDelete && <Button variant="outline" size="sm" onClick={(e) => { e.preventDefault(); onDelete(); }}>Delete</Button>}
+        {onDelete && <Button variant="destructive" size="sm" onClick={(e) => { e.preventDefault(); onDelete(); }}>Delete</Button>}
       </div>
     </form>
   );

--- a/artifacts/sales-order/generated/web/sales-order/OrderLineForm.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderLineForm.jsx
@@ -1,70 +1,14 @@
-import React from 'react';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
+import { EntityForm } from '@/components/contract-ui';
 
-export default function OrderLineForm({ data, onChange }) {
-  return (
-    <div className="grid grid-cols-2 gap-3">
-        <div className="space-y-1.5">
-          <Label htmlFor="product" className="text-sm text-foreground font-medium">Product *</Label>
-          <Input
-            id="product"
-            name="product"
-            type="text"
-            value={data?.product ?? ''}
-            onChange={(e) => onChange?.('product', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none" required
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="quantity" className="text-sm text-foreground font-medium">Quantity *</Label>
-          <Input
-            id="quantity"
-            name="quantity"
-            type="number"
-            value={data?.quantity ?? ''}
-            onChange={(e) => onChange?.('quantity', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none" required
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="unitPrice" className="text-sm text-foreground font-medium">Unit Price *</Label>
-          <Input
-            id="unitPrice"
-            name="unitPrice"
-            type="number"
-            value={data?.unitPrice ?? ''}
-            onChange={(e) => onChange?.('unitPrice', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none" required
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="discount" className="text-sm text-foreground font-medium">Discount</Label>
-          <Input
-            id="discount"
-            name="discount"
-            type="number"
-            value={data?.discount ?? ''}
-            onChange={(e) => onChange?.('discount', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="tax" className="text-sm text-foreground font-medium">Tax</Label>
-          <Input
-            id="tax"
-            name="tax"
-            type="text"
-            value={data?.tax ?? ''}
-            onChange={(e) => onChange?.('tax', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="description" className="text-sm text-foreground font-medium">Description</Label>
-          <Input
-            id="description"
-            name="description"
-            type="text"
-            value={data?.description ?? ''}
-            onChange={(e) => onChange?.('description', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"
-          />
-        </div>
-    </div>
-  );
+const fields = [
+  { key: 'product', label: 'Product', type: 'text', required: true },
+  { key: 'quantity', label: 'Quantity', type: 'number', required: true },
+  { key: 'unitPrice', label: 'Unit Price', type: 'number', required: true },
+  { key: 'discount', label: 'Discount', type: 'number' },
+  { key: 'tax', label: 'Tax', type: 'text' },
+  { key: 'description', label: 'Description', type: 'text' },
+];
+
+export default function OrderLineForm(props) {
+  return <EntityForm fields={fields} {...props} />;
 }

--- a/artifacts/sales-order/generated/web/sales-order/OrderLineForm.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderLineForm.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Button } from '@/components/ui/button';
-import { Separator } from '@/components/ui/separator';
 
-export default function OrderLineForm({ data, onChange, onSave, onDelete, onProcess }) {
+export default function OrderLineForm({ data, onChange }) {
   return (
-    <form onSubmit={(e) => { e.preventDefault(); onSave?.(data); }} className="space-y-4">
-      <div className="grid grid-cols-2 gap-3 rounded-lg border p-4 bg-muted/20">
+    <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1.5">
           <Label htmlFor="product" className="text-sm text-foreground font-medium">Product *</Label>
           <Input
@@ -68,34 +65,6 @@ export default function OrderLineForm({ data, onChange, onSave, onDelete, onProc
             onChange={(e) => onChange?.('description', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"
           />
         </div>
-      </div>
-      <div className="space-y-3 rounded-lg border border-dashed p-4 bg-muted/10">
-        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">System Fields</p>
-        <div className="space-y-1.5">
-          <Label htmlFor="lineNo" className="text-sm text-muted-foreground">Line No *</Label>
-          <Input
-            id="lineNo"
-            name="lineNo"
-            type="number"
-            value={data?.lineNo ?? ''}
-            onChange={(e) => onChange?.('lineNo', e.target.value)} disabled readOnly className="bg-muted/50 text-muted-foreground border-dashed cursor-not-allowed" required
-          />
-        </div>
-        <div className="space-y-1.5">
-          <Label htmlFor="lineNetAmount" className="text-sm text-muted-foreground">Line Net Amount</Label>
-          <Input
-            id="lineNetAmount"
-            name="lineNetAmount"
-            type="number"
-            value={data?.lineNetAmount ?? ''}
-            onChange={(e) => onChange?.('lineNetAmount', e.target.value)} disabled readOnly className="bg-muted/50 text-muted-foreground border-dashed cursor-not-allowed"
-          />
-        </div>
-      </div>
-      <div className="flex items-center gap-2 pt-2">
-        <Button type="submit" size="sm">Save</Button>
-        {onDelete && <Button variant="destructive" size="sm" onClick={(e) => { e.preventDefault(); onDelete(); }}>Delete</Button>}
-      </div>
-    </form>
+    </div>
   );
 }

--- a/artifacts/sales-order/generated/web/sales-order/OrderLineTable.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderLineTable.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Input } from '@/components/ui/input';
+import { Search } from 'lucide-react';
 
-export default function OrderLineTable({ data = [], onRowSelect }) {
+export default function OrderLineTable({ data = [], onRowSelect, selectedId }) {
   const [filterProduct, setFilterProduct] = useState('');
 
   const filteredData = data.filter(row => {
@@ -12,29 +13,43 @@ export default function OrderLineTable({ data = [], onRowSelect }) {
 
   return (
     <div className="space-y-4">
-      <div className="flex gap-2">
-        <Input
-          placeholder="Filter Product..."
-          value={filterProduct}
-          onChange={(e) => setFilterProduct(e.target.value)}
-          className="max-w-xs"
-        />
+      <div className="flex gap-2 flex-wrap">
+        <div className="relative">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Filter Product..."
+            value={filterProduct}
+            onChange={(e) => setFilterProduct(e.target.value)}
+            className="pl-8 max-w-xs focus:ring-2 focus:ring-primary focus:outline-none transition-colors duration-200"
+            aria-label={"Filter by Product"}
+          />
+        </div>
       </div>
-      <Table>
-        <TableHeader>
-          <TableRow className="border-b border-gray-100">
-            <TableHead className="text-xs font-medium text-gray-500 uppercase tracking-wider">Line No</TableHead>
-            <TableHead className="text-xs font-medium text-gray-500 uppercase tracking-wider">Product</TableHead>
-            <TableHead className="text-xs font-medium text-gray-500 uppercase tracking-wider">Quantity</TableHead>
-            <TableHead className="text-xs font-medium text-gray-500 uppercase tracking-wider">Unit Price</TableHead>
-            <TableHead className="text-xs font-medium text-gray-500 uppercase tracking-wider">Discount</TableHead>
-            <TableHead className="text-xs font-medium text-gray-500 uppercase tracking-wider">Line Net Amount</TableHead>
-            <TableHead className="text-xs font-medium text-gray-500 uppercase tracking-wider">Tax</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody className="divide-y divide-gray-50">
-          {filteredData.map((row, idx) => (
-            <TableRow key={row.id ?? idx} onClick={() => onRowSelect?.(row)} className="cursor-pointer hover:bg-gray-50 transition-colors">
+      <div className="rounded-lg border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="border-b-2 border-primary/20 bg-muted/40">
+            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Line No</TableHead>
+            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Product</TableHead>
+            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Quantity</TableHead>
+            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Unit Price</TableHead>
+            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Discount</TableHead>
+            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Line Net Amount</TableHead>
+            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Tax</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredData.map((row, idx) => (
+              <TableRow
+                key={row.id ?? idx}
+                onClick={() => onRowSelect?.(row)}
+                className={[
+                  'cursor-pointer transition-colors',
+                  row.id === selectedId ? 'bg-primary/10 border-l-2 border-l-primary' : '',
+                  idx % 2 !== 0 && row.id !== selectedId ? 'bg-muted/30' : '',
+                  'hover:bg-primary/5',
+                ].filter(Boolean).join(' ')}
+              >
             <TableCell>{row.lineNo}</TableCell>
             <TableCell>{row.product}</TableCell>
             <TableCell>{row.quantity}</TableCell>
@@ -42,10 +57,12 @@ export default function OrderLineTable({ data = [], onRowSelect }) {
             <TableCell>{row.discount}</TableCell>
             <TableCell className="tabular-nums">{row.lineNetAmount?.toLocaleString()}</TableCell>
             <TableCell>{row.tax}</TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <p className="text-xs text-muted-foreground">{filteredData.length} of {data.length} records</p>
     </div>
   );
 }

--- a/artifacts/sales-order/generated/web/sales-order/OrderLineTable.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderLineTable.jsx
@@ -1,68 +1,17 @@
-import React, { useState } from 'react';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Input } from '@/components/ui/input';
-import { Search } from 'lucide-react';
+import { DataTable } from '@/components/contract-ui';
 
-export default function OrderLineTable({ data = [], onRowSelect, selectedId }) {
-  const [filterProduct, setFilterProduct] = useState('');
+const columns = [
+  { key: 'lineNo', label: 'Line No', type: 'number' },
+  { key: 'product', label: 'Product', type: 'string' },
+  { key: 'quantity', label: 'Quantity', type: 'number' },
+  { key: 'unitPrice', label: 'Unit Price', type: 'amount' },
+  { key: 'discount', label: 'Discount', type: 'number' },
+  { key: 'lineNetAmount', label: 'Line Net Amount', type: 'amount' },
+  { key: 'tax', label: 'Tax', type: 'string' },
+];
 
-  const filteredData = data.filter(row => {
-    if (filterProduct && !String(row.product ?? '').toLowerCase().includes(filterProduct.toLowerCase())) return false;
-    return true;
-  });
+const filters = ['product'];
 
-  return (
-    <div className="space-y-4">
-      <div className="flex gap-2 flex-wrap">
-        <div className="relative">
-          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Filter Product..."
-            value={filterProduct}
-            onChange={(e) => setFilterProduct(e.target.value)}
-            className="pl-8 max-w-xs focus:ring-2 focus:ring-primary focus:outline-none transition-colors duration-200"
-            aria-label={"Filter by Product"}
-          />
-        </div>
-      </div>
-      <div className="rounded-lg border overflow-hidden">
-        <Table>
-          <TableHeader>
-            <TableRow className="border-b-2 border-primary/20 bg-muted/40">
-            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Line No</TableHead>
-            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Product</TableHead>
-            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Quantity</TableHead>
-            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Unit Price</TableHead>
-            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Discount</TableHead>
-            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Line Net Amount</TableHead>
-            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Tax</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {filteredData.map((row, idx) => (
-              <TableRow
-                key={row.id ?? idx}
-                onClick={() => onRowSelect?.(row)}
-                className={[
-                  'cursor-pointer transition-colors',
-                  row.id === selectedId ? 'bg-primary/10 border-l-2 border-l-primary' : '',
-                  idx % 2 !== 0 && row.id !== selectedId ? 'bg-muted/30' : '',
-                  'hover:bg-primary/5',
-                ].filter(Boolean).join(' ')}
-              >
-            <TableCell>{row.lineNo}</TableCell>
-            <TableCell>{row.product}</TableCell>
-            <TableCell>{row.quantity}</TableCell>
-            <TableCell className="tabular-nums">{row.unitPrice?.toLocaleString()}</TableCell>
-            <TableCell>{row.discount}</TableCell>
-            <TableCell className="tabular-nums">{row.lineNetAmount?.toLocaleString()}</TableCell>
-            <TableCell>{row.tax}</TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
-      <p className="text-xs text-muted-foreground">{filteredData.length} of {data.length} records</p>
-    </div>
-  );
+export default function OrderLineTable(props) {
+  return <DataTable columns={columns} filters={filters} {...props} />;
 }

--- a/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
@@ -19,12 +19,33 @@ export default function OrderPage({ token, apiBaseUrl }) {
   };
 
   return (
-    <div className="p-6">
+    <div>
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-semibold text-gray-900">Orders</h2>
-        <Button onClick={order.handleNew}>New</Button>
+        <div>
+          <h2 className="text-xl font-semibold text-foreground">Orders</h2>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            {order.loading ? 'Loading...' : `${order.items.length} records`}
+          </p>
+        </div>
+        <Button onClick={order.handleNew} size="sm">+ New Order</Button>
       </div>
-      <OrderTable data={order.items} onRowSelect={order.handleSelect} />
+      {order.loading ? (
+        <div className="flex items-center justify-center py-20 text-muted-foreground">
+          <div className="animate-pulse space-y-3 w-full">
+            <div className="h-10 bg-muted rounded" />
+            <div className="h-8 bg-muted/60 rounded" />
+            <div className="h-8 bg-muted/40 rounded" />
+            <div className="h-8 bg-muted/60 rounded" />
+            <div className="h-8 bg-muted/40 rounded" />
+          </div>
+        </div>
+      ) : (
+        <OrderTable
+          data={order.items}
+          onRowSelect={order.handleSelect}
+          selectedId={order.selected?.id}
+        />
+      )}
       <SlidePanel
         open={!!order.editing}
         onClose={handleClose}
@@ -38,7 +59,7 @@ export default function OrderPage({ token, apiBaseUrl }) {
           onProcess={order.handleProcess}
         />
         <Separator className="my-6" />
-        <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wider mb-3">Order Lines</h3>
+        <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider mb-3">Order Lines</h3>
         <OrderLineTable data={order.children} />
       </SlidePanel>
     </div>

--- a/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Separator } from '@/components/ui/separator';
 import { Button } from '@/components/ui/button';
 import { useEntity } from '@/hooks/useEntity';
+import { StatusBadge } from '@/components/ui/status-badge';
 import OrderTable from './OrderTable';
 import OrderForm from './OrderForm';
 import OrderLineTable from './OrderLineTable';
@@ -46,30 +46,64 @@ export default function OrderPage({ token, apiBaseUrl }) {
         </div>
       </div>
 
-      {/* Right panel: Form + Detail */}
+      {/* Right panel: Toolbar + Summary + Form + Detail */}
       {order.editing && (
-        <div className="flex-1 flex flex-col overflow-hidden">
-          <div className="flex items-center justify-between px-5 py-3 border-b bg-muted/20">
-            <h2 className="text-lg font-semibold text-foreground">{detailTitle}</h2>
-            <button
-              onClick={() => order.handleSelect(null)}
-              className="h-8 w-8 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-              aria-label="Close detail"
-            >
-              &times;
-            </button>
+        <div className="flex-1 flex flex-col overflow-hidden bg-white">
+          {/* Toolbar: title, status, process actions, save/delete */}
+          <div className="flex items-center gap-2 px-5 py-2.5 border-b border-slate-200 bg-white shadow-sm">
+            <h2 className="text-base font-semibold text-foreground truncate">{detailTitle}</h2>
+            <StatusBadge status={order.editing?.docStatus} />
+            <div className="flex-1" />
+            <div className="flex items-center gap-2">
+            <div className="h-5 w-px bg-border" />
+            <Button variant="outline" size="sm" className="border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100" onClick={() => order.handleProcess?.('completeOrder')}>Complete Order</Button>
+            <Button variant="outline" size="sm" className="border-amber-300 bg-amber-50 text-amber-700 hover:bg-amber-100" onClick={() => order.handleProcess?.('voidOrder')}>Void Order</Button>
+              <Button size="sm" onClick={() => order.handleSave(order.editing)}>Save</Button>
+              {order.selected && (
+                <Button variant="destructive" size="sm" onClick={order.handleDelete}>Delete</Button>
+              )}
+              <button
+                onClick={() => order.handleSelect(null)}
+                className="h-8 w-8 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                aria-label="Close detail"
+              >
+                &times;
+              </button>
+            </div>
           </div>
-          <div className="flex-1 overflow-y-auto px-5 py-4 space-y-6">
+
+          {/* Summary strip: read-only reference fields */}
+          <div className="flex items-center gap-5 px-5 py-2.5 border-b border-slate-200 bg-slate-50 text-xs">
+            <div className="flex items-center gap-1.5">
+              <span className="text-slate-500">Document No:</span>
+              <span className="font-semibold text-foreground ">{order.editing?.documentNo ?? '—'}</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="text-slate-500">Currency:</span>
+              <span className="font-semibold text-foreground ">{order.editing?.currency ?? '—'}</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="text-slate-500">Total Lines:</span>
+              <span className="font-semibold text-foreground tabular-nums">{order.editing?.totalLines?.toLocaleString() ?? '—'}</span>
+            </div>
+            <div className="flex items-center gap-1.5">
+              <span className="text-slate-500">Grand Total:</span>
+              <span className="font-semibold text-foreground tabular-nums">{order.editing?.grandTotal?.toLocaleString() ?? '—'}</span>
+            </div>
+          </div>
+
+          {/* Form zone: editable fields only */}
+          <div className="px-5 pt-4 pb-3 border-b">
             <OrderForm
               data={order.editing}
               onChange={order.handleChange}
-              onSave={order.handleSave}
-              onDelete={order.selected ? order.handleDelete : undefined}
-              onProcess={order.handleProcess}
             />
-            <Separator />
-            <div>
-              <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider mb-3">Order Lines</h3>
+          </div>
+
+          {/* Detail zone: fills remaining height */}
+          <div className="flex-1 flex flex-col overflow-hidden px-5 py-3">
+            <h3 className="text-xs font-bold text-slate-500 uppercase tracking-widest mb-3">Order Lines</h3>
+            <div className="flex-1 overflow-auto">
               <OrderLineTable data={order.children} />
             </div>
           </div>

--- a/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
@@ -1,203 +1,50 @@
-import React, { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { useEntity } from '@/hooks/useEntity';
-import { StatusBadge } from '@/components/ui/status-badge';
+import { MasterDetailPage } from '@/components/contract-ui';
 import OrderTable from './OrderTable';
 import OrderForm from './OrderForm';
 import OrderLineTable from './OrderLineTable';
 
-export default function OrderPage({ token, apiBaseUrl }) {
-  const order = useEntity('order', 'orderLine', { token, apiBaseUrl });
+const summary = [
+  { key: 'documentNo', label: 'Document No', type: 'string' },
+  { key: 'currency', label: 'Currency', type: 'string' },
+  { key: 'totalLines', label: 'Total Lines', type: 'amount' },
+  { key: 'grandTotal', label: 'Grand Total', type: 'amount' },
+];
 
-  const [showAddLine, setShowAddLine] = useState(false);
-  const [newLine, setNewLine] = useState({ product: '', quantity: '', unitPrice: '', discount: '', tax: '', description: '' });
+const statusField = 'docStatus';
 
-  const detailTitle = order.editing?.id
-    ? `Order ${order.editing.documentNo || order.editing.id}`
-    : 'New Order';
+const processes = [
+  { name: 'completeOrder', label: 'Complete Order', style: 'positive' },
+  { name: 'voidOrder', label: 'Void Order', style: 'destructive' },
+];
 
-  const handleAddLine = () => {
-    order.handleAddChild?.(newLine);
-    setNewLine({ product: '', quantity: '', unitPrice: '', discount: '', tax: '', description: '' });
-    setShowAddLine(false);
-  };
+const addLineFields = {
+  entry: [
+    { key: 'product', label: 'Product', type: 'text', required: true, lookup: true },
+    { key: 'quantity', label: 'Quantity', type: 'number', required: true },
+    { key: 'description', label: 'Description', type: 'text' },
+  ],
+  derived: [
+    { key: 'unitPrice', label: 'Unit Price', type: 'number' },
+    { key: 'discount', label: 'Discount', type: 'number' },
+    { key: 'tax', label: 'Tax', type: 'text' },
+  ],
+};
 
-  const handleProductLookup = async (value) => {
-    const defaults = await order.lookupChildDefaults?.(value);
-    if (defaults) {
-      setNewLine(prev => ({ ...prev, ...defaults }));
-    }
-  };
-
+export default function OrderPage(props) {
   return (
-    <div className="flex h-[calc(100vh-4rem)] gap-0">
-      {/* Left panel: Table */}
-      <div className={`flex flex-col border-r transition-all duration-300 ${order.editing ? 'w-2/5' : 'w-full'}`}>
-        <div className="flex items-center justify-between px-4 py-3 border-b bg-muted/20">
-          <div>
-            <h2 className="text-lg font-semibold text-foreground">Orders</h2>
-            <p className="text-xs text-muted-foreground">
-              {order.loading ? 'Loading...' : `${order.items.length} records`}
-            </p>
-          </div>
-          <Button onClick={order.handleNew} size="sm">+ New</Button>
-        </div>
-        <div className="flex-1 overflow-auto p-3">
-          {order.loading ? (
-            <div className="animate-pulse space-y-3">
-              <div className="h-10 bg-muted rounded" />
-              <div className="h-8 bg-muted/60 rounded" />
-              <div className="h-8 bg-muted/40 rounded" />
-              <div className="h-8 bg-muted/60 rounded" />
-              <div className="h-8 bg-muted/40 rounded" />
-            </div>
-          ) : (
-            <OrderTable
-              data={order.items}
-              onRowSelect={order.handleSelect}
-              selectedId={order.selected?.id}
-              compact={!!order.editing}
-            />
-          )}
-        </div>
-      </div>
-
-      {/* Right panel: Toolbar + Summary + Form + Detail */}
-      {order.editing && (
-        <div className="flex-1 flex flex-col overflow-hidden bg-white">
-          {/* Toolbar: title, status, process actions, save/delete */}
-          <div className="flex items-center gap-2 px-5 py-2.5 border-b border-slate-200 bg-white shadow-sm">
-            <h2 className="text-base font-semibold text-foreground truncate">{detailTitle}</h2>
-            <StatusBadge status={order.editing?.docStatus} />
-            <div className="flex-1" />
-            <div className="flex items-center gap-2">
-            <div className="h-5 w-px bg-border" />
-            <Button variant="outline" size="sm" className="border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100" onClick={() => order.handleProcess?.('completeOrder')}>Complete Order</Button>
-            <Button variant="outline" size="sm" className="border-amber-300 bg-amber-50 text-amber-700 hover:bg-amber-100" onClick={() => order.handleProcess?.('voidOrder')}>Void Order</Button>
-              <Button size="sm" onClick={() => order.handleSave(order.editing)}>Save</Button>
-              {order.selected && (
-                <Button variant="destructive" size="sm" onClick={order.handleDelete}>Delete</Button>
-              )}
-              <button
-                onClick={() => order.handleSelect(null)}
-                className="h-8 w-8 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                aria-label="Close detail"
-              >
-                &times;
-              </button>
-            </div>
-          </div>
-
-          {/* Summary strip: read-only reference fields */}
-          <div className="flex items-center gap-5 px-5 py-2.5 border-b border-slate-200 bg-slate-50 text-xs">
-            <div className="flex items-center gap-1.5">
-              <span className="text-slate-500">Document No:</span>
-              <span className="font-semibold text-foreground ">{order.editing?.documentNo ?? '—'}</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <span className="text-slate-500">Currency:</span>
-              <span className="font-semibold text-foreground ">{order.editing?.currency ?? '—'}</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <span className="text-slate-500">Total Lines:</span>
-              <span className="font-semibold text-foreground tabular-nums">{order.editing?.totalLines?.toLocaleString() ?? '—'}</span>
-            </div>
-            <div className="flex items-center gap-1.5">
-              <span className="text-slate-500">Grand Total:</span>
-              <span className="font-semibold text-foreground tabular-nums">{order.editing?.grandTotal?.toLocaleString() ?? '—'}</span>
-            </div>
-          </div>
-
-          {/* Form zone: editable fields only */}
-          <div className="px-5 pt-4 pb-3 border-b">
-            <OrderForm
-              data={order.editing}
-              onChange={order.handleChange}
-            />
-          </div>
-
-          {/* Detail zone: fills remaining height */}
-          <div className="flex-1 flex flex-col overflow-hidden px-5 py-3">
-            <div className="flex items-center justify-between mb-3">
-              <h3 className="text-xs font-bold text-slate-500 uppercase tracking-widest">Order Lines</h3>
-              <Button
-                variant="outline"
-                size="sm"
-                className="text-xs h-7"
-                onClick={() => setShowAddLine(!showAddLine)}
-              >
-                {showAddLine ? 'Cancel' : '+ Add Line'}
-              </Button>
-            </div>
-            {showAddLine && (
-              <form
-                onSubmit={(e) => { e.preventDefault(); handleAddLine(); }}
-                className="flex items-end gap-2 mb-3 p-3 rounded-lg border border-dashed border-primary/30 bg-primary/5"
-              >
-              <div className="flex-1 min-w-0">
-                <label className="text-xs text-slate-500 mb-1 block">Product *</label>
-                <input
-                  name="product"
-                  type="text"
-                  placeholder="Product"
-                  value={newLine.product ?? ''}
-                  onChange={(e) => setNewLine(prev => ({ ...prev, product: e.target.value }))}
-                  onBlur={(e) => { if (e.target.value) handleProductLookup(e.target.value); }}
-                  className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"
-                  required
-                />
-              </div>
-              <div className="flex-1 min-w-0">
-                <label className="text-xs text-slate-500 mb-1 block">Quantity *</label>
-                <input
-                  name="quantity"
-                  type="number"
-                  placeholder="Quantity"
-                  value={newLine.quantity ?? ''}
-                  onChange={(e) => setNewLine(prev => ({ ...prev, quantity: e.target.value }))}
-                  className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"
-                  required
-                />
-              </div>
-              <div className="flex-1 min-w-0">
-                <label className="text-xs text-slate-500 mb-1 block">Description</label>
-                <input
-                  name="description"
-                  type="text"
-                  placeholder="Description"
-                  value={newLine.description ?? ''}
-                  onChange={(e) => setNewLine(prev => ({ ...prev, description: e.target.value }))}
-                  className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"
-                />
-              </div>
-              <div className="w-px h-8 bg-slate-200 self-end mb-0.5" />
-              <div className="flex-1 min-w-0">
-                <label className="text-xs text-slate-400 mb-1 block">Unit Price</label>
-                <div className="h-8 text-sm rounded-md border border-dashed border-slate-200 bg-slate-50 px-2 flex items-center text-slate-600 tabular-nums">
-                  {newLine.unitPrice || '—'}
-                </div>
-              </div>
-              <div className="flex-1 min-w-0">
-                <label className="text-xs text-slate-400 mb-1 block">Discount</label>
-                <div className="h-8 text-sm rounded-md border border-dashed border-slate-200 bg-slate-50 px-2 flex items-center text-slate-600 tabular-nums">
-                  {newLine.discount || '—'}
-                </div>
-              </div>
-              <div className="flex-1 min-w-0">
-                <label className="text-xs text-slate-400 mb-1 block">Tax</label>
-                <div className="h-8 text-sm rounded-md border border-dashed border-slate-200 bg-slate-50 px-2 flex items-center text-slate-600 tabular-nums">
-                  {newLine.tax || '—'}
-                </div>
-              </div>
-                <Button type="submit" size="sm" className="h-8 shrink-0">Add</Button>
-              </form>
-            )}
-            <div className="flex-1 overflow-auto">
-              <OrderLineTable data={order.children} />
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
+    <MasterDetailPage
+      entity="order"
+      detailEntity="orderLine"
+      Table={OrderTable}
+      Form={OrderForm}
+      DetailTable={OrderLineTable}
+      summary={summary}
+      statusField={statusField}
+      processes={processes}
+      addLineFields={addLineFields}
+      entityLabel="Order"
+      detailLabel="Order Line"
+      {...props}
+    />
   );
 }

--- a/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { useEntity } from '@/hooks/useEntity';
 import { StatusBadge } from '@/components/ui/status-badge';
@@ -9,9 +9,18 @@ import OrderLineTable from './OrderLineTable';
 export default function OrderPage({ token, apiBaseUrl }) {
   const order = useEntity('order', 'orderLine', { token, apiBaseUrl });
 
+  const [showAddLine, setShowAddLine] = useState(false);
+  const [newLine, setNewLine] = useState({ product: '', quantity: '', unitPrice: '', discount: '', tax: '', description: '' });
+
   const detailTitle = order.editing?.id
     ? `Order ${order.editing.documentNo || order.editing.id}`
     : 'New Order';
+
+  const handleAddLine = () => {
+    order.handleAddChild?.(newLine);
+    setNewLine({ product: '', quantity: '', unitPrice: '', discount: '', tax: '', description: '' });
+    setShowAddLine(false);
+  };
 
   return (
     <div className="flex h-[calc(100vh-4rem)] gap-0">
@@ -102,7 +111,94 @@ export default function OrderPage({ token, apiBaseUrl }) {
 
           {/* Detail zone: fills remaining height */}
           <div className="flex-1 flex flex-col overflow-hidden px-5 py-3">
-            <h3 className="text-xs font-bold text-slate-500 uppercase tracking-widest mb-3">Order Lines</h3>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-xs font-bold text-slate-500 uppercase tracking-widest">Order Lines</h3>
+              <Button
+                variant="outline"
+                size="sm"
+                className="text-xs h-7"
+                onClick={() => setShowAddLine(!showAddLine)}
+              >
+                {showAddLine ? 'Cancel' : '+ Add Line'}
+              </Button>
+            </div>
+            {showAddLine && (
+              <form
+                onSubmit={(e) => { e.preventDefault(); handleAddLine(); }}
+                className="flex items-end gap-2 mb-3 p-3 rounded-lg border border-dashed border-primary/30 bg-primary/5"
+              >
+              <div className="flex-1 min-w-0">
+                <label className="text-xs text-slate-500 mb-1 block">Product *</label>
+                <input
+                  name="product"
+                  type="text"
+                  placeholder="Product"
+                  value={newLine.product ?? ''}
+                  onChange={(e) => setNewLine(prev => ({ ...prev, product: e.target.value }))}
+                  className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"
+                  required
+                />
+              </div>
+              <div className="flex-1 min-w-0">
+                <label className="text-xs text-slate-500 mb-1 block">Quantity *</label>
+                <input
+                  name="quantity"
+                  type="number"
+                  placeholder="Quantity"
+                  value={newLine.quantity ?? ''}
+                  onChange={(e) => setNewLine(prev => ({ ...prev, quantity: e.target.value }))}
+                  className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"
+                  required
+                />
+              </div>
+              <div className="flex-1 min-w-0">
+                <label className="text-xs text-slate-500 mb-1 block">Unit Price *</label>
+                <input
+                  name="unitPrice"
+                  type="number"
+                  placeholder="Unit Price"
+                  value={newLine.unitPrice ?? ''}
+                  onChange={(e) => setNewLine(prev => ({ ...prev, unitPrice: e.target.value }))}
+                  className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"
+                  required
+                />
+              </div>
+              <div className="flex-1 min-w-0">
+                <label className="text-xs text-slate-500 mb-1 block">Discount</label>
+                <input
+                  name="discount"
+                  type="number"
+                  placeholder="Discount"
+                  value={newLine.discount ?? ''}
+                  onChange={(e) => setNewLine(prev => ({ ...prev, discount: e.target.value }))}
+                  className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"
+                />
+              </div>
+              <div className="flex-1 min-w-0">
+                <label className="text-xs text-slate-500 mb-1 block">Tax</label>
+                <input
+                  name="tax"
+                  type="text"
+                  placeholder="Tax"
+                  value={newLine.tax ?? ''}
+                  onChange={(e) => setNewLine(prev => ({ ...prev, tax: e.target.value }))}
+                  className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"
+                />
+              </div>
+              <div className="flex-1 min-w-0">
+                <label className="text-xs text-slate-500 mb-1 block">Description</label>
+                <input
+                  name="description"
+                  type="text"
+                  placeholder="Description"
+                  value={newLine.description ?? ''}
+                  onChange={(e) => setNewLine(prev => ({ ...prev, description: e.target.value }))}
+                  className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"
+                />
+              </div>
+                <Button type="submit" size="sm" className="h-8 shrink-0">Add</Button>
+              </form>
+            )}
             <div className="flex-1 overflow-auto">
               <OrderLineTable data={order.children} />
             </div>

--- a/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Separator } from '@/components/ui/separator';
 import { Button } from '@/components/ui/button';
-import { SlidePanel } from '@/components/ui/slide-panel';
 import { useEntity } from '@/hooks/useEntity';
 import OrderTable from './OrderTable';
 import OrderForm from './OrderForm';
@@ -10,58 +9,72 @@ import OrderLineTable from './OrderLineTable';
 export default function OrderPage({ token, apiBaseUrl }) {
   const order = useEntity('order', 'orderLine', { token, apiBaseUrl });
 
-  const panelTitle = order.editing?.id
+  const detailTitle = order.editing?.id
     ? `Order ${order.editing.documentNo || order.editing.id}`
     : 'New Order';
 
-  const handleClose = () => {
-    order.handleSelect(null);
-  };
-
   return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h2 className="text-xl font-semibold text-foreground">Orders</h2>
-          <p className="text-sm text-muted-foreground mt-0.5">
-            {order.loading ? 'Loading...' : `${order.items.length} records`}
-          </p>
+    <div className="flex h-[calc(100vh-4rem)] gap-0">
+      {/* Left panel: Table */}
+      <div className={`flex flex-col border-r transition-all duration-300 ${order.editing ? 'w-2/5' : 'w-full'}`}>
+        <div className="flex items-center justify-between px-4 py-3 border-b bg-muted/20">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">Orders</h2>
+            <p className="text-xs text-muted-foreground">
+              {order.loading ? 'Loading...' : `${order.items.length} records`}
+            </p>
+          </div>
+          <Button onClick={order.handleNew} size="sm">+ New</Button>
         </div>
-        <Button onClick={order.handleNew} size="sm">+ New Order</Button>
+        <div className="flex-1 overflow-auto p-3">
+          {order.loading ? (
+            <div className="animate-pulse space-y-3">
+              <div className="h-10 bg-muted rounded" />
+              <div className="h-8 bg-muted/60 rounded" />
+              <div className="h-8 bg-muted/40 rounded" />
+              <div className="h-8 bg-muted/60 rounded" />
+              <div className="h-8 bg-muted/40 rounded" />
+            </div>
+          ) : (
+            <OrderTable
+              data={order.items}
+              onRowSelect={order.handleSelect}
+              selectedId={order.selected?.id}
+              compact={!!order.editing}
+            />
+          )}
+        </div>
       </div>
-      {order.loading ? (
-        <div className="flex items-center justify-center py-20 text-muted-foreground">
-          <div className="animate-pulse space-y-3 w-full">
-            <div className="h-10 bg-muted rounded" />
-            <div className="h-8 bg-muted/60 rounded" />
-            <div className="h-8 bg-muted/40 rounded" />
-            <div className="h-8 bg-muted/60 rounded" />
-            <div className="h-8 bg-muted/40 rounded" />
+
+      {/* Right panel: Form + Detail */}
+      {order.editing && (
+        <div className="flex-1 flex flex-col overflow-hidden">
+          <div className="flex items-center justify-between px-5 py-3 border-b bg-muted/20">
+            <h2 className="text-lg font-semibold text-foreground">{detailTitle}</h2>
+            <button
+              onClick={() => order.handleSelect(null)}
+              className="h-8 w-8 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+              aria-label="Close detail"
+            >
+              &times;
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto px-5 py-4 space-y-6">
+            <OrderForm
+              data={order.editing}
+              onChange={order.handleChange}
+              onSave={order.handleSave}
+              onDelete={order.selected ? order.handleDelete : undefined}
+              onProcess={order.handleProcess}
+            />
+            <Separator />
+            <div>
+              <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider mb-3">Order Lines</h3>
+              <OrderLineTable data={order.children} />
+            </div>
           </div>
         </div>
-      ) : (
-        <OrderTable
-          data={order.items}
-          onRowSelect={order.handleSelect}
-          selectedId={order.selected?.id}
-        />
       )}
-      <SlidePanel
-        open={!!order.editing}
-        onClose={handleClose}
-        title={panelTitle}
-      >
-        <OrderForm
-          data={order.editing}
-          onChange={order.handleChange}
-          onSave={order.handleSave}
-          onDelete={order.selected ? order.handleDelete : undefined}
-          onProcess={order.handleProcess}
-        />
-        <Separator className="my-6" />
-        <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider mb-3">Order Lines</h3>
-        <OrderLineTable data={order.children} />
-      </SlidePanel>
     </div>
   );
 }

--- a/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
@@ -22,6 +22,13 @@ export default function OrderPage({ token, apiBaseUrl }) {
     setShowAddLine(false);
   };
 
+  const handleProductLookup = async (value) => {
+    const defaults = await order.lookupChildDefaults?.(value);
+    if (defaults) {
+      setNewLine(prev => ({ ...prev, ...defaults }));
+    }
+  };
+
   return (
     <div className="flex h-[calc(100vh-4rem)] gap-0">
       {/* Left panel: Table */}
@@ -135,6 +142,7 @@ export default function OrderPage({ token, apiBaseUrl }) {
                   placeholder="Product"
                   value={newLine.product ?? ''}
                   onChange={(e) => setNewLine(prev => ({ ...prev, product: e.target.value }))}
+                  onBlur={(e) => { if (e.target.value) handleProductLookup(e.target.value); }}
                   className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"
                   required
                 />
@@ -152,40 +160,6 @@ export default function OrderPage({ token, apiBaseUrl }) {
                 />
               </div>
               <div className="flex-1 min-w-0">
-                <label className="text-xs text-slate-500 mb-1 block">Unit Price *</label>
-                <input
-                  name="unitPrice"
-                  type="number"
-                  placeholder="Unit Price"
-                  value={newLine.unitPrice ?? ''}
-                  onChange={(e) => setNewLine(prev => ({ ...prev, unitPrice: e.target.value }))}
-                  className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"
-                  required
-                />
-              </div>
-              <div className="flex-1 min-w-0">
-                <label className="text-xs text-slate-500 mb-1 block">Discount</label>
-                <input
-                  name="discount"
-                  type="number"
-                  placeholder="Discount"
-                  value={newLine.discount ?? ''}
-                  onChange={(e) => setNewLine(prev => ({ ...prev, discount: e.target.value }))}
-                  className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"
-                />
-              </div>
-              <div className="flex-1 min-w-0">
-                <label className="text-xs text-slate-500 mb-1 block">Tax</label>
-                <input
-                  name="tax"
-                  type="text"
-                  placeholder="Tax"
-                  value={newLine.tax ?? ''}
-                  onChange={(e) => setNewLine(prev => ({ ...prev, tax: e.target.value }))}
-                  className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"
-                />
-              </div>
-              <div className="flex-1 min-w-0">
                 <label className="text-xs text-slate-500 mb-1 block">Description</label>
                 <input
                   name="description"
@@ -195,6 +169,25 @@ export default function OrderPage({ token, apiBaseUrl }) {
                   onChange={(e) => setNewLine(prev => ({ ...prev, description: e.target.value }))}
                   className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"
                 />
+              </div>
+              <div className="w-px h-8 bg-slate-200 self-end mb-0.5" />
+              <div className="flex-1 min-w-0">
+                <label className="text-xs text-slate-400 mb-1 block">Unit Price</label>
+                <div className="h-8 text-sm rounded-md border border-dashed border-slate-200 bg-slate-50 px-2 flex items-center text-slate-600 tabular-nums">
+                  {newLine.unitPrice || '—'}
+                </div>
+              </div>
+              <div className="flex-1 min-w-0">
+                <label className="text-xs text-slate-400 mb-1 block">Discount</label>
+                <div className="h-8 text-sm rounded-md border border-dashed border-slate-200 bg-slate-50 px-2 flex items-center text-slate-600 tabular-nums">
+                  {newLine.discount || '—'}
+                </div>
+              </div>
+              <div className="flex-1 min-w-0">
+                <label className="text-xs text-slate-400 mb-1 block">Tax</label>
+                <div className="h-8 text-sm rounded-md border border-dashed border-slate-200 bg-slate-50 px-2 flex items-center text-slate-600 tabular-nums">
+                  {newLine.tax || '—'}
+                </div>
               </div>
                 <Button type="submit" size="sm" className="h-8 shrink-0">Add</Button>
               </form>

--- a/artifacts/sales-order/generated/web/sales-order/OrderTable.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderTable.jsx
@@ -1,93 +1,17 @@
-import React, { useState } from 'react';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Input } from '@/components/ui/input';
-import { Search } from 'lucide-react';
-import { StatusBadge } from '@/components/ui/status-badge';
+import { DataTable } from '@/components/contract-ui';
 
-export default function OrderTable({ data = [], onRowSelect, selectedId }) {
-  const [filterDocumentNo, setFilterDocumentNo] = useState('');
-  const [filterBusinessPartner, setFilterBusinessPartner] = useState('');
-  const [filterDocStatus, setFilterDocStatus] = useState('');
+const columns = [
+  { key: 'documentNo', label: 'Document No', type: 'string' },
+  { key: 'businessPartner', label: 'Business Partner', type: 'string' },
+  { key: 'orderDate', label: 'Order Date', type: 'date' },
+  { key: 'currency', label: 'Currency', type: 'string' },
+  { key: 'totalLines', label: 'Total Lines', type: 'amount' },
+  { key: 'grandTotal', label: 'Grand Total', type: 'amount' },
+  { key: 'docStatus', label: 'Doc Status', type: 'status' },
+];
 
-  const filteredData = data.filter(row => {
-    if (filterDocumentNo && !String(row.documentNo ?? '').toLowerCase().includes(filterDocumentNo.toLowerCase())) return false;
-    if (filterBusinessPartner && !String(row.businessPartner ?? '').toLowerCase().includes(filterBusinessPartner.toLowerCase())) return false;
-    if (filterDocStatus && !String(row.docStatus ?? '').toLowerCase().includes(filterDocStatus.toLowerCase())) return false;
-    return true;
-  });
+const filters = ['documentNo', 'businessPartner', 'docStatus'];
 
-  return (
-    <div className="space-y-4">
-      <div className="flex gap-2 flex-wrap">
-        <div className="relative">
-          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Filter Document No..."
-            value={filterDocumentNo}
-            onChange={(e) => setFilterDocumentNo(e.target.value)}
-            className="pl-8 max-w-xs focus:ring-2 focus:ring-primary focus:outline-none transition-colors duration-200"
-            aria-label={"Filter by Document No"}
-          />
-        </div>
-        <div className="relative">
-          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Filter Business Partner..."
-            value={filterBusinessPartner}
-            onChange={(e) => setFilterBusinessPartner(e.target.value)}
-            className="pl-8 max-w-xs focus:ring-2 focus:ring-primary focus:outline-none transition-colors duration-200"
-            aria-label={"Filter by Business Partner"}
-          />
-        </div>
-        <div className="relative">
-          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Filter Doc Status..."
-            value={filterDocStatus}
-            onChange={(e) => setFilterDocStatus(e.target.value)}
-            className="pl-8 max-w-xs focus:ring-2 focus:ring-primary focus:outline-none transition-colors duration-200"
-            aria-label={"Filter by Doc Status"}
-          />
-        </div>
-      </div>
-      <div className="rounded-lg border overflow-hidden">
-        <Table>
-          <TableHeader>
-            <TableRow className="border-b-2 border-primary/20 bg-muted/40">
-            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Document No</TableHead>
-            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Business Partner</TableHead>
-            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Order Date</TableHead>
-            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Currency</TableHead>
-            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Total Lines</TableHead>
-            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Grand Total</TableHead>
-            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Doc Status</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {filteredData.map((row, idx) => (
-              <TableRow
-                key={row.id ?? idx}
-                onClick={() => onRowSelect?.(row)}
-                className={[
-                  'cursor-pointer transition-colors',
-                  row.id === selectedId ? 'bg-primary/10 border-l-2 border-l-primary' : '',
-                  idx % 2 !== 0 && row.id !== selectedId ? 'bg-muted/30' : '',
-                  'hover:bg-primary/5',
-                ].filter(Boolean).join(' ')}
-              >
-            <TableCell>{row.documentNo}</TableCell>
-            <TableCell>{row.businessPartner}</TableCell>
-            <TableCell>{row.orderDate}</TableCell>
-            <TableCell>{row.currency}</TableCell>
-            <TableCell className="tabular-nums">{row.totalLines?.toLocaleString()}</TableCell>
-            <TableCell className="tabular-nums">{row.grandTotal?.toLocaleString()}</TableCell>
-            <TableCell><StatusBadge status={row.docStatus} /></TableCell>
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
-      <p className="text-xs text-muted-foreground">{filteredData.length} of {data.length} records</p>
-    </div>
-  );
+export default function OrderTable(props) {
+  return <DataTable columns={columns} filters={filters} {...props} />;
 }

--- a/artifacts/sales-order/generated/web/sales-order/OrderTable.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderTable.jsx
@@ -1,9 +1,10 @@
 import React, { useState } from 'react';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Input } from '@/components/ui/input';
+import { Search } from 'lucide-react';
 import { StatusBadge } from '@/components/ui/status-badge';
 
-export default function OrderTable({ data = [], onRowSelect }) {
+export default function OrderTable({ data = [], onRowSelect, selectedId }) {
   const [filterDocumentNo, setFilterDocumentNo] = useState('');
   const [filterBusinessPartner, setFilterBusinessPartner] = useState('');
   const [filterDocStatus, setFilterDocStatus] = useState('');
@@ -17,41 +18,63 @@ export default function OrderTable({ data = [], onRowSelect }) {
 
   return (
     <div className="space-y-4">
-      <div className="flex gap-2">
-        <Input
-          placeholder="Filter Document No..."
-          value={filterDocumentNo}
-          onChange={(e) => setFilterDocumentNo(e.target.value)}
-          className="max-w-xs"
-        />
-        <Input
-          placeholder="Filter Business Partner..."
-          value={filterBusinessPartner}
-          onChange={(e) => setFilterBusinessPartner(e.target.value)}
-          className="max-w-xs"
-        />
-        <Input
-          placeholder="Filter Doc Status..."
-          value={filterDocStatus}
-          onChange={(e) => setFilterDocStatus(e.target.value)}
-          className="max-w-xs"
-        />
+      <div className="flex gap-2 flex-wrap">
+        <div className="relative">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Filter Document No..."
+            value={filterDocumentNo}
+            onChange={(e) => setFilterDocumentNo(e.target.value)}
+            className="pl-8 max-w-xs focus:ring-2 focus:ring-primary focus:outline-none transition-colors duration-200"
+            aria-label={"Filter by Document No"}
+          />
+        </div>
+        <div className="relative">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Filter Business Partner..."
+            value={filterBusinessPartner}
+            onChange={(e) => setFilterBusinessPartner(e.target.value)}
+            className="pl-8 max-w-xs focus:ring-2 focus:ring-primary focus:outline-none transition-colors duration-200"
+            aria-label={"Filter by Business Partner"}
+          />
+        </div>
+        <div className="relative">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Filter Doc Status..."
+            value={filterDocStatus}
+            onChange={(e) => setFilterDocStatus(e.target.value)}
+            className="pl-8 max-w-xs focus:ring-2 focus:ring-primary focus:outline-none transition-colors duration-200"
+            aria-label={"Filter by Doc Status"}
+          />
+        </div>
       </div>
-      <Table>
-        <TableHeader>
-          <TableRow className="border-b border-gray-100">
-            <TableHead className="text-xs font-medium text-gray-500 uppercase tracking-wider">Document No</TableHead>
-            <TableHead className="text-xs font-medium text-gray-500 uppercase tracking-wider">Business Partner</TableHead>
-            <TableHead className="text-xs font-medium text-gray-500 uppercase tracking-wider">Order Date</TableHead>
-            <TableHead className="text-xs font-medium text-gray-500 uppercase tracking-wider">Currency</TableHead>
-            <TableHead className="text-xs font-medium text-gray-500 uppercase tracking-wider">Total Lines</TableHead>
-            <TableHead className="text-xs font-medium text-gray-500 uppercase tracking-wider">Grand Total</TableHead>
-            <TableHead className="text-xs font-medium text-gray-500 uppercase tracking-wider">Doc Status</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody className="divide-y divide-gray-50">
-          {filteredData.map((row, idx) => (
-            <TableRow key={row.id ?? idx} onClick={() => onRowSelect?.(row)} className="cursor-pointer hover:bg-gray-50 transition-colors">
+      <div className="rounded-lg border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="border-b-2 border-primary/20 bg-muted/40">
+            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Document No</TableHead>
+            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Business Partner</TableHead>
+            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Order Date</TableHead>
+            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Currency</TableHead>
+            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Total Lines</TableHead>
+            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Grand Total</TableHead>
+            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">Doc Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredData.map((row, idx) => (
+              <TableRow
+                key={row.id ?? idx}
+                onClick={() => onRowSelect?.(row)}
+                className={[
+                  'cursor-pointer transition-colors',
+                  row.id === selectedId ? 'bg-primary/10 border-l-2 border-l-primary' : '',
+                  idx % 2 !== 0 && row.id !== selectedId ? 'bg-muted/30' : '',
+                  'hover:bg-primary/5',
+                ].filter(Boolean).join(' ')}
+              >
             <TableCell>{row.documentNo}</TableCell>
             <TableCell>{row.businessPartner}</TableCell>
             <TableCell>{row.orderDate}</TableCell>
@@ -59,10 +82,12 @@ export default function OrderTable({ data = [], onRowSelect }) {
             <TableCell className="tabular-nums">{row.totalLines?.toLocaleString()}</TableCell>
             <TableCell className="tabular-nums">{row.grandTotal?.toLocaleString()}</TableCell>
             <TableCell><StatusBadge status={row.docStatus} /></TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <p className="text-xs text-muted-foreground">{filteredData.length} of {data.length} records</p>
     </div>
   );
 }

--- a/artifacts/sales-order/generated/web/sales-order/index.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/index.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import OrderPage from './OrderPage';
 
 export default function App({ token, apiBaseUrl, window }) {

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -194,7 +194,7 @@ export function generateFormComponent(entityName, contract) {
 export default function ${compName}({ data, onChange, onSave, onDelete, onProcess }) {
   return (
     <form onSubmit={(e) => { e.preventDefault(); onSave?.(data); }} className="space-y-4">
-      <div className="space-y-3 rounded-lg border p-4 bg-muted/20">
+      <div className="grid grid-cols-2 gap-3 rounded-lg border p-4 bg-muted/20">
 ${editableElements}
       </div>${readOnlySection}
       <div className="flex items-center gap-2 pt-2">
@@ -208,8 +208,8 @@ ${editableElements}
 }
 
 /**
- * Generate a header-detail page component with SlidePanel.
- * Features: loading state, selected row tracking, record count subtitle.
+ * Generate a header-detail page component with Split View layout.
+ * Features: table on left (40%), form+detail on right (60%), loading state, selected row tracking.
  */
 export function generatePageComponent(headerEntity, detailEntity, contract) {
   const headerName = capitalize(headerEntity);
@@ -219,7 +219,6 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
   return `import React from 'react';
 import { Separator } from '@/components/ui/separator';
 import { Button } from '@/components/ui/button';
-import { SlidePanel } from '@/components/ui/slide-panel';
 import { useEntity } from '@/hooks/useEntity';
 import ${headerName}Table from './${headerName}Table';
 import ${headerName}Form from './${headerName}Form';
@@ -228,58 +227,72 @@ import ${detailName}Table from './${detailName}Table';
 export default function ${compName}({ token, apiBaseUrl }) {
   const ${headerEntity} = useEntity('${headerEntity}', '${detailEntity}', { token, apiBaseUrl });
 
-  const panelTitle = ${headerEntity}.editing?.id
+  const detailTitle = ${headerEntity}.editing?.id
     ? \`${toLabel(headerEntity)} \${${headerEntity}.editing.documentNo || ${headerEntity}.editing.id}\`
     : 'New ${toLabel(headerEntity)}';
 
-  const handleClose = () => {
-    ${headerEntity}.handleSelect(null);
-  };
-
   return (
-    <div>
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h2 className="text-xl font-semibold text-foreground">${toLabel(headerEntity)}s</h2>
-          <p className="text-sm text-muted-foreground mt-0.5">
-            {${headerEntity}.loading ? 'Loading...' : \`\${${headerEntity}.items.length} records\`}
-          </p>
+    <div className="flex h-[calc(100vh-4rem)] gap-0">
+      {/* Left panel: Table */}
+      <div className={\`flex flex-col border-r transition-all duration-300 \${${headerEntity}.editing ? 'w-2/5' : 'w-full'}\`}>
+        <div className="flex items-center justify-between px-4 py-3 border-b bg-muted/20">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">${toLabel(headerEntity)}s</h2>
+            <p className="text-xs text-muted-foreground">
+              {${headerEntity}.loading ? 'Loading...' : \`\${${headerEntity}.items.length} records\`}
+            </p>
+          </div>
+          <Button onClick={${headerEntity}.handleNew} size="sm">+ New</Button>
         </div>
-        <Button onClick={${headerEntity}.handleNew} size="sm">+ New ${toLabel(headerEntity)}</Button>
+        <div className="flex-1 overflow-auto p-3">
+          {${headerEntity}.loading ? (
+            <div className="animate-pulse space-y-3">
+              <div className="h-10 bg-muted rounded" />
+              <div className="h-8 bg-muted/60 rounded" />
+              <div className="h-8 bg-muted/40 rounded" />
+              <div className="h-8 bg-muted/60 rounded" />
+              <div className="h-8 bg-muted/40 rounded" />
+            </div>
+          ) : (
+            <${headerName}Table
+              data={${headerEntity}.items}
+              onRowSelect={${headerEntity}.handleSelect}
+              selectedId={${headerEntity}.selected?.id}
+              compact={!!${headerEntity}.editing}
+            />
+          )}
+        </div>
       </div>
-      {${headerEntity}.loading ? (
-        <div className="flex items-center justify-center py-20 text-muted-foreground">
-          <div className="animate-pulse space-y-3 w-full">
-            <div className="h-10 bg-muted rounded" />
-            <div className="h-8 bg-muted/60 rounded" />
-            <div className="h-8 bg-muted/40 rounded" />
-            <div className="h-8 bg-muted/60 rounded" />
-            <div className="h-8 bg-muted/40 rounded" />
+
+      {/* Right panel: Form + Detail */}
+      {${headerEntity}.editing && (
+        <div className="flex-1 flex flex-col overflow-hidden">
+          <div className="flex items-center justify-between px-5 py-3 border-b bg-muted/20">
+            <h2 className="text-lg font-semibold text-foreground">{detailTitle}</h2>
+            <button
+              onClick={() => ${headerEntity}.handleSelect(null)}
+              className="h-8 w-8 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+              aria-label="Close detail"
+            >
+              &times;
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto px-5 py-4 space-y-6">
+            <${headerName}Form
+              data={${headerEntity}.editing}
+              onChange={${headerEntity}.handleChange}
+              onSave={${headerEntity}.handleSave}
+              onDelete={${headerEntity}.selected ? ${headerEntity}.handleDelete : undefined}
+              onProcess={${headerEntity}.handleProcess}
+            />
+            <Separator />
+            <div>
+              <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider mb-3">${toLabel(detailEntity)}s</h3>
+              <${detailName}Table data={${headerEntity}.children} />
+            </div>
           </div>
         </div>
-      ) : (
-        <${headerName}Table
-          data={${headerEntity}.items}
-          onRowSelect={${headerEntity}.handleSelect}
-          selectedId={${headerEntity}.selected?.id}
-        />
       )}
-      <SlidePanel
-        open={!!${headerEntity}.editing}
-        onClose={handleClose}
-        title={panelTitle}
-      >
-        <${headerName}Form
-          data={${headerEntity}.editing}
-          onChange={${headerEntity}.handleChange}
-          onSave={${headerEntity}.handleSave}
-          onDelete={${headerEntity}.selected ? ${headerEntity}.handleDelete : undefined}
-          onProcess={${headerEntity}.handleProcess}
-        />
-        <Separator className="my-6" />
-        <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider mb-3">${toLabel(detailEntity)}s</h3>
-        <${detailName}Table data={${headerEntity}.children} />
-      </SlidePanel>
     </div>
   );
 }

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -197,6 +197,10 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
   const processes = getProcessesForEntity(contract, headerEntity);
   const readOnlyFields = getReadOnlyFields(contract, headerEntity);
 
+  // Detail entity editable fields for the add-line mini form
+  const detailFields = contract.frontendContract.entities[detailEntity]?.fields ?? [];
+  const detailEditableFields = detailFields.filter(f => f.form && f.visibility !== 'readOnly');
+
   // Status field gets a badge in the header; others go in the summary strip
   const statusField = readOnlyFields.find(f => f.name.toLowerCase().includes('status'));
   const summaryFields = readOnlyFields.filter(f => f !== statusField);
@@ -230,7 +234,26 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
     ? `\n            <StatusBadge status={${headerEntity}.editing?.${statusField.name}} />`
     : '';
 
-  return `import React from 'react';
+  // Build mini form field inputs
+  const miniFormFields = detailEditableFields.map(f => {
+    const label = toLabel(f.name);
+    const inputType = f.tsType === 'number' ? 'number' : 'text';
+    return `              <div className="flex-1 min-w-0">
+                <label className="text-xs text-slate-500 mb-1 block">${label}${f.required ? ' *' : ''}</label>
+                <input
+                  name="${f.name}"
+                  type="${inputType}"
+                  placeholder="${label}"
+                  value={newLine.${f.name} ?? ''}
+                  onChange={(e) => setNewLine(prev => ({ ...prev, ${f.name}: e.target.value }))}
+                  className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"${f.required ? '\n                  required' : ''}
+                />
+              </div>`;
+  }).join('\n');
+
+  const emptyLineObj = `{ ${detailEditableFields.map(f => `${f.name}: ''`).join(', ')} }`;
+
+  return `import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { useEntity } from '@/hooks/useEntity';${statusBadgeImport}
 import ${headerName}Table from './${headerName}Table';
@@ -240,9 +263,18 @@ import ${detailName}Table from './${detailName}Table';
 export default function ${compName}({ token, apiBaseUrl }) {
   const ${headerEntity} = useEntity('${headerEntity}', '${detailEntity}', { token, apiBaseUrl });
 
+  const [showAddLine, setShowAddLine] = useState(false);
+  const [newLine, setNewLine] = useState(${emptyLineObj});
+
   const detailTitle = ${headerEntity}.editing?.id
     ? \`${toLabel(headerEntity)} \${${headerEntity}.editing.documentNo || ${headerEntity}.editing.id}\`
     : 'New ${toLabel(headerEntity)}';
+
+  const handleAddLine = () => {
+    ${headerEntity}.handleAddChild?.(newLine);
+    setNewLine(${emptyLineObj});
+    setShowAddLine(false);
+  };
 
   return (
     <div className="flex h-[calc(100vh-4rem)] gap-0">
@@ -314,7 +346,26 @@ ${summaryItems}
 
           {/* Detail zone: fills remaining height */}
           <div className="flex-1 flex flex-col overflow-hidden px-5 py-3">
-            <h3 className="text-xs font-bold text-slate-500 uppercase tracking-widest mb-3">${toLabel(detailEntity)}s</h3>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-xs font-bold text-slate-500 uppercase tracking-widest">${toLabel(detailEntity)}s</h3>
+              <Button
+                variant="outline"
+                size="sm"
+                className="text-xs h-7"
+                onClick={() => setShowAddLine(!showAddLine)}
+              >
+                {showAddLine ? 'Cancel' : '+ Add Line'}
+              </Button>
+            </div>
+            {showAddLine && (
+              <form
+                onSubmit={(e) => { e.preventDefault(); handleAddLine(); }}
+                className="flex items-end gap-2 mb-3 p-3 rounded-lg border border-dashed border-primary/30 bg-primary/5"
+              >
+${miniFormFields}
+                <Button type="submit" size="sm" className="h-8 shrink-0">Add</Button>
+              </form>
+            )}
             <div className="flex-1 overflow-auto">
               <${detailName}Table data={${headerEntity}.children} />
             </div>

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -29,8 +29,7 @@ export function getProcessesForEntity(contract, entityName) {
 
 /**
  * Generate a data table component for an entity.
- * Renders grid:true fields as columns, searchableFields as filter inputs.
- * Uses StatusBadge for status fields and clean Holded-style styling.
+ * Features: search filters with icons, zebra rows, selected row highlight, record count.
  */
 export function generateTableComponent(entityName, contract) {
   const entity = contract.frontendContract.entities[entityName];
@@ -44,6 +43,7 @@ export function generateTableComponent(entityName, contract) {
     `import React, { useState } from 'react';`,
     `import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';`,
     `import { Input } from '@/components/ui/input';`,
+    `import { Search } from 'lucide-react';`,
   ];
   if (hasStatusField) {
     imports.push(`import { StatusBadge } from '@/components/ui/status-badge';`);
@@ -54,16 +54,20 @@ export function generateTableComponent(entityName, contract) {
     .join('\n');
 
   const filterInputs = searchableFields
-    .map(f => `        <Input
-          placeholder="Filter ${toLabel(f)}..."
-          value={filter${capitalize(f)}}
-          onChange={(e) => setFilter${capitalize(f)}(e.target.value)}
-          className="max-w-xs"
-        />`)
+    .map(f => `        <div className="relative">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Filter ${toLabel(f)}..."
+            value={filter${capitalize(f)}}
+            onChange={(e) => setFilter${capitalize(f)}(e.target.value)}
+            className="pl-8 max-w-xs focus:ring-2 focus:ring-primary focus:outline-none transition-colors duration-200"
+            aria-label={"Filter by ${toLabel(f)}"}
+          />
+        </div>`)
     .join('\n');
 
   const headerCells = gridFields
-    .map(f => `            <TableHead className="text-xs font-medium text-gray-500 uppercase tracking-wider">${toLabel(f.name)}</TableHead>`)
+    .map(f => `            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">${toLabel(f.name)}</TableHead>`)
     .join('\n');
 
   const bodyCells = gridFields
@@ -80,7 +84,7 @@ export function generateTableComponent(entityName, contract) {
 
   return `${imports.join('\n')}
 
-export default function ${compName}({ data = [], onRowSelect }) {
+export default function ${compName}({ data = [], onRowSelect, selectedId }) {
 ${filterState}
 
   const filteredData = data.filter(row => {
@@ -90,23 +94,35 @@ ${searchableFields.map(f => `    if (filter${capitalize(f)} && !String(row.${f} 
 
   return (
     <div className="space-y-4">
-      <div className="flex gap-2">
+      <div className="flex gap-2 flex-wrap">
 ${filterInputs}
       </div>
-      <Table>
-        <TableHeader>
-          <TableRow className="border-b border-gray-100">
+      <div className="rounded-lg border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="border-b-2 border-primary/20 bg-muted/40">
 ${headerCells}
-          </TableRow>
-        </TableHeader>
-        <TableBody className="divide-y divide-gray-50">
-          {filteredData.map((row, idx) => (
-            <TableRow key={row.id ?? idx} onClick={() => onRowSelect?.(row)} className="cursor-pointer hover:bg-gray-50 transition-colors">
-${bodyCells}
             </TableRow>
-          ))}
-        </TableBody>
-      </Table>
+          </TableHeader>
+          <TableBody>
+            {filteredData.map((row, idx) => (
+              <TableRow
+                key={row.id ?? idx}
+                onClick={() => onRowSelect?.(row)}
+                className={[
+                  'cursor-pointer transition-colors',
+                  row.id === selectedId ? 'bg-primary/10 border-l-2 border-l-primary' : '',
+                  idx % 2 !== 0 && row.id !== selectedId ? 'bg-muted/30' : '',
+                  'hover:bg-primary/5',
+                ].filter(Boolean).join(' ')}
+              >
+${bodyCells}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <p className="text-xs text-muted-foreground">{filteredData.length} of {data.length} records</p>
     </div>
   );
 }
@@ -115,14 +131,16 @@ ${bodyCells}
 
 /**
  * Generate a detail/edit form component for an entity.
- * Renders form:true fields in single-column layout for panel width.
- * Includes Save/Delete buttons and process action buttons.
+ * Features: grouped fields (editable vs readOnly), distinct disabled styling, separated process actions.
  */
 export function generateFormComponent(entityName, contract) {
   const entity = contract.frontendContract.entities[entityName];
   const formFields = entity.fields.filter(f => f.form);
   const processes = getProcessesForEntity(contract, entityName);
   const compName = `${capitalize(entityName)}Form`;
+
+  const editableFields = formFields.filter(f => f.visibility !== 'readOnly');
+  const readOnlyFields = formFields.filter(f => f.visibility === 'readOnly');
 
   const imports = [
     `import React from 'react';`,
@@ -132,15 +150,17 @@ export function generateFormComponent(entityName, contract) {
     `import { Separator } from '@/components/ui/separator';`,
   ];
 
-  const fieldElements = formFields.map(f => {
+  function renderField(f) {
     const label = toLabel(f.name);
     const isReadOnly = f.visibility === 'readOnly';
     const inputType = f.tsType === 'number' ? 'number' : 'text';
-    const disabledAttr = isReadOnly ? ' disabled readOnly className="bg-gray-50 text-gray-500"' : '';
+    const disabledAttr = isReadOnly
+      ? ' disabled readOnly className="bg-muted/50 text-muted-foreground border-dashed cursor-not-allowed"'
+      : ' className="focus:ring-2 focus:ring-primary focus:outline-none"';
     const requiredAttr = f.required ? ' required' : '';
 
     return `        <div className="space-y-1.5">
-          <Label htmlFor="${f.name}" className="text-sm text-gray-600">${label}${f.required ? ' *' : ''}</Label>
+          <Label htmlFor="${f.name}" className="text-sm ${isReadOnly ? 'text-muted-foreground' : 'text-foreground font-medium'}">${label}${f.required ? ' *' : ''}</Label>
           <Input
             id="${f.name}"
             name="${f.name}"
@@ -149,31 +169,37 @@ export function generateFormComponent(entityName, contract) {
             onChange={(e) => onChange?.('${f.name}', e.target.value)}${disabledAttr}${requiredAttr}
           />
         </div>`;
-  }).join('\n');
+  }
+
+  const editableElements = editableFields.map(renderField).join('\n');
+  const readOnlyElements = readOnlyFields.map(renderField).join('\n');
+
+  const readOnlySection = readOnlyFields.length > 0
+    ? `\n      <div className="space-y-3 rounded-lg border border-dashed p-4 bg-muted/10">\n        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">System Fields</p>\n${readOnlyElements}\n      </div>`
+    : '';
 
   const processButtons = processes.map(p => {
     const label = toLabel(p.name);
-    return `          <Button variant="outline" size="sm" onClick={() => onProcess?.('${p.name}')}>
+    return `          <Button variant="secondary" size="sm" onClick={() => onProcess?.('${p.name}')}>
             ${label}
           </Button>`;
   }).join('\n');
 
   const processSection = processes.length > 0
-    ? `\n      <Separator className="my-4" />\n      <div className="flex gap-2">\n${processButtons}\n      </div>`
+    ? `\n      <div className="rounded-lg border p-4 bg-muted/10 space-y-2">\n        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Actions</p>\n        <div className="flex gap-2">\n${processButtons}\n        </div>\n      </div>`
     : '';
 
   return `${imports.join('\n')}
 
 export default function ${compName}({ data, onChange, onSave, onDelete, onProcess }) {
   return (
-    <form onSubmit={(e) => { e.preventDefault(); onSave?.(data); }} className="space-y-3">
-      <div className="space-y-3">
-${fieldElements}
-      </div>
-      <Separator className="my-4" />
-      <div className="flex gap-2">
+    <form onSubmit={(e) => { e.preventDefault(); onSave?.(data); }} className="space-y-4">
+      <div className="space-y-3 rounded-lg border p-4 bg-muted/20">
+${editableElements}
+      </div>${readOnlySection}
+      <div className="flex items-center gap-2 pt-2">
         <Button type="submit" size="sm">Save</Button>
-        {onDelete && <Button variant="outline" size="sm" onClick={(e) => { e.preventDefault(); onDelete(); }}>Delete</Button>}
+        {onDelete && <Button variant="destructive" size="sm" onClick={(e) => { e.preventDefault(); onDelete(); }}>Delete</Button>}
       </div>${processSection}
     </form>
   );
@@ -183,8 +209,7 @@ ${fieldElements}
 
 /**
  * Generate a header-detail page component with SlidePanel.
- * Shows header table with New button. Form and detail table open in a slide panel.
- * Uses useEntity hook for state management and API calls.
+ * Features: loading state, selected row tracking, record count subtitle.
  */
 export function generatePageComponent(headerEntity, detailEntity, contract) {
   const headerName = capitalize(headerEntity);
@@ -212,12 +237,33 @@ export default function ${compName}({ token, apiBaseUrl }) {
   };
 
   return (
-    <div className="p-6">
+    <div>
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-xl font-semibold text-gray-900">${toLabel(headerEntity)}s</h2>
-        <Button onClick={${headerEntity}.handleNew}>New</Button>
+        <div>
+          <h2 className="text-xl font-semibold text-foreground">${toLabel(headerEntity)}s</h2>
+          <p className="text-sm text-muted-foreground mt-0.5">
+            {${headerEntity}.loading ? 'Loading...' : \`\${${headerEntity}.items.length} records\`}
+          </p>
+        </div>
+        <Button onClick={${headerEntity}.handleNew} size="sm">+ New ${toLabel(headerEntity)}</Button>
       </div>
-      <${headerName}Table data={${headerEntity}.items} onRowSelect={${headerEntity}.handleSelect} />
+      {${headerEntity}.loading ? (
+        <div className="flex items-center justify-center py-20 text-muted-foreground">
+          <div className="animate-pulse space-y-3 w-full">
+            <div className="h-10 bg-muted rounded" />
+            <div className="h-8 bg-muted/60 rounded" />
+            <div className="h-8 bg-muted/40 rounded" />
+            <div className="h-8 bg-muted/60 rounded" />
+            <div className="h-8 bg-muted/40 rounded" />
+          </div>
+        </div>
+      ) : (
+        <${headerName}Table
+          data={${headerEntity}.items}
+          onRowSelect={${headerEntity}.handleSelect}
+          selectedId={${headerEntity}.selected?.id}
+        />
+      )}
       <SlidePanel
         open={!!${headerEntity}.editing}
         onClose={handleClose}
@@ -231,7 +277,7 @@ export default function ${compName}({ token, apiBaseUrl }) {
           onProcess={${headerEntity}.handleProcess}
         />
         <Separator className="my-6" />
-        <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wider mb-3">${toLabel(detailEntity)}s</h3>
+        <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider mb-3">${toLabel(detailEntity)}s</h3>
         <${detailName}Table data={${headerEntity}.children} />
       </SlidePanel>
     </div>

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -131,95 +131,108 @@ ${bodyCells}
 
 /**
  * Generate a detail/edit form component for an entity.
- * Features: grouped fields (editable vs readOnly), distinct disabled styling, separated process actions.
+ * Only renders editable fields in a 2-column grid.
+ * Read-only fields and process actions are handled by the page component.
  */
 export function generateFormComponent(entityName, contract) {
   const entity = contract.frontendContract.entities[entityName];
   const formFields = entity.fields.filter(f => f.form);
-  const processes = getProcessesForEntity(contract, entityName);
   const compName = `${capitalize(entityName)}Form`;
 
   const editableFields = formFields.filter(f => f.visibility !== 'readOnly');
-  const readOnlyFields = formFields.filter(f => f.visibility === 'readOnly');
 
   const imports = [
     `import React from 'react';`,
     `import { Input } from '@/components/ui/input';`,
     `import { Label } from '@/components/ui/label';`,
-    `import { Button } from '@/components/ui/button';`,
-    `import { Separator } from '@/components/ui/separator';`,
   ];
 
   function renderField(f) {
     const label = toLabel(f.name);
-    const isReadOnly = f.visibility === 'readOnly';
     const inputType = f.tsType === 'number' ? 'number' : 'text';
-    const disabledAttr = isReadOnly
-      ? ' disabled readOnly className="bg-muted/50 text-muted-foreground border-dashed cursor-not-allowed"'
-      : ' className="focus:ring-2 focus:ring-primary focus:outline-none"';
     const requiredAttr = f.required ? ' required' : '';
 
     return `        <div className="space-y-1.5">
-          <Label htmlFor="${f.name}" className="text-sm ${isReadOnly ? 'text-muted-foreground' : 'text-foreground font-medium'}">${label}${f.required ? ' *' : ''}</Label>
+          <Label htmlFor="${f.name}" className="text-sm text-foreground font-medium">${label}${f.required ? ' *' : ''}</Label>
           <Input
             id="${f.name}"
             name="${f.name}"
             type="${inputType}"
             value={data?.${f.name} ?? ''}
-            onChange={(e) => onChange?.('${f.name}', e.target.value)}${disabledAttr}${requiredAttr}
+            onChange={(e) => onChange?.('${f.name}', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"${requiredAttr}
           />
         </div>`;
   }
 
   const editableElements = editableFields.map(renderField).join('\n');
-  const readOnlyElements = readOnlyFields.map(renderField).join('\n');
-
-  const readOnlySection = readOnlyFields.length > 0
-    ? `\n      <div className="space-y-3 rounded-lg border border-dashed p-4 bg-muted/10">\n        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">System Fields</p>\n${readOnlyElements}\n      </div>`
-    : '';
-
-  const processButtons = processes.map(p => {
-    const label = toLabel(p.name);
-    return `          <Button variant="secondary" size="sm" onClick={() => onProcess?.('${p.name}')}>
-            ${label}
-          </Button>`;
-  }).join('\n');
-
-  const processSection = processes.length > 0
-    ? `\n      <div className="rounded-lg border p-4 bg-muted/10 space-y-2">\n        <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Actions</p>\n        <div className="flex gap-2">\n${processButtons}\n        </div>\n      </div>`
-    : '';
 
   return `${imports.join('\n')}
 
-export default function ${compName}({ data, onChange, onSave, onDelete, onProcess }) {
+export default function ${compName}({ data, onChange }) {
   return (
-    <form onSubmit={(e) => { e.preventDefault(); onSave?.(data); }} className="space-y-4">
-      <div className="grid grid-cols-2 gap-3 rounded-lg border p-4 bg-muted/20">
+    <div className="grid grid-cols-2 gap-3">
 ${editableElements}
-      </div>${readOnlySection}
-      <div className="flex items-center gap-2 pt-2">
-        <Button type="submit" size="sm">Save</Button>
-        {onDelete && <Button variant="destructive" size="sm" onClick={(e) => { e.preventDefault(); onDelete(); }}>Delete</Button>}
-      </div>${processSection}
-    </form>
+    </div>
   );
 }
 `;
 }
 
 /**
+ * Get the read-only fields for an entity (used by page component for summary strip).
+ */
+export function getReadOnlyFields(contract, entityName) {
+  const entity = contract.frontendContract.entities[entityName];
+  return entity.fields.filter(f => f.form && f.visibility === 'readOnly');
+}
+
+/**
  * Generate a header-detail page component with Split View layout.
- * Features: table on left (40%), form+detail on right (60%), loading state, selected row tracking.
+ * Features: table left (40%), detail right (60%) with toolbar, summary strip, form, and lines.
  */
 export function generatePageComponent(headerEntity, detailEntity, contract) {
   const headerName = capitalize(headerEntity);
   const detailName = capitalize(detailEntity);
   const compName = `${headerName}Page`;
+  const processes = getProcessesForEntity(contract, headerEntity);
+  const readOnlyFields = getReadOnlyFields(contract, headerEntity);
+
+  // Status field gets a badge in the header; others go in the summary strip
+  const statusField = readOnlyFields.find(f => f.name.toLowerCase().includes('status'));
+  const summaryFields = readOnlyFields.filter(f => f !== statusField);
+
+  const summaryItems = summaryFields.map(f => {
+    const label = toLabel(f.name);
+    const isNumber = f.tsType === 'number';
+    const valueExpr = isNumber
+      ? `${headerEntity}.editing?.${f.name}?.toLocaleString() ?? '—'`
+      : `${headerEntity}.editing?.${f.name} ?? '—'`;
+    return `            <div className="flex items-center gap-1.5">\n              <span className="text-slate-500">${label}:</span>\n              <span className="font-semibold text-foreground ${isNumber ? 'tabular-nums' : ''}">{${valueExpr}}</span>\n            </div>`;
+  }).join('\n');
+
+  const processButtons = processes.map(p => {
+    const label = toLabel(p.name);
+    const isDestructive = p.name.toLowerCase().includes('void') || p.name.toLowerCase().includes('cancel') || p.name.toLowerCase().includes('reject');
+    const btnClass = isDestructive
+      ? 'border-amber-300 bg-amber-50 text-amber-700 hover:bg-amber-100'
+      : 'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100';
+    return `            <Button variant="outline" size="sm" className="${btnClass}" onClick={() => ${headerEntity}.handleProcess?.('${p.name}')}>${label}</Button>`;
+  }).join('\n');
+
+  const processSection = processes.length > 0
+    ? `\n            <div className="h-5 w-px bg-border" />\n${processButtons}`
+    : '';
+
+  const statusBadgeImport = statusField
+    ? `\nimport { StatusBadge } from '@/components/ui/status-badge';`
+    : '';
+  const statusBadgeInHeader = statusField
+    ? `\n            <StatusBadge status={${headerEntity}.editing?.${statusField.name}} />`
+    : '';
 
   return `import React from 'react';
-import { Separator } from '@/components/ui/separator';
 import { Button } from '@/components/ui/button';
-import { useEntity } from '@/hooks/useEntity';
+import { useEntity } from '@/hooks/useEntity';${statusBadgeImport}
 import ${headerName}Table from './${headerName}Table';
 import ${headerName}Form from './${headerName}Form';
 import ${detailName}Table from './${detailName}Table';
@@ -264,30 +277,45 @@ export default function ${compName}({ token, apiBaseUrl }) {
         </div>
       </div>
 
-      {/* Right panel: Form + Detail */}
+      {/* Right panel: Toolbar + Summary + Form + Detail */}
       {${headerEntity}.editing && (
-        <div className="flex-1 flex flex-col overflow-hidden">
-          <div className="flex items-center justify-between px-5 py-3 border-b bg-muted/20">
-            <h2 className="text-lg font-semibold text-foreground">{detailTitle}</h2>
-            <button
-              onClick={() => ${headerEntity}.handleSelect(null)}
-              className="h-8 w-8 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-              aria-label="Close detail"
-            >
-              &times;
-            </button>
+        <div className="flex-1 flex flex-col overflow-hidden bg-white">
+          {/* Toolbar: title, status, process actions, save/delete */}
+          <div className="flex items-center gap-2 px-5 py-2.5 border-b border-slate-200 bg-white shadow-sm">
+            <h2 className="text-base font-semibold text-foreground truncate">{detailTitle}</h2>${statusBadgeInHeader}
+            <div className="flex-1" />
+            <div className="flex items-center gap-2">${processSection}
+              <Button size="sm" onClick={() => ${headerEntity}.handleSave(${headerEntity}.editing)}>Save</Button>
+              {${headerEntity}.selected && (
+                <Button variant="destructive" size="sm" onClick={${headerEntity}.handleDelete}>Delete</Button>
+              )}
+              <button
+                onClick={() => ${headerEntity}.handleSelect(null)}
+                className="h-8 w-8 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                aria-label="Close detail"
+              >
+                &times;
+              </button>
+            </div>
           </div>
-          <div className="flex-1 overflow-y-auto px-5 py-4 space-y-6">
+
+          {/* Summary strip: read-only reference fields */}
+          <div className="flex items-center gap-5 px-5 py-2.5 border-b border-slate-200 bg-slate-50 text-xs">
+${summaryItems}
+          </div>
+
+          {/* Form zone: editable fields only */}
+          <div className="px-5 pt-4 pb-3 border-b">
             <${headerName}Form
               data={${headerEntity}.editing}
               onChange={${headerEntity}.handleChange}
-              onSave={${headerEntity}.handleSave}
-              onDelete={${headerEntity}.selected ? ${headerEntity}.handleDelete : undefined}
-              onProcess={${headerEntity}.handleProcess}
             />
-            <Separator />
-            <div>
-              <h3 className="text-sm font-semibold text-foreground uppercase tracking-wider mb-3">${toLabel(detailEntity)}s</h3>
+          </div>
+
+          {/* Detail zone: fills remaining height */}
+          <div className="flex-1 flex flex-col overflow-hidden px-5 py-3">
+            <h3 className="text-xs font-bold text-slate-500 uppercase tracking-widest mb-3">${toLabel(detailEntity)}s</h3>
+            <div className="flex-1 overflow-auto">
               <${detailName}Table data={${headerEntity}.children} />
             </div>
           </div>

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -234,10 +234,22 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
     ? `\n            <StatusBadge status={${headerEntity}.editing?.${statusField.name}} />`
     : '';
 
-  // Build mini form field inputs
-  const miniFormFields = detailEditableFields.map(f => {
+  // Separate entry fields (user types) from auto-derived fields (price, tax, discount, amount)
+  const autoPatterns = /price|tax|discount|amount|total|cost|net/i;
+  const entryFields = detailEditableFields.filter(f => !autoPatterns.test(f.name));
+  const derivedFields = detailEditableFields.filter(f => autoPatterns.test(f.name));
+
+  // The first entry field (usually product) triggers a lookup on blur
+  const lookupTriggerField = entryFields[0];
+
+  // Build entry field inputs (user types these)
+  const entryInputs = entryFields.map(f => {
     const label = toLabel(f.name);
     const inputType = f.tsType === 'number' ? 'number' : 'text';
+    const isLookupTrigger = f === lookupTriggerField;
+    const onBlurAttr = isLookupTrigger
+      ? `\n                  onBlur={(e) => { if (e.target.value) handleProductLookup(e.target.value); }}`
+      : '';
     return `              <div className="flex-1 min-w-0">
                 <label className="text-xs text-slate-500 mb-1 block">${label}${f.required ? ' *' : ''}</label>
                 <input
@@ -245,11 +257,26 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
                   type="${inputType}"
                   placeholder="${label}"
                   value={newLine.${f.name} ?? ''}
-                  onChange={(e) => setNewLine(prev => ({ ...prev, ${f.name}: e.target.value }))}
+                  onChange={(e) => setNewLine(prev => ({ ...prev, ${f.name}: e.target.value }))}${onBlurAttr}
                   className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"${f.required ? '\n                  required' : ''}
                 />
               </div>`;
   }).join('\n');
+
+  // Build derived field displays (auto-filled, read-only in mini form)
+  const derivedInputs = derivedFields.map(f => {
+    const label = toLabel(f.name);
+    return `              <div className="flex-1 min-w-0">
+                <label className="text-xs text-slate-400 mb-1 block">${label}</label>
+                <div className="h-8 text-sm rounded-md border border-dashed border-slate-200 bg-slate-50 px-2 flex items-center text-slate-600 tabular-nums">
+                  {newLine.${f.name} || '—'}
+                </div>
+              </div>`;
+  }).join('\n');
+
+  const miniFormFields = derivedFields.length > 0
+    ? `${entryInputs}\n              <div className="w-px h-8 bg-slate-200 self-end mb-0.5" />\n${derivedInputs}`
+    : entryInputs;
 
   const emptyLineObj = `{ ${detailEditableFields.map(f => `${f.name}: ''`).join(', ')} }`;
 
@@ -274,6 +301,13 @@ export default function ${compName}({ token, apiBaseUrl }) {
     ${headerEntity}.handleAddChild?.(newLine);
     setNewLine(${emptyLineObj});
     setShowAddLine(false);
+  };
+
+  const handleProductLookup = async (value) => {
+    const defaults = await ${headerEntity}.lookupChildDefaults?.(value);
+    if (defaults) {
+      setNewLine(prev => ({ ...prev, ...defaults }));
+    }
   };
 
   return (

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -28,157 +28,6 @@ export function getProcessesForEntity(contract, entityName) {
 }
 
 /**
- * Generate a data table component for an entity.
- * Features: search filters with icons, zebra rows, selected row highlight, record count.
- */
-export function generateTableComponent(entityName, contract) {
-  const entity = contract.frontendContract.entities[entityName];
-  const gridFields = entity.fields.filter(f => f.grid);
-  const searchableFields = entity.searchableFields ?? [];
-  const compName = `${capitalize(entityName)}Table`;
-
-  const hasStatusField = gridFields.some(f => f.name.toLowerCase().includes('status'));
-
-  const imports = [
-    `import React, { useState } from 'react';`,
-    `import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';`,
-    `import { Input } from '@/components/ui/input';`,
-    `import { Search } from 'lucide-react';`,
-  ];
-  if (hasStatusField) {
-    imports.push(`import { StatusBadge } from '@/components/ui/status-badge';`);
-  }
-
-  const filterState = searchableFields
-    .map(f => `  const [filter${capitalize(f)}, setFilter${capitalize(f)}] = useState('');`)
-    .join('\n');
-
-  const filterInputs = searchableFields
-    .map(f => `        <div className="relative">
-          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Filter ${toLabel(f)}..."
-            value={filter${capitalize(f)}}
-            onChange={(e) => setFilter${capitalize(f)}(e.target.value)}
-            className="pl-8 max-w-xs focus:ring-2 focus:ring-primary focus:outline-none transition-colors duration-200"
-            aria-label={"Filter by ${toLabel(f)}"}
-          />
-        </div>`)
-    .join('\n');
-
-  const headerCells = gridFields
-    .map(f => `            <TableHead className="text-xs font-medium text-blue-800 uppercase tracking-wider">${toLabel(f.name)}</TableHead>`)
-    .join('\n');
-
-  const bodyCells = gridFields
-    .map(f => {
-      if (f.name.toLowerCase().includes('status')) {
-        return `            <TableCell><StatusBadge status={row.${f.name}} /></TableCell>`;
-      }
-      if (f.type === 'amount') {
-        return `            <TableCell className="tabular-nums">{row.${f.name}?.toLocaleString()}</TableCell>`;
-      }
-      return `            <TableCell>{row.${f.name}}</TableCell>`;
-    })
-    .join('\n');
-
-  return `${imports.join('\n')}
-
-export default function ${compName}({ data = [], onRowSelect, selectedId }) {
-${filterState}
-
-  const filteredData = data.filter(row => {
-${searchableFields.map(f => `    if (filter${capitalize(f)} && !String(row.${f} ?? '').toLowerCase().includes(filter${capitalize(f)}.toLowerCase())) return false;`).join('\n')}
-    return true;
-  });
-
-  return (
-    <div className="space-y-4">
-      <div className="flex gap-2 flex-wrap">
-${filterInputs}
-      </div>
-      <div className="rounded-lg border overflow-hidden">
-        <Table>
-          <TableHeader>
-            <TableRow className="border-b-2 border-primary/20 bg-muted/40">
-${headerCells}
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {filteredData.map((row, idx) => (
-              <TableRow
-                key={row.id ?? idx}
-                onClick={() => onRowSelect?.(row)}
-                className={[
-                  'cursor-pointer transition-colors',
-                  row.id === selectedId ? 'bg-primary/10 border-l-2 border-l-primary' : '',
-                  idx % 2 !== 0 && row.id !== selectedId ? 'bg-muted/30' : '',
-                  'hover:bg-primary/5',
-                ].filter(Boolean).join(' ')}
-              >
-${bodyCells}
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </div>
-      <p className="text-xs text-muted-foreground">{filteredData.length} of {data.length} records</p>
-    </div>
-  );
-}
-`;
-}
-
-/**
- * Generate a detail/edit form component for an entity.
- * Only renders editable fields in a 2-column grid.
- * Read-only fields and process actions are handled by the page component.
- */
-export function generateFormComponent(entityName, contract) {
-  const entity = contract.frontendContract.entities[entityName];
-  const formFields = entity.fields.filter(f => f.form);
-  const compName = `${capitalize(entityName)}Form`;
-
-  const editableFields = formFields.filter(f => f.visibility !== 'readOnly');
-
-  const imports = [
-    `import React from 'react';`,
-    `import { Input } from '@/components/ui/input';`,
-    `import { Label } from '@/components/ui/label';`,
-  ];
-
-  function renderField(f) {
-    const label = toLabel(f.name);
-    const inputType = f.tsType === 'number' ? 'number' : 'text';
-    const requiredAttr = f.required ? ' required' : '';
-
-    return `        <div className="space-y-1.5">
-          <Label htmlFor="${f.name}" className="text-sm text-foreground font-medium">${label}${f.required ? ' *' : ''}</Label>
-          <Input
-            id="${f.name}"
-            name="${f.name}"
-            type="${inputType}"
-            value={data?.${f.name} ?? ''}
-            onChange={(e) => onChange?.('${f.name}', e.target.value)} className="focus:ring-2 focus:ring-primary focus:outline-none"${requiredAttr}
-          />
-        </div>`;
-  }
-
-  const editableElements = editableFields.map(renderField).join('\n');
-
-  return `${imports.join('\n')}
-
-export default function ${compName}({ data, onChange }) {
-  return (
-    <div className="grid grid-cols-2 gap-3">
-${editableElements}
-    </div>
-  );
-}
-`;
-}
-
-/**
  * Get the read-only fields for an entity (used by page component for summary strip).
  */
 export function getReadOnlyFields(contract, entityName) {
@@ -187,8 +36,88 @@ export function getReadOnlyFields(contract, entityName) {
 }
 
 /**
+ * Map a contract field type to a column/field type for the declarative config.
+ */
+function mapFieldType(field) {
+  if (field.name.toLowerCase().includes('status')) return 'status';
+  if (field.type === 'amount') return 'amount';
+  if (field.type === 'number' || field.type === 'integer') return 'number';
+  if (field.type === 'date') return 'date';
+  return 'string';
+}
+
+/**
+ * Map a contract field to a form field type.
+ */
+function mapFormFieldType(field) {
+  if (field.tsType === 'number') return 'number';
+  if (field.type === 'date') return 'date';
+  return 'text';
+}
+
+/**
+ * Generate a data table component for an entity.
+ * Produces a thin declarative component that imports DataTable from contract-ui.
+ */
+export function generateTableComponent(entityName, contract) {
+  const entity = contract.frontendContract.entities[entityName];
+  const gridFields = entity.fields.filter(f => f.grid);
+  const searchableFields = entity.searchableFields ?? [];
+  const compName = `${capitalize(entityName)}Table`;
+
+  const columnsArray = gridFields.map(f => {
+    const type = mapFieldType(f);
+    return `  { key: '${f.name}', label: '${toLabel(f.name)}', type: '${type}' },`;
+  }).join('\n');
+
+  const filtersArray = searchableFields.map(f => `'${f}'`).join(', ');
+
+  return `import { DataTable } from '@/components/contract-ui';
+
+const columns = [
+${columnsArray}
+];
+
+const filters = [${filtersArray}];
+
+export default function ${compName}(props) {
+  return <DataTable columns={columns} filters={filters} {...props} />;
+}
+`;
+}
+
+/**
+ * Generate a detail/edit form component for an entity.
+ * Produces a thin declarative component that imports EntityForm from contract-ui.
+ * Only renders editable fields (visibility !== 'readOnly').
+ */
+export function generateFormComponent(entityName, contract) {
+  const entity = contract.frontendContract.entities[entityName];
+  const formFields = entity.fields.filter(f => f.form);
+  const editableFields = formFields.filter(f => f.visibility !== 'readOnly');
+  const compName = `${capitalize(entityName)}Form`;
+
+  const fieldsArray = editableFields.map(f => {
+    const type = mapFormFieldType(f);
+    const requiredPart = f.required ? ', required: true' : '';
+    return `  { key: '${f.name}', label: '${toLabel(f.name)}', type: '${type}'${requiredPart} },`;
+  }).join('\n');
+
+  return `import { EntityForm } from '@/components/contract-ui';
+
+const fields = [
+${fieldsArray}
+];
+
+export default function ${compName}(props) {
+  return <EntityForm fields={fields} {...props} />;
+}
+`;
+}
+
+/**
  * Generate a header-detail page component with Split View layout.
- * Features: table left (40%), detail right (60%) with toolbar, summary strip, form, and lines.
+ * Produces a thin declarative component that imports MasterDetailPage from contract-ui.
  */
 export function generatePageComponent(headerEntity, detailEntity, contract) {
   const headerName = capitalize(headerEntity);
@@ -205,208 +134,80 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
   const statusField = readOnlyFields.find(f => f.name.toLowerCase().includes('status'));
   const summaryFields = readOnlyFields.filter(f => f !== statusField);
 
-  const summaryItems = summaryFields.map(f => {
-    const label = toLabel(f.name);
-    const isNumber = f.tsType === 'number';
-    const valueExpr = isNumber
-      ? `${headerEntity}.editing?.${f.name}?.toLocaleString() ?? '—'`
-      : `${headerEntity}.editing?.${f.name} ?? '—'`;
-    return `            <div className="flex items-center gap-1.5">\n              <span className="text-slate-500">${label}:</span>\n              <span className="font-semibold text-foreground ${isNumber ? 'tabular-nums' : ''}">{${valueExpr}}</span>\n            </div>`;
+  // Summary config
+  const summaryArray = summaryFields.map(f => {
+    const type = mapFieldType(f);
+    return `  { key: '${f.name}', label: '${toLabel(f.name)}', type: '${type}' },`;
   }).join('\n');
 
-  const processButtons = processes.map(p => {
-    const label = toLabel(p.name);
-    const isDestructive = p.name.toLowerCase().includes('void') || p.name.toLowerCase().includes('cancel') || p.name.toLowerCase().includes('reject');
-    const btnClass = isDestructive
-      ? 'border-amber-300 bg-amber-50 text-amber-700 hover:bg-amber-100'
-      : 'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100';
-    return `            <Button variant="outline" size="sm" className="${btnClass}" onClick={() => ${headerEntity}.handleProcess?.('${p.name}')}>${label}</Button>`;
+  // Status field config
+  const statusFieldLine = statusField ? `'${statusField.name}'` : 'null';
+
+  // Process config
+  const processesArray = processes.map(p => {
+    const isDestructive = /void|cancel|reject/i.test(p.name);
+    const style = isDestructive ? 'destructive' : 'positive';
+    return `  { name: '${p.name}', label: '${toLabel(p.name)}', style: '${style}' },`;
   }).join('\n');
-
-  const processSection = processes.length > 0
-    ? `\n            <div className="h-5 w-px bg-border" />\n${processButtons}`
-    : '';
-
-  const statusBadgeImport = statusField
-    ? `\nimport { StatusBadge } from '@/components/ui/status-badge';`
-    : '';
-  const statusBadgeInHeader = statusField
-    ? `\n            <StatusBadge status={${headerEntity}.editing?.${statusField.name}} />`
-    : '';
 
   // Separate entry fields (user types) from auto-derived fields (price, tax, discount, amount)
   const autoPatterns = /price|tax|discount|amount|total|cost|net/i;
   const entryFields = detailEditableFields.filter(f => !autoPatterns.test(f.name));
   const derivedFields = detailEditableFields.filter(f => autoPatterns.test(f.name));
 
-  // The first entry field (usually product) triggers a lookup on blur
-  const lookupTriggerField = entryFields[0];
-
-  // Build entry field inputs (user types these)
-  const entryInputs = entryFields.map(f => {
-    const label = toLabel(f.name);
-    const inputType = f.tsType === 'number' ? 'number' : 'text';
-    const isLookupTrigger = f === lookupTriggerField;
-    const onBlurAttr = isLookupTrigger
-      ? `\n                  onBlur={(e) => { if (e.target.value) handleProductLookup(e.target.value); }}`
-      : '';
-    return `              <div className="flex-1 min-w-0">
-                <label className="text-xs text-slate-500 mb-1 block">${label}${f.required ? ' *' : ''}</label>
-                <input
-                  name="${f.name}"
-                  type="${inputType}"
-                  placeholder="${label}"
-                  value={newLine.${f.name} ?? ''}
-                  onChange={(e) => setNewLine(prev => ({ ...prev, ${f.name}: e.target.value }))}${onBlurAttr}
-                  className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"${f.required ? '\n                  required' : ''}
-                />
-              </div>`;
+  // The first entry field (usually product) triggers a lookup
+  const entryArray = entryFields.map((f, i) => {
+    const type = mapFormFieldType(f);
+    const requiredPart = f.required ? ', required: true' : '';
+    const lookupPart = i === 0 ? ', lookup: true' : '';
+    return `    { key: '${f.name}', label: '${toLabel(f.name)}', type: '${type}'${requiredPart}${lookupPart} },`;
   }).join('\n');
 
-  // Build derived field displays (auto-filled, read-only in mini form)
-  const derivedInputs = derivedFields.map(f => {
-    const label = toLabel(f.name);
-    return `              <div className="flex-1 min-w-0">
-                <label className="text-xs text-slate-400 mb-1 block">${label}</label>
-                <div className="h-8 text-sm rounded-md border border-dashed border-slate-200 bg-slate-50 px-2 flex items-center text-slate-600 tabular-nums">
-                  {newLine.${f.name} || '—'}
-                </div>
-              </div>`;
+  const derivedArray = derivedFields.map(f => {
+    const type = mapFormFieldType(f);
+    return `    { key: '${f.name}', label: '${toLabel(f.name)}', type: '${type}' },`;
   }).join('\n');
 
-  const miniFormFields = derivedFields.length > 0
-    ? `${entryInputs}\n              <div className="w-px h-8 bg-slate-200 self-end mb-0.5" />\n${derivedInputs}`
-    : entryInputs;
-
-  const emptyLineObj = `{ ${detailEditableFields.map(f => `${f.name}: ''`).join(', ')} }`;
-
-  return `import React, { useState } from 'react';
-import { Button } from '@/components/ui/button';
-import { useEntity } from '@/hooks/useEntity';${statusBadgeImport}
+  return `import { MasterDetailPage } from '@/components/contract-ui';
 import ${headerName}Table from './${headerName}Table';
 import ${headerName}Form from './${headerName}Form';
 import ${detailName}Table from './${detailName}Table';
 
-export default function ${compName}({ token, apiBaseUrl }) {
-  const ${headerEntity} = useEntity('${headerEntity}', '${detailEntity}', { token, apiBaseUrl });
+const summary = [
+${summaryArray}
+];
 
-  const [showAddLine, setShowAddLine] = useState(false);
-  const [newLine, setNewLine] = useState(${emptyLineObj});
+const statusField = ${statusFieldLine};
 
-  const detailTitle = ${headerEntity}.editing?.id
-    ? \`${toLabel(headerEntity)} \${${headerEntity}.editing.documentNo || ${headerEntity}.editing.id}\`
-    : 'New ${toLabel(headerEntity)}';
+const processes = [
+${processesArray}
+];
 
-  const handleAddLine = () => {
-    ${headerEntity}.handleAddChild?.(newLine);
-    setNewLine(${emptyLineObj});
-    setShowAddLine(false);
-  };
+const addLineFields = {
+  entry: [
+${entryArray}
+  ],
+  derived: [
+${derivedArray}
+  ],
+};
 
-  const handleProductLookup = async (value) => {
-    const defaults = await ${headerEntity}.lookupChildDefaults?.(value);
-    if (defaults) {
-      setNewLine(prev => ({ ...prev, ...defaults }));
-    }
-  };
-
+export default function ${compName}(props) {
   return (
-    <div className="flex h-[calc(100vh-4rem)] gap-0">
-      {/* Left panel: Table */}
-      <div className={\`flex flex-col border-r transition-all duration-300 \${${headerEntity}.editing ? 'w-2/5' : 'w-full'}\`}>
-        <div className="flex items-center justify-between px-4 py-3 border-b bg-muted/20">
-          <div>
-            <h2 className="text-lg font-semibold text-foreground">${toLabel(headerEntity)}s</h2>
-            <p className="text-xs text-muted-foreground">
-              {${headerEntity}.loading ? 'Loading...' : \`\${${headerEntity}.items.length} records\`}
-            </p>
-          </div>
-          <Button onClick={${headerEntity}.handleNew} size="sm">+ New</Button>
-        </div>
-        <div className="flex-1 overflow-auto p-3">
-          {${headerEntity}.loading ? (
-            <div className="animate-pulse space-y-3">
-              <div className="h-10 bg-muted rounded" />
-              <div className="h-8 bg-muted/60 rounded" />
-              <div className="h-8 bg-muted/40 rounded" />
-              <div className="h-8 bg-muted/60 rounded" />
-              <div className="h-8 bg-muted/40 rounded" />
-            </div>
-          ) : (
-            <${headerName}Table
-              data={${headerEntity}.items}
-              onRowSelect={${headerEntity}.handleSelect}
-              selectedId={${headerEntity}.selected?.id}
-              compact={!!${headerEntity}.editing}
-            />
-          )}
-        </div>
-      </div>
-
-      {/* Right panel: Toolbar + Summary + Form + Detail */}
-      {${headerEntity}.editing && (
-        <div className="flex-1 flex flex-col overflow-hidden bg-white">
-          {/* Toolbar: title, status, process actions, save/delete */}
-          <div className="flex items-center gap-2 px-5 py-2.5 border-b border-slate-200 bg-white shadow-sm">
-            <h2 className="text-base font-semibold text-foreground truncate">{detailTitle}</h2>${statusBadgeInHeader}
-            <div className="flex-1" />
-            <div className="flex items-center gap-2">${processSection}
-              <Button size="sm" onClick={() => ${headerEntity}.handleSave(${headerEntity}.editing)}>Save</Button>
-              {${headerEntity}.selected && (
-                <Button variant="destructive" size="sm" onClick={${headerEntity}.handleDelete}>Delete</Button>
-              )}
-              <button
-                onClick={() => ${headerEntity}.handleSelect(null)}
-                className="h-8 w-8 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
-                aria-label="Close detail"
-              >
-                &times;
-              </button>
-            </div>
-          </div>
-
-          {/* Summary strip: read-only reference fields */}
-          <div className="flex items-center gap-5 px-5 py-2.5 border-b border-slate-200 bg-slate-50 text-xs">
-${summaryItems}
-          </div>
-
-          {/* Form zone: editable fields only */}
-          <div className="px-5 pt-4 pb-3 border-b">
-            <${headerName}Form
-              data={${headerEntity}.editing}
-              onChange={${headerEntity}.handleChange}
-            />
-          </div>
-
-          {/* Detail zone: fills remaining height */}
-          <div className="flex-1 flex flex-col overflow-hidden px-5 py-3">
-            <div className="flex items-center justify-between mb-3">
-              <h3 className="text-xs font-bold text-slate-500 uppercase tracking-widest">${toLabel(detailEntity)}s</h3>
-              <Button
-                variant="outline"
-                size="sm"
-                className="text-xs h-7"
-                onClick={() => setShowAddLine(!showAddLine)}
-              >
-                {showAddLine ? 'Cancel' : '+ Add Line'}
-              </Button>
-            </div>
-            {showAddLine && (
-              <form
-                onSubmit={(e) => { e.preventDefault(); handleAddLine(); }}
-                className="flex items-end gap-2 mb-3 p-3 rounded-lg border border-dashed border-primary/30 bg-primary/5"
-              >
-${miniFormFields}
-                <Button type="submit" size="sm" className="h-8 shrink-0">Add</Button>
-              </form>
-            )}
-            <div className="flex-1 overflow-auto">
-              <${detailName}Table data={${headerEntity}.children} />
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
+    <MasterDetailPage
+      entity="${headerEntity}"
+      detailEntity="${detailEntity}"
+      Table={${headerName}Table}
+      Form={${headerName}Form}
+      DetailTable={${detailName}Table}
+      summary={summary}
+      statusField={statusField}
+      processes={processes}
+      addLineFields={addLineFields}
+      entityLabel="${toLabel(headerEntity)}"
+      detailLabel="${toLabel(detailEntity)}"
+      {...props}
+    />
   );
 }
 `;
@@ -420,8 +221,7 @@ export function generateIndexComponent(headerEntity, detailEntity) {
   const headerName = capitalize(headerEntity);
 
   if (detailEntity) {
-    return `import React from 'react';
-import ${headerName}Page from './${headerName}Page';
+    return `import ${headerName}Page from './${headerName}Page';
 
 export default function App({ token, apiBaseUrl, window }) {
   return <${headerName}Page token={token} apiBaseUrl={apiBaseUrl} window={window} />;
@@ -429,17 +229,13 @@ export default function App({ token, apiBaseUrl, window }) {
 `;
   }
 
-  return `import React from 'react';
-import ${headerName}Table from './${headerName}Table';
+  return `import ${headerName}Table from './${headerName}Table';
 import ${headerName}Form from './${headerName}Form';
 
 export default function App({ token, apiBaseUrl, window }) {
-  const [selected, setSelected] = React.useState(null);
-
   return (
-    <div className="space-y-6 p-4">
-      <${headerName}Table data={[]} onRowSelect={setSelected} />
-      {selected && <${headerName}Form data={selected} />}
+    <div>
+      <${headerName}Table data={[]} />
     </div>
   );
 }

--- a/cli/test/generate-frontend.test.js
+++ b/cli/test/generate-frontend.test.js
@@ -43,218 +43,178 @@ const sampleContract = {
 };
 
 describe('generateTableComponent', () => {
-  it('generates valid JSX string with imports', () => {
+  it('generates thin component importing from contract-ui', () => {
     const code = generateTableComponent('order', sampleContract);
-    assert.ok(code.includes('import'), 'should have imports');
+    assert.ok(code.includes("import { DataTable } from '@/components/contract-ui'"), 'should import DataTable from contract-ui');
     assert.ok(code.includes('export default function OrderTable'), 'should export OrderTable');
+    assert.ok(code.includes('<DataTable'), 'should render DataTable component');
   });
 
-  it('includes grid columns from contract fields', () => {
+  it('declares columns array with correct entries', () => {
     const code = generateTableComponent('order', sampleContract);
-    assert.ok(code.includes('documentNo'), 'should include documentNo column');
-    assert.ok(code.includes('businessPartner'), 'should include businessPartner column');
-    assert.ok(code.includes('grandTotal'), 'should include grandTotal column');
+    assert.ok(code.includes("key: 'documentNo'"), 'should have documentNo column');
+    assert.ok(code.includes("label: 'Document No'"), 'should have Document No label');
+    assert.ok(code.includes("key: 'businessPartner'"), 'should have businessPartner column');
+    assert.ok(code.includes("key: 'grandTotal'"), 'should have grandTotal column');
+    assert.ok(code.includes("type: 'amount'"), 'should mark grandTotal as amount type');
+    assert.ok(code.includes("type: 'status'"), 'should mark docStatus as status type');
   });
 
-  it('includes search filters with search icon', () => {
+  it('declares filters array from searchableFields', () => {
     const code = generateTableComponent('order', sampleContract);
-    assert.ok(code.includes('Filter'), 'should have filter inputs');
-    assert.ok(code.includes('Search'), 'should import Search icon');
-    assert.ok(code.includes('lucide-react'), 'should import from lucide-react');
-    assert.ok(code.includes('pl-8'), 'should have left padding for icon');
+    assert.ok(code.includes("'documentNo'"), 'should include documentNo filter');
+    assert.ok(code.includes("'businessPartner'"), 'should include businessPartner filter');
+    assert.ok(code.includes("'docStatus'"), 'should include docStatus filter');
+    assert.ok(code.includes('const filters'), 'should declare filters array');
   });
 
-  it('renders status fields with StatusBadge', () => {
+  it('passes columns and filters as props to DataTable', () => {
     const code = generateTableComponent('order', sampleContract);
-    assert.ok(code.includes('StatusBadge'), 'should import and use StatusBadge');
-    assert.ok(code.includes('status-badge'), 'should import from status-badge');
+    assert.ok(code.includes('columns={columns}'), 'should pass columns prop');
+    assert.ok(code.includes('filters={filters}'), 'should pass filters prop');
+    assert.ok(code.includes('{...props}'), 'should spread remaining props');
   });
 
-  it('adds hover styling to rows', () => {
+  it('does NOT contain inline CSS classes (moved to generic components)', () => {
     const code = generateTableComponent('order', sampleContract);
-    assert.ok(code.includes('hover:bg-primary/5'), 'should have hover effect on rows');
+    assert.ok(!code.includes('hover:bg-primary'), 'should NOT have hover classes inline');
+    assert.ok(!code.includes('bg-muted/30'), 'should NOT have zebra classes inline');
+    assert.ok(!code.includes('rounded-lg border overflow-hidden'), 'should NOT have container classes inline');
+    assert.ok(!code.includes('text-blue-800'), 'should NOT have header classes inline');
+    assert.ok(!code.includes('pl-8'), 'should NOT have filter padding inline');
+    assert.ok(!code.includes('lucide-react'), 'should NOT import from lucide-react');
   });
 
-  it('uses zebra stripe pattern for rows', () => {
+  it('does NOT contain inline state management', () => {
     const code = generateTableComponent('order', sampleContract);
-    assert.ok(code.includes('bg-muted/30'), 'should have alternating background');
-  });
-
-  it('highlights selected row', () => {
-    const code = generateTableComponent('order', sampleContract);
-    assert.ok(code.includes('selectedId'), 'should accept selectedId prop');
-    assert.ok(code.includes('bg-primary/10'), 'should highlight selected row');
-    assert.ok(code.includes('border-l-primary'), 'should have left border on selected');
-  });
-
-  it('shows record count', () => {
-    const code = generateTableComponent('order', sampleContract);
-    assert.ok(code.includes('records'), 'should show record count');
-    assert.ok(code.includes('filteredData.length'), 'should show filtered count');
-  });
-
-  it('uses professional styled table headers', () => {
-    const code = generateTableComponent('order', sampleContract);
-    assert.ok(code.includes('text-blue-800'), 'should use blue-800 for header text');
-    assert.ok(code.includes('border-primary/20'), 'should use primary border for header');
-    assert.ok(code.includes('bg-muted/40'), 'should have subtle header background');
-  });
-
-  it('adds aria-label to filter inputs', () => {
-    const code = generateTableComponent('order', sampleContract);
-    assert.ok(code.includes('aria-label'), 'should have aria-label on filter inputs');
-  });
-
-  it('wraps table in bordered container', () => {
-    const code = generateTableComponent('order', sampleContract);
-    assert.ok(code.includes('rounded-lg border overflow-hidden'), 'should wrap table in bordered container');
+    assert.ok(!code.includes('useState'), 'should NOT have useState (handled by DataTable)');
+    assert.ok(!code.includes('filteredData'), 'should NOT have filteredData logic inline');
   });
 });
 
 describe('generateFormComponent', () => {
-  it('generates valid JSX string', () => {
+  it('generates thin component importing from contract-ui', () => {
     const code = generateFormComponent('order', sampleContract);
+    assert.ok(code.includes("import { EntityForm } from '@/components/contract-ui'"), 'should import EntityForm from contract-ui');
     assert.ok(code.includes('export default function OrderForm'), 'should export OrderForm');
+    assert.ok(code.includes('<EntityForm'), 'should render EntityForm component');
   });
 
-  it('renders only editable fields as inputs', () => {
+  it('declares fields array with only editable fields', () => {
     const code = generateFormComponent('order', sampleContract);
-    assert.ok(code.includes('businessPartner'), 'should include editable businessPartner');
-    assert.ok(!code.includes('documentNo'), 'should NOT include readOnly documentNo');
-    assert.ok(!code.includes('docStatus'), 'should NOT include readOnly docStatus');
+    assert.ok(code.includes("key: 'businessPartner'"), 'should include editable businessPartner');
+    assert.ok(!code.includes("key: 'documentNo'"), 'should NOT include readOnly documentNo');
+    assert.ok(!code.includes("key: 'docStatus'"), 'should NOT include readOnly docStatus');
+    assert.ok(!code.includes("key: 'grandTotal'"), 'should NOT include readOnly grandTotal');
   });
 
-  it('adds focus ring to editable inputs', () => {
+  it('includes required flag on required fields', () => {
     const code = generateFormComponent('order', sampleContract);
-    assert.ok(code.includes('focus:ring-2'), 'should have focus ring on editable inputs');
-    assert.ok(code.includes('focus:ring-primary'), 'should use primary focus ring');
+    assert.ok(code.includes("required: true"), 'should mark required fields');
   });
 
-  it('uses two-column grid for editable fields', () => {
+  it('includes labels for editable fields', () => {
     const code = generateFormComponent('order', sampleContract);
-    assert.ok(code.includes('grid-cols-2'), 'should use 2-column grid');
-    assert.ok(code.includes('gap-3'), 'should have gap between grid items');
+    assert.ok(code.includes("label: 'Business Partner'"), 'should have Business Partner label');
+  });
+
+  it('does NOT contain inline CSS classes or layout', () => {
+    const code = generateFormComponent('order', sampleContract);
+    assert.ok(!code.includes('grid-cols-2'), 'should NOT have grid classes inline');
+    assert.ok(!code.includes('focus:ring'), 'should NOT have focus ring classes inline');
+    assert.ok(!code.includes('space-y-1.5'), 'should NOT have spacing classes inline');
   });
 
   it('does not render save/delete buttons or process actions', () => {
     const code = generateFormComponent('order', sampleContract);
-    assert.ok(!code.includes('Save'), 'should NOT have Save button (lives in page toolbar)');
-    assert.ok(!code.includes('completeOrder'), 'should NOT have process actions (lives in page toolbar)');
+    assert.ok(!code.includes('Save'), 'should NOT have Save button');
+    assert.ok(!code.includes('completeOrder'), 'should NOT have process actions');
   });
 });
 
 describe('generatePageComponent', () => {
-  it('generates page with Split View layout', () => {
+  it('generates thin component importing from contract-ui', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
+    assert.ok(code.includes("import { MasterDetailPage } from '@/components/contract-ui'"), 'should import MasterDetailPage from contract-ui');
     assert.ok(code.includes('export default function OrderPage'), 'should export OrderPage');
-    assert.ok(code.includes('w-2/5'), 'should have 40% width for table panel');
-    assert.ok(code.includes('flex-1'), 'should have flex-1 for detail panel');
-    assert.ok(!code.includes('SlidePanel'), 'should NOT use SlidePanel');
+    assert.ok(code.includes('<MasterDetailPage'), 'should render MasterDetailPage component');
   });
 
-  it('imports useEntity from @/hooks/useEntity', () => {
+  it('does NOT import useEntity or useState directly', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
-    assert.ok(code.includes("from '@/hooks/useEntity'"), 'should import useEntity');
+    assert.ok(!code.includes("from '@/hooks/useEntity'"), 'should NOT import useEntity (handled by MasterDetailPage)');
+    assert.ok(!code.includes('useState'), 'should NOT import useState');
+    assert.ok(!code.includes('fetch('), 'should NOT have fetch calls');
   });
 
-  it('calls useEntity with correct entity names', () => {
+  it('declares summary array from read-only fields (excluding status)', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
-    assert.ok(code.includes("useEntity('order', 'orderLine'"), 'should call useEntity with entity names');
+    assert.ok(code.includes("key: 'documentNo'"), 'should include documentNo in summary');
+    assert.ok(code.includes("label: 'Document No'"), 'should label Document No');
+    assert.ok(code.includes("key: 'grandTotal'"), 'should include grandTotal in summary');
+    assert.ok(code.includes("label: 'Grand Total'"), 'should label Grand Total');
   });
 
-  it('does NOT contain inline useState or fetch', () => {
+  it('declares statusField string', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
-    assert.ok(!code.includes('fetch('), 'should not have fetch calls');
+    assert.ok(code.includes("const statusField = 'docStatus'"), 'should set statusField to docStatus');
   });
 
-  it('passes hook properties to child components', () => {
+  it('declares processes array with style flags', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
-    assert.ok(code.includes('.items'), 'should pass items to table');
-    assert.ok(code.includes('.editing'), 'should pass editing to form');
-    assert.ok(code.includes('.handleSelect'), 'should pass handleSelect');
-    assert.ok(code.includes('.handleChange'), 'should pass handleChange');
-    assert.ok(code.includes('.handleSave'), 'should pass handleSave');
-    assert.ok(code.includes('.handleProcess'), 'should pass handleProcess');
-    assert.ok(code.includes('.children'), 'should pass children to detail table');
+    assert.ok(code.includes("name: 'completeOrder'"), 'should include completeOrder process');
+    assert.ok(code.includes("label: 'Complete Order'"), 'should label Complete Order');
+    assert.ok(code.includes("style: 'positive'"), 'should mark complete as positive');
+    assert.ok(code.includes("name: 'voidOrder'"), 'should include voidOrder process');
+    assert.ok(code.includes("label: 'Void Order'"), 'should label Void Order');
+    assert.ok(code.includes("style: 'destructive'"), 'should mark void as destructive');
   });
 
-  it('has toolbar with process actions, Save, Delete, and close', () => {
+  it('declares addLineFields with entry and derived arrays', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
-    assert.ok(code.includes('.handleNew'), 'should wire handleNew');
-    assert.ok(code.includes('handleSelect(null)'), 'should clear selection on close');
-    assert.ok(code.includes('aria-label="Close detail"'), 'should have accessible close button');
-    assert.ok(code.includes('.handleSave'), 'should have Save in toolbar');
-    assert.ok(code.includes('.handleDelete'), 'should have Delete in toolbar');
-    assert.ok(code.includes('truncate'), 'should truncate long titles');
-    assert.ok(code.includes('Complete Order') || code.includes('completeOrder'), 'should have process actions in toolbar');
-    assert.ok(code.includes('Void Order') || code.includes('voidOrder'), 'should have void action in toolbar');
-    assert.ok(code.includes('bg-emerald-50'), 'should color-code complete action green');
-    assert.ok(code.includes('bg-amber-50'), 'should color-code void action amber');
+    assert.ok(code.includes('addLineFields'), 'should declare addLineFields');
+    assert.ok(code.includes('entry:'), 'should have entry section');
+    assert.ok(code.includes('derived:'), 'should have derived section');
+    assert.ok(code.includes("key: 'product'"), 'should include product in entry fields');
+    assert.ok(code.includes("key: 'quantity'"), 'should include quantity in entry fields');
+    assert.ok(code.includes('lookup: true'), 'should mark first entry field with lookup');
   });
 
-  it('shows summary strip with read-only reference fields', () => {
+  it('passes all config props to MasterDetailPage', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
-    assert.ok(code.includes('Summary strip'), 'should have labeled summary strip');
-    assert.ok(code.includes('Document No'), 'should show documentNo in summary');
-    assert.ok(code.includes('Grand Total'), 'should show grandTotal in summary');
-    assert.ok(code.includes('tabular-nums'), 'should use tabular-nums for amounts');
-    assert.ok(code.includes('bg-slate-50'), 'should have distinct summary background');
-    assert.ok(code.includes('font-semibold'), 'should use semibold for values');
+    assert.ok(code.includes('entity="order"'), 'should pass entity prop');
+    assert.ok(code.includes('detailEntity="orderLine"'), 'should pass detailEntity prop');
+    assert.ok(code.includes('Table={OrderTable}'), 'should pass Table component');
+    assert.ok(code.includes('Form={OrderForm}'), 'should pass Form component');
+    assert.ok(code.includes('DetailTable={OrderLineTable}'), 'should pass DetailTable component');
+    assert.ok(code.includes('summary={summary}'), 'should pass summary prop');
+    assert.ok(code.includes('statusField={statusField}'), 'should pass statusField prop');
+    assert.ok(code.includes('processes={processes}'), 'should pass processes prop');
+    assert.ok(code.includes('addLineFields={addLineFields}'), 'should pass addLineFields prop');
+    assert.ok(code.includes('{...props}'), 'should spread remaining props');
   });
 
-  it('shows status badge in toolbar header', () => {
+  it('imports child components with correct names', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
-    assert.ok(code.includes('StatusBadge'), 'should render StatusBadge in toolbar');
-    assert.ok(code.includes('status-badge'), 'should import StatusBadge');
+    assert.ok(code.includes("import OrderTable from './OrderTable'"), 'should import OrderTable');
+    assert.ok(code.includes("import OrderForm from './OrderForm'"), 'should import OrderForm');
+    assert.ok(code.includes("import OrderLineTable from './OrderLineTable'"), 'should import OrderLineTable');
   });
 
-  it('puts form and detail table in separate zones', () => {
+  it('does NOT contain inline layout CSS (moved to generic components)', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
-    const rightPanel = code.slice(code.indexOf('Right panel'));
-    assert.ok(rightPanel.includes('Form'), 'form should be in right panel');
-    assert.ok(rightPanel.includes('Table'), 'detail table should be in right panel');
-    assert.ok(rightPanel.includes('Form zone'), 'should have labeled form zone');
-    assert.ok(rightPanel.includes('Detail zone'), 'should have labeled detail zone');
+    assert.ok(!code.includes('w-2/5'), 'should NOT have split view widths inline');
+    assert.ok(!code.includes('animate-pulse'), 'should NOT have loading skeleton inline');
+    assert.ok(!code.includes('bg-emerald-50'), 'should NOT have process button colors inline');
+    assert.ok(!code.includes('bg-amber-50'), 'should NOT have process button colors inline');
+    assert.ok(!code.includes('truncate'), 'should NOT have truncate class inline');
+    assert.ok(!code.includes('shadow-sm'), 'should NOT have toolbar shadow inline');
   });
 
-  it('has add-line mini form for detail entity', () => {
+  it('passes entityLabel and detailLabel props', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
-    assert.ok(code.includes('showAddLine'), 'should have showAddLine state');
-    assert.ok(code.includes('Add Line'), 'should have Add Line button');
-    assert.ok(code.includes('handleAddChild'), 'should call handleAddChild on submit');
-    assert.ok(code.includes('newLine'), 'should track newLine state');
-    assert.ok(code.includes('product'), 'should include product field in mini form');
-    assert.ok(code.includes('quantity'), 'should include quantity field in mini form');
-  });
-
-  it('auto-derives price fields via product lookup', () => {
-    const code = generatePageComponent('order', 'orderLine', sampleContract);
-    assert.ok(code.includes('lookupChildDefaults'), 'should call lookupChildDefaults for auto-fill');
-    assert.ok(code.includes('handleProductLookup'), 'should have product lookup handler');
-    assert.ok(code.includes('onBlur'), 'should trigger lookup on blur of product field');
-  });
-
-  it('shows loading skeleton when loading', () => {
-    const code = generatePageComponent('order', 'orderLine', sampleContract);
-    assert.ok(code.includes('.loading'), 'should check loading state');
-    assert.ok(code.includes('animate-pulse'), 'should show pulse animation when loading');
-  });
-
-  it('passes selectedId to table for row highlighting', () => {
-    const code = generatePageComponent('order', 'orderLine', sampleContract);
-    assert.ok(code.includes('selectedId'), 'should pass selectedId to table');
-    assert.ok(code.includes('.selected?.id'), 'should derive selectedId from hook');
-  });
-
-  it('passes compact prop to table when detail is open', () => {
-    const code = generatePageComponent('order', 'orderLine', sampleContract);
-    assert.ok(code.includes('compact={'), 'should pass compact prop to table');
-  });
-
-  it('table expands to full width when no selection', () => {
-    const code = generatePageComponent('order', 'orderLine', sampleContract);
-    assert.ok(code.includes('w-full'), 'should use full width when no editing');
-    assert.ok(code.includes('transition-all'), 'should animate width transition');
+    assert.ok(code.includes('entityLabel="Order"'), 'should pass entityLabel');
+    assert.ok(code.includes('detailLabel="Order Line"'), 'should pass detailLabel');
   });
 });
 
@@ -266,6 +226,18 @@ describe('generateIndexComponent', () => {
     assert.ok(code.includes('window'), 'should accept window prop');
     assert.ok(code.includes('export default'), 'should have default export');
   });
+
+  it('imports page component for header-detail entity', () => {
+    const code = generateIndexComponent('order', 'orderLine');
+    assert.ok(code.includes("import OrderPage from './OrderPage'"), 'should import OrderPage');
+    assert.ok(code.includes('<OrderPage'), 'should render OrderPage');
+  });
+
+  it('handles single-entity without page component', () => {
+    const code = generateIndexComponent('item', null);
+    assert.ok(code.includes("import ItemTable"), 'should import ItemTable');
+    assert.ok(!code.includes('Page'), 'should NOT have a Page component');
+  });
 });
 
 describe('generateAll', () => {
@@ -276,6 +248,17 @@ describe('generateAll', () => {
     assert.ok(files['OrderLineTable.jsx'], 'should produce OrderLineTable.jsx');
     assert.ok(files['OrderPage.jsx'], 'should produce OrderPage.jsx');
     assert.ok(files['index.jsx'], 'should produce index.jsx');
+  });
+
+  it('all generated files import from contract-ui (not individual UI components)', () => {
+    const files = generateAll(sampleContract);
+    for (const [name, code] of Object.entries(files)) {
+      if (name.endsWith('Table.jsx') || name.endsWith('Form.jsx') || name.endsWith('Page.jsx')) {
+        assert.ok(code.includes('@/components/contract-ui'), `${name} should import from contract-ui`);
+        assert.ok(!code.includes('@/components/ui/table'), `${name} should NOT import from ui/table directly`);
+        assert.ok(!code.includes('@/components/ui/input'), `${name} should NOT import from ui/input directly`);
+      }
+    }
   });
 
   it('handles single-entity contract without detail', () => {
@@ -296,5 +279,15 @@ describe('generateAll', () => {
     assert.ok(files['ItemTable.jsx'], 'should produce ItemTable.jsx');
     assert.ok(files['ItemForm.jsx'], 'should produce ItemForm.jsx');
     assert.ok(files['index.jsx'], 'should produce index.jsx');
+    assert.ok(!files['ItemPage.jsx'], 'should NOT produce ItemPage.jsx for single entity');
+  });
+});
+
+describe('getReadOnlyFields', () => {
+  it('returns only form fields with readOnly visibility', () => {
+    const fields = getReadOnlyFields(sampleContract, 'order');
+    assert.ok(fields.length > 0, 'should find readOnly fields');
+    assert.ok(fields.every(f => f.visibility === 'readOnly'), 'all should be readOnly');
+    assert.ok(fields.every(f => f.form === true), 'all should be form fields');
   });
 });

--- a/cli/test/generate-frontend.test.js
+++ b/cli/test/generate-frontend.test.js
@@ -227,6 +227,13 @@ describe('generatePageComponent', () => {
     assert.ok(code.includes('quantity'), 'should include quantity field in mini form');
   });
 
+  it('auto-derives price fields via product lookup', () => {
+    const code = generatePageComponent('order', 'orderLine', sampleContract);
+    assert.ok(code.includes('lookupChildDefaults'), 'should call lookupChildDefaults for auto-fill');
+    assert.ok(code.includes('handleProductLookup'), 'should have product lookup handler');
+    assert.ok(code.includes('onBlur'), 'should trigger lookup on blur of product field');
+  });
+
   it('shows loading skeleton when loading', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
     assert.ok(code.includes('.loading'), 'should check loading state');

--- a/cli/test/generate-frontend.test.js
+++ b/cli/test/generate-frontend.test.js
@@ -217,6 +217,16 @@ describe('generatePageComponent', () => {
     assert.ok(rightPanel.includes('Detail zone'), 'should have labeled detail zone');
   });
 
+  it('has add-line mini form for detail entity', () => {
+    const code = generatePageComponent('order', 'orderLine', sampleContract);
+    assert.ok(code.includes('showAddLine'), 'should have showAddLine state');
+    assert.ok(code.includes('Add Line'), 'should have Add Line button');
+    assert.ok(code.includes('handleAddChild'), 'should call handleAddChild on submit');
+    assert.ok(code.includes('newLine'), 'should track newLine state');
+    assert.ok(code.includes('product'), 'should include product field in mini form');
+    assert.ok(code.includes('quantity'), 'should include quantity field in mini form');
+  });
+
   it('shows loading skeleton when loading', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
     assert.ok(code.includes('.loading'), 'should check loading state');

--- a/cli/test/generate-frontend.test.js
+++ b/cli/test/generate-frontend.test.js
@@ -55,9 +55,12 @@ describe('generateTableComponent', () => {
     assert.ok(code.includes('grandTotal'), 'should include grandTotal column');
   });
 
-  it('includes search filters for searchable fields', () => {
+  it('includes search filters with search icon', () => {
     const code = generateTableComponent('order', sampleContract);
     assert.ok(code.includes('Filter'), 'should have filter inputs');
+    assert.ok(code.includes('Search'), 'should import Search icon');
+    assert.ok(code.includes('lucide-react'), 'should import from lucide-react');
+    assert.ok(code.includes('pl-8'), 'should have left padding for icon');
   });
 
   it('renders status fields with StatusBadge', () => {
@@ -68,7 +71,42 @@ describe('generateTableComponent', () => {
 
   it('adds hover styling to rows', () => {
     const code = generateTableComponent('order', sampleContract);
-    assert.ok(code.includes('hover:bg-gray-50'), 'should have hover effect on rows');
+    assert.ok(code.includes('hover:bg-primary/5'), 'should have hover effect on rows');
+  });
+
+  it('uses zebra stripe pattern for rows', () => {
+    const code = generateTableComponent('order', sampleContract);
+    assert.ok(code.includes('bg-muted/30'), 'should have alternating background');
+  });
+
+  it('highlights selected row', () => {
+    const code = generateTableComponent('order', sampleContract);
+    assert.ok(code.includes('selectedId'), 'should accept selectedId prop');
+    assert.ok(code.includes('bg-primary/10'), 'should highlight selected row');
+    assert.ok(code.includes('border-l-primary'), 'should have left border on selected');
+  });
+
+  it('shows record count', () => {
+    const code = generateTableComponent('order', sampleContract);
+    assert.ok(code.includes('records'), 'should show record count');
+    assert.ok(code.includes('filteredData.length'), 'should show filtered count');
+  });
+
+  it('uses professional styled table headers', () => {
+    const code = generateTableComponent('order', sampleContract);
+    assert.ok(code.includes('text-blue-800'), 'should use blue-800 for header text');
+    assert.ok(code.includes('border-primary/20'), 'should use primary border for header');
+    assert.ok(code.includes('bg-muted/40'), 'should have subtle header background');
+  });
+
+  it('adds aria-label to filter inputs', () => {
+    const code = generateTableComponent('order', sampleContract);
+    assert.ok(code.includes('aria-label'), 'should have aria-label on filter inputs');
+  });
+
+  it('wraps table in bordered container', () => {
+    const code = generateTableComponent('order', sampleContract);
+    assert.ok(code.includes('rounded-lg border overflow-hidden'), 'should wrap table in bordered container');
   });
 });
 
@@ -83,15 +121,24 @@ describe('generateFormComponent', () => {
     assert.ok(code.includes('businessPartner'), 'should include editable businessPartner');
   });
 
-  it('renders readOnly fields as disabled', () => {
+  it('separates readOnly fields into system fields group', () => {
     const code = generateFormComponent('order', sampleContract);
-    assert.ok(code.includes('readOnly') || code.includes('disabled'), 'should mark readOnly fields');
+    assert.ok(code.includes('System Fields'), 'should have System Fields section');
+    assert.ok(code.includes('border-dashed'), 'should use dashed border for readOnly group');
+    assert.ok(code.includes('cursor-not-allowed'), 'should show not-allowed cursor on disabled');
   });
 
-  it('includes process action buttons for matching entity', () => {
+  it('styles disabled inputs distinctly', () => {
+    const code = generateFormComponent('order', sampleContract);
+    assert.ok(code.includes('bg-muted/50'), 'should use muted background for disabled');
+    assert.ok(code.includes('text-muted-foreground'), 'should use muted text for disabled');
+  });
+
+  it('includes process action buttons in Actions section', () => {
     const code = generateFormComponent('order', sampleContract);
     assert.ok(code.includes('completeOrder') || code.includes('Complete Order'), 'should include completeOrder button');
     assert.ok(code.includes('voidOrder') || code.includes('Void Order'), 'should include voidOrder button');
+    assert.ok(code.includes('Actions'), 'should have Actions section label');
   });
 
   it('does not include process buttons for non-matching entity', () => {
@@ -99,10 +146,16 @@ describe('generateFormComponent', () => {
     assert.ok(!code.includes('completeOrder'), 'should not include order processes in orderLine form');
   });
 
+  it('adds focus ring to editable inputs', () => {
+    const code = generateFormComponent('order', sampleContract);
+    assert.ok(code.includes('focus:ring-2'), 'should have focus ring on editable inputs');
+    assert.ok(code.includes('focus:ring-primary'), 'should use primary focus ring');
+  });
+
   it('uses single-column layout for panel width', () => {
     const code = generateFormComponent('order', sampleContract);
     assert.ok(!code.includes('grid-cols-2'), 'should not use 2-column grid (panel is narrow)');
-    assert.ok(code.includes('space-y-3'), 'should use vertical stacking');
+    assert.ok(code.includes('space-y-3') || code.includes('space-y-4'), 'should use vertical stacking');
   });
 });
 
@@ -153,6 +206,18 @@ describe('generatePageComponent', () => {
     const panelContent = code.slice(panelStart, panelEnd);
     assert.ok(panelContent.includes('Form'), 'form should be inside SlidePanel');
     assert.ok(panelContent.includes('Table'), 'detail table should be inside SlidePanel');
+  });
+
+  it('shows loading skeleton when loading', () => {
+    const code = generatePageComponent('order', 'orderLine', sampleContract);
+    assert.ok(code.includes('.loading'), 'should check loading state');
+    assert.ok(code.includes('animate-pulse'), 'should show pulse animation when loading');
+  });
+
+  it('passes selectedId to table for row highlighting', () => {
+    const code = generatePageComponent('order', 'orderLine', sampleContract);
+    assert.ok(code.includes('selectedId'), 'should pass selectedId to table');
+    assert.ok(code.includes('.selected?.id'), 'should derive selectedId from hook');
   });
 });
 

--- a/cli/test/generate-frontend.test.js
+++ b/cli/test/generate-frontend.test.js
@@ -152,19 +152,20 @@ describe('generateFormComponent', () => {
     assert.ok(code.includes('focus:ring-primary'), 'should use primary focus ring');
   });
 
-  it('uses single-column layout for panel width', () => {
+  it('uses two-column grid for editable fields', () => {
     const code = generateFormComponent('order', sampleContract);
-    assert.ok(!code.includes('grid-cols-2'), 'should not use 2-column grid (panel is narrow)');
-    assert.ok(code.includes('space-y-3') || code.includes('space-y-4'), 'should use vertical stacking');
+    assert.ok(code.includes('grid-cols-2'), 'should use 2-column grid for split view');
+    assert.ok(code.includes('gap-3'), 'should have gap between grid items');
   });
 });
 
 describe('generatePageComponent', () => {
-  it('generates page with SlidePanel', () => {
+  it('generates page with Split View layout', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
     assert.ok(code.includes('export default function OrderPage'), 'should export OrderPage');
-    assert.ok(code.includes('SlidePanel'), 'should use SlidePanel');
-    assert.ok(code.includes('slide-panel'), 'should import from slide-panel');
+    assert.ok(code.includes('w-2/5'), 'should have 40% width for table panel');
+    assert.ok(code.includes('flex-1'), 'should have flex-1 for detail panel');
+    assert.ok(!code.includes('SlidePanel'), 'should NOT use SlidePanel');
   });
 
   it('imports useEntity from @/hooks/useEntity', () => {
@@ -193,19 +194,18 @@ describe('generatePageComponent', () => {
     assert.ok(code.includes('.children'), 'should pass children to detail table');
   });
 
-  it('includes New button and close panel clears editing', () => {
+  it('has close button that clears selection', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
     assert.ok(code.includes('.handleNew'), 'should wire handleNew');
-    assert.ok(code.includes('onClose'), 'should have onClose for panel');
+    assert.ok(code.includes('handleSelect(null)'), 'should clear selection on close');
+    assert.ok(code.includes('aria-label="Close detail"'), 'should have accessible close button');
   });
 
-  it('puts form and detail table inside SlidePanel', () => {
+  it('puts form and detail table in right panel', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
-    const panelStart = code.indexOf('<SlidePanel');
-    const panelEnd = code.indexOf('</SlidePanel>');
-    const panelContent = code.slice(panelStart, panelEnd);
-    assert.ok(panelContent.includes('Form'), 'form should be inside SlidePanel');
-    assert.ok(panelContent.includes('Table'), 'detail table should be inside SlidePanel');
+    const rightPanel = code.slice(code.indexOf('Right panel'));
+    assert.ok(rightPanel.includes('Form'), 'form should be in right panel');
+    assert.ok(rightPanel.includes('Table'), 'detail table should be in right panel');
   });
 
   it('shows loading skeleton when loading', () => {
@@ -218,6 +218,17 @@ describe('generatePageComponent', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
     assert.ok(code.includes('selectedId'), 'should pass selectedId to table');
     assert.ok(code.includes('.selected?.id'), 'should derive selectedId from hook');
+  });
+
+  it('passes compact prop to table when detail is open', () => {
+    const code = generatePageComponent('order', 'orderLine', sampleContract);
+    assert.ok(code.includes('compact={'), 'should pass compact prop to table');
+  });
+
+  it('table expands to full width when no selection', () => {
+    const code = generatePageComponent('order', 'orderLine', sampleContract);
+    assert.ok(code.includes('w-full'), 'should use full width when no editing');
+    assert.ok(code.includes('transition-all'), 'should animate width transition');
   });
 });
 

--- a/cli/test/generate-frontend.test.js
+++ b/cli/test/generate-frontend.test.js
@@ -6,6 +6,7 @@ import {
   generatePageComponent,
   generateIndexComponent,
   generateAll,
+  getReadOnlyFields,
 } from '../src/generate-frontend.js';
 
 const sampleContract = {
@@ -116,34 +117,11 @@ describe('generateFormComponent', () => {
     assert.ok(code.includes('export default function OrderForm'), 'should export OrderForm');
   });
 
-  it('renders editable fields as inputs', () => {
+  it('renders only editable fields as inputs', () => {
     const code = generateFormComponent('order', sampleContract);
     assert.ok(code.includes('businessPartner'), 'should include editable businessPartner');
-  });
-
-  it('separates readOnly fields into system fields group', () => {
-    const code = generateFormComponent('order', sampleContract);
-    assert.ok(code.includes('System Fields'), 'should have System Fields section');
-    assert.ok(code.includes('border-dashed'), 'should use dashed border for readOnly group');
-    assert.ok(code.includes('cursor-not-allowed'), 'should show not-allowed cursor on disabled');
-  });
-
-  it('styles disabled inputs distinctly', () => {
-    const code = generateFormComponent('order', sampleContract);
-    assert.ok(code.includes('bg-muted/50'), 'should use muted background for disabled');
-    assert.ok(code.includes('text-muted-foreground'), 'should use muted text for disabled');
-  });
-
-  it('includes process action buttons in Actions section', () => {
-    const code = generateFormComponent('order', sampleContract);
-    assert.ok(code.includes('completeOrder') || code.includes('Complete Order'), 'should include completeOrder button');
-    assert.ok(code.includes('voidOrder') || code.includes('Void Order'), 'should include voidOrder button');
-    assert.ok(code.includes('Actions'), 'should have Actions section label');
-  });
-
-  it('does not include process buttons for non-matching entity', () => {
-    const code = generateFormComponent('orderLine', sampleContract);
-    assert.ok(!code.includes('completeOrder'), 'should not include order processes in orderLine form');
+    assert.ok(!code.includes('documentNo'), 'should NOT include readOnly documentNo');
+    assert.ok(!code.includes('docStatus'), 'should NOT include readOnly docStatus');
   });
 
   it('adds focus ring to editable inputs', () => {
@@ -154,8 +132,14 @@ describe('generateFormComponent', () => {
 
   it('uses two-column grid for editable fields', () => {
     const code = generateFormComponent('order', sampleContract);
-    assert.ok(code.includes('grid-cols-2'), 'should use 2-column grid for split view');
+    assert.ok(code.includes('grid-cols-2'), 'should use 2-column grid');
     assert.ok(code.includes('gap-3'), 'should have gap between grid items');
+  });
+
+  it('does not render save/delete buttons or process actions', () => {
+    const code = generateFormComponent('order', sampleContract);
+    assert.ok(!code.includes('Save'), 'should NOT have Save button (lives in page toolbar)');
+    assert.ok(!code.includes('completeOrder'), 'should NOT have process actions (lives in page toolbar)');
   });
 });
 
@@ -194,18 +178,43 @@ describe('generatePageComponent', () => {
     assert.ok(code.includes('.children'), 'should pass children to detail table');
   });
 
-  it('has close button that clears selection', () => {
+  it('has toolbar with process actions, Save, Delete, and close', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
     assert.ok(code.includes('.handleNew'), 'should wire handleNew');
     assert.ok(code.includes('handleSelect(null)'), 'should clear selection on close');
     assert.ok(code.includes('aria-label="Close detail"'), 'should have accessible close button');
+    assert.ok(code.includes('.handleSave'), 'should have Save in toolbar');
+    assert.ok(code.includes('.handleDelete'), 'should have Delete in toolbar');
+    assert.ok(code.includes('truncate'), 'should truncate long titles');
+    assert.ok(code.includes('Complete Order') || code.includes('completeOrder'), 'should have process actions in toolbar');
+    assert.ok(code.includes('Void Order') || code.includes('voidOrder'), 'should have void action in toolbar');
+    assert.ok(code.includes('bg-emerald-50'), 'should color-code complete action green');
+    assert.ok(code.includes('bg-amber-50'), 'should color-code void action amber');
   });
 
-  it('puts form and detail table in right panel', () => {
+  it('shows summary strip with read-only reference fields', () => {
+    const code = generatePageComponent('order', 'orderLine', sampleContract);
+    assert.ok(code.includes('Summary strip'), 'should have labeled summary strip');
+    assert.ok(code.includes('Document No'), 'should show documentNo in summary');
+    assert.ok(code.includes('Grand Total'), 'should show grandTotal in summary');
+    assert.ok(code.includes('tabular-nums'), 'should use tabular-nums for amounts');
+    assert.ok(code.includes('bg-slate-50'), 'should have distinct summary background');
+    assert.ok(code.includes('font-semibold'), 'should use semibold for values');
+  });
+
+  it('shows status badge in toolbar header', () => {
+    const code = generatePageComponent('order', 'orderLine', sampleContract);
+    assert.ok(code.includes('StatusBadge'), 'should render StatusBadge in toolbar');
+    assert.ok(code.includes('status-badge'), 'should import StatusBadge');
+  });
+
+  it('puts form and detail table in separate zones', () => {
     const code = generatePageComponent('order', 'orderLine', sampleContract);
     const rightPanel = code.slice(code.indexOf('Right panel'));
     assert.ok(rightPanel.includes('Form'), 'form should be in right panel');
     assert.ok(rightPanel.includes('Table'), 'detail table should be in right panel');
+    assert.ok(rightPanel.includes('Form zone'), 'should have labeled form zone');
+    assert.ok(rightPanel.includes('Detail zone'), 'should have labeled detail zone');
   });
 
   it('shows loading skeleton when loading', () => {

--- a/tools/app-shell/src/auth/LoginPage.jsx
+++ b/tools/app-shell/src/auth/LoginPage.jsx
@@ -28,10 +28,13 @@ export default function LoginPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-muted/40">
-      <Card className="w-full max-w-sm">
-        <CardHeader className="text-center">
-          <CardTitle className="text-2xl">Schema Forge</CardTitle>
+    <div className="min-h-screen flex items-center justify-center" style={{ backgroundColor: 'hsl(var(--sidebar-bg))' }}>
+      <Card className="w-full max-w-sm shadow-2xl border-0 bg-white">
+        <CardHeader className="text-center pb-2">
+          <div className="mx-auto mb-3 h-12 w-12 rounded-xl bg-primary flex items-center justify-center">
+            <span className="text-xl font-bold text-white">SF</span>
+          </div>
+          <CardTitle className="text-xl">Schema Forge</CardTitle>
           <p className="text-sm text-muted-foreground">Sign in to your Etendo instance</p>
         </CardHeader>
         <CardContent>

--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -1,0 +1,101 @@
+import React, { useState, useMemo } from 'react';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Input } from '@/components/ui/input';
+import { StatusBadge } from '@/components/ui/status-badge';
+import { Search } from 'lucide-react';
+
+/**
+ * Generic data table driven by column/filter declarations.
+ *
+ * Props:
+ *  - columns: Array<{ key, label, type }>  (type can be 'string' | 'amount' | 'status')
+ *  - filters: string[] of column keys that are searchable
+ *  - data: array of row objects
+ *  - onRowSelect: (row) => void
+ *  - selectedId: string | number
+ *  - compact: boolean (reserved for narrower layout)
+ */
+export function DataTable({ columns = [], filters = [], data = [], onRowSelect, selectedId, compact }) {
+  const [filterValues, setFilterValues] = useState({});
+
+  const setFilter = (key, value) => {
+    setFilterValues(prev => ({ ...prev, [key]: value }));
+  };
+
+  const filteredData = useMemo(() => {
+    return data.filter(row => {
+      for (const key of filters) {
+        const filterVal = filterValues[key];
+        if (filterVal && !String(row[key] ?? '').toLowerCase().includes(filterVal.toLowerCase())) {
+          return false;
+        }
+      }
+      return true;
+    });
+  }, [data, filters, filterValues]);
+
+  const renderCellValue = (row, col) => {
+    if (col.type === 'status') {
+      return <StatusBadge status={row[col.key]} />;
+    }
+    if (col.type === 'amount') {
+      return <span className="tabular-nums">{row[col.key]?.toLocaleString()}</span>;
+    }
+    return row[col.key];
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex gap-2 flex-wrap">
+        {filters.map(key => {
+          const col = columns.find(c => c.key === key);
+          const label = col?.label ?? key;
+          return (
+            <div key={key} className="relative">
+              <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder={`Filter ${label}...`}
+                value={filterValues[key] ?? ''}
+                onChange={(e) => setFilter(key, e.target.value)}
+                className="pl-8 max-w-xs focus:ring-2 focus:ring-primary focus:outline-none transition-colors duration-200"
+                aria-label={`Filter by ${label}`}
+              />
+            </div>
+          );
+        })}
+      </div>
+      <div className="rounded-lg border overflow-hidden">
+        <Table>
+          <TableHeader>
+            <TableRow className="border-b-2 border-primary/20 bg-muted/40">
+              {columns.map(col => (
+                <TableHead key={col.key} className="text-xs font-medium text-blue-800 uppercase tracking-wider">
+                  {col.label}
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredData.map((row, idx) => (
+              <TableRow
+                key={row.id ?? idx}
+                onClick={() => onRowSelect?.(row)}
+                className={[
+                  'cursor-pointer transition-colors',
+                  row.id === selectedId ? 'bg-primary/10 border-l-2 border-l-primary' : '',
+                  idx % 2 !== 0 && row.id !== selectedId ? 'bg-muted/30' : '',
+                  'hover:bg-primary/5',
+                ].filter(Boolean).join(' ')}
+              >
+                {columns.map(col => (
+                  <TableCell key={col.key}>{renderCellValue(row, col)}</TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+      <p className="text-xs text-muted-foreground">{filteredData.length} of {data.length} records</p>
+    </div>
+  );
+}

--- a/tools/app-shell/src/components/contract-ui/EntityForm.jsx
+++ b/tools/app-shell/src/components/contract-ui/EntityForm.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+/**
+ * Generic entity form driven by field declarations.
+ *
+ * Props:
+ *  - fields: Array<{ key, label, type, required }>  (type: 'text' | 'number' | 'date')
+ *  - data: object with current field values
+ *  - onChange: (fieldKey, value) => void
+ */
+export function EntityForm({ fields = [], data, onChange }) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      {fields.map(f => {
+        const inputType = f.type === 'number' ? 'number' : 'text';
+        return (
+          <div key={f.key} className="space-y-1.5">
+            <Label htmlFor={f.key} className="text-sm text-foreground font-medium">
+              {f.label}{f.required ? ' *' : ''}
+            </Label>
+            <Input
+              id={f.key}
+              name={f.key}
+              type={inputType}
+              value={data?.[f.key] ?? ''}
+              onChange={(e) => onChange?.(f.key, e.target.value)}
+              className="focus:ring-2 focus:ring-primary focus:outline-none"
+              required={f.required}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/tools/app-shell/src/components/contract-ui/MasterDetailPage.jsx
+++ b/tools/app-shell/src/components/contract-ui/MasterDetailPage.jsx
@@ -1,0 +1,234 @@
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { StatusBadge } from '@/components/ui/status-badge';
+import { useEntity } from '@/hooks/useEntity';
+
+/**
+ * Generic master-detail page with Split View layout (40/60).
+ *
+ * Props:
+ *  - entity: string (primary entity name)
+ *  - detailEntity: string (child entity name)
+ *  - Table: React component for the master table
+ *  - Form: React component for the edit form
+ *  - DetailTable: React component for the child table
+ *  - summary: Array<{ key, label, type }> (read-only summary fields)
+ *  - statusField: string (field key used for status badge in toolbar)
+ *  - processes: Array<{ name, label, style }> (style: 'positive' | 'destructive')
+ *  - addLineFields: { entry: Array<{ key, label, type, required, lookup }>, derived: Array<{ key, label, type }> }
+ *  - token: string
+ *  - apiBaseUrl: string
+ *  - entityLabel: string (human-readable entity name, e.g. 'Order')
+ *  - detailLabel: string (human-readable detail name, e.g. 'Order Line')
+ *  - titleField: string (field key for display title, defaults to 'documentNo')
+ */
+export function MasterDetailPage({
+  entity,
+  detailEntity,
+  Table,
+  Form,
+  DetailTable,
+  summary = [],
+  statusField,
+  processes = [],
+  addLineFields = { entry: [], derived: [] },
+  token,
+  apiBaseUrl,
+  entityLabel,
+  detailLabel,
+  titleField = 'documentNo',
+}) {
+  const hook = useEntity(entity, detailEntity, { token, apiBaseUrl });
+  const [showAddLine, setShowAddLine] = useState(false);
+
+  const allEntryFields = addLineFields.entry ?? [];
+  const allDerivedFields = addLineFields.derived ?? [];
+  const allDetailFields = [...allEntryFields, ...allDerivedFields];
+
+  const emptyLine = Object.fromEntries(allDetailFields.map(f => [f.key, '']));
+  const [newLine, setNewLine] = useState(emptyLine);
+
+  const detailTitle = hook.editing?.id
+    ? `${entityLabel || entity} ${hook.editing[titleField] || hook.editing.id}`
+    : `New ${entityLabel || entity}`;
+
+  const handleAddLine = () => {
+    hook.handleAddChild?.(newLine);
+    setNewLine({ ...emptyLine });
+    setShowAddLine(false);
+  };
+
+  const handleProductLookup = async (value) => {
+    const defaults = await hook.lookupChildDefaults?.(value);
+    if (defaults) {
+      setNewLine(prev => ({ ...prev, ...defaults }));
+    }
+  };
+
+  const renderSummaryValue = (field) => {
+    const val = hook.editing?.[field.key];
+    if (val == null) return '\u2014';
+    if (field.type === 'amount' || field.type === 'number') {
+      return val.toLocaleString?.() ?? val;
+    }
+    return val;
+  };
+
+  // Find the lookup trigger field (first entry field with lookup: true, or first entry field)
+  const lookupTriggerKey = allEntryFields.find(f => f.lookup)?.key ?? allEntryFields[0]?.key;
+
+  return (
+    <div className="flex h-[calc(100vh-4rem)] gap-0">
+      {/* Left panel: Table */}
+      <div className={`flex flex-col border-r transition-all duration-300 ${hook.editing ? 'w-2/5' : 'w-full'}`}>
+        <div className="flex items-center justify-between px-4 py-3 border-b bg-muted/20">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">{entityLabel || entity}s</h2>
+            <p className="text-xs text-muted-foreground">
+              {hook.loading ? 'Loading...' : `${hook.items.length} records`}
+            </p>
+          </div>
+          <Button onClick={hook.handleNew} size="sm">+ New</Button>
+        </div>
+        <div className="flex-1 overflow-auto p-3">
+          {hook.loading ? (
+            <div className="animate-pulse space-y-3">
+              <div className="h-10 bg-muted rounded" />
+              <div className="h-8 bg-muted/60 rounded" />
+              <div className="h-8 bg-muted/40 rounded" />
+              <div className="h-8 bg-muted/60 rounded" />
+              <div className="h-8 bg-muted/40 rounded" />
+            </div>
+          ) : (
+            <Table
+              data={hook.items}
+              onRowSelect={hook.handleSelect}
+              selectedId={hook.selected?.id}
+              compact={!!hook.editing}
+            />
+          )}
+        </div>
+      </div>
+
+      {/* Right panel: Toolbar + Summary + Form + Detail */}
+      {hook.editing && (
+        <div className="flex-1 flex flex-col overflow-hidden bg-white">
+          {/* Toolbar: title, status, process actions, save/delete */}
+          <div className="flex items-center gap-2 px-5 py-2.5 border-b border-slate-200 bg-white shadow-sm">
+            <h2 className="text-base font-semibold text-foreground truncate">{detailTitle}</h2>
+            {statusField && <StatusBadge status={hook.editing?.[statusField]} />}
+            <div className="flex-1" />
+            <div className="flex items-center gap-2">
+              {processes.length > 0 && <div className="h-5 w-px bg-border" />}
+              {processes.map(p => {
+                const btnClass = p.style === 'destructive'
+                  ? 'border-amber-300 bg-amber-50 text-amber-700 hover:bg-amber-100'
+                  : 'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100';
+                return (
+                  <Button
+                    key={p.name}
+                    variant="outline"
+                    size="sm"
+                    className={btnClass}
+                    onClick={() => hook.handleProcess?.(p.name)}
+                  >
+                    {p.label}
+                  </Button>
+                );
+              })}
+              <Button size="sm" onClick={() => hook.handleSave(hook.editing)}>Save</Button>
+              {hook.selected && (
+                <Button variant="destructive" size="sm" onClick={hook.handleDelete}>Delete</Button>
+              )}
+              <button
+                onClick={() => hook.handleSelect(null)}
+                className="h-8 w-8 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                aria-label="Close detail"
+              >
+                &times;
+              </button>
+            </div>
+          </div>
+
+          {/* Summary strip: read-only reference fields */}
+          <div className="flex items-center gap-5 px-5 py-2.5 border-b border-slate-200 bg-slate-50 text-xs">
+            {summary.map(field => (
+              <div key={field.key} className="flex items-center gap-1.5">
+                <span className="text-slate-500">{field.label}:</span>
+                <span className={`font-semibold text-foreground ${field.type === 'amount' || field.type === 'number' ? 'tabular-nums' : ''}`}>
+                  {renderSummaryValue(field)}
+                </span>
+              </div>
+            ))}
+          </div>
+
+          {/* Form zone: editable fields only */}
+          <div className="px-5 pt-4 pb-3 border-b">
+            <Form
+              data={hook.editing}
+              onChange={hook.handleChange}
+            />
+          </div>
+
+          {/* Detail zone: fills remaining height */}
+          <div className="flex-1 flex flex-col overflow-hidden px-5 py-3">
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-xs font-bold text-slate-500 uppercase tracking-widest">{detailLabel || detailEntity}s</h3>
+              <Button
+                variant="outline"
+                size="sm"
+                className="text-xs h-7"
+                onClick={() => setShowAddLine(!showAddLine)}
+              >
+                {showAddLine ? 'Cancel' : '+ Add Line'}
+              </Button>
+            </div>
+            {showAddLine && (
+              <form
+                onSubmit={(e) => { e.preventDefault(); handleAddLine(); }}
+                className="flex items-end gap-2 mb-3 p-3 rounded-lg border border-dashed border-primary/30 bg-primary/5"
+              >
+                {allEntryFields.map(f => {
+                  const inputType = f.type === 'number' ? 'number' : 'text';
+                  const isLookupTrigger = f.key === lookupTriggerKey;
+                  return (
+                    <div key={f.key} className="flex-1 min-w-0">
+                      <label className="text-xs text-slate-500 mb-1 block">
+                        {f.label}{f.required ? ' *' : ''}
+                      </label>
+                      <input
+                        name={f.key}
+                        type={inputType}
+                        placeholder={f.label}
+                        value={newLine[f.key] ?? ''}
+                        onChange={(e) => setNewLine(prev => ({ ...prev, [f.key]: e.target.value }))}
+                        onBlur={isLookupTrigger ? (e) => { if (e.target.value) handleProductLookup(e.target.value); } : undefined}
+                        className="w-full h-8 text-sm rounded-md border border-input bg-white px-2 focus:ring-2 focus:ring-primary focus:outline-none"
+                        required={f.required}
+                      />
+                    </div>
+                  );
+                })}
+                {allDerivedFields.length > 0 && (
+                  <div className="w-px h-8 bg-slate-200 self-end mb-0.5" />
+                )}
+                {allDerivedFields.map(f => (
+                  <div key={f.key} className="flex-1 min-w-0">
+                    <label className="text-xs text-slate-400 mb-1 block">{f.label}</label>
+                    <div className="h-8 text-sm rounded-md border border-dashed border-slate-200 bg-slate-50 px-2 flex items-center text-slate-600 tabular-nums">
+                      {newLine[f.key] || '\u2014'}
+                    </div>
+                  </div>
+                ))}
+                <Button type="submit" size="sm" className="h-8 shrink-0">Add</Button>
+              </form>
+            )}
+            <div className="flex-1 overflow-auto">
+              <DetailTable data={hook.children} />
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tools/app-shell/src/components/contract-ui/index.js
+++ b/tools/app-shell/src/components/contract-ui/index.js
@@ -1,0 +1,3 @@
+export { DataTable } from './DataTable';
+export { EntityForm } from './EntityForm';
+export { MasterDetailPage } from './MasterDetailPage';

--- a/tools/app-shell/src/components/ui/input.jsx
+++ b/tools/app-shell/src/components/ui/input.jsx
@@ -5,7 +5,7 @@ const Input = React.forwardRef(({ className, type, ...props }, ref) => (
   <input
     type={type}
     className={cn(
-      'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+      'flex h-9 w-full rounded-md border border-input bg-white px-3 py-1 text-sm shadow-sm transition-colors hover:border-slate-400 file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
       className
     )}
     ref={ref}

--- a/tools/app-shell/src/components/ui/slide-panel.jsx
+++ b/tools/app-shell/src/components/ui/slide-panel.jsx
@@ -1,36 +1,49 @@
 import * as React from 'react';
 import { cn } from '@/lib/utils';
+import { X } from 'lucide-react';
 
 export function SlidePanel({ open, onClose, title, children }) {
+  React.useEffect(() => {
+    if (!open) return;
+    const handleKey = (e) => {
+      if (e.key === 'Escape') onClose?.();
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open, onClose]);
+
   return (
     <>
       <div
         className={cn(
-          'fixed inset-0 bg-black/30 z-40 transition-opacity duration-300',
+          'fixed inset-0 bg-black/20 backdrop-blur-sm z-40 transition-opacity duration-300',
           open ? 'opacity-100' : 'opacity-0 pointer-events-none'
         )}
         onClick={onClose}
+        aria-hidden="true"
       />
       <div
         className={cn(
-          'fixed top-0 right-0 h-full w-[480px] max-w-full bg-white z-50 shadow-xl',
+          'fixed top-0 right-0 h-full w-[520px] max-w-full bg-white z-50',
           'transform transition-transform duration-300 ease-in-out',
-          'flex flex-col',
+          'flex flex-col shadow-2xl',
           open ? 'translate-x-0' : 'translate-x-full'
         )}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
       >
-        <div className="flex items-center justify-between px-6 py-4 border-b">
-          <h2 className="text-lg font-semibold text-gray-900">{title}</h2>
+        <div className="flex items-center justify-between px-6 py-4 border-b bg-muted/30">
+          <h2 className="text-base font-semibold text-foreground">{title}</h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 transition-colors"
+            aria-label="Close panel"
+            className="h-8 w-8 rounded-lg flex items-center justify-center text-muted-foreground hover:text-foreground hover:bg-muted transition-colors focus:ring-2 focus:ring-primary focus:outline-none"
           >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X className="h-4 w-4" />
           </button>
         </div>
-        <div className="flex-1 overflow-y-auto px-6 py-4">
+        <div className="flex-1 overflow-y-auto px-6 py-5">
           {children}
         </div>
       </div>

--- a/tools/app-shell/src/components/ui/status-badge.jsx
+++ b/tools/app-shell/src/components/ui/status-badge.jsx
@@ -2,16 +2,16 @@ import * as React from 'react';
 import { cn } from '@/lib/utils';
 
 const STATUS_MAP = {
-  DR: { label: 'Draft', className: 'bg-gray-100 text-gray-700' },
-  CO: { label: 'Complete', className: 'bg-green-100 text-green-700' },
-  VO: { label: 'Void', className: 'bg-red-100 text-red-700' },
-  IP: { label: 'In Process', className: 'bg-yellow-100 text-yellow-700' },
+  DR: { label: 'Draft', className: 'bg-slate-100 text-slate-600 ring-slate-200' },
+  CO: { label: 'Complete', className: 'bg-emerald-50 text-emerald-700 ring-emerald-200' },
+  VO: { label: 'Void', className: 'bg-red-50 text-red-600 ring-red-200' },
+  IP: { label: 'In Process', className: 'bg-amber-50 text-amber-700 ring-amber-200' },
 };
 
 export function StatusBadge({ status }) {
-  const config = STATUS_MAP[status] || { label: status, className: 'bg-gray-100 text-gray-600' };
+  const config = STATUS_MAP[status] || { label: status, className: 'bg-slate-100 text-slate-600 ring-slate-200' };
   return (
-    <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium', config.className)}>
+    <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset', config.className)}>
       {config.label}
     </span>
   );

--- a/tools/app-shell/src/index.css
+++ b/tools/app-shell/src/index.css
@@ -3,31 +3,35 @@
 @tailwind utilities;
 
 :root {
-  --background: 0 0% 100%;
-  --foreground: 0 0% 3.9%;
+  --background: 210 20% 98%;
+  --foreground: 222 47% 11%;
   --card: 0 0% 100%;
-  --card-foreground: 0 0% 3.9%;
+  --card-foreground: 222 47% 11%;
   --popover: 0 0% 100%;
-  --popover-foreground: 0 0% 3.9%;
-  --primary: 0 0% 9%;
-  --primary-foreground: 0 0% 98%;
-  --secondary: 0 0% 96.1%;
-  --secondary-foreground: 0 0% 9%;
-  --muted: 0 0% 96.1%;
-  --muted-foreground: 0 0% 45.1%;
-  --accent: 0 0% 96.1%;
-  --accent-foreground: 0 0% 9%;
-  --destructive: 0 84.2% 60.2%;
-  --destructive-foreground: 0 0% 98%;
-  --border: 0 0% 89.8%;
-  --input: 0 0% 89.8%;
-  --ring: 0 0% 3.9%;
+  --popover-foreground: 222 47% 11%;
+  --primary: 221 83% 53%;
+  --primary-foreground: 210 40% 98%;
+  --secondary: 210 40% 96%;
+  --secondary-foreground: 222 47% 11%;
+  --muted: 210 40% 96%;
+  --muted-foreground: 215 16% 47%;
+  --accent: 210 40% 96%;
+  --accent-foreground: 222 47% 11%;
+  --destructive: 0 84% 60%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 214 32% 91%;
+  --input: 214 32% 91%;
+  --ring: 221 83% 53%;
   --radius: 0.5rem;
+
+  --sidebar-bg: 222 47% 11%;
+  --sidebar-text: 213 31% 91%;
+  --sidebar-active: 221 83% 53%;
 }
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   -webkit-font-smoothing: antialiased;
   background-color: hsl(var(--background));
   color: hsl(var(--foreground));

--- a/tools/app-shell/src/layout/Sidebar.jsx
+++ b/tools/app-shell/src/layout/Sidebar.jsx
@@ -4,19 +4,22 @@ import { LayoutDashboard, Eye } from 'lucide-react';
 
 export default function Sidebar({ menuItems }) {
   return (
-    <aside className="w-60 border-r bg-muted/30 flex flex-col">
-      <div className="p-4 border-b">
-        <h1 className="text-lg font-bold tracking-tight">Schema Forge</h1>
+    <aside className="w-60 flex flex-col" style={{ backgroundColor: 'hsl(var(--sidebar-bg))' }}>
+      <div className="px-5 py-5 border-b border-white/10">
+        <h1 className="text-lg font-bold tracking-tight text-white">Schema Forge</h1>
+        <p className="text-xs mt-0.5" style={{ color: 'hsl(var(--sidebar-text))' }}>ERP Generator</p>
       </div>
-      <nav className="flex-1 p-2 space-y-1">
+      <nav className="flex-1 p-3 space-y-1">
         {menuItems.map(item => (
           <NavLink
             key={item.name}
             to={`/${item.name}`}
             className={({ isActive }) =>
               cn(
-                'flex items-center gap-3 rounded-md px-3 py-2 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground',
-                isActive && 'bg-accent text-accent-foreground'
+                'flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors',
+                isActive
+                  ? 'bg-white/15 text-white'
+                  : 'text-white/60 hover:bg-white/10 hover:text-white'
               )
             }
           >
@@ -25,13 +28,15 @@ export default function Sidebar({ menuItems }) {
           </NavLink>
         ))}
       </nav>
-      <div className="border-t p-2">
+      <div className="border-t border-white/10 p-3">
         <NavLink
           to="/preview"
           className={({ isActive }) =>
             cn(
-              'flex items-center gap-3 rounded-md px-3 py-2 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground',
-              isActive && 'bg-accent text-accent-foreground'
+              'flex items-center gap-3 rounded-lg px-3 py-2 text-xs font-medium transition-colors',
+              isActive
+                ? 'bg-white/15 text-white'
+                : 'text-white/40 hover:bg-white/10 hover:text-white/80'
             )
           }
         >

--- a/tools/app-shell/src/layout/TopBar.jsx
+++ b/tools/app-shell/src/layout/TopBar.jsx
@@ -13,9 +13,14 @@ export default function TopBar() {
   }
 
   return (
-    <header className="h-12 border-b flex items-center justify-end px-4 gap-4 bg-background">
-      <span className="text-sm text-muted-foreground">{username}</span>
-      <Button variant="ghost" size="sm" onClick={handleLogout}>
+    <header className="h-14 border-b flex items-center justify-end px-6 gap-4 bg-white">
+      <div className="flex items-center gap-3">
+        <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center">
+          <span className="text-xs font-semibold text-primary">{username?.charAt(0).toUpperCase()}</span>
+        </div>
+        <span className="text-sm font-medium text-foreground">{username}</span>
+      </div>
+      <Button variant="ghost" size="sm" onClick={handleLogout} className="text-muted-foreground hover:text-foreground">
         <LogOut className="h-4 w-4 mr-1" />
         Logout
       </Button>

--- a/tools/app-shell/tailwind.config.js
+++ b/tools/app-shell/tailwind.config.js
@@ -1,6 +1,53 @@
 /** @type {import('tailwindcss').Config} */
 export default {
-  content: ['./index.html', './src/**/*.{js,jsx}'],
-  theme: { extend: {} },
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx}',
+    '../../artifacts/**/generated/**/*.{js,jsx}',
+  ],
+  theme: {
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+    },
+  },
   plugins: [],
 };


### PR DESCRIPTION
## Summary

- Created generic runtime components (`DataTable`, `EntityForm`, `MasterDetailPage`) in `tools/app-shell/src/components/contract-ui/` containing ALL layout, CSS, and behavior
- Rewrote `cli/src/generate-frontend.js` to produce thin declarative code: only config arrays (columns, fields, processes) that import and compose the generic components
- Updated tests to verify declarative output structure instead of inline CSS classes
- Regenerated `artifacts/sales-order/generated/web/sales-order/*.jsx`

## Changes

**New files:**
- `tools/app-shell/src/components/contract-ui/DataTable.jsx` - Generic table with filters, zebra rows, status badges, selected row highlight
- `tools/app-shell/src/components/contract-ui/EntityForm.jsx` - Generic 2-column form with label+input rendering
- `tools/app-shell/src/components/contract-ui/MasterDetailPage.jsx` - Generic split view page with toolbar, summary strip, form zone, detail zone, add-line mini form
- `tools/app-shell/src/components/contract-ui/index.js` - Barrel export

**Modified files:**
- `cli/src/generate-frontend.js` - Now produces ~15-50 line thin components instead of ~500 lines of inline JSX/CSS
- `cli/test/generate-frontend.test.js` - 29 tests verifying declarative config structure
- `artifacts/sales-order/generated/web/sales-order/*.jsx` - Regenerated output

## Test plan

- [x] `node --test 'cli/test/generate-frontend.test.js'` - 29 tests pass
- [x] `node --test 'cli/test/*.test.js'` - 292 tests pass, 0 failures
- [x] Regenerated artifacts match target format
- [ ] Visual regression check in browser (app-shell dev server)

Generated with [Claude Code](https://claude.com/claude-code)