### PR TITLE
feat: BP master-detail (BP -> Locations)

### DIFF
--- a/artifacts/business-partner/contract.json
+++ b/artifacts/business-partner/contract.json
@@ -1,7 +1,7 @@
 {
   "version": "0.1.0",
-  "generatedAt": "2026-03-06T14:48:21.353Z",
-  "checksum": "acda6284c4d7f4e7",
+  "generatedAt": "2026-03-06T15:07:15.175Z",
+  "checksum": "6ba1934af34a7cef",
   "frontendContract": {
     "window": {
       "id": "200",
@@ -76,6 +76,75 @@
         "searchableFields": [
           "name",
           "searchKey"
+        ],
+        "computedFields": []
+      },
+      "bpLocation": {
+        "fields": [
+          {
+            "name": "name",
+            "column": "Name",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "address",
+            "column": "Address1",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": false,
+            "form": true
+          },
+          {
+            "name": "city",
+            "column": "City",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "postalCode",
+            "column": "Postal",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": false,
+            "form": true
+          },
+          {
+            "name": "country",
+            "column": "C_Country_ID",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "phone",
+            "column": "Phone",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": false,
+            "form": true
+          }
+        ],
+        "searchableFields": [
+          "name",
+          "city"
         ],
         "computedFields": []
       }
@@ -162,6 +231,87 @@
             "required": true
           }
         ]
+      },
+      "bpLocation": {
+        "fields": [
+          {
+            "name": "name",
+            "column": "Name",
+            "type": "string",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "address",
+            "column": "Address1",
+            "type": "string",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "city",
+            "column": "City",
+            "type": "string",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "postalCode",
+            "column": "Postal",
+            "type": "string",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "country",
+            "column": "C_Country_ID",
+            "type": "string",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "phone",
+            "column": "Phone",
+            "type": "string",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "adClientId",
+            "column": "AD_Client_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "adOrgId",
+            "column": "AD_Org_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "cBpartnerId",
+            "column": "C_BPartner_ID",
+            "type": "foreignKey",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "created",
+            "column": "Created",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updated",
+            "column": "Updated",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          }
+        ]
       }
     },
     "endpoints": [
@@ -196,6 +346,39 @@
         "method": "DELETE",
         "path": "/businessPartner/:id",
         "entity": "businessPartner",
+        "supportedFilters": []
+      },
+      {
+        "method": "GET",
+        "path": "/bpLocation",
+        "entity": "bpLocation",
+        "supportedFilters": [
+          "name",
+          "city"
+        ]
+      },
+      {
+        "method": "GET",
+        "path": "/bpLocation/:id",
+        "entity": "bpLocation",
+        "supportedFilters": []
+      },
+      {
+        "method": "POST",
+        "path": "/bpLocation",
+        "entity": "bpLocation",
+        "supportedFilters": []
+      },
+      {
+        "method": "PUT",
+        "path": "/bpLocation/:id",
+        "entity": "bpLocation",
+        "supportedFilters": []
+      },
+      {
+        "method": "DELETE",
+        "path": "/bpLocation/:id",
+        "entity": "bpLocation",
         "supportedFilters": []
       }
     ],
