### PR TITLE
feat: record no-changes entries in generation log

### DIFF
--- a/cli/src/generation-log.js
+++ b/cli/src/generation-log.js
@@ -201,7 +201,6 @@ export function compareGenerated(windowName, oldFiles, newFiles) {
  */
 export function createLogEntries(windowName, trigger, oldFiles, newFiles, existingLog = []) {
   const rawChanges = compareGenerated(windowName, oldFiles, newFiles);
-  if (rawChanges.length === 0) return [];
 
   // Auto-increment runId
   const existingRunIds = existingLog
@@ -212,6 +211,21 @@ export function createLogEntries(windowName, trigger, oldFiles, newFiles, existi
   const nextRun = existingRunIds.length > 0 ? Math.max(...existingRunIds) + 1 : 1;
   const runId = `run-${String(nextRun).padStart(3, '0')}`;
   const run = new Date().toISOString();
+
+  if (rawChanges.length === 0) {
+    return [{
+      run,
+      runId,
+      trigger,
+      window: windowName,
+      entity: null,
+      field: null,
+      file: null,
+      change: 'no-changes',
+      before: null,
+      after: null,
+    }];
+  }
 
   return rawChanges.map(change => ({
     run,
@@ -426,9 +440,9 @@ if (isDirectRun) {
   // Create entries
   const entries = createLogEntries(windowName, trigger, oldFiles, newFiles, existingLog);
 
-  if (entries.length === 0) {
-    console.log(`No changes detected for ${windowName}`);
-    process.exit(0);
+  const isNoChanges = entries.length === 1 && entries[0].change === 'no-changes';
+  if (isNoChanges) {
+    console.log(`No changes detected for ${windowName} (logged as no-changes)`);
   }
 
   // Append

--- a/cli/test/generation-log.test.js
+++ b/cli/test/generation-log.test.js
@@ -181,10 +181,11 @@ describe('createLogEntries', () => {
     assert.equal(entries[0].runId, 'run-006');
   });
 
-  it('returns empty array when no changes', () => {
+  it('returns single no-changes entry when no changes', () => {
     const content = 'same content';
     const entries = createLogEntries('w', 'test', { 'a.jsx': content }, { 'a.jsx': content }, []);
-    assert.equal(entries.length, 0);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].change, 'no-changes');
   });
 
   it('entry has all required fields', () => {
@@ -194,6 +195,30 @@ describe('createLogEntries', () => {
     for (const key of requiredKeys) {
       assert.ok(key in e, `missing key: ${key}`);
     }
+  });
+});
+
+// --- createLogEntries no-changes ---
+
+describe('createLogEntries no-changes', () => {
+  it('returns a single no-changes entry when old and new files are identical', () => {
+    const oldFiles = { 'OrderTable.jsx': 'const x = 1;' };
+    const newFiles = { 'OrderTable.jsx': 'const x = 1;' };
+    const existingLog = [{ runId: 'run-005' }];
+    const entries = createLogEntries('sales-order', 'verify-test', oldFiles, newFiles, existingLog);
+
+    assert.equal(entries.length, 1);
+    const entry = entries[0];
+    assert.equal(entry.change, 'no-changes');
+    assert.equal(entry.window, 'sales-order');
+    assert.equal(entry.trigger, 'verify-test');
+    assert.equal(entry.runId, 'run-006');
+    assert.equal(entry.entity, null);
+    assert.equal(entry.field, null);
+    assert.equal(entry.file, null);
+    assert.equal(entry.before, null);
+    assert.equal(entry.after, null);
+    assert.ok(entry.run); // ISO timestamp present
   });
 });
 


### PR DESCRIPTION
## Summary
- When `createLogEntries()` detects no differences between old and new files, it now returns a single entry with `change: 'no-changes'` instead of an empty array
- CLI entry point no longer exits early on zero changes — always appends to log and regenerates markdown views
- Updated existing test and added new test for the no-changes behavior

## Test plan
- [x] All 364 tests pass (0 failures)
- [x] New test verifies no-changes entry has correct shape (runId, window, trigger, null entity/field/file)
- [x] Existing test updated to match new behavior

Generated with [Claude Code](https://claude.com/claude-code)