### PR TITLE
feat: add generate-frontend step (F8) to pipeline

### DIFF
--- a/cli/src/pipeline.js
+++ b/cli/src/pipeline.js
@@ -15,6 +15,7 @@ export function buildPipelineSteps() {
     { name: 'human-decisions', description: 'Open Decision Panel for human review', phase: 'F4', interactive: true },
     { name: 'generate-contract', description: 'Generate frontend/backend contracts + test manifest', phase: 'F6' },
     { name: 'generate-backend', description: 'Generate Etendo Java module from templates', phase: 'F7' },
+    { name: 'generate-frontend', description: 'Generate React components from contract', phase: 'F8' },
     { name: 'run-tests', description: 'Run contract tests (Node.js side)', phase: 'F9' },
   ];
 }
@@ -99,6 +100,19 @@ async function main() {
           const contract = JSON.parse(await readFile(`artifacts/${windowName}/contract.json`, 'utf8'));
           await generateBackend(schema, rules.rules || [], processes.processes || [], contract, windowName);
           console.log('  ✓ Backend module generated');
+          break;
+        }
+        case 'generate-frontend': {
+          const { generateAll } = await import('./generate-frontend.js');
+          const { readFile, writeFile, mkdir } = await import('node:fs/promises');
+          const contract = JSON.parse(await readFile(`artifacts/${windowName}/contract.json`, 'utf8'));
+          const files = generateAll(contract);
+          const outDir = `artifacts/${windowName}/generated/web/${windowName}`;
+          await mkdir(outDir, { recursive: true });
+          for (const [filename, code] of Object.entries(files)) {
+            await writeFile(`${outDir}/${filename}`, code, 'utf8');
+          }
+          console.log(`  ✓ ${Object.keys(files).length} frontend components generated`);
           break;
         }
         case 'run-tests': {

--- a/cli/test/pipeline.test.js
+++ b/cli/test/pipeline.test.js
@@ -67,9 +67,26 @@ describe('buildPipelineSteps', () => {
     assert.equal(humanStep.interactive, true);
   });
 
-  it('returns exactly 8 steps', () => {
+  it('returns exactly 9 steps', () => {
     const steps = buildPipelineSteps();
-    assert.equal(steps.length, 8);
+    assert.equal(steps.length, 9);
+  });
+
+  it('includes generate-frontend step with phase F8', () => {
+    const steps = buildPipelineSteps();
+    const f8 = steps.find(s => s.name === 'generate-frontend');
+    assert.ok(f8, 'generate-frontend step must exist');
+    assert.equal(f8.phase, 'F8');
+    assert.ok(f8.description, 'generate-frontend must have a description');
+  });
+
+  it('F8 comes after F7 and before F9', () => {
+    const steps = buildPipelineSteps();
+    const f7Index = steps.findIndex(s => s.phase === 'F7');
+    const f8Index = steps.findIndex(s => s.phase === 'F8');
+    const f9Index = steps.findIndex(s => s.phase === 'F9');
+    assert.ok(f7Index < f8Index, 'F7 must come before F8');
+    assert.ok(f8Index < f9Index, 'F8 must come before F9');
   });
 
   it('all step names are unique', () => {


### PR DESCRIPTION
## Summary
- Add `generate-frontend` step (F8) to `buildPipelineSteps()` between F7 and F9
- Add F8 case in `main()` switch: imports `generateAll`, writes components to `artifacts/{window}/generated/web/{window}/`
- Add 3 tests: F8 step exists with correct phase, ordering F7 < F8 < F9, step count updated to 9

## Test plan
- [x] All 294 tests pass (48 suites, 0 failures)
- [x] Pipeline step count updated from 8 to 9
- [x] F8 ordering verified between F7 and F9

Generated with [Claude Code](https://claude.com/claude-code)