@@ -324,6 +507,125 @@
       },
       {
         "id": "t-16",
+        "category": "field-presence",
+        "entity": "bpLocation",
+        "field": "name",
+        "runner": "node",
+        "description": "Field 'name' should be present in bpLocation"
+      },
+      {
+        "id": "t-17",
+        "category": "field-presence",
+        "entity": "bpLocation",
+        "field": "address",
+        "runner": "node",
+        "description": "Field 'address' should be present in bpLocation"
+      },
+      {
+        "id": "t-18",
+        "category": "field-presence",
+        "entity": "bpLocation",
+        "field": "city",
+        "runner": "node",
+        "description": "Field 'city' should be present in bpLocation"
+      },
+      {
+        "id": "t-19",
+        "category": "field-presence",
+        "entity": "bpLocation",
+        "field": "postalCode",
+        "runner": "node",
+        "description": "Field 'postalCode' should be present in bpLocation"
+      },
+      {
+        "id": "t-20",
+        "category": "field-presence",
+        "entity": "bpLocation",
+        "field": "country",
+        "runner": "node",
+        "description": "Field 'country' should be present in bpLocation"
+      },
+      {
+        "id": "t-21",
+        "category": "field-presence",
+        "entity": "bpLocation",
+        "field": "phone",
+        "runner": "node",
+        "description": "Field 'phone' should be present in bpLocation"
+      },
+      {
+        "id": "t-22",
+        "category": "field-type",
+        "entity": "bpLocation",
+        "field": "name",
+        "runner": "node",
+        "description": "Field 'name' should have type 'string' in bpLocation"
+      },
+      {
+        "id": "t-23",
+        "category": "field-type",
+        "entity": "bpLocation",
+        "field": "address",
+        "runner": "node",
+        "description": "Field 'address' should have type 'string' in bpLocation"
+      },
+      {
+        "id": "t-24",
+        "category": "field-type",
+        "entity": "bpLocation",
+        "field": "city",
+        "runner": "node",
+        "description": "Field 'city' should have type 'string' in bpLocation"
+      },
+      {
+        "id": "t-25",
+        "category": "field-type",
+        "entity": "bpLocation",
+        "field": "postalCode",
+        "runner": "node",
+        "description": "Field 'postalCode' should have type 'string' in bpLocation"
+      },
+      {
+        "id": "t-26",
+        "category": "field-type",
+        "entity": "bpLocation",
+        "field": "country",
+        "runner": "node",
+        "description": "Field 'country' should have type 'string' in bpLocation"
+      },
+      {
+        "id": "t-27",
+        "category": "field-type",
+        "entity": "bpLocation",
+        "field": "phone",
+        "runner": "node",
+        "description": "Field 'phone' should have type 'string' in bpLocation"
+      },
+      {
+        "id": "t-28",
+        "category": "searchable-filters",
+        "entity": "bpLocation",
+        "field": "name",
+        "runner": "node",
+        "description": "Field 'name' should be a supported filter for bpLocation"
+      },
+      {
+        "id": "t-29",
+        "category": "searchable-filters",
+        "entity": "bpLocation",
+        "field": "city",
+        "runner": "node",
+        "description": "Field 'city' should be a supported filter for bpLocation"
+      },
+      {
+        "id": "t-30",
+        "category": "visibility",
+        "entity": "bpLocation",
+        "runner": "node",
+        "description": "Entity 'bpLocation' should only expose visible fields in frontend"
+      },
+      {
+        "id": "t-31",
         "category": "system-field",
         "entity": "businessPartner",
         "field": "adClientId",
@@ -331,7 +633,7 @@
         "description": "System field 'adClientId' should exist in backend but not frontend for businessPartner"
       },
       {
-        "id": "t-17",
+        "id": "t-32",
         "category": "system-field",
         "entity": "businessPartner",
         "field": "adOrgId",
@@ -339,7 +641,7 @@
         "description": "System field 'adOrgId' should exist in backend but not frontend for businessPartner"
       },
       {
-        "id": "t-18",
+        "id": "t-33",
         "category": "system-field",
         "entity": "businessPartner",
         "field": "created",
@@ -347,25 +649,65 @@
         "description": "System field 'created' should exist in backend but not frontend for businessPartner"
       },
       {
-        "id": "t-19",
+        "id": "t-34",
         "category": "system-field",
         "entity": "businessPartner",
         "field": "updated",
         "runner": "node",
         "description": "System field 'updated' should exist in backend but not frontend for businessPartner"
+      },
+      {
+        "id": "t-35",
+        "category": "system-field",
+        "entity": "bpLocation",
+        "field": "adClientId",
+        "runner": "node",
+        "description": "System field 'adClientId' should exist in backend but not frontend for bpLocation"
+      },
+      {
+        "id": "t-36",
+        "category": "system-field",
+        "entity": "bpLocation",
+        "field": "adOrgId",
+        "runner": "node",
+        "description": "System field 'adOrgId' should exist in backend but not frontend for bpLocation"
+      },
+      {
+        "id": "t-37",
+        "category": "system-field",
+        "entity": "bpLocation",
+        "field": "cBpartnerId",
+        "runner": "node",
+        "description": "System field 'cBpartnerId' should exist in backend but not frontend for bpLocation"
+      },
+      {
+        "id": "t-38",
+        "category": "system-field",
+        "entity": "bpLocation",
+        "field": "created",
+        "runner": "node",
+        "description": "System field 'created' should exist in backend but not frontend for bpLocation"
+      },
+      {
+        "id": "t-39",
+        "category": "system-field",
+        "entity": "bpLocation",
+        "field": "updated",
+        "runner": "node",
+        "description": "System field 'updated' should exist in backend but not frontend for bpLocation"
       }
     ],
     "summary": {
-      "total": 19,
+      "total": 39,
       "byCategory": {
-        "field-presence": 6,
-        "field-type": 6,
-        "searchable-filters": 2,
-        "visibility": 1,
-        "system-field": 4
+        "field-presence": 12,
+        "field-type": 12,
+        "searchable-filters": 4,
+        "visibility": 2,
+        "system-field": 9
       },
       "byRunner": {
-        "node": 19,
+        "node": 39,
         "junit": 0
       }
     }

