### PR TITLE
fix: add shadcn border reset for dark mode

### DIFF
--- a/tools/app-shell/src/index.css
+++ b/tools/app-shell/src/index.css
@@ -3,6 +3,17 @@
 @tailwind utilities;
 
 @layer base {
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+    margin: 0;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+
   :root {
     --background: 210 20% 98%;
     --foreground: 222 47% 11%;
@@ -68,12 +79,4 @@
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
-}
-
-body {
-  margin: 0;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  background-color: hsl(var(--background));
-  color: hsl(var(--foreground));
 }


### PR DESCRIPTION
## Summary
- Add `* { @apply border-border; }` to `@layer base` so all elements default to the theme's border color instead of `currentColor`
- Move `body` styles into `@layer base` using `@apply bg-background text-foreground` (standard shadcn pattern)
- Remove duplicate `body` block that was outside `@layer base`

## What this fixes
In dark mode, Tailwind's `border` utility uses `currentColor` for border-color. Since text is near-white in dark mode, all borders appeared as bright white lines. The shadcn border reset ensures borders use `hsl(var(--border))` which resolves to a subtle dark gray in dark mode.

## Test plan
- [x] `npx vite build` passes with no errors
- [ ] Visual check: dark mode borders should be subtle gray, not white

Generated with [Claude Code](https://claude.com/claude-code)