### PR TITLE
feat: add light/dark/system theme toggle

### DIFF
--- a/tools/app-shell/src/index.css
+++ b/tools/app-shell/src/index.css
@@ -51,6 +51,26 @@ body {
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
   .dark {
+    --background: 222 47% 11%;
+    --foreground: 210 20% 98%;
+    --card: 224 30% 15%;
+    --card-foreground: 210 20% 98%;
+    --popover: 224 30% 15%;
+    --popover-foreground: 210 20% 98%;
+    --primary: 217 91% 60%;
+    --primary-foreground: 222 47% 11%;
+    --secondary: 215 20% 18%;
+    --secondary-foreground: 210 20% 98%;
+    --muted: 215 20% 18%;
+    --muted-foreground: 215 16% 60%;
+    --accent: 215 20% 18%;
+    --accent-foreground: 210 20% 98%;
+    --destructive: 0 63% 50%;
+    --destructive-foreground: 210 20% 98%;
+    --border: 215 20% 22%;
+    --input: 215 20% 22%;
+    --ring: 217 91% 60%;
+
     --sidebar-background: 240 5.9% 10%;
     --sidebar-foreground: 240 4.8% 95.9%;
     --sidebar-primary: 224.3 76.3% 48%;

--- a/tools/app-shell/src/layout/TopBar.jsx
+++ b/tools/app-shell/src/layout/TopBar.jsx
@@ -1,5 +1,35 @@
+import { Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
 import { SidebarTrigger } from '@/components/ui/sidebar.jsx';
 import { Separator } from '@/components/ui/separator.jsx';
+import { Button } from '@/components/ui/button.jsx';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu.jsx';
+
+function ModeToggle() {
+  const { setTheme } = useTheme();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="icon">
+          <Sun className="h-[1.2rem] w-[1.2rem] scale-100 rotate-0 transition-all dark:scale-0 dark:-rotate-90" />
+          <Moon className="absolute h-[1.2rem] w-[1.2rem] scale-0 rotate-90 transition-all dark:scale-100 dark:rotate-0" />
+          <span className="sr-only">Toggle theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme('light')}>Light</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('dark')}>Dark</DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('system')}>System</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
 
 export default function TopBar() {
   return (
@@ -7,6 +37,7 @@ export default function TopBar() {
       <SidebarTrigger className="-ml-1" />
       <Separator orientation="vertical" className="mr-2 h-4" />
       <div className="flex-1" />
+      <ModeToggle />
     </header>
   );
 }

--- a/tools/app-shell/src/main.jsx
+++ b/tools/app-shell/src/main.jsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client';
+import { ThemeProvider } from 'next-themes';
 import App from './App.jsx';
 import './index.css';
 
-createRoot(document.getElementById('root')).render(<App />);
+createRoot(document.getElementById('root')).render(
+  <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+    <App />
+  </ThemeProvider>
+);


### PR DESCRIPTION
## Summary
- Add complete dark mode CSS variables to `index.css` `.dark` block (background, foreground, card, popover, primary, secondary, muted, accent, destructive, border, input, ring)
- Wrap app root with `next-themes` ThemeProvider (`attribute="class"`, `defaultTheme="system"`, `enableSystem`) in `main.jsx`
- Add shadcn ModeToggle dropdown (Light/Dark/System) to TopBar right side

## Test plan
- [ ] Verify build passes (`npx vite build` -- confirmed)
- [ ] Toggle to Dark mode and verify all UI surfaces use dark palette
- [ ] Toggle to Light mode and verify original light palette
- [ ] Toggle to System and verify it follows OS preference
- [ ] Verify sidebar colors remain correct in both themes

Generated with [Claude Code](https://claude.com/claude-code)