--- a/artifacts/business-partner/generated/web/business-partner/BpLocationForm.jsx
+++ b/artifacts/business-partner/generated/web/business-partner/BpLocationForm.jsx
@@ -1,0 +1,14 @@
+import { EntityForm } from '@/components/contract-ui';
+
+const fields = [
+  { key: 'name', label: 'Name', type: 'text', required: true },
+  { key: 'address', label: 'Address', type: 'text' },
+  { key: 'city', label: 'City', type: 'text' },
+  { key: 'postalCode', label: 'Postal Code', type: 'text' },
+  { key: 'country', label: 'Country', type: 'text' },
+  { key: 'phone', label: 'Phone', type: 'text' },
+];
+
+export default function BpLocationForm(props) {
+  return <EntityForm fields={fields} {...props} />;
+}

--- a/artifacts/business-partner/generated/web/business-partner/BpLocationTable.jsx
+++ b/artifacts/business-partner/generated/web/business-partner/BpLocationTable.jsx
@@ -1,0 +1,13 @@
+import { DataTable } from '@/components/contract-ui';
+
+const columns = [
+  { key: 'name', label: 'Name', type: 'string' },
+  { key: 'city', label: 'City', type: 'string' },
+  { key: 'country', label: 'Country', type: 'string' },
+];
+
+const filters = ['name', 'city'];
+
+export default function BpLocationTable(props) {
+  return <DataTable columns={columns} filters={filters} {...props} />;
+}

--- a/artifacts/business-partner/generated/web/business-partner/BusinessPartnerPage.jsx
+++ b/artifacts/business-partner/generated/web/business-partner/BusinessPartnerPage.jsx
@@ -1,0 +1,49 @@
+import { MasterDetailPage } from '@/components/contract-ui';
+import BusinessPartnerTable from './BusinessPartnerTable';
+import BusinessPartnerForm from './BusinessPartnerForm';
+import BpLocationTable from './BpLocationTable';
+import catalogs from './mockCatalogs';
+
+const summary = [
+  { key: 'isActive', label: 'Is Active', type: 'string' },
+];
+
+const statusField = null;
+
+const processes = [
+
+];
+
+const addLineFields = {
+  entry: [
+    { key: 'name', label: 'Name', type: 'text', required: true, lookup: true },
+    { key: 'address', label: 'Address', type: 'text' },
+    { key: 'city', label: 'City', type: 'text' },
+    { key: 'postalCode', label: 'Postal Code', type: 'text' },
+    { key: 'country', label: 'Country', type: 'text' },
+    { key: 'phone', label: 'Phone', type: 'text' },
+  ],
+  derived: [
+
+  ],
+};
+
+export default function BusinessPartnerPage(props) {
+  return (
+    <MasterDetailPage
+      entity="businessPartner"
+      detailEntity="bpLocation"
+      Table={BusinessPartnerTable}
+      Form={BusinessPartnerForm}
+      DetailTable={BpLocationTable}
+      summary={summary}
+      statusField={statusField}
+      processes={processes}
+      addLineFields={addLineFields}
+      catalogs={catalogs}
+      entityLabel="Business Partner"
+      detailLabel="Bp Location"
+      {...props}
+    />
+  );
+}

