### PR TITLE
feat: include contract tests in test report

### DIFF
--- a/cli/test/contract-all.test.js
+++ b/cli/test/contract-all.test.js
@@ -1,0 +1,33 @@
+// Contract tests for all artifact windows.
+// Discovers artifacts/*/contract.json and runs each assertion as a node:test case.
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { generateTestAssertions } from '../src/run-contract-tests.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const artifactsDir = resolve(__dirname, '../../artifacts');
+
+// Discover all windows with contract.json
+const windows = readdirSync(artifactsDir).filter(dir => {
+  try {
+    readFileSync(resolve(artifactsDir, dir, 'contract.json'));
+    return true;
+  } catch { return false; }
+});
+
+for (const window of windows) {
+  describe(`contract: ${window}`, () => {
+    const contractPath = resolve(artifactsDir, window, 'contract.json');
+    const contract = JSON.parse(readFileSync(contractPath, 'utf-8'));
+    const results = generateTestAssertions(contract);
+
+    for (const result of results) {
+      it(`[${result.category}] ${result.description}`, () => {
+        assert.ok(result.passed, result.reason || `Test ${result.id} failed`);
+      });
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Adds `cli/test/contract-all.test.js` that dynamically discovers all `artifacts/*/contract.json` files
- Each contract assertion runs as an individual `node:test` case, appearing in JUnit XML and HTML reports
- 307 contract tests across 11 windows now included alongside 364 unit tests (671 total, all passing)

## Per-window breakdown
| Window | Tests |
|--------|-------|
| bp-location | 25 |
| business-partner | 39 |
| payment-method | 16 |
| payment-term | 25 |
| price-list | 39 |
| product | 25 |
| sales-order | 79 |
| tax | 16 |
| uom | 16 |
| user | 16 |
| warehouse | 11 |

## Test plan
- [x] All 671 tests pass (364 unit + 307 contract)
- [x] HTML report generated at artifacts/test-report.html
- [x] JUnit XML generated at artifacts/test-report.xml
- [x] Each window appears as a separate test suite in the report

Generated with [Claude Code](https://claude.com/claude-code)