--- a/artifacts/business-partner/generated/web/business-partner/index.jsx
+++ b/artifacts/business-partner/generated/web/business-partner/index.jsx
@@ -1,18 +1,5 @@
-import { SingleEntityPage } from '@/components/contract-ui';
-import BusinessPartnerTable from './BusinessPartnerTable';
-import BusinessPartnerForm from './BusinessPartnerForm';
-import catalogs from './mockCatalogs';
+import BusinessPartnerPage from './BusinessPartnerPage';
 
 export default function App({ token, apiBaseUrl, window }) {
-  return (
-    <SingleEntityPage
-      entity="businessPartner"
-      Table={BusinessPartnerTable}
-      Form={BusinessPartnerForm}
-      catalogs={catalogs}
-      token={token}
-      apiBaseUrl={apiBaseUrl}
-      entityLabel="Business Partner"
-    />
-  );
+  return <BusinessPartnerPage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
 }

--- a/artifacts/business-partner/generated/web/business-partner/mockData.js
+++ b/artifacts/business-partner/generated/web/business-partner/mockData.js
@@ -1,139 +1,55 @@
 // Auto-generated mock data - do not edit manually
 
 export const businessPartner = [
-  {
-    "id": "bp-001",
-    "name": "Acme Corp",
-    "searchKey": "ACME",
-    "taxId": "US12345678",
-    "description": "Global technology supplier",
-    "creditLimit": 50000,
-    "isActive": true
-  },
-  {
-    "id": "bp-002",
-    "name": "TechFlow Inc",
-    "searchKey": "TECH",
-    "taxId": "US23456789",
-    "description": "Software development firm",
-    "creditLimit": 75000,
-    "isActive": true
-  },
-  {
-    "id": "bp-003",
-    "name": "Global Trade Ltd",
-    "searchKey": "GLBT",
-    "taxId": "UK34567890",
-    "description": "International trade company",
-    "creditLimit": 100000,
-    "isActive": true
-  },
-  {
-    "id": "bp-004",
-    "name": "Summit Industries",
-    "searchKey": "SMIT",
-    "taxId": "DE45678901",
-    "description": "Industrial manufacturer",
-    "creditLimit": 30000,
-    "isActive": true
-  },
-  {
-    "id": "bp-005",
-    "name": "Pacific Partners",
-    "searchKey": "PCFP",
-    "taxId": "FR56789012",
-    "description": "Consulting and services",
-    "creditLimit": 45000,
-    "isActive": true
-  },
-  {
-    "id": "bp-006",
-    "name": "Alpine Solutions",
-    "searchKey": "ALPS",
-    "taxId": "ES67890123",
-    "description": "IT solutions provider",
-    "creditLimit": 60000,
-    "isActive": true
-  },
-  {
-    "id": "bp-007",
-    "name": "Meridian Group",
-    "searchKey": "MRDG",
-    "taxId": "IT78901234",
-    "description": "Business consulting group",
-    "creditLimit": 80000,
-    "isActive": true
-  },
-  {
-    "id": "bp-008",
-    "name": "Vertex Systems",
-    "searchKey": "VTXS",
-    "taxId": "US89012345",
-    "description": "System integrator",
-    "creditLimit": 55000,
-    "isActive": true
-  },
-  {
-    "id": "bp-009",
-    "name": "Atlas Manufacturing",
-    "searchKey": "ATLM",
-    "taxId": "CA90123456",
-    "description": "Heavy equipment manufacturer",
-    "creditLimit": 120000,
-    "isActive": true
-  },
-  {
-    "id": "bp-010",
-    "name": "Nova Enterprises",
-    "searchKey": "NVAE",
-    "taxId": "AU01234567",
-    "description": "Startup accelerator",
-    "creditLimit": 25000,
-    "isActive": true
-  },
-  {
-    "id": "bp-011",
-    "name": "Pinnacle Services",
-    "searchKey": "PNCS",
-    "taxId": "JP11223344",
-    "description": "Professional services",
-    "creditLimit": 40000,
-    "isActive": true
-  },
-  {
-    "id": "bp-012",
-    "name": "Horizon Labs",
-    "searchKey": "HRZL",
-    "taxId": "BR22334455",
-    "description": "R&D laboratory",
-    "creditLimit": 35000,
-    "isActive": true
-  },
-  {
-    "id": "bp-013",
-    "name": "Cedar Holdings",
-    "searchKey": "CDRH",
-    "taxId": "MX33445566",
-    "description": "Investment holding company",
-    "creditLimit": 90000,
-    "isActive": true
-  },
-  {
-    "id": "bp-014",
-    "name": "Sterling & Co",
-    "searchKey": "STRL",
-    "taxId": "NL44556677",
-    "description": "Financial advisory",
-    "creditLimit": 70000,
-    "isActive": false
-  },
-  {
-    "id": "bp-015",
-    "name": "Quantum Logistics",
-    "searchKey": "QNTL",
-    "taxId": "SE55667788",
-    "description": "Supply chain management",
-    "creditLimit": 65000,
-    "isActive": false
-  }
+  { "id": "mock-bp-001", "name": "Acme Corp", "searchKey": "ACME", "taxId": "US-12345678", "description": "Global manufacturing conglomerate", "creditLimit": 500000, "isActive": true },
+  { "id": "mock-bp-002", "name": "TechFlow Inc", "searchKey": "TECHFLOW", "taxId": "US-23456789", "description": "IT services and cloud solutions", "creditLimit": 250000, "isActive": true },
+  { "id": "mock-bp-003", "name": "Global Trade Ltd", "searchKey": "GLOBTRADE", "taxId": "GB-34567890", "description": "Import/export trading company", "creditLimit": 750000, "isActive": true },
+  { "id": "mock-bp-004", "name": "Summit Industries", "searchKey": "SUMMIT", "taxId": "US-45678901", "description": "Heavy machinery and equipment", "creditLimit": 300000, "isActive": true },
+  { "id": "mock-bp-005", "name": "Pacific Partners", "searchKey": "PACIFIC", "taxId": "AU-56789012", "description": "Asia-Pacific distribution network", "creditLimit": 400000, "isActive": true },
+  { "id": "mock-bp-006", "name": "Alpine Solutions", "searchKey": "ALPINE", "taxId": "CH-67890123", "description": "Consulting and advisory services", "creditLimit": 150000, "isActive": true },
+  { "id": "mock-bp-007", "name": "Meridian Group", "searchKey": "MERIDIAN", "taxId": "US-78901234", "description": "Real estate and property management", "creditLimit": 600000, "isActive": true },
+  { "id": "mock-bp-008", "name": "Vertex Systems", "searchKey": "VERTEX", "taxId": "DE-89012345", "description": "ERP software and integrations", "creditLimit": 200000, "isActive": true },
+  { "id": "mock-bp-009", "name": "Atlas Manufacturing", "searchKey": "ATLAS", "taxId": "US-90123456", "description": "Precision parts manufacturer", "creditLimit": 350000, "isActive": true },
+  { "id": "mock-bp-010", "name": "Nova Enterprises", "searchKey": "NOVA", "taxId": "CA-01234567", "description": "Renewable energy solutions", "creditLimit": 450000, "isActive": true },
+  { "id": "mock-bp-011", "name": "Pinnacle Services", "searchKey": "PINNACLE", "taxId": "US-11223344", "description": "Facilities management", "creditLimit": 180000, "isActive": true },
+  { "id": "mock-bp-012", "name": "Horizon Labs", "searchKey": "HORIZON", "taxId": "GB-22334455", "description": "Pharmaceutical research", "creditLimit": 800000, "isActive": true },
+  { "id": "mock-bp-013", "name": "Cedar Holdings", "searchKey": "CEDAR", "taxId": "US-33445566", "description": "Investment and financial services", "creditLimit": 1000000, "isActive": false },
+  { "id": "mock-bp-014", "name": "Sterling & Co", "searchKey": "STERLING", "taxId": "GB-44556677", "description": "Legal and compliance advisory", "creditLimit": 120000, "isActive": true },
+  { "id": "mock-bp-015", "name": "Quantum Logistics", "searchKey": "QUANTUM", "taxId": "NL-55667788", "description": "Freight and supply chain management", "creditLimit": 550000, "isActive": true }
+];
+
+export const bpLocation = [
+  { "id": "mock-bploc-001", "name": "HQ - New York", "address": "100 Broadway", "city": "New York", "postalCode": "10001", "country": "United States", "phone": "+1-212-555-0100", "businessPartnerId": "mock-bp-001" },
+  { "id": "mock-bploc-002", "name": "Factory - Detroit", "address": "500 Industrial Blvd", "city": "Detroit", "postalCode": "48201", "country": "United States", "phone": "+1-313-555-0200", "businessPartnerId": "mock-bp-001" },
+  { "id": "mock-bploc-003", "name": "Warehouse - Chicago", "address": "300 Lake Shore Dr", "city": "Chicago", "postalCode": "60601", "country": "United States", "phone": "+1-312-555-0300", "businessPartnerId": "mock-bp-001" },
+  { "id": "mock-bploc-004", "name": "Main Office - San Jose", "address": "1200 Tech Park Ave", "city": "San Jose", "postalCode": "95110", "country": "United States", "phone": "+1-408-555-0400", "businessPartnerId": "mock-bp-002" },
+  { "id": "mock-bploc-005", "name": "Data Center - Austin", "address": "800 Server Lane", "city": "Austin", "postalCode": "73301", "country": "United States", "phone": "+1-512-555-0500", "businessPartnerId": "mock-bp-002" },
+  { "id": "mock-bploc-006", "name": "London Office", "address": "50 Canary Wharf", "city": "London", "postalCode": "E14 5AB", "country": "United Kingdom", "phone": "+44-20-7555-0600", "businessPartnerId": "mock-bp-003" },
+  { "id": "mock-bploc-007", "name": "Singapore Hub", "address": "10 Marina Bay", "city": "Singapore", "postalCode": "018956", "country": "Singapore", "phone": "+65-6555-0700", "businessPartnerId": "mock-bp-003" },
+  { "id": "mock-bploc-008", "name": "Shanghai Office", "address": "888 Nanjing Road", "city": "Shanghai", "postalCode": "200001", "country": "China", "phone": "+86-21-5555-0800", "businessPartnerId": "mock-bp-003" },
+  { "id": "mock-bploc-009", "name": "Plant - Houston", "address": "2200 Energy Pkwy", "city": "Houston", "postalCode": "77001", "country": "United States", "phone": "+1-713-555-0900", "businessPartnerId": "mock-bp-004" },
+  { "id": "mock-bploc-010", "name": "Office - Dallas", "address": "400 Commerce St", "city": "Dallas", "postalCode": "75201", "country": "United States", "phone": "+1-214-555-1000", "businessPartnerId": "mock-bp-004" },
+  { "id": "mock-bploc-011", "name": "Sydney Office", "address": "1 George St", "city": "Sydney", "postalCode": "2000", "country": "Australia", "phone": "+61-2-5555-1100", "businessPartnerId": "mock-bp-005" },
+  { "id": "mock-bploc-012", "name": "Tokyo Branch", "address": "3-1 Marunouchi", "city": "Tokyo", "postalCode": "100-0005", "country": "Japan", "phone": "+81-3-5555-1200", "businessPartnerId": "mock-bp-005" },
+  { "id": "mock-bploc-013", "name": "Zurich HQ", "address": "15 Bahnhofstrasse", "city": "Zurich", "postalCode": "8001", "country": "Switzerland", "phone": "+41-44-555-1300", "businessPartnerId": "mock-bp-006" },
+  { "id": "mock-bploc-014", "name": "Geneva Office", "address": "5 Rue du Rhone", "city": "Geneva", "postalCode": "1204", "country": "Switzerland", "phone": "+41-22-555-1400", "businessPartnerId": "mock-bp-006" },
+  { "id": "mock-bploc-015", "name": "Corporate HQ - Boston", "address": "200 Seaport Blvd", "city": "Boston", "postalCode": "02210", "country": "United States", "phone": "+1-617-555-1500", "businessPartnerId": "mock-bp-007" },
+  { "id": "mock-bploc-016", "name": "Miami Office", "address": "100 Brickell Ave", "city": "Miami", "postalCode": "33131", "country": "United States", "phone": "+1-305-555-1600", "businessPartnerId": "mock-bp-007" },
+  { "id": "mock-bploc-017", "name": "Berlin Office", "address": "50 Friedrichstrasse", "city": "Berlin", "postalCode": "10117", "country": "Germany", "phone": "+49-30-555-1700", "businessPartnerId": "mock-bp-008" },
+  { "id": "mock-bploc-018", "name": "Munich Dev Center", "address": "20 Maximilianstrasse", "city": "Munich", "postalCode": "80539", "country": "Germany", "phone": "+49-89-555-1800", "businessPartnerId": "mock-bp-008" },
+  { "id": "mock-bploc-019", "name": "Main Plant - Cleveland", "address": "700 Euclid Ave", "city": "Cleveland", "postalCode": "44114", "country": "United States", "phone": "+1-216-555-1900", "businessPartnerId": "mock-bp-009" },
+  { "id": "mock-bploc-020", "name": "Distribution - Columbus", "address": "350 High St", "city": "Columbus", "postalCode": "43215", "country": "United States", "phone": "+1-614-555-2000", "businessPartnerId": "mock-bp-009" },
+  { "id": "mock-bploc-021", "name": "Toronto Office", "address": "100 King St W", "city": "Toronto", "postalCode": "M5X 1A9", "country": "Canada", "phone": "+1-416-555-2100", "businessPartnerId": "mock-bp-010" },
+  { "id": "mock-bploc-022", "name": "Vancouver Lab", "address": "55 Water St", "city": "Vancouver", "postalCode": "V6B 1A1", "country": "Canada", "phone": "+1-604-555-2200", "businessPartnerId": "mock-bp-010" },
+  { "id": "mock-bploc-023", "name": "Denver Office", "address": "1600 Market St", "city": "Denver", "postalCode": "80202", "country": "United States", "phone": "+1-303-555-2300", "businessPartnerId": "mock-bp-011" },
+  { "id": "mock-bploc-024", "name": "Phoenix Branch", "address": "2 N Central Ave", "city": "Phoenix", "postalCode": "85004", "country": "United States", "phone": "+1-602-555-2400", "businessPartnerId": "mock-bp-011" },
+  { "id": "mock-bploc-025", "name": "Cambridge Lab", "address": "30 Science Park", "city": "Cambridge", "postalCode": "CB4 0GF", "country": "United Kingdom", "phone": "+44-1223-555-2500", "businessPartnerId": "mock-bp-012" },
+  { "id": "mock-bploc-026", "name": "Oxford Research", "address": "10 Woodstock Rd", "city": "Oxford", "postalCode": "OX2 6HA", "country": "United Kingdom", "phone": "+44-1865-555-2600", "businessPartnerId": "mock-bp-012" },
+  { "id": "mock-bploc-027", "name": "Wall Street Office", "address": "85 Wall St", "city": "New York", "postalCode": "10005", "country": "United States", "phone": "+1-212-555-2700", "businessPartnerId": "mock-bp-013" },
+  { "id": "mock-bploc-028", "name": "Mayfair Office", "address": "25 Berkeley Square", "city": "London", "postalCode": "W1J 6HB", "country": "United Kingdom", "phone": "+44-20-7555-2800", "businessPartnerId": "mock-bp-013" },
+  { "id": "mock-bploc-029", "name": "City of London", "address": "1 Fleet St", "city": "London", "postalCode": "EC4Y 1BD", "country": "United Kingdom", "phone": "+44-20-7555-2900", "businessPartnerId": "mock-bp-014" },
+  { "id": "mock-bploc-030", "name": "Edinburgh Office", "address": "40 Princes St", "city": "Edinburgh", "postalCode": "EH2 2BY", "country": "United Kingdom", "phone": "+44-131-555-3000", "businessPartnerId": "mock-bp-014" },
+  { "id": "mock-bploc-031", "name": "Rotterdam HQ", "address": "100 Erasmusbrug", "city": "Rotterdam", "postalCode": "3011 BN", "country": "Netherlands", "phone": "+31-10-555-3100", "businessPartnerId": "mock-bp-015" },
+  { "id": "mock-bploc-032", "name": "Amsterdam Depot", "address": "15 Keizersgracht", "city": "Amsterdam", "postalCode": "1015 CK", "country": "Netherlands", "phone": "+31-20-555-3200", "businessPartnerId": "mock-bp-015" },
+  { "id": "mock-bploc-033", "name": "Antwerp Port", "address": "8 Haven Rd", "city": "Antwerp", "postalCode": "2000", "country": "Belgium", "phone": "+32-3-555-3300", "businessPartnerId": "mock-bp-015" }
 ];

--- a/artifacts/business-partner/schema-curated.json
+++ b/artifacts/business-partner/schema-curated.json
@@ -128,6 +128,23 @@
           }
         }
       ]
+    },
+    {
+      "name": "bpLocation",
+      "tableName": "C_BPartner_Location",
+      "fields": [
+        { "name": "name", "column": "Name", "type": "string", "visibility": "editable", "required": true, "grid": true, "form": true, "searchable": true },
+        { "name": "address", "column": "Address1", "type": "string", "visibility": "editable", "required": false, "grid": false, "form": true, "searchable": false },
+        { "name": "city", "column": "City", "type": "string", "visibility": "editable", "required": false, "grid": true, "form": true, "searchable": true },
+        { "name": "postalCode", "column": "Postal", "type": "string", "visibility": "editable", "required": false, "grid": false, "form": true, "searchable": false },
+        { "name": "country", "column": "C_Country_ID", "type": "string", "visibility": "editable", "required": false, "grid": true, "form": true, "searchable": false },
+        { "name": "phone", "column": "Phone", "type": "string", "visibility": "editable", "required": false, "grid": false, "form": true, "searchable": false },
+        { "name": "adClientId", "column": "AD_Client_ID", "type": "id", "visibility": "system", "required": true, "grid": false, "form": false, "searchable": false, "derivation": { "type": "fromConfig", "source": "context.client" } },
+        { "name": "adOrgId", "column": "AD_Org_ID", "type": "id", "visibility": "system", "required": true, "grid": false, "form": false, "searchable": false, "derivation": { "type": "fromParent", "source": "businessPartner.adOrgId" } },
+        { "name": "cBpartnerId", "column": "C_BPartner_ID", "type": "foreignKey", "visibility": "system", "required": true, "grid": false, "form": false, "searchable": false, "derivation": { "type": "fromParent", "source": "businessPartner.id" } },
+        { "name": "created", "column": "Created", "type": "datetime", "visibility": "system", "required": true, "grid": false, "form": false, "searchable": false, "derivation": { "type": "computed", "expression": "now()" } },
+        { "name": "updated", "column": "Updated", "type": "datetime", "visibility": "system", "required": true, "grid": false, "form": false, "searchable": false, "derivation": { "type": "computed", "expression": "now()" } }
+      ]
     }
   ]
 }

--- a/tools/app-shell/src/App.jsx
+++ b/tools/app-shell/src/App.jsx
@@ -32,7 +32,6 @@ async function loadAllMockData() {
   const modules = await Promise.all([
     import('@generated/sales-order/generated/web/sales-order/mockData.js'),
     import('@generated/business-partner/generated/web/business-partner/mockData.js'),
-    import('@generated/bp-location/generated/web/bp-location/mockData.js'),
     import('@generated/warehouse/generated/web/warehouse/mockData.js'),
     import('@generated/price-list/generated/web/price-list/mockData.js'),
     import('@generated/payment-term/generated/web/payment-term/mockData.js'),

--- a/tools/app-shell/src/windows/registry.js
+++ b/tools/app-shell/src/windows/registry.js
@@ -12,7 +12,6 @@ function toSlug(name) {
 const windowLoaders = {
   'sales-order': () => import('@generated/sales-order/generated/web/sales-order/index.jsx'),
   'business-partner': () => import('@generated/business-partner/generated/web/business-partner/index.jsx'),
-  'bp-location': () => import('@generated/bp-location/generated/web/bp-location/index.jsx'),
   'warehouse': () => import('@generated/warehouse/generated/web/warehouse/index.jsx'),
   'price-list': () => import('@generated/price-list/generated/web/price-list/index.jsx'),
   'payment-term': () => import('@generated/payment-term/generated/web/payment-term/index.jsx'),
@@ -28,7 +27,6 @@ const windowLoaders = {
  */
 const REFERENCE_WINDOWS = [
   { name: 'business-partner', label: 'Business Partner' },
-  { name: 'bp-location', label: 'BP Location' },
   { name: 'warehouse', label: 'Warehouse' },
   { name: 'price-list', label: 'Price List' },
   { name: 'payment-term', label: 'Payment Term' },


### PR DESCRIPTION
## Summary
- Convert Business Partner from single-entity to master-detail window with BP Location as child entity
- BP Location gets `fromParent` derivations for `cBpartnerId` and `adOrgId`, matching the Sales Order -> Order Lines pattern
- Remove bp-location as independent window from registry and App mock data loading
- Realistic mock data: 15 business partners with 2-3 locations each (33 total locations)

## Test plan
- [x] All 306 CLI tests pass (49 suites, 0 failures)
- [ ] Verify BusinessPartnerPage renders as MasterDetailPage in browser
- [ ] Verify bp-location no longer appears in sidebar menu
- [ ] Verify add-line form allows creating locations inline

Generated with [Claude Code](https://claude.com/claude-code)