### PR TITLE
feat: aggregate contracts for overview pages

### DIFF
--- a/.claude/skills/aggregate-contracts/SKILL.md
+++ b/.claude/skills/aggregate-contracts/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: aggregate-contracts
+description: Use when creating or modifying overview/dashboard pages, adding KPIs, kanban boards, alert panels, or activity feeds to module landing pages. Triggers - aggregate-contract.json, overview page, module dashboard, KPI header data.
+---
+
+# Aggregate Contracts
+
+## Overview
+
+Aggregate contracts define overview/dashboard pages that aggregate data across multiple entities. Unlike entity contracts (CRUD windows), aggregate contracts drive module landing pages with KPIs, tables, kanban boards, alerts, and activity feeds.
+
+**Rule: Overview pages never hardcode data. Everything comes from the aggregate contract.**
+
+## When to Use
+
+- Creating a new module overview page (e.g., Inventory, Sales, CRM)
+- Adding KPIs, data tables, kanban, or alert panels to a landing page
+- Modifying existing overview page data or layout
+
+When NOT to use: For CRUD windows with entity forms — use the entity contract pipeline instead (see schema-forge-pipeline skill).
+
+## Contract Location
+
+`artifacts/{module-name}/aggregate-contract.json` — same level as entity contracts.
+
+## Contract Schema
+
+```json
+{
+  "version": "0.1.0",
+  "type": "aggregate",
+  "module": "inventory",
+  "label": "Inventory",
+  "icon": "Package",
+  "route": "/inventory",
+  "sections": [
+    { "id": "kpis", "type": "kpi-header", "kpis": [
+      { "key": "totalSkus", "label": "Total SKUs", "format": "number", "icon": "Package" }
+    ]},
+    { "id": "stockLevels", "type": "data-table", "title": "Stock Levels",
+      "columns": [{ "key": "sku", "label": "SKU" }], "filters": ["name"] },
+    { "id": "pipeline", "type": "kanban",
+      "columns": [{ "id": "draft", "title": "Draft", "color": "gray" }] },
+    { "id": "lowStock", "type": "alerts-panel", "title": "Alerts",
+      "severities": ["red", "amber"], "fields": { "label": "name", "current": "current", "threshold": "minimum" } },
+    { "id": "recentMovements", "type": "activity-feed",
+      "fields": { "direction": "direction", "label": "product", "detail": "qty", "time": "time" } },
+    { "id": "revenueTrend", "type": "chart", "chartType": "line" },
+    { "id": "quickActions", "type": "quick-actions" },
+    { "id": "notes", "type": "chatter" }
+  ],
+  "layout": { "type": "grid", "areas": [
+    { "section": "kpis", "span": "full" },
+    { "section": "stockLevels", "span": "2/3" },
+    { "section": "lowStock", "span": "1/3" }
+  ]},
+  "actions": [
+    { "label": "Physical Inventory", "route": "/physical-inventory", "variant": "outline" }
+  ],
+  "mockData": {
+    "kpis": { "totalSkus": 248 },
+    "stockLevels": [{ "id": 1, "sku": "PRD-001" }]
+  }
+}
+```
+
+## Section Types
+
+| Type | Config | mockData Shape |
+|------|--------|----------------|
+| `kpi-header` | `kpis[]: { key, label, format, icon?, trend? }` | `{ [key]: value }` |
+| `data-table` | `columns[], filters[]` | `[{ id, ...row }]` |
+| `kanban` | `columns[]: { id, title, color }` | `[{ id, columnId, title, subtitle }]` |
+| `alerts-panel` | `severities[], fields` | `[{ severity, ...fields }]` |
+| `activity-feed` | `fields: { label, detail, time, ... }` | `[{ id, ...fields }]` |
+| `chart` | `chartType` | `{ labels[], values[] }` |
+| `quick-actions` | (none, uses actions[]) | (none) |
+| `chatter` | (none) | `[{ id, author, text, timestamp, type }]` |
+
+Valid KPI formats: `currency`, `number`, `percent`.
+
+## CLI Commands
+
+```bash
+# Generate config.js + mockData.js from contract
+node cli/src/generate-aggregate.js artifacts/inventory/aggregate-contract.json
+
+# Generate all aggregates
+node cli/src/generate-aggregate.js --all
+
+# Run aggregate tests (single)
+node -e "import { runAggregateTests } from './cli/src/run-aggregate-tests.js'; ..."
+
+# Run all tests (includes aggregate tests in suite)
+node --test 'cli/test/*.test.js'
+```
+
+## Generated Outputs
+
+`artifacts/{module}/generated/config.js` exports:
+- `meta` — { module, label, icon, route }
+- `kpisConfig` — KPI definitions array
+- `sections` — keyed by id, excludes kpi-header
+- `layout` — areas array with spans
+- `actions` — action buttons
+
+`artifacts/{module}/generated/mockData.js` exports:
+- One named export per section id (e.g., `kpis`, `stockLevels`, `lowStock`)
+
+## UI Consumption Pattern
+
+```jsx
+import { kpisConfig, sections, actions } from '@generated/inventory/generated/config';
+import * as mockData from '@generated/inventory/generated/mockData';
+
+const KPIS = kpisConfig.map(k => ({ ...k, value: mockData.kpis[k.key] }));
+const COLUMNS = sections.stockLevels.columns;
+const DATA = mockData.stockLevels;
+```
+
+**Never** define data constants inline in overview pages.
+
+## Test Categories (8)
+
+| Category | Validates |
+|----------|-----------|
+| `section-presence` | Each section has mockData |
+| `kpi-integrity` | Valid format, label, and value |
+| `table-column-match` | Columns exist in mockData rows |
+| `kanban-column-match` | Card columnId in columns |
+| `alert-severity` | Severity in declared set |
+| `link-validity` | Action routes in menu.json |
+| `layout-coverage` | All sections in layout |
+| `mockData-shape` | Non-empty arrays/objects |
+
+## Existing Modules
+
+| Module | Route | Sections |
+|--------|-------|----------|
+| dashboard | /dashboard | kpis, chart, quick-actions, activity-feed, chatter |
+| sales | /sales | kpis, kanban, data-table |
+| purchases | /purchases | kpis, kanban, data-table |
+| inventory | /inventory | kpis, data-table, alerts-panel, activity-feed |
+| contacts | /contacts | kpis, kanban, data-table, chatter |
+
+## Common Mistakes
+
+- Forgetting to add section to `layout.areas` (fails layout-coverage test)
+- Using invalid KPI format like "money" (must be currency/number/percent)
+- Missing mockData key for a declared section (fails section-presence)
+- Empty mockData arrays (fails mockData-shape)
+- Action route not matching a menu.json window name (fails link-validity)
+- Forgetting to regenerate after editing contract: `node cli/src/generate-aggregate.js artifacts/{module}/aggregate-contract.json`

--- a/artifacts/bp-location/generated/web/bp-location/index.jsx
+++ b/artifacts/bp-location/generated/web/bp-location/index.jsx
@@ -3,6 +3,8 @@ import BpLocationTable from './BpLocationTable';
 import BpLocationForm from './BpLocationForm';
 import catalogs from './mockCatalogs';
 
+const windowMeta = { category: 'reference', name: 'BP Location' };
+
 export default function App(props) {
   return (
     <SingleEntityPage
@@ -11,6 +13,7 @@ export default function App(props) {
       Form={BpLocationForm}
       catalogs={catalogs}
       entityLabel="Bp Location"
+      window={windowMeta}
       {...props}
     />
   );

--- a/artifacts/business-partner/generated/web/business-partner/BusinessPartnerForm.jsx
+++ b/artifacts/business-partner/generated/web/business-partner/BusinessPartnerForm.jsx
@@ -4,7 +4,7 @@ const fields = [
   { key: 'name', label: 'Name', type: 'text', required: true },
   { key: 'searchKey', label: 'Search Key', type: 'text', required: true },
   { key: 'taxId', label: 'Tax Id', type: 'text' },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'creditLimit', label: 'Credit Limit', type: 'number' },
 ];
 

--- a/artifacts/business-partner/generated/web/business-partner/index.jsx
+++ b/artifacts/business-partner/generated/web/business-partner/index.jsx
@@ -1,5 +1,7 @@
 import BusinessPartnerPage from './BusinessPartnerPage';
 
+const windowMeta = { category: 'reference', name: 'Business Partner' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <BusinessPartnerPage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <BusinessPartnerPage token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }

--- a/artifacts/contacts/aggregate-contract.json
+++ b/artifacts/contacts/aggregate-contract.json
@@ -1,0 +1,101 @@
+{
+  "version": "0.1.0",
+  "type": "aggregate",
+  "meta": {
+    "module": "contacts",
+    "label": "Contacts",
+    "icon": "Users",
+    "route": "/contacts"
+  },
+  "sections": [
+    {
+      "id": "kpis",
+      "type": "kpi",
+      "kpis": [
+        { "key": "totalContacts", "label": "Total Contacts", "format": "number", "icon": "Users" },
+        { "key": "customers", "label": "Customers", "format": "number" },
+        { "key": "vendors", "label": "Vendors", "format": "number" },
+        { "key": "pendingBalance", "label": "Pending Balance", "format": "currency" }
+      ]
+    },
+    {
+      "id": "directory",
+      "type": "kanban",
+      "columns": [
+        { "id": "customer", "title": "Customers", "color": "blue" },
+        { "id": "vendor", "title": "Vendors", "color": "green" },
+        { "id": "both", "title": "Customer & Vendor", "color": "purple" },
+        { "id": "prospect", "title": "Prospects", "color": "yellow" }
+      ]
+    },
+    {
+      "id": "contactList",
+      "type": "data-table",
+      "columns": [
+        { "key": "name", "label": "Name", "align": "left" },
+        { "key": "category", "label": "Category", "align": "left" },
+        { "key": "location", "label": "Location", "align": "left" },
+        { "key": "email", "label": "Email", "align": "left" },
+        { "key": "totalInvoiced", "label": "Total Invoiced", "align": "right", "format": "currency" },
+        { "key": "pendingBalance", "label": "Pending Balance", "align": "right", "format": "currency" }
+      ]
+    },
+    {
+      "id": "notes",
+      "type": "chatter",
+      "entityType": "contact"
+    }
+  ],
+  "layout": {
+    "areas": [
+      { "section": "kpis", "span": "full" },
+      { "section": "directory", "span": "full" },
+      { "section": "contactList", "span": "full" },
+      { "section": "notes", "span": "1/3" }
+    ]
+  },
+  "actions": [
+    { "label": "+ New Contact", "route": "/business-partner", "default": true }
+  ],
+  "mockData": {
+    "kpis": {
+      "totalContacts": 156,
+      "customers": 89,
+      "vendors": 42,
+      "pendingBalance": 27300,
+      "trends": {
+        "customers": 5,
+        "pendingBalance": -8
+      }
+    },
+    "directory": [
+      { "id": "BP-001", "columnId": "customer", "title": "Empresa ABC S.L.", "subtitle": "Madrid, Spain", "avatar": "E", "badges": ["VIP"], "value": 52000 },
+      { "id": "BP-002", "columnId": "customer", "title": "Tech Solutions", "subtitle": "Barcelona, Spain", "avatar": "T", "value": 28000 },
+      { "id": "BP-003", "columnId": "customer", "title": "Global Trade Ltd", "subtitle": "London, UK", "avatar": "G", "badges": ["VIP"], "value": 85000 },
+      { "id": "BP-004", "columnId": "vendor", "title": "Suministros Garcia", "subtitle": "Valencia, Spain", "avatar": "S" },
+      { "id": "BP-005", "columnId": "vendor", "title": "Nordic Components", "subtitle": "Stockholm, Sweden", "avatar": "N" },
+      { "id": "BP-006", "columnId": "both", "title": "Iberica Industrial", "subtitle": "Bilbao, Spain", "avatar": "I", "value": 34000 },
+      { "id": "BP-007", "columnId": "both", "title": "Mediterranean Foods", "subtitle": "Sevilla, Spain", "avatar": "M", "value": 15000 },
+      { "id": "BP-008", "columnId": "prospect", "title": "StartupXYZ", "subtitle": "Remote", "avatar": "S" },
+      { "id": "BP-009", "columnId": "prospect", "title": "New Retail Co", "subtitle": "Malaga, Spain", "avatar": "N" },
+      { "id": "BP-010", "columnId": "customer", "title": "Zaragoza Motors", "subtitle": "Zaragoza, Spain", "avatar": "Z", "value": 19000 }
+    ],
+    "contactList": [
+      { "name": "Empresa ABC S.L.", "category": "Customer", "location": "Madrid, Spain", "email": "contact@empresaabc.es", "phone": "+34 91 555 1234", "totalInvoiced": 52000, "pendingBalance": 6240 },
+      { "name": "Tech Solutions", "category": "Customer", "location": "Barcelona, Spain", "email": "info@techsolutions.com", "phone": "+34 93 444 5678", "totalInvoiced": 28000, "pendingBalance": 3360 },
+      { "name": "Global Trade Ltd", "category": "Customer", "location": "London, UK", "email": "sales@globaltrade.co.uk", "phone": "+44 20 7946 0958", "totalInvoiced": 85000, "pendingBalance": 10200 },
+      { "name": "Suministros Garcia", "category": "Vendor", "location": "Valencia, Spain", "email": "pedidos@suministrosgarcia.es", "phone": "+34 96 333 4567", "totalInvoiced": null, "pendingBalance": null },
+      { "name": "Nordic Components", "category": "Vendor", "location": "Stockholm, Sweden", "email": "order@nordiccomponents.se", "phone": "+46 8 123 4567", "totalInvoiced": null, "pendingBalance": null },
+      { "name": "Iberica Industrial", "category": "Customer & Vendor", "location": "Bilbao, Spain", "email": "admin@ibericaindustrial.es", "phone": "+34 94 222 3456", "totalInvoiced": 34000, "pendingBalance": 4080 },
+      { "name": "Mediterranean Foods", "category": "Customer & Vendor", "location": "Sevilla, Spain", "email": "hello@medfoods.es", "phone": "+34 95 111 2345", "totalInvoiced": 15000, "pendingBalance": 1800 },
+      { "name": "StartupXYZ", "category": "Prospect", "location": "Remote", "email": "hi@startupxyz.io", "phone": "+1 555 987 6543", "totalInvoiced": null, "pendingBalance": null },
+      { "name": "New Retail Co", "category": "Prospect", "location": "Malaga, Spain", "email": "info@newretailco.es", "phone": "+34 95 666 7890", "totalInvoiced": null, "pendingBalance": null },
+      { "name": "Zaragoza Motors", "category": "Customer", "location": "Zaragoza, Spain", "email": "ventas@zaragozamotors.es", "phone": "+34 97 888 9012", "totalInvoiced": 19000, "pendingBalance": 2280 }
+    ],
+    "notes": [
+      { "id": "1", "author": "Ana Garcia", "text": "Renewed annual contract for $52,000", "timestamp": "2026-03-08T10:30:00", "type": "note" },
+      { "id": "2", "author": "System", "text": "Invoice INV-0142 sent via email", "timestamp": "2026-03-07T14:00:00", "type": "system" },
+      { "id": "3", "author": "Pedro Lopez", "text": "Meeting scheduled for Q2 review", "timestamp": "2026-03-05T09:00:00", "type": "note" }
+    ]
+  }
+}

--- a/artifacts/contacts/generated/config.js
+++ b/artifacts/contacts/generated/config.js
@@ -1,0 +1,132 @@
+// Auto-generated from aggregate-contract.json — DO NOT EDIT
+
+export const meta = {
+  "module": "contacts",
+  "label": "Contacts",
+  "icon": "Users",
+  "route": "/contacts"
+};
+
+export const kpisConfig = [];
+
+export const sections = {
+  "kpis": {
+    "type": "kpi",
+    "kpis": [
+      {
+        "key": "totalContacts",
+        "label": "Total Contacts",
+        "format": "number",
+        "icon": "Users"
+      },
+      {
+        "key": "customers",
+        "label": "Customers",
+        "format": "number"
+      },
+      {
+        "key": "vendors",
+        "label": "Vendors",
+        "format": "number"
+      },
+      {
+        "key": "pendingBalance",
+        "label": "Pending Balance",
+        "format": "currency"
+      }
+    ]
+  },
+  "directory": {
+    "type": "kanban",
+    "columns": [
+      {
+        "id": "customer",
+        "title": "Customers",
+        "color": "blue"
+      },
+      {
+        "id": "vendor",
+        "title": "Vendors",
+        "color": "green"
+      },
+      {
+        "id": "both",
+        "title": "Customer & Vendor",
+        "color": "purple"
+      },
+      {
+        "id": "prospect",
+        "title": "Prospects",
+        "color": "yellow"
+      }
+    ]
+  },
+  "contactList": {
+    "type": "data-table",
+    "columns": [
+      {
+        "key": "name",
+        "label": "Name",
+        "align": "left"
+      },
+      {
+        "key": "category",
+        "label": "Category",
+        "align": "left"
+      },
+      {
+        "key": "location",
+        "label": "Location",
+        "align": "left"
+      },
+      {
+        "key": "email",
+        "label": "Email",
+        "align": "left"
+      },
+      {
+        "key": "totalInvoiced",
+        "label": "Total Invoiced",
+        "align": "right",
+        "format": "currency"
+      },
+      {
+        "key": "pendingBalance",
+        "label": "Pending Balance",
+        "align": "right",
+        "format": "currency"
+      }
+    ]
+  },
+  "notes": {
+    "type": "chatter",
+    "entityType": "contact"
+  }
+};
+
+export const layout = [
+  {
+    "section": "kpis",
+    "span": "full"
+  },
+  {
+    "section": "directory",
+    "span": "full"
+  },
+  {
+    "section": "contactList",
+    "span": "full"
+  },
+  {
+    "section": "notes",
+    "span": "1/3"
+  }
+];
+
+export const actions = [
+  {
+    "label": "+ New Contact",
+    "route": "/business-partner",
+    "default": true
+  }
+];

--- a/artifacts/contacts/generated/mockData.js
+++ b/artifacts/contacts/generated/mockData.js
@@ -1,0 +1,214 @@
+// Auto-generated from aggregate-contract.json — DO NOT EDIT
+
+export const kpis = {
+  "totalContacts": 156,
+  "customers": 89,
+  "vendors": 42,
+  "pendingBalance": 27300,
+  "trends": {
+    "customers": 5,
+    "pendingBalance": -8
+  }
+};
+
+export const directory = [
+  {
+    "id": "BP-001",
+    "columnId": "customer",
+    "title": "Empresa ABC S.L.",
+    "subtitle": "Madrid, Spain",
+    "avatar": "E",
+    "badges": [
+      "VIP"
+    ],
+    "value": 52000
+  },
+  {
+    "id": "BP-002",
+    "columnId": "customer",
+    "title": "Tech Solutions",
+    "subtitle": "Barcelona, Spain",
+    "avatar": "T",
+    "value": 28000
+  },
+  {
+    "id": "BP-003",
+    "columnId": "customer",
+    "title": "Global Trade Ltd",
+    "subtitle": "London, UK",
+    "avatar": "G",
+    "badges": [
+      "VIP"
+    ],
+    "value": 85000
+  },
+  {
+    "id": "BP-004",
+    "columnId": "vendor",
+    "title": "Suministros Garcia",
+    "subtitle": "Valencia, Spain",
+    "avatar": "S"
+  },
+  {
+    "id": "BP-005",
+    "columnId": "vendor",
+    "title": "Nordic Components",
+    "subtitle": "Stockholm, Sweden",
+    "avatar": "N"
+  },
+  {
+    "id": "BP-006",
+    "columnId": "both",
+    "title": "Iberica Industrial",
+    "subtitle": "Bilbao, Spain",
+    "avatar": "I",
+    "value": 34000
+  },
+  {
+    "id": "BP-007",
+    "columnId": "both",
+    "title": "Mediterranean Foods",
+    "subtitle": "Sevilla, Spain",
+    "avatar": "M",
+    "value": 15000
+  },
+  {
+    "id": "BP-008",
+    "columnId": "prospect",
+    "title": "StartupXYZ",
+    "subtitle": "Remote",
+    "avatar": "S"
+  },
+  {
+    "id": "BP-009",
+    "columnId": "prospect",
+    "title": "New Retail Co",
+    "subtitle": "Malaga, Spain",
+    "avatar": "N"
+  },
+  {
+    "id": "BP-010",
+    "columnId": "customer",
+    "title": "Zaragoza Motors",
+    "subtitle": "Zaragoza, Spain",
+    "avatar": "Z",
+    "value": 19000
+  }
+];
+
+export const contactList = [
+  {
+    "name": "Empresa ABC S.L.",
+    "category": "Customer",
+    "location": "Madrid, Spain",
+    "email": "contact@empresaabc.es",
+    "phone": "+34 91 555 1234",
+    "totalInvoiced": 52000,
+    "pendingBalance": 6240
+  },
+  {
+    "name": "Tech Solutions",
+    "category": "Customer",
+    "location": "Barcelona, Spain",
+    "email": "info@techsolutions.com",
+    "phone": "+34 93 444 5678",
+    "totalInvoiced": 28000,
+    "pendingBalance": 3360
+  },
+  {
+    "name": "Global Trade Ltd",
+    "category": "Customer",
+    "location": "London, UK",
+    "email": "sales@globaltrade.co.uk",
+    "phone": "+44 20 7946 0958",
+    "totalInvoiced": 85000,
+    "pendingBalance": 10200
+  },
+  {
+    "name": "Suministros Garcia",
+    "category": "Vendor",
+    "location": "Valencia, Spain",
+    "email": "pedidos@suministrosgarcia.es",
+    "phone": "+34 96 333 4567",
+    "totalInvoiced": null,
+    "pendingBalance": null
+  },
+  {
+    "name": "Nordic Components",
+    "category": "Vendor",
+    "location": "Stockholm, Sweden",
+    "email": "order@nordiccomponents.se",
+    "phone": "+46 8 123 4567",
+    "totalInvoiced": null,
+    "pendingBalance": null
+  },
+  {
+    "name": "Iberica Industrial",
+    "category": "Customer & Vendor",
+    "location": "Bilbao, Spain",
+    "email": "admin@ibericaindustrial.es",
+    "phone": "+34 94 222 3456",
+    "totalInvoiced": 34000,
+    "pendingBalance": 4080
+  },
+  {
+    "name": "Mediterranean Foods",
+    "category": "Customer & Vendor",
+    "location": "Sevilla, Spain",
+    "email": "hello@medfoods.es",
+    "phone": "+34 95 111 2345",
+    "totalInvoiced": 15000,
+    "pendingBalance": 1800
+  },
+  {
+    "name": "StartupXYZ",
+    "category": "Prospect",
+    "location": "Remote",
+    "email": "hi@startupxyz.io",
+    "phone": "+1 555 987 6543",
+    "totalInvoiced": null,
+    "pendingBalance": null
+  },
+  {
+    "name": "New Retail Co",
+    "category": "Prospect",
+    "location": "Malaga, Spain",
+    "email": "info@newretailco.es",
+    "phone": "+34 95 666 7890",
+    "totalInvoiced": null,
+    "pendingBalance": null
+  },
+  {
+    "name": "Zaragoza Motors",
+    "category": "Customer",
+    "location": "Zaragoza, Spain",
+    "email": "ventas@zaragozamotors.es",
+    "phone": "+34 97 888 9012",
+    "totalInvoiced": 19000,
+    "pendingBalance": 2280
+  }
+];
+
+export const notes = [
+  {
+    "id": "1",
+    "author": "Ana Garcia",
+    "text": "Renewed annual contract for $52,000",
+    "timestamp": "2026-03-08T10:30:00",
+    "type": "note"
+  },
+  {
+    "id": "2",
+    "author": "System",
+    "text": "Invoice INV-0142 sent via email",
+    "timestamp": "2026-03-07T14:00:00",
+    "type": "system"
+  },
+  {
+    "id": "3",
+    "author": "Pedro Lopez",
+    "text": "Meeting scheduled for Q2 review",
+    "timestamp": "2026-03-05T09:00:00",
+    "type": "note"
+  }
+];

--- a/artifacts/dashboard/aggregate-contract.json
+++ b/artifacts/dashboard/aggregate-contract.json
@@ -1,0 +1,86 @@
+{
+  "version": "0.1.0",
+  "type": "aggregate",
+  "meta": {
+    "module": "dashboard",
+    "label": "Dashboard",
+    "icon": "LayoutDashboard",
+    "route": "/dashboard"
+  },
+  "sections": [
+    {
+      "id": "kpi-header",
+      "type": "kpi",
+      "kpis": [
+        { "key": "revenueThisMonth", "label": "Revenue this month", "format": "currency", "icon": "DollarSign" },
+        { "key": "expensesThisMonth", "label": "Expenses this month", "format": "currency", "icon": "CreditCard" },
+        { "key": "netProfit", "label": "Net Profit", "format": "currency", "icon": "TrendingUp" },
+        { "key": "pendingInvoices", "label": "Pending Invoices", "format": "number", "icon": "Clock" }
+      ]
+    },
+    {
+      "id": "revenue-trend",
+      "type": "chart",
+      "chartType": "line",
+      "xAxis": "Month",
+      "yAxis": "Revenue ($)"
+    },
+    {
+      "id": "quick-actions",
+      "type": "quick-actions"
+    },
+    {
+      "id": "pending-tasks",
+      "type": "activity-feed",
+      "fields": {
+        "label": "text",
+        "detail": "amount",
+        "link": "link",
+        "type": "type"
+      }
+    },
+    {
+      "id": "recent-messages",
+      "type": "chatter"
+    }
+  ],
+  "layout": {
+    "areas": [
+      { "section": "kpi-header", "span": "full" },
+      { "section": "revenue-trend", "span": "2/3" },
+      { "section": "quick-actions", "span": "2/3" },
+      { "section": "pending-tasks", "span": "1/3" },
+      { "section": "recent-messages", "span": "1/3" }
+    ]
+  },
+  "actions": [
+    { "label": "+ Invoice", "route": "/sales-invoice", "icon": "FileText" },
+    { "label": "+ Order", "route": "/sales-order", "icon": "ShoppingCart" },
+    { "label": "+ Contact", "route": "/business-partner", "icon": "Users" },
+    { "label": "+ Product", "route": "/product", "icon": "Box" }
+  ],
+  "mockData": {
+    "kpi-header": {
+      "revenueThisMonth": { "value": 48250, "trend": 12.5 },
+      "expensesThisMonth": { "value": 31800, "trend": 3.2 },
+      "netProfit": { "value": 16450, "trend": 28.7 },
+      "pendingInvoices": { "value": 7, "trend": -2 }
+    },
+    "revenue-trend": {
+      "labels": ["Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec", "Jan", "Feb", "Mar"],
+      "values": [32000, 35000, 28000, 41000, 38000, 45000, 42000, 39000, 44000, 47000, 43000, 48250]
+    },
+    "pending-tasks": [
+      { "type": "warning", "text": "3 overdue invoices", "link": "/sales-invoice", "amount": "$12,400" },
+      { "type": "info", "text": "2 orders pending shipment", "link": "/goods-shipment" },
+      { "type": "info", "text": "5 purchase orders to confirm", "link": "/purchase-order" },
+      { "type": "warning", "text": "1 low stock alert", "link": "/physical-inventory", "detail": "Cerveza Ale 0.5L" }
+    ],
+    "recent-messages": [
+      { "id": "1", "author": "System", "text": "Invoice INV-2026-0142 was paid by Empresa ABC", "timestamp": "2026-03-09T08:30:00", "type": "system" },
+      { "id": "2", "author": "Ana Garcia", "text": "New quotation QT-0089 created for $8,500", "timestamp": "2026-03-09T07:15:00", "type": "note" },
+      { "id": "3", "author": "System", "text": "Purchase Order PO-0234 received (15 items)", "timestamp": "2026-03-08T16:45:00", "type": "system" },
+      { "id": "4", "author": "Pedro Lopez", "text": "Stock adjustment completed for warehouse Madrid", "timestamp": "2026-03-08T14:20:00", "type": "note" }
+    ]
+  }
+}

--- a/artifacts/dashboard/generated/config.js
+++ b/artifacts/dashboard/generated/config.js
@@ -1,0 +1,105 @@
+// Auto-generated from aggregate-contract.json — DO NOT EDIT
+
+export const meta = {
+  "module": "dashboard",
+  "label": "Dashboard",
+  "icon": "LayoutDashboard",
+  "route": "/dashboard"
+};
+
+export const kpisConfig = [
+  {
+    "key": "revenueThisMonth",
+    "label": "Revenue this month",
+    "format": "currency",
+    "icon": "DollarSign"
+  },
+  {
+    "key": "expensesThisMonth",
+    "label": "Expenses this month",
+    "format": "currency",
+    "icon": "CreditCard"
+  },
+  {
+    "key": "netProfit",
+    "label": "Net Profit",
+    "format": "currency",
+    "icon": "TrendingUp"
+  },
+  {
+    "key": "pendingInvoices",
+    "label": "Pending Invoices",
+    "format": "number",
+    "icon": "Clock"
+  }
+];
+
+export const sections = {
+  "revenue-trend": {
+    "type": "chart",
+    "chartType": "line",
+    "xAxis": "Month",
+    "yAxis": "Revenue ($)"
+  },
+  "quick-actions": {
+    "type": "quick-actions"
+  },
+  "pending-tasks": {
+    "type": "activity-feed",
+    "fields": {
+      "label": "text",
+      "detail": "amount",
+      "link": "link",
+      "type": "type"
+    }
+  },
+  "recent-messages": {
+    "type": "chatter"
+  }
+};
+
+export const layout = [
+  {
+    "section": "kpi-header",
+    "span": "full"
+  },
+  {
+    "section": "revenue-trend",
+    "span": "2/3"
+  },
+  {
+    "section": "quick-actions",
+    "span": "2/3"
+  },
+  {
+    "section": "pending-tasks",
+    "span": "1/3"
+  },
+  {
+    "section": "recent-messages",
+    "span": "1/3"
+  }
+];
+
+export const actions = [
+  {
+    "label": "+ Invoice",
+    "route": "/sales-invoice",
+    "icon": "FileText"
+  },
+  {
+    "label": "+ Order",
+    "route": "/sales-order",
+    "icon": "ShoppingCart"
+  },
+  {
+    "label": "+ Contact",
+    "route": "/business-partner",
+    "icon": "Users"
+  },
+  {
+    "label": "+ Product",
+    "route": "/product",
+    "icon": "Box"
+  }
+];

--- a/artifacts/dashboard/generated/mockData.js
+++ b/artifacts/dashboard/generated/mockData.js
@@ -1,0 +1,107 @@
+// Auto-generated from aggregate-contract.json — DO NOT EDIT
+
+export const kpis = {
+  "revenueThisMonth": {
+    "value": 48250,
+    "trend": 12.5
+  },
+  "expensesThisMonth": {
+    "value": 31800,
+    "trend": 3.2
+  },
+  "netProfit": {
+    "value": 16450,
+    "trend": 28.7
+  },
+  "pendingInvoices": {
+    "value": 7,
+    "trend": -2
+  }
+};
+
+export const revenueTrend = {
+  "labels": [
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+    "Jan",
+    "Feb",
+    "Mar"
+  ],
+  "values": [
+    32000,
+    35000,
+    28000,
+    41000,
+    38000,
+    45000,
+    42000,
+    39000,
+    44000,
+    47000,
+    43000,
+    48250
+  ]
+};
+
+export const pendingTasks = [
+  {
+    "type": "warning",
+    "text": "3 overdue invoices",
+    "link": "/sales-invoice",
+    "amount": "$12,400"
+  },
+  {
+    "type": "info",
+    "text": "2 orders pending shipment",
+    "link": "/goods-shipment"
+  },
+  {
+    "type": "info",
+    "text": "5 purchase orders to confirm",
+    "link": "/purchase-order"
+  },
+  {
+    "type": "warning",
+    "text": "1 low stock alert",
+    "link": "/physical-inventory",
+    "detail": "Cerveza Ale 0.5L"
+  }
+];
+
+export const recentMessages = [
+  {
+    "id": "1",
+    "author": "System",
+    "text": "Invoice INV-2026-0142 was paid by Empresa ABC",
+    "timestamp": "2026-03-09T08:30:00",
+    "type": "system"
+  },
+  {
+    "id": "2",
+    "author": "Ana Garcia",
+    "text": "New quotation QT-0089 created for $8,500",
+    "timestamp": "2026-03-09T07:15:00",
+    "type": "note"
+  },
+  {
+    "id": "3",
+    "author": "System",
+    "text": "Purchase Order PO-0234 received (15 items)",
+    "timestamp": "2026-03-08T16:45:00",
+    "type": "system"
+  },
+  {
+    "id": "4",
+    "author": "Pedro Lopez",
+    "text": "Stock adjustment completed for warehouse Madrid",
+    "timestamp": "2026-03-08T14:20:00",
+    "type": "note"
+  }
+];

--- a/artifacts/goods-movements/generated/web/goods-movements/GoodsMovementForm.jsx
+++ b/artifacts/goods-movements/generated/web/goods-movements/GoodsMovementForm.jsx
@@ -2,7 +2,7 @@ import { EntityForm } from '@/components/contract-ui';
 
 const fields = [
   { key: 'movementDate', label: 'Movement Date', type: 'date', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'isActive', label: 'Is Active', type: 'checkbox', required: true },
 ];
 

--- a/artifacts/goods-movements/generated/web/goods-movements/GoodsMovementLineForm.jsx
+++ b/artifacts/goods-movements/generated/web/goods-movements/GoodsMovementLineForm.jsx
@@ -6,7 +6,7 @@ const fields = [
   { key: 'locatorFrom', label: 'Locator From', type: 'selector', required: true, reference: 'Locator', inputMode: 'selector' },
   { key: 'locatorTo', label: 'Locator To', type: 'selector', required: true, reference: 'Locator', inputMode: 'selector' },
   { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
 ];
 
 export default function GoodsMovementLineForm(props) {

--- a/artifacts/goods-movements/generated/web/goods-movements/GoodsMovementPage.jsx
+++ b/artifacts/goods-movements/generated/web/goods-movements/GoodsMovementPage.jsx
@@ -21,7 +21,7 @@ const addLineFields = {
     { key: 'locatorFrom', label: 'Locator From', type: 'selector', required: true, reference: 'Locator', inputMode: 'selector' },
     { key: 'locatorTo', label: 'Locator To', type: 'selector', required: true, reference: 'Locator', inputMode: 'selector' },
     { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-    { key: 'description', label: 'Description', type: 'text' },
+    { key: 'description', label: 'Description', type: 'textarea' },
   ],
   derived: [
 

--- a/artifacts/goods-movements/generated/web/goods-movements/index.jsx
+++ b/artifacts/goods-movements/generated/web/goods-movements/index.jsx
@@ -1,5 +1,7 @@
 import GoodsMovementPage from './GoodsMovementPage';
 
+const windowMeta = { category: 'warehouseManagement', name: 'Goods Movements' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <GoodsMovementPage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <GoodsMovementPage token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }

--- a/artifacts/goods-receipt/generated/web/goods-receipt/GoodsReceiptForm.jsx
+++ b/artifacts/goods-receipt/generated/web/goods-receipt/GoodsReceiptForm.jsx
@@ -6,7 +6,7 @@ const fields = [
   { key: 'movementDate', label: 'Movement Date', type: 'date', required: true },
   { key: 'dateAcct', label: 'Date Acct', type: 'date', required: true },
   { key: 'warehouse', label: 'Warehouse', type: 'selector', required: true, reference: 'Warehouse', inputMode: 'selector' },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'poReference', label: 'Po Reference', type: 'text' },
   { key: 'isActive', label: 'Is Active', type: 'checkbox', required: true },
 ];

--- a/artifacts/goods-receipt/generated/web/goods-receipt/GoodsReceiptLineForm.jsx
+++ b/artifacts/goods-receipt/generated/web/goods-receipt/GoodsReceiptLineForm.jsx
@@ -5,7 +5,7 @@ const fields = [
   { key: 'movementQty', label: 'Movement Qty', type: 'number', required: true },
   { key: 'locator', label: 'Locator', type: 'selector', required: true, reference: 'Locator', inputMode: 'selector' },
   { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
 ];
 
 export default function GoodsReceiptLineForm(props) {

--- a/artifacts/goods-receipt/generated/web/goods-receipt/GoodsReceiptPage.jsx
+++ b/artifacts/goods-receipt/generated/web/goods-receipt/GoodsReceiptPage.jsx
@@ -20,7 +20,7 @@ const addLineFields = {
     { key: 'movementQty', label: 'Movement Qty', type: 'number', required: true },
     { key: 'locator', label: 'Locator', type: 'selector', required: true, reference: 'Locator', inputMode: 'selector' },
     { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-    { key: 'description', label: 'Description', type: 'text' },
+    { key: 'description', label: 'Description', type: 'textarea' },
   ],
   derived: [
 

--- a/artifacts/goods-receipt/generated/web/goods-receipt/index.jsx
+++ b/artifacts/goods-receipt/generated/web/goods-receipt/index.jsx
@@ -1,5 +1,7 @@
 import GoodsReceiptPage from './GoodsReceiptPage';
 
+const windowMeta = { category: 'procurement', name: 'Goods Receipt' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <GoodsReceiptPage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <GoodsReceiptPage token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }

--- a/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentForm.jsx
+++ b/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentForm.jsx
@@ -6,7 +6,7 @@ const fields = [
   { key: 'movementDate', label: 'Movement Date', type: 'date', required: true },
   { key: 'dateAcct', label: 'Date Acct', type: 'date', required: true },
   { key: 'warehouse', label: 'Warehouse', type: 'selector', required: true, reference: 'Warehouse', inputMode: 'selector' },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'poReference', label: 'Po Reference', type: 'text' },
   { key: 'isActive', label: 'Is Active', type: 'checkbox', required: true },
 ];

--- a/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentLineForm.jsx
+++ b/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentLineForm.jsx
@@ -5,7 +5,7 @@ const fields = [
   { key: 'movementQty', label: 'Movement Qty', type: 'number', required: true },
   { key: 'locator', label: 'Locator', type: 'selector', required: true, reference: 'Locator', inputMode: 'selector' },
   { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
 ];
 
 export default function GoodsShipmentLineForm(props) {

--- a/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentPage.jsx
+++ b/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentPage.jsx
@@ -20,7 +20,7 @@ const addLineFields = {
     { key: 'movementQty', label: 'Movement Qty', type: 'number', required: true },
     { key: 'locator', label: 'Locator', type: 'selector', required: true, reference: 'Locator', inputMode: 'selector' },
     { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-    { key: 'description', label: 'Description', type: 'text' },
+    { key: 'description', label: 'Description', type: 'textarea' },
   ],
   derived: [
 

--- a/artifacts/goods-shipment/generated/web/goods-shipment/index.jsx
+++ b/artifacts/goods-shipment/generated/web/goods-shipment/index.jsx
@@ -1,5 +1,7 @@
 import GoodsShipmentPage from './GoodsShipmentPage';
 
+const windowMeta = { category: 'sales', name: 'Goods Shipment' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <GoodsShipmentPage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <GoodsShipmentPage token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }

--- a/artifacts/inventory/aggregate-contract.json
+++ b/artifacts/inventory/aggregate-contract.json
@@ -1,0 +1,109 @@
+{
+  "version": "0.1.0",
+  "type": "aggregate",
+  "meta": {
+    "module": "inventory",
+    "label": "Inventory",
+    "icon": "Package",
+    "route": "/inventory"
+  },
+  "sections": [
+    {
+      "id": "kpi-header",
+      "type": "kpi",
+      "kpis": [
+        { "key": "totalSkus", "label": "Total SKUs", "format": "number", "icon": "Package" },
+        { "key": "stockValue", "label": "Stock Value", "format": "currency" },
+        { "key": "lowStockAlerts", "label": "Low Stock Alerts", "format": "number", "icon": "AlertTriangle" },
+        { "key": "movementsToday", "label": "Movements Today", "format": "number" }
+      ]
+    },
+    {
+      "id": "stock-levels",
+      "type": "data-table",
+      "label": "Stock Levels",
+      "columns": [
+        { "key": "sku", "label": "SKU" },
+        { "key": "name", "label": "Product Name" },
+        { "key": "warehouse", "label": "Warehouse" },
+        { "key": "available", "label": "Available", "type": "amount" },
+        { "key": "reserved", "label": "Reserved", "type": "amount" },
+        { "key": "minimum", "label": "Minimum", "type": "amount" },
+        { "key": "status", "label": "Status", "type": "status" }
+      ],
+      "filters": ["name", "warehouse"]
+    },
+    {
+      "id": "low-stock",
+      "type": "alerts",
+      "label": "Low Stock Alerts",
+      "severities": ["red", "amber"],
+      "fields": {
+        "label": "name",
+        "current": "current",
+        "threshold": "minimum"
+      }
+    },
+    {
+      "id": "recent-movements",
+      "type": "activity-feed",
+      "label": "Recent Movements",
+      "fields": {
+        "direction": "direction",
+        "label": "product",
+        "detail": "qty",
+        "location": "warehouse",
+        "time": "time"
+      }
+    }
+  ],
+  "layout": {
+    "areas": [
+      { "section": "kpi-header", "width": "full" },
+      { "section": "stock-levels", "width": "2/3" },
+      { "section": "low-stock", "width": "1/3" },
+      { "section": "recent-movements", "width": "1/3" }
+    ]
+  },
+  "actions": [
+    { "label": "Physical Inventory", "route": "/physical-inventory", "variant": "outline" },
+    { "label": "Goods Movements", "route": "/goods-movements", "variant": "default" }
+  ],
+  "mockData": {
+    "kpi-header": {
+      "totalSkus": 248,
+      "stockValue": 1245000,
+      "lowStockAlerts": 5,
+      "movementsToday": 12
+    },
+    "stock-levels": [
+      { "id": 1, "sku": "PRD-001", "name": "Steel Bolts M8", "warehouse": "Madrid Central", "available": 1200, "reserved": 150, "minimum": 200, "status": "In Stock" },
+      { "id": 2, "sku": "PRD-002", "name": "Copper Wire 2.5mm", "warehouse": "Barcelona North", "available": 340, "reserved": 40, "minimum": 100, "status": "In Stock" },
+      { "id": 3, "sku": "PRD-003", "name": "Hydraulic Pump HP-50", "warehouse": "Madrid Central", "available": 18, "reserved": 5, "minimum": 25, "status": "Low Stock" },
+      { "id": 4, "sku": "PRD-004", "name": "LED Panel 60x60", "warehouse": "Barcelona North", "available": 85, "reserved": 20, "minimum": 50, "status": "In Stock" },
+      { "id": 5, "sku": "PRD-005", "name": "Rubber Gasket Set", "warehouse": "Madrid Central", "available": 12, "reserved": 8, "minimum": 30, "status": "Low Stock" },
+      { "id": 6, "sku": "PRD-006", "name": "Stainless Pipe DN50", "warehouse": "Barcelona North", "available": 450, "reserved": 60, "minimum": 100, "status": "In Stock" },
+      { "id": 7, "sku": "PRD-007", "name": "Circuit Breaker 32A", "warehouse": "Madrid Central", "available": 95, "reserved": 10, "minimum": 40, "status": "In Stock" },
+      { "id": 8, "sku": "PRD-008", "name": "Thermal Insulation Roll", "warehouse": "Barcelona North", "available": 8, "reserved": 3, "minimum": 15, "status": "Low Stock" },
+      { "id": 9, "sku": "PRD-009", "name": "PVC Conduit 25mm", "warehouse": "Madrid Central", "available": 620, "reserved": 80, "minimum": 150, "status": "In Stock" },
+      { "id": 10, "sku": "PRD-010", "name": "Bearing SKF 6205", "warehouse": "Barcelona North", "available": 5, "reserved": 2, "minimum": 20, "status": "Low Stock" },
+      { "id": 11, "sku": "PRD-011", "name": "Welding Rod E6013", "warehouse": "Madrid Central", "available": 2000, "reserved": 300, "minimum": 500, "status": "In Stock" },
+      { "id": 12, "sku": "PRD-012", "name": "Air Filter Element", "warehouse": "Barcelona North", "available": 3, "reserved": 1, "minimum": 10, "status": "Low Stock" }
+    ],
+    "low-stock": [
+      { "name": "Hydraulic Pump HP-50", "current": 18, "minimum": 25, "severity": "amber" },
+      { "name": "Rubber Gasket Set", "current": 12, "minimum": 30, "severity": "red" },
+      { "name": "Thermal Insulation Roll", "current": 8, "minimum": 15, "severity": "red" },
+      { "name": "Bearing SKF 6205", "current": 5, "minimum": 20, "severity": "red" },
+      { "name": "Air Filter Element", "current": 3, "minimum": 10, "severity": "red" }
+    ],
+    "recent-movements": [
+      { "id": 1, "direction": "in", "product": "Steel Bolts M8", "qty": 500, "warehouse": "Madrid Central", "time": "2 hours ago" },
+      { "id": 2, "direction": "out", "product": "Copper Wire 2.5mm", "qty": 120, "warehouse": "Barcelona North", "time": "3 hours ago" },
+      { "id": 3, "direction": "in", "product": "LED Panel 60x60", "qty": 50, "warehouse": "Barcelona North", "time": "5 hours ago" },
+      { "id": 4, "direction": "out", "product": "Circuit Breaker 32A", "qty": 15, "warehouse": "Madrid Central", "time": "6 hours ago" },
+      { "id": 5, "direction": "in", "product": "PVC Conduit 25mm", "qty": 200, "warehouse": "Madrid Central", "time": "8 hours ago" },
+      { "id": 6, "direction": "out", "product": "Welding Rod E6013", "qty": 300, "warehouse": "Madrid Central", "time": "1 day ago" }
+    ]
+  }
+}

--- a/artifacts/inventory/generated/config.js
+++ b/artifacts/inventory/generated/config.js
@@ -1,0 +1,134 @@
+// Auto-generated from aggregate-contract.json — DO NOT EDIT
+
+export const meta = {
+  "module": "inventory",
+  "label": "Inventory",
+  "icon": "Package",
+  "route": "/inventory"
+};
+
+export const kpisConfig = [
+  {
+    "key": "totalSkus",
+    "label": "Total SKUs",
+    "format": "number",
+    "icon": "Package"
+  },
+  {
+    "key": "stockValue",
+    "label": "Stock Value",
+    "format": "currency"
+  },
+  {
+    "key": "lowStockAlerts",
+    "label": "Low Stock Alerts",
+    "format": "number",
+    "icon": "AlertTriangle"
+  },
+  {
+    "key": "movementsToday",
+    "label": "Movements Today",
+    "format": "number"
+  }
+];
+
+export const sections = {
+  "stock-levels": {
+    "type": "data-table",
+    "label": "Stock Levels",
+    "columns": [
+      {
+        "key": "sku",
+        "label": "SKU"
+      },
+      {
+        "key": "name",
+        "label": "Product Name"
+      },
+      {
+        "key": "warehouse",
+        "label": "Warehouse"
+      },
+      {
+        "key": "available",
+        "label": "Available",
+        "type": "amount"
+      },
+      {
+        "key": "reserved",
+        "label": "Reserved",
+        "type": "amount"
+      },
+      {
+        "key": "minimum",
+        "label": "Minimum",
+        "type": "amount"
+      },
+      {
+        "key": "status",
+        "label": "Status",
+        "type": "status"
+      }
+    ],
+    "filters": [
+      "name",
+      "warehouse"
+    ]
+  },
+  "low-stock": {
+    "type": "alerts",
+    "label": "Low Stock Alerts",
+    "severities": [
+      "red",
+      "amber"
+    ],
+    "fields": {
+      "label": "name",
+      "current": "current",
+      "threshold": "minimum"
+    }
+  },
+  "recent-movements": {
+    "type": "activity-feed",
+    "label": "Recent Movements",
+    "fields": {
+      "direction": "direction",
+      "label": "product",
+      "detail": "qty",
+      "location": "warehouse",
+      "time": "time"
+    }
+  }
+};
+
+export const layout = [
+  {
+    "section": "kpi-header",
+    "width": "full"
+  },
+  {
+    "section": "stock-levels",
+    "width": "2/3"
+  },
+  {
+    "section": "low-stock",
+    "width": "1/3"
+  },
+  {
+    "section": "recent-movements",
+    "width": "1/3"
+  }
+];
+
+export const actions = [
+  {
+    "label": "Physical Inventory",
+    "route": "/physical-inventory",
+    "variant": "outline"
+  },
+  {
+    "label": "Goods Movements",
+    "route": "/goods-movements",
+    "variant": "default"
+  }
+];

--- a/artifacts/inventory/generated/mockData.js
+++ b/artifacts/inventory/generated/mockData.js
@@ -1,0 +1,215 @@
+// Auto-generated from aggregate-contract.json — DO NOT EDIT
+
+export const kpis = {
+  "totalSkus": 248,
+  "stockValue": 1245000,
+  "lowStockAlerts": 5,
+  "movementsToday": 12
+};
+
+export const stockLevels = [
+  {
+    "id": 1,
+    "sku": "PRD-001",
+    "name": "Steel Bolts M8",
+    "warehouse": "Madrid Central",
+    "available": 1200,
+    "reserved": 150,
+    "minimum": 200,
+    "status": "In Stock"
+  },
+  {
+    "id": 2,
+    "sku": "PRD-002",
+    "name": "Copper Wire 2.5mm",
+    "warehouse": "Barcelona North",
+    "available": 340,
+    "reserved": 40,
+    "minimum": 100,
+    "status": "In Stock"
+  },
+  {
+    "id": 3,
+    "sku": "PRD-003",
+    "name": "Hydraulic Pump HP-50",
+    "warehouse": "Madrid Central",
+    "available": 18,
+    "reserved": 5,
+    "minimum": 25,
+    "status": "Low Stock"
+  },
+  {
+    "id": 4,
+    "sku": "PRD-004",
+    "name": "LED Panel 60x60",
+    "warehouse": "Barcelona North",
+    "available": 85,
+    "reserved": 20,
+    "minimum": 50,
+    "status": "In Stock"
+  },
+  {
+    "id": 5,
+    "sku": "PRD-005",
+    "name": "Rubber Gasket Set",
+    "warehouse": "Madrid Central",
+    "available": 12,
+    "reserved": 8,
+    "minimum": 30,
+    "status": "Low Stock"
+  },
+  {
+    "id": 6,
+    "sku": "PRD-006",
+    "name": "Stainless Pipe DN50",
+    "warehouse": "Barcelona North",
+    "available": 450,
+    "reserved": 60,
+    "minimum": 100,
+    "status": "In Stock"
+  },
+  {
+    "id": 7,
+    "sku": "PRD-007",
+    "name": "Circuit Breaker 32A",
+    "warehouse": "Madrid Central",
+    "available": 95,
+    "reserved": 10,
+    "minimum": 40,
+    "status": "In Stock"
+  },
+  {
+    "id": 8,
+    "sku": "PRD-008",
+    "name": "Thermal Insulation Roll",
+    "warehouse": "Barcelona North",
+    "available": 8,
+    "reserved": 3,
+    "minimum": 15,
+    "status": "Low Stock"
+  },
+  {
+    "id": 9,
+    "sku": "PRD-009",
+    "name": "PVC Conduit 25mm",
+    "warehouse": "Madrid Central",
+    "available": 620,
+    "reserved": 80,
+    "minimum": 150,
+    "status": "In Stock"
+  },
+  {
+    "id": 10,
+    "sku": "PRD-010",
+    "name": "Bearing SKF 6205",
+    "warehouse": "Barcelona North",
+    "available": 5,
+    "reserved": 2,
+    "minimum": 20,
+    "status": "Low Stock"
+  },
+  {
+    "id": 11,
+    "sku": "PRD-011",
+    "name": "Welding Rod E6013",
+    "warehouse": "Madrid Central",
+    "available": 2000,
+    "reserved": 300,
+    "minimum": 500,
+    "status": "In Stock"
+  },
+  {
+    "id": 12,
+    "sku": "PRD-012",
+    "name": "Air Filter Element",
+    "warehouse": "Barcelona North",
+    "available": 3,
+    "reserved": 1,
+    "minimum": 10,
+    "status": "Low Stock"
+  }
+];
+
+export const lowStock = [
+  {
+    "name": "Hydraulic Pump HP-50",
+    "current": 18,
+    "minimum": 25,
+    "severity": "amber"
+  },
+  {
+    "name": "Rubber Gasket Set",
+    "current": 12,
+    "minimum": 30,
+    "severity": "red"
+  },
+  {
+    "name": "Thermal Insulation Roll",
+    "current": 8,
+    "minimum": 15,
+    "severity": "red"
+  },
+  {
+    "name": "Bearing SKF 6205",
+    "current": 5,
+    "minimum": 20,
+    "severity": "red"
+  },
+  {
+    "name": "Air Filter Element",
+    "current": 3,
+    "minimum": 10,
+    "severity": "red"
+  }
+];
+
+export const recentMovements = [
+  {
+    "id": 1,
+    "direction": "in",
+    "product": "Steel Bolts M8",
+    "qty": 500,
+    "warehouse": "Madrid Central",
+    "time": "2 hours ago"
+  },
+  {
+    "id": 2,
+    "direction": "out",
+    "product": "Copper Wire 2.5mm",
+    "qty": 120,
+    "warehouse": "Barcelona North",
+    "time": "3 hours ago"
+  },
+  {
+    "id": 3,
+    "direction": "in",
+    "product": "LED Panel 60x60",
+    "qty": 50,
+    "warehouse": "Barcelona North",
+    "time": "5 hours ago"
+  },
+  {
+    "id": 4,
+    "direction": "out",
+    "product": "Circuit Breaker 32A",
+    "qty": 15,
+    "warehouse": "Madrid Central",
+    "time": "6 hours ago"
+  },
+  {
+    "id": 5,
+    "direction": "in",
+    "product": "PVC Conduit 25mm",
+    "qty": 200,
+    "warehouse": "Madrid Central",
+    "time": "8 hours ago"
+  },
+  {
+    "id": 6,
+    "direction": "out",
+    "product": "Welding Rod E6013",
+    "qty": 300,
+    "warehouse": "Madrid Central",
+    "time": "1 day ago"
+  }
+];

--- a/artifacts/payment-method/generated/web/payment-method/PaymentMethodForm.jsx
+++ b/artifacts/payment-method/generated/web/payment-method/PaymentMethodForm.jsx
@@ -2,7 +2,7 @@ import { EntityForm } from '@/components/contract-ui';
 
 const fields = [
   { key: 'name', label: 'Name', type: 'text', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
 ];
 
 export default function PaymentMethodForm(props) {

--- a/artifacts/payment-method/generated/web/payment-method/index.jsx
+++ b/artifacts/payment-method/generated/web/payment-method/index.jsx
@@ -3,6 +3,8 @@ import PaymentMethodTable from './PaymentMethodTable';
 import PaymentMethodForm from './PaymentMethodForm';
 import catalogs from './mockCatalogs';
 
+const windowMeta = { category: 'reference', name: 'Payment Method' };
+
 export default function App(props) {
   return (
     <SingleEntityPage
@@ -11,6 +13,7 @@ export default function App(props) {
       Form={PaymentMethodForm}
       catalogs={catalogs}
       entityLabel="Payment Method"
+      window={windowMeta}
       {...props}
     />
   );

--- a/artifacts/payment-term/generated/web/payment-term/PaymentTermForm.jsx
+++ b/artifacts/payment-term/generated/web/payment-term/PaymentTermForm.jsx
@@ -3,7 +3,7 @@ import { EntityForm } from '@/components/contract-ui';
 const fields = [
   { key: 'name', label: 'Name', type: 'text', required: true },
   { key: 'searchKey', label: 'Search Key', type: 'text', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'netDays', label: 'Net Days', type: 'number', required: true },
   { key: 'discountDays', label: 'Discount Days', type: 'number' },
   { key: 'discount', label: 'Discount', type: 'number' },

--- a/artifacts/payment-term/generated/web/payment-term/index.jsx
+++ b/artifacts/payment-term/generated/web/payment-term/index.jsx
@@ -3,6 +3,8 @@ import PaymentTermTable from './PaymentTermTable';
 import PaymentTermForm from './PaymentTermForm';
 import catalogs from './mockCatalogs';
 
+const windowMeta = { category: 'reference', name: 'Payment Term' };
+
 export default function App(props) {
   return (
     <SingleEntityPage
@@ -11,6 +13,7 @@ export default function App(props) {
       Form={PaymentTermForm}
       catalogs={catalogs}
       entityLabel="Payment Term"
+      window={windowMeta}
       {...props}
     />
   );

--- a/artifacts/physical-inventory/generated/web/physical-inventory/InventoryForm.jsx
+++ b/artifacts/physical-inventory/generated/web/physical-inventory/InventoryForm.jsx
@@ -4,7 +4,7 @@ const fields = [
   { key: 'warehouse', label: 'Warehouse', type: 'selector', required: true, reference: 'Warehouse', inputMode: 'selector' },
   { key: 'movementDate', label: 'Movement Date', type: 'date', required: true },
   { key: 'inventoryType', label: 'Inventory Type', type: 'text', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
 ];
 
 export default function InventoryForm(props) {

--- a/artifacts/physical-inventory/generated/web/physical-inventory/index.jsx
+++ b/artifacts/physical-inventory/generated/web/physical-inventory/index.jsx
@@ -1,5 +1,7 @@
 import InventoryPage from './InventoryPage';
 
+const windowMeta = { category: 'warehouse', name: 'Physical Inventory' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <InventoryPage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <InventoryPage token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }

--- a/artifacts/price-list/generated/web/price-list/PriceListForm.jsx
+++ b/artifacts/price-list/generated/web/price-list/PriceListForm.jsx
@@ -2,7 +2,7 @@ import { EntityForm } from '@/components/contract-ui';
 
 const fields = [
   { key: 'name', label: 'Name', type: 'text', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'currency', label: 'Currency', type: 'text', required: true },
   { key: 'isDefault', label: 'Is Default', type: 'checkbox' },
 ];

--- a/artifacts/price-list/generated/web/price-list/index.jsx
+++ b/artifacts/price-list/generated/web/price-list/index.jsx
@@ -1,5 +1,7 @@
 import PriceListPage from './PriceListPage';
 
+const windowMeta = { category: 'reference', name: 'Price List' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <PriceListPage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <PriceListPage token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }

--- a/artifacts/product-category/generated/web/product-category/ProductCategoryForm.jsx
+++ b/artifacts/product-category/generated/web/product-category/ProductCategoryForm.jsx
@@ -3,7 +3,7 @@ import { EntityForm } from '@/components/contract-ui';
 const fields = [
   { key: 'name', label: 'Name', type: 'text', required: true },
   { key: 'searchKey', label: 'Search Key', type: 'text', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
 ];
 
 export default function ProductCategoryForm(props) {

--- a/artifacts/product-category/generated/web/product-category/index.jsx
+++ b/artifacts/product-category/generated/web/product-category/index.jsx
@@ -3,6 +3,8 @@ import ProductCategoryTable from './ProductCategoryTable';
 import ProductCategoryForm from './ProductCategoryForm';
 import catalogs from './mockCatalogs';
 
+const windowMeta = { category: 'reference', name: 'Product Category' };
+
 export default function App(props) {
   return (
     <SingleEntityPage
@@ -11,6 +13,7 @@ export default function App(props) {
       Form={ProductCategoryForm}
       catalogs={catalogs}
       entityLabel="Product Category"
+      window={windowMeta}
       {...props}
     />
   );

--- a/artifacts/product/generated/web/product/ProductForm.jsx
+++ b/artifacts/product/generated/web/product/ProductForm.jsx
@@ -3,7 +3,7 @@ import { EntityForm } from '@/components/contract-ui';
 const fields = [
   { key: 'name', label: 'Name', type: 'text', required: true },
   { key: 'searchKey', label: 'Search Key', type: 'text', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'uom', label: 'Uom', type: 'selector', required: true, reference: 'UOM', inputMode: 'selector' },
   { key: 'productCategory', label: 'Product Category', type: 'selector', required: true, reference: 'ProductCategory', inputMode: 'selector' },
   { key: 'listPrice', label: 'List Price', type: 'number' },

--- a/artifacts/product/generated/web/product/index.jsx
+++ b/artifacts/product/generated/web/product/index.jsx
@@ -3,6 +3,8 @@ import ProductTable from './ProductTable';
 import ProductForm from './ProductForm';
 import catalogs from './mockCatalogs';
 
+const windowMeta = { category: 'reference', name: 'Product' };
+
 export default function App(props) {
   return (
     <SingleEntityPage
@@ -11,6 +13,7 @@ export default function App(props) {
       Form={ProductForm}
       catalogs={catalogs}
       entityLabel="Product"
+      window={windowMeta}
       {...props}
     />
   );

--- a/artifacts/purchase-invoice/generated/web/purchase-invoice/InvoiceForm.jsx
+++ b/artifacts/purchase-invoice/generated/web/purchase-invoice/InvoiceForm.jsx
@@ -10,7 +10,7 @@ const fields = [
   { key: 'priceList', label: 'Price List', type: 'selector', required: true, reference: 'PriceList', inputMode: 'selector' },
   { key: 'currency', label: 'Currency', type: 'selector', required: true, reference: 'Currency', inputMode: 'selector' },
   { key: 'poReference', label: 'Po Reference', type: 'text' },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'isActive', label: 'Is Active', type: 'checkbox', required: true },
 ];
 

--- a/artifacts/purchase-invoice/generated/web/purchase-invoice/InvoiceLineForm.jsx
+++ b/artifacts/purchase-invoice/generated/web/purchase-invoice/InvoiceLineForm.jsx
@@ -8,7 +8,7 @@ const fields = [
   { key: 'tax', label: 'Tax', type: 'selector', required: true, reference: 'Tax', inputMode: 'selector' },
   { key: 'discount', label: 'Discount', type: 'number' },
   { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
 ];
 
 export default function InvoiceLineForm(props) {

--- a/artifacts/purchase-invoice/generated/web/purchase-invoice/InvoicePage.jsx
+++ b/artifacts/purchase-invoice/generated/web/purchase-invoice/InvoicePage.jsx
@@ -22,7 +22,7 @@ const addLineFields = {
     { key: 'product', label: 'Product', type: 'search', required: true, lookup: true, reference: 'Product', inputMode: 'search' },
     { key: 'quantity', label: 'Quantity', type: 'number', required: true },
     { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-    { key: 'description', label: 'Description', type: 'text' },
+    { key: 'description', label: 'Description', type: 'textarea' },
   ],
   derived: [
     { key: 'unitPrice', label: 'Unit Price', type: 'number' },

--- a/artifacts/purchase-invoice/generated/web/purchase-invoice/index.jsx
+++ b/artifacts/purchase-invoice/generated/web/purchase-invoice/index.jsx
@@ -1,5 +1,7 @@
 import InvoicePage from './InvoicePage';
 
+const windowMeta = { category: 'procurement', name: 'Purchase Invoice' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <InvoicePage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <InvoicePage token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }

--- a/artifacts/purchase-order/generated/web/purchase-order/OrderForm.jsx
+++ b/artifacts/purchase-order/generated/web/purchase-order/OrderForm.jsx
@@ -12,7 +12,7 @@ const fields = [
   { key: 'invoiceAddress', label: 'Invoice Address', type: 'dependent', required: true, reference: 'BusinessPartnerLocation', inputMode: 'dependent', dependsOn: { field: 'businessPartner', filterKey: 'businessPartnerId' } },
   { key: 'deliveryLocation', label: 'Delivery Location', type: 'text' },
   { key: 'poReference', label: 'Po Reference', type: 'text' },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'isActive', label: 'Is Active', type: 'checkbox', required: true },
 ];
 

--- a/artifacts/purchase-order/generated/web/purchase-order/OrderLineForm.jsx
+++ b/artifacts/purchase-order/generated/web/purchase-order/OrderLineForm.jsx
@@ -6,7 +6,7 @@ const fields = [
   { key: 'unitPrice', label: 'Unit Price', type: 'number', required: true },
   { key: 'tax', label: 'Tax', type: 'selector', required: true, reference: 'Tax', inputMode: 'selector' },
   { key: 'discount', label: 'Discount', type: 'number' },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'lineNo', label: 'Line No', type: 'number', required: true },
 ];
 

--- a/artifacts/purchase-order/generated/web/purchase-order/OrderPage.jsx
+++ b/artifacts/purchase-order/generated/web/purchase-order/OrderPage.jsx
@@ -21,7 +21,7 @@ const addLineFields = {
   entry: [
     { key: 'product', label: 'Product', type: 'search', required: true, lookup: true, reference: 'Product', inputMode: 'search' },
     { key: 'quantity', label: 'Quantity', type: 'number', required: true },
-    { key: 'description', label: 'Description', type: 'text' },
+    { key: 'description', label: 'Description', type: 'textarea' },
     { key: 'lineNo', label: 'Line No', type: 'number', required: true },
   ],
   derived: [

--- a/artifacts/purchase-order/generated/web/purchase-order/index.jsx
+++ b/artifacts/purchase-order/generated/web/purchase-order/index.jsx
@@ -1,5 +1,7 @@
 import OrderPage from './OrderPage';
 
+const windowMeta = { category: 'procurement', name: 'Purchase Order' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <OrderPage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <OrderPage token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }

--- a/artifacts/purchases/aggregate-contract.json
+++ b/artifacts/purchases/aggregate-contract.json
@@ -1,0 +1,84 @@
+{
+  "version": "0.1.0",
+  "type": "aggregate",
+  "meta": {
+    "module": "purchases",
+    "label": "Purchases",
+    "icon": "Truck",
+    "route": "/purchases"
+  },
+  "sections": [
+    {
+      "id": "kpi-header",
+      "type": "kpi",
+      "kpis": [
+        { "key": "totalOrdered", "label": "Total Ordered", "format": "currency", "icon": "FileText" },
+        { "key": "receivedOnTime", "label": "Received On Time", "format": "percent", "icon": "Truck" },
+        { "key": "pendingInvoices", "label": "Pending Invoices", "format": "number" },
+        { "key": "overdue", "label": "Overdue", "format": "currency" }
+      ]
+    },
+    {
+      "id": "pipeline",
+      "type": "kanban",
+      "label": "Pipeline",
+      "columns": [
+        { "id": "draft", "title": "Draft", "color": "gray" },
+        { "id": "confirmed", "title": "Confirmed", "color": "blue" },
+        { "id": "in-transit", "title": "In Transit", "color": "yellow" },
+        { "id": "received", "title": "Received", "color": "green" },
+        { "id": "invoiced", "title": "Invoiced", "color": "purple" }
+      ]
+    },
+    {
+      "id": "orders",
+      "type": "data-table",
+      "label": "Purchase Orders",
+      "columns": [
+        { "key": "docNo", "label": "Doc No" },
+        { "key": "vendor", "label": "Vendor" },
+        { "key": "amount", "label": "Amount", "type": "currency" },
+        { "key": "status", "label": "Status", "type": "status" },
+        { "key": "date", "label": "Date" }
+      ]
+    }
+  ],
+  "layout": {
+    "areas": [
+      { "section": "kpi-header", "width": "full" },
+      { "section": "pipeline", "width": "full" },
+      { "section": "orders", "width": "full" }
+    ]
+  },
+  "actions": [
+    { "label": "+ New PO", "route": "/purchase-order", "variant": "default" }
+  ],
+  "mockData": {
+    "kpi-header": {
+      "totalOrdered": 89500,
+      "receivedOnTime": 92,
+      "pendingInvoices": 8,
+      "overdue": 12400
+    },
+    "pipeline": [
+      { "id": "PO-001", "columnId": "draft", "title": "PO-2026-0234", "subtitle": "Suministros Garcia", "value": 12500 },
+      { "id": "PO-002", "columnId": "draft", "title": "PO-2026-0235", "subtitle": "Nordic Components", "value": 8200 },
+      { "id": "PO-003", "columnId": "confirmed", "title": "PO-2026-0236", "subtitle": "China Imports Ltd", "value": 45000, "badges": ["Priority"] },
+      { "id": "PO-004", "columnId": "confirmed", "title": "PO-2026-0237", "subtitle": "Local Parts SL", "value": 3400 },
+      { "id": "PO-005", "columnId": "in-transit", "title": "PO-2026-0238", "subtitle": "Euro Materials", "value": 18700, "badges": ["Delayed"] },
+      { "id": "PO-006", "columnId": "received", "title": "PO-2026-0239", "subtitle": "Steel Works AG", "value": 6800 },
+      { "id": "PO-007", "columnId": "received", "title": "PO-2026-0240", "subtitle": "Paper Supply Co", "value": 2100 },
+      { "id": "PO-008", "columnId": "invoiced", "title": "PO-2026-0241", "subtitle": "Iberica Industrial", "value": 15000 }
+    ],
+    "orders": [
+      { "id": "PO-001", "docNo": "PO-2026-0234", "vendor": "Suministros Garcia", "amount": 12500, "status": "Draft", "date": "2026-03-09" },
+      { "id": "PO-002", "docNo": "PO-2026-0235", "vendor": "Nordic Components", "amount": 8200, "status": "Draft", "date": "2026-03-09" },
+      { "id": "PO-003", "docNo": "PO-2026-0236", "vendor": "China Imports Ltd", "amount": 45000, "status": "Confirmed", "date": "2026-03-09" },
+      { "id": "PO-004", "docNo": "PO-2026-0237", "vendor": "Local Parts SL", "amount": 3400, "status": "Confirmed", "date": "2026-03-09" },
+      { "id": "PO-005", "docNo": "PO-2026-0238", "vendor": "Euro Materials", "amount": 18700, "status": "In Transit", "date": "2026-03-09" },
+      { "id": "PO-006", "docNo": "PO-2026-0239", "vendor": "Steel Works AG", "amount": 6800, "status": "Received", "date": "2026-03-09" },
+      { "id": "PO-007", "docNo": "PO-2026-0240", "vendor": "Paper Supply Co", "amount": 2100, "status": "Received", "date": "2026-03-09" },
+      { "id": "PO-008", "docNo": "PO-2026-0241", "vendor": "Iberica Industrial", "amount": 15000, "status": "Invoiced", "date": "2026-03-09" }
+    ]
+  }
+}

--- a/artifacts/purchases/generated/config.js
+++ b/artifacts/purchases/generated/config.js
@@ -1,0 +1,118 @@
+// Auto-generated from aggregate-contract.json — DO NOT EDIT
+
+export const meta = {
+  "module": "purchases",
+  "label": "Purchases",
+  "icon": "Truck",
+  "route": "/purchases"
+};
+
+export const kpisConfig = [
+  {
+    "key": "totalOrdered",
+    "label": "Total Ordered",
+    "format": "currency",
+    "icon": "FileText"
+  },
+  {
+    "key": "receivedOnTime",
+    "label": "Received On Time",
+    "format": "percent",
+    "icon": "Truck"
+  },
+  {
+    "key": "pendingInvoices",
+    "label": "Pending Invoices",
+    "format": "number"
+  },
+  {
+    "key": "overdue",
+    "label": "Overdue",
+    "format": "currency"
+  }
+];
+
+export const sections = {
+  "pipeline": {
+    "type": "kanban",
+    "label": "Pipeline",
+    "columns": [
+      {
+        "id": "draft",
+        "title": "Draft",
+        "color": "gray"
+      },
+      {
+        "id": "confirmed",
+        "title": "Confirmed",
+        "color": "blue"
+      },
+      {
+        "id": "in-transit",
+        "title": "In Transit",
+        "color": "yellow"
+      },
+      {
+        "id": "received",
+        "title": "Received",
+        "color": "green"
+      },
+      {
+        "id": "invoiced",
+        "title": "Invoiced",
+        "color": "purple"
+      }
+    ]
+  },
+  "orders": {
+    "type": "data-table",
+    "label": "Purchase Orders",
+    "columns": [
+      {
+        "key": "docNo",
+        "label": "Doc No"
+      },
+      {
+        "key": "vendor",
+        "label": "Vendor"
+      },
+      {
+        "key": "amount",
+        "label": "Amount",
+        "type": "currency"
+      },
+      {
+        "key": "status",
+        "label": "Status",
+        "type": "status"
+      },
+      {
+        "key": "date",
+        "label": "Date"
+      }
+    ]
+  }
+};
+
+export const layout = [
+  {
+    "section": "kpi-header",
+    "width": "full"
+  },
+  {
+    "section": "pipeline",
+    "width": "full"
+  },
+  {
+    "section": "orders",
+    "width": "full"
+  }
+];
+
+export const actions = [
+  {
+    "label": "+ New PO",
+    "route": "/purchase-order",
+    "variant": "default"
+  }
+];

--- a/artifacts/purchases/generated/mockData.js
+++ b/artifacts/purchases/generated/mockData.js
@@ -1,0 +1,140 @@
+// Auto-generated from aggregate-contract.json — DO NOT EDIT
+
+export const kpis = {
+  "totalOrdered": 89500,
+  "receivedOnTime": 92,
+  "pendingInvoices": 8,
+  "overdue": 12400
+};
+
+export const pipeline = [
+  {
+    "id": "PO-001",
+    "columnId": "draft",
+    "title": "PO-2026-0234",
+    "subtitle": "Suministros Garcia",
+    "value": 12500
+  },
+  {
+    "id": "PO-002",
+    "columnId": "draft",
+    "title": "PO-2026-0235",
+    "subtitle": "Nordic Components",
+    "value": 8200
+  },
+  {
+    "id": "PO-003",
+    "columnId": "confirmed",
+    "title": "PO-2026-0236",
+    "subtitle": "China Imports Ltd",
+    "value": 45000,
+    "badges": [
+      "Priority"
+    ]
+  },
+  {
+    "id": "PO-004",
+    "columnId": "confirmed",
+    "title": "PO-2026-0237",
+    "subtitle": "Local Parts SL",
+    "value": 3400
+  },
+  {
+    "id": "PO-005",
+    "columnId": "in-transit",
+    "title": "PO-2026-0238",
+    "subtitle": "Euro Materials",
+    "value": 18700,
+    "badges": [
+      "Delayed"
+    ]
+  },
+  {
+    "id": "PO-006",
+    "columnId": "received",
+    "title": "PO-2026-0239",
+    "subtitle": "Steel Works AG",
+    "value": 6800
+  },
+  {
+    "id": "PO-007",
+    "columnId": "received",
+    "title": "PO-2026-0240",
+    "subtitle": "Paper Supply Co",
+    "value": 2100
+  },
+  {
+    "id": "PO-008",
+    "columnId": "invoiced",
+    "title": "PO-2026-0241",
+    "subtitle": "Iberica Industrial",
+    "value": 15000
+  }
+];
+
+export const orders = [
+  {
+    "id": "PO-001",
+    "docNo": "PO-2026-0234",
+    "vendor": "Suministros Garcia",
+    "amount": 12500,
+    "status": "Draft",
+    "date": "2026-03-09"
+  },
+  {
+    "id": "PO-002",
+    "docNo": "PO-2026-0235",
+    "vendor": "Nordic Components",
+    "amount": 8200,
+    "status": "Draft",
+    "date": "2026-03-09"
+  },
+  {
+    "id": "PO-003",
+    "docNo": "PO-2026-0236",
+    "vendor": "China Imports Ltd",
+    "amount": 45000,
+    "status": "Confirmed",
+    "date": "2026-03-09"
+  },
+  {
+    "id": "PO-004",
+    "docNo": "PO-2026-0237",
+    "vendor": "Local Parts SL",
+    "amount": 3400,
+    "status": "Confirmed",
+    "date": "2026-03-09"
+  },
+  {
+    "id": "PO-005",
+    "docNo": "PO-2026-0238",
+    "vendor": "Euro Materials",
+    "amount": 18700,
+    "status": "In Transit",
+    "date": "2026-03-09"
+  },
+  {
+    "id": "PO-006",
+    "docNo": "PO-2026-0239",
+    "vendor": "Steel Works AG",
+    "amount": 6800,
+    "status": "Received",
+    "date": "2026-03-09"
+  },
+  {
+    "id": "PO-007",
+    "docNo": "PO-2026-0240",
+    "vendor": "Paper Supply Co",
+    "amount": 2100,
+    "status": "Received",
+    "date": "2026-03-09"
+  },
+  {
+    "id": "PO-008",
+    "docNo": "PO-2026-0241",
+    "vendor": "Iberica Industrial",
+    "amount": 15000,
+    "status": "Invoiced",
+    "date": "2026-03-09"
+  }
+];

--- a/artifacts/return-from-customer/generated/web/return-from-customer/CustomerReturnLineForm.jsx
+++ b/artifacts/return-from-customer/generated/web/return-from-customer/CustomerReturnLineForm.jsx
@@ -4,7 +4,7 @@ const fields = [
   { key: 'originalShipmentLine', label: 'Original Shipment Line', type: 'selector', required: true, reference: 'ShipmentLine', inputMode: 'selector' },
   { key: 'quantity', label: 'Quantity', type: 'number', required: true },
   { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
 ];
 
 export default function CustomerReturnLineForm(props) {

--- a/artifacts/return-from-customer/generated/web/return-from-customer/CustomerReturnPage.jsx
+++ b/artifacts/return-from-customer/generated/web/return-from-customer/CustomerReturnPage.jsx
@@ -21,7 +21,7 @@ const addLineFields = {
     { key: 'originalShipmentLine', label: 'Original Shipment Line', type: 'selector', required: true, lookup: true, reference: 'ShipmentLine', inputMode: 'selector' },
     { key: 'quantity', label: 'Quantity', type: 'number', required: true },
     { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-    { key: 'description', label: 'Description', type: 'text' },
+    { key: 'description', label: 'Description', type: 'textarea' },
   ],
   derived: [
 

--- a/artifacts/return-from-customer/generated/web/return-from-customer/index.jsx
+++ b/artifacts/return-from-customer/generated/web/return-from-customer/index.jsx
@@ -1,5 +1,7 @@
 import CustomerReturnPage from './CustomerReturnPage';
 
+const windowMeta = { category: 'sales', name: 'Return from Customer' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <CustomerReturnPage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <CustomerReturnPage token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }

--- a/artifacts/return-material-receipt/generated/web/return-material-receipt/ReturnReceiptForm.jsx
+++ b/artifacts/return-material-receipt/generated/web/return-material-receipt/ReturnReceiptForm.jsx
@@ -8,7 +8,7 @@ const fields = [
   { key: 'warehouse', label: 'Warehouse', type: 'selector', required: true, reference: 'Warehouse', inputMode: 'selector' },
   { key: 'returnReason', label: 'Return Reason', type: 'search', reference: 'ReturnMaterialAuthorization', inputMode: 'search' },
   { key: 'orderReference', label: 'Order Reference', type: 'search', reference: 'SalesOrder', inputMode: 'search' },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'poReference', label: 'Po Reference', type: 'text' },
   { key: 'isActive', label: 'Is Active', type: 'checkbox', required: true },
 ];

--- a/artifacts/return-material-receipt/generated/web/return-material-receipt/ReturnReceiptLineForm.jsx
+++ b/artifacts/return-material-receipt/generated/web/return-material-receipt/ReturnReceiptLineForm.jsx
@@ -5,7 +5,7 @@ const fields = [
   { key: 'movementQty', label: 'Movement Qty', type: 'number', required: true },
   { key: 'locator', label: 'Locator', type: 'selector', required: true, reference: 'Locator', inputMode: 'selector' },
   { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'returnOrderLine', label: 'Return Order Line', type: 'dependent', reference: 'SalesOrderLine', inputMode: 'dependent', dependsOn: { field: 'returnReceipt.orderReference', filterKey: 'cOrderId' } },
   { key: 'rmaLine', label: 'Rma Line', type: 'dependent', reference: 'ReturnMaterialAuthorizationLine', inputMode: 'dependent', dependsOn: { field: 'returnReceipt.returnReason', filterKey: 'mRmaId' } },
 ];

--- a/artifacts/return-material-receipt/generated/web/return-material-receipt/ReturnReceiptPage.jsx
+++ b/artifacts/return-material-receipt/generated/web/return-material-receipt/ReturnReceiptPage.jsx
@@ -20,7 +20,7 @@ const addLineFields = {
     { key: 'movementQty', label: 'Movement Qty', type: 'number', required: true },
     { key: 'locator', label: 'Locator', type: 'selector', required: true, reference: 'Locator', inputMode: 'selector' },
     { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-    { key: 'description', label: 'Description', type: 'text' },
+    { key: 'description', label: 'Description', type: 'textarea' },
     { key: 'returnOrderLine', label: 'Return Order Line', type: 'dependent', reference: 'SalesOrderLine', inputMode: 'dependent', dependsOn: { field: 'returnReceipt.orderReference', filterKey: 'cOrderId' } },
     { key: 'rmaLine', label: 'Rma Line', type: 'dependent', reference: 'ReturnMaterialAuthorizationLine', inputMode: 'dependent', dependsOn: { field: 'returnReceipt.returnReason', filterKey: 'mRmaId' } },
   ],

--- a/artifacts/return-material-receipt/generated/web/return-material-receipt/index.jsx
+++ b/artifacts/return-material-receipt/generated/web/return-material-receipt/index.jsx
@@ -1,5 +1,7 @@
 import ReturnReceiptPage from './ReturnReceiptPage';
 
+const windowMeta = { category: 'sales', name: 'Return Material Receipt' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <ReturnReceiptPage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <ReturnReceiptPage token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }

--- a/artifacts/return-to-vendor-shipment/generated/web/return-to-vendor-shipment/ReturnShipmentForm.jsx
+++ b/artifacts/return-to-vendor-shipment/generated/web/return-to-vendor-shipment/ReturnShipmentForm.jsx
@@ -8,7 +8,7 @@ const fields = [
   { key: 'warehouse', label: 'Warehouse', type: 'selector', required: true, reference: 'Warehouse', inputMode: 'selector' },
   { key: 'returnReason', label: 'Return Reason', type: 'search', reference: 'ReturnMaterialAuthorization', inputMode: 'search' },
   { key: 'orderReference', label: 'Order Reference', type: 'search', reference: 'PurchaseOrder', inputMode: 'search' },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'poReference', label: 'Po Reference', type: 'text' },
   { key: 'isActive', label: 'Is Active', type: 'checkbox', required: true },
 ];

--- a/artifacts/return-to-vendor-shipment/generated/web/return-to-vendor-shipment/ReturnShipmentLineForm.jsx
+++ b/artifacts/return-to-vendor-shipment/generated/web/return-to-vendor-shipment/ReturnShipmentLineForm.jsx
@@ -5,7 +5,7 @@ const fields = [
   { key: 'movementQty', label: 'Movement Qty', type: 'number', required: true },
   { key: 'locator', label: 'Locator', type: 'selector', required: true, reference: 'Locator', inputMode: 'selector' },
   { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'returnOrderLine', label: 'Return Order Line', type: 'dependent', reference: 'PurchaseOrderLine', inputMode: 'dependent', dependsOn: { field: 'returnShipment.orderReference', filterKey: 'cOrderId' } },
   { key: 'rmaLine', label: 'Rma Line', type: 'dependent', reference: 'ReturnMaterialAuthorizationLine', inputMode: 'dependent', dependsOn: { field: 'returnShipment.returnReason', filterKey: 'mRmaId' } },
 ];

--- a/artifacts/return-to-vendor-shipment/generated/web/return-to-vendor-shipment/ReturnShipmentPage.jsx
+++ b/artifacts/return-to-vendor-shipment/generated/web/return-to-vendor-shipment/ReturnShipmentPage.jsx
@@ -20,7 +20,7 @@ const addLineFields = {
     { key: 'movementQty', label: 'Movement Qty', type: 'number', required: true },
     { key: 'locator', label: 'Locator', type: 'selector', required: true, reference: 'Locator', inputMode: 'selector' },
     { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-    { key: 'description', label: 'Description', type: 'text' },
+    { key: 'description', label: 'Description', type: 'textarea' },
     { key: 'returnOrderLine', label: 'Return Order Line', type: 'dependent', reference: 'PurchaseOrderLine', inputMode: 'dependent', dependsOn: { field: 'returnShipment.orderReference', filterKey: 'cOrderId' } },
     { key: 'rmaLine', label: 'Rma Line', type: 'dependent', reference: 'ReturnMaterialAuthorizationLine', inputMode: 'dependent', dependsOn: { field: 'returnShipment.returnReason', filterKey: 'mRmaId' } },
   ],

--- a/artifacts/return-to-vendor-shipment/generated/web/return-to-vendor-shipment/index.jsx
+++ b/artifacts/return-to-vendor-shipment/generated/web/return-to-vendor-shipment/index.jsx
@@ -1,5 +1,7 @@
 import ReturnShipmentPage from './ReturnShipmentPage';
 
+const windowMeta = { category: 'procurement', name: 'Return to Vendor Shipment' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <ReturnShipmentPage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <ReturnShipmentPage token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }

--- a/artifacts/return-to-vendor/generated/web/return-to-vendor/ReturnMaterialLineForm.jsx
+++ b/artifacts/return-to-vendor/generated/web/return-to-vendor/ReturnMaterialLineForm.jsx
@@ -4,7 +4,7 @@ const fields = [
   { key: 'originalReceiptLine', label: 'Original Receipt Line', type: 'selector', required: true, reference: 'MaterialReceiptLine', inputMode: 'selector' },
   { key: 'quantity', label: 'Quantity', type: 'number', required: true },
   { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
 ];
 
 export default function ReturnMaterialLineForm(props) {

--- a/artifacts/return-to-vendor/generated/web/return-to-vendor/ReturnMaterialPage.jsx
+++ b/artifacts/return-to-vendor/generated/web/return-to-vendor/ReturnMaterialPage.jsx
@@ -21,7 +21,7 @@ const addLineFields = {
     { key: 'originalReceiptLine', label: 'Original Receipt Line', type: 'selector', required: true, lookup: true, reference: 'MaterialReceiptLine', inputMode: 'selector' },
     { key: 'quantity', label: 'Quantity', type: 'number', required: true },
     { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-    { key: 'description', label: 'Description', type: 'text' },
+    { key: 'description', label: 'Description', type: 'textarea' },
   ],
   derived: [
 

--- a/artifacts/return-to-vendor/generated/web/return-to-vendor/index.jsx
+++ b/artifacts/return-to-vendor/generated/web/return-to-vendor/index.jsx
@@ -1,5 +1,7 @@
 import ReturnMaterialPage from './ReturnMaterialPage';
 
+const windowMeta = { category: 'procurement', name: 'Return to Vendor' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <ReturnMaterialPage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <ReturnMaterialPage token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }

--- a/artifacts/sales-invoice/generated/web/sales-invoice/InvoiceForm.jsx
+++ b/artifacts/sales-invoice/generated/web/sales-invoice/InvoiceForm.jsx
@@ -11,7 +11,7 @@ const fields = [
   { key: 'currency', label: 'Currency', type: 'selector', required: true, reference: 'Currency', inputMode: 'selector' },
   { key: 'salesRep', label: 'Sales Rep', type: 'search', reference: 'User', inputMode: 'search' },
   { key: 'poReference', label: 'Po Reference', type: 'text' },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'isActive', label: 'Is Active', type: 'checkbox', required: true },
 ];
 

--- a/artifacts/sales-invoice/generated/web/sales-invoice/InvoiceLineForm.jsx
+++ b/artifacts/sales-invoice/generated/web/sales-invoice/InvoiceLineForm.jsx
@@ -8,7 +8,7 @@ const fields = [
   { key: 'tax', label: 'Tax', type: 'selector', required: true, reference: 'Tax', inputMode: 'selector' },
   { key: 'discount', label: 'Discount', type: 'number' },
   { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
 ];
 
 export default function InvoiceLineForm(props) {

--- a/artifacts/sales-invoice/generated/web/sales-invoice/InvoicePage.jsx
+++ b/artifacts/sales-invoice/generated/web/sales-invoice/InvoicePage.jsx
@@ -22,7 +22,7 @@ const addLineFields = {
     { key: 'product', label: 'Product', type: 'search', required: true, lookup: true, reference: 'Product', inputMode: 'search' },
     { key: 'quantity', label: 'Quantity', type: 'number', required: true },
     { key: 'lineNo', label: 'Line No', type: 'number', required: true },
-    { key: 'description', label: 'Description', type: 'text' },
+    { key: 'description', label: 'Description', type: 'textarea' },
   ],
   derived: [
     { key: 'unitPrice', label: 'Unit Price', type: 'number' },

--- a/artifacts/sales-invoice/generated/web/sales-invoice/index.jsx
+++ b/artifacts/sales-invoice/generated/web/sales-invoice/index.jsx
@@ -1,5 +1,7 @@
 import InvoicePage from './InvoicePage';
 
+const windowMeta = { category: 'sales', name: 'Sales Invoice' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <InvoicePage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <InvoicePage token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }

--- a/artifacts/sales-order/generated/web/sales-order/OrderForm.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderForm.jsx
@@ -13,7 +13,7 @@ const fields = [
   { key: 'deliveryLocation', label: 'Delivery Location', type: 'text' },
   { key: 'poReference', label: 'Po Reference', type: 'text' },
   { key: 'salesRep', label: 'Sales Rep', type: 'search', reference: 'User', inputMode: 'search' },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
 ];
 
 export default function OrderForm(props) {

--- a/artifacts/sales-order/generated/web/sales-order/OrderLineForm.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderLineForm.jsx
@@ -6,7 +6,7 @@ const fields = [
   { key: 'unitPrice', label: 'Unit Price', type: 'number', required: true },
   { key: 'tax', label: 'Tax', type: 'selector', required: true, reference: 'Tax', inputMode: 'selector' },
   { key: 'discount', label: 'Discount', type: 'number' },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'lineNo', label: 'Line No', type: 'number', required: true },
 ];
 

--- a/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/OrderPage.jsx
@@ -22,7 +22,7 @@ const addLineFields = {
   entry: [
     { key: 'product', label: 'Product', type: 'search', required: true, lookup: true, reference: 'Product', inputMode: 'search' },
     { key: 'quantity', label: 'Quantity', type: 'number', required: true },
-    { key: 'description', label: 'Description', type: 'text' },
+    { key: 'description', label: 'Description', type: 'textarea' },
     { key: 'lineNo', label: 'Line No', type: 'number', required: true },
   ],
   derived: [

--- a/artifacts/sales-order/generated/web/sales-order/index.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/index.jsx
@@ -1,5 +1,7 @@
 import OrderPage from './OrderPage';
 
+const windowMeta = { category: 'sales', name: 'Sales Order' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <OrderPage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <OrderPage token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }

--- a/artifacts/sales-quotation/generated/web/sales-quotation/QuotationForm.jsx
+++ b/artifacts/sales-quotation/generated/web/sales-quotation/QuotationForm.jsx
@@ -11,7 +11,7 @@ const fields = [
   { key: 'invoiceAddress', label: 'Invoice Address', type: 'dependent', required: true, reference: 'BusinessPartnerLocation', inputMode: 'dependent', dependsOn: { field: 'businessPartner', filterKey: 'businessPartnerId' } },
   { key: 'poReference', label: 'Po Reference', type: 'text' },
   { key: 'salesRep', label: 'Sales Rep', type: 'search', reference: 'User', inputMode: 'search' },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
 ];
 
 export default function QuotationForm(props) {

--- a/artifacts/sales-quotation/generated/web/sales-quotation/QuotationLineForm.jsx
+++ b/artifacts/sales-quotation/generated/web/sales-quotation/QuotationLineForm.jsx
@@ -6,7 +6,7 @@ const fields = [
   { key: 'unitPrice', label: 'Unit Price', type: 'number', required: true },
   { key: 'tax', label: 'Tax', type: 'selector', required: true, reference: 'Tax', inputMode: 'selector' },
   { key: 'discount', label: 'Discount', type: 'number' },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'lineNo', label: 'Line No', type: 'number', required: true },
 ];
 

--- a/artifacts/sales-quotation/generated/web/sales-quotation/QuotationPage.jsx
+++ b/artifacts/sales-quotation/generated/web/sales-quotation/QuotationPage.jsx
@@ -21,7 +21,7 @@ const addLineFields = {
   entry: [
     { key: 'product', label: 'Product', type: 'search', required: true, lookup: true, reference: 'Product', inputMode: 'search' },
     { key: 'quantity', label: 'Quantity', type: 'number', required: true },
-    { key: 'description', label: 'Description', type: 'text' },
+    { key: 'description', label: 'Description', type: 'textarea' },
     { key: 'lineNo', label: 'Line No', type: 'number', required: true },
   ],
   derived: [

--- a/artifacts/sales-quotation/generated/web/sales-quotation/index.jsx
+++ b/artifacts/sales-quotation/generated/web/sales-quotation/index.jsx
@@ -1,5 +1,7 @@
 import QuotationPage from './QuotationPage';
 
+const windowMeta = { category: 'sales', name: 'Sales Quotation' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <QuotationPage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <QuotationPage token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }

--- a/artifacts/sales/aggregate-contract.json
+++ b/artifacts/sales/aggregate-contract.json
@@ -1,0 +1,90 @@
+{
+  "version": "0.1.0",
+  "type": "aggregate",
+  "meta": {
+    "module": "sales",
+    "label": "Sales",
+    "icon": "ShoppingCart",
+    "route": "/sales"
+  },
+  "sections": [
+    {
+      "id": "kpis",
+      "type": "kpi",
+      "kpis": [
+        { "key": "totalQuoted", "label": "Total Quoted", "format": "currency", "icon": "FileText" },
+        { "key": "totalInvoiced", "label": "Total Invoiced", "format": "currency", "icon": "TrendingUp" },
+        { "key": "pendingCollection", "label": "Pending Collection", "format": "currency", "icon": "ShoppingCart" },
+        { "key": "ordersThisMonth", "label": "Orders This Month", "format": "number" }
+      ]
+    },
+    {
+      "id": "pipeline",
+      "type": "kanban",
+      "columns": [
+        { "id": "draft", "title": "Draft", "color": "gray" },
+        { "id": "sent", "title": "Sent", "color": "blue" },
+        { "id": "negotiation", "title": "Negotiation", "color": "yellow" },
+        { "id": "won", "title": "Won", "color": "green" },
+        { "id": "lost", "title": "Lost", "color": "red" }
+      ]
+    },
+    {
+      "id": "quotations",
+      "type": "data-table",
+      "columns": [
+        { "key": "documentNo", "label": "Document No", "align": "left" },
+        { "key": "customer", "label": "Customer", "align": "left" },
+        { "key": "amount", "label": "Amount", "align": "right", "format": "currency" },
+        { "key": "status", "label": "Status", "align": "left" },
+        { "key": "date", "label": "Date", "align": "left" }
+      ]
+    }
+  ],
+  "layout": {
+    "areas": [
+      { "section": "kpis", "span": "full" },
+      { "section": "pipeline", "span": "full" },
+      { "section": "quotations", "span": "full" }
+    ]
+  },
+  "actions": [
+    { "label": "+ New Quotation", "route": "/sales-quotation", "default": true }
+  ],
+  "mockData": {
+    "kpis": {
+      "totalQuoted": 125400,
+      "totalInvoiced": 98200,
+      "pendingCollection": 27300,
+      "ordersThisMonth": 23,
+      "trends": {
+        "totalQuoted": 15,
+        "totalInvoiced": 8,
+        "pendingCollection": -5,
+        "ordersThisMonth": 3
+      }
+    },
+    "pipeline": [
+      { "id": "QT-001", "columnId": "draft", "title": "QT-2026-0089", "subtitle": "Empresa ABC S.L.", "value": 8500, "badges": ["Priority"] },
+      { "id": "QT-002", "columnId": "draft", "title": "QT-2026-0090", "subtitle": "Tech Solutions", "value": 3200 },
+      { "id": "QT-003", "columnId": "sent", "title": "QT-2026-0085", "subtitle": "Global Trade Ltd", "value": 15000, "badges": ["VIP"] },
+      { "id": "QT-004", "columnId": "sent", "title": "QT-2026-0087", "subtitle": "Madrid Logistics", "value": 4800 },
+      { "id": "QT-005", "columnId": "negotiation", "title": "QT-2026-0082", "subtitle": "Barcelona Foods", "value": 22000, "badges": ["Priority", "VIP"], "priority": 3 },
+      { "id": "QT-006", "columnId": "negotiation", "title": "QT-2026-0084", "subtitle": "Sevilla Motors", "value": 6700, "priority": 2 },
+      { "id": "QT-007", "columnId": "won", "title": "QT-2026-0078", "subtitle": "Valencia Exports", "value": 18500 },
+      { "id": "QT-008", "columnId": "won", "title": "QT-2026-0080", "subtitle": "Bilbao Tech", "value": 9200 },
+      { "id": "QT-009", "columnId": "lost", "title": "QT-2026-0076", "subtitle": "Zaragoza Industrial", "value": 5400 }
+    ],
+    "quotations": [
+      { "documentNo": "QT-2026-0089", "customer": "Empresa ABC S.L.", "amount": 8500, "status": "Draft", "date": "2026-03-09" },
+      { "documentNo": "QT-2026-0090", "customer": "Tech Solutions", "amount": 3200, "status": "Draft", "date": "2026-03-09" },
+      { "documentNo": "QT-2026-0085", "customer": "Global Trade Ltd", "amount": 15000, "status": "Sent", "date": "2026-03-09" },
+      { "documentNo": "QT-2026-0087", "customer": "Madrid Logistics", "amount": 4800, "status": "Sent", "date": "2026-03-09" },
+      { "documentNo": "QT-2026-0082", "customer": "Barcelona Foods", "amount": 22000, "status": "Negotiation", "date": "2026-03-09" },
+      { "documentNo": "QT-2026-0084", "customer": "Sevilla Motors", "amount": 6700, "status": "Negotiation", "date": "2026-03-09" },
+      { "documentNo": "QT-2026-0078", "customer": "Valencia Exports", "amount": 18500, "status": "Won", "date": "2026-03-09" },
+      { "documentNo": "QT-2026-0080", "customer": "Bilbao Tech", "amount": 9200, "status": "Won", "date": "2026-03-09" },
+      { "documentNo": "QT-2026-0076", "customer": "Zaragoza Industrial", "amount": 5400, "status": "Lost", "date": "2026-03-09" }
+    ]
+  }
+}

--- a/artifacts/sales/generated/config.js
+++ b/artifacts/sales/generated/config.js
@@ -1,0 +1,125 @@
+// Auto-generated from aggregate-contract.json — DO NOT EDIT
+
+export const meta = {
+  "module": "sales",
+  "label": "Sales",
+  "icon": "ShoppingCart",
+  "route": "/sales"
+};
+
+export const kpisConfig = [];
+
+export const sections = {
+  "kpis": {
+    "type": "kpi",
+    "kpis": [
+      {
+        "key": "totalQuoted",
+        "label": "Total Quoted",
+        "format": "currency",
+        "icon": "FileText"
+      },
+      {
+        "key": "totalInvoiced",
+        "label": "Total Invoiced",
+        "format": "currency",
+        "icon": "TrendingUp"
+      },
+      {
+        "key": "pendingCollection",
+        "label": "Pending Collection",
+        "format": "currency",
+        "icon": "ShoppingCart"
+      },
+      {
+        "key": "ordersThisMonth",
+        "label": "Orders This Month",
+        "format": "number"
+      }
+    ]
+  },
+  "pipeline": {
+    "type": "kanban",
+    "columns": [
+      {
+        "id": "draft",
+        "title": "Draft",
+        "color": "gray"
+      },
+      {
+        "id": "sent",
+        "title": "Sent",
+        "color": "blue"
+      },
+      {
+        "id": "negotiation",
+        "title": "Negotiation",
+        "color": "yellow"
+      },
+      {
+        "id": "won",
+        "title": "Won",
+        "color": "green"
+      },
+      {
+        "id": "lost",
+        "title": "Lost",
+        "color": "red"
+      }
+    ]
+  },
+  "quotations": {
+    "type": "data-table",
+    "columns": [
+      {
+        "key": "documentNo",
+        "label": "Document No",
+        "align": "left"
+      },
+      {
+        "key": "customer",
+        "label": "Customer",
+        "align": "left"
+      },
+      {
+        "key": "amount",
+        "label": "Amount",
+        "align": "right",
+        "format": "currency"
+      },
+      {
+        "key": "status",
+        "label": "Status",
+        "align": "left"
+      },
+      {
+        "key": "date",
+        "label": "Date",
+        "align": "left"
+      }
+    ]
+  }
+};
+
+export const layout = [
+  {
+    "section": "kpis",
+    "span": "full"
+  },
+  {
+    "section": "pipeline",
+    "span": "full"
+  },
+  {
+    "section": "quotations",
+    "span": "full"
+  }
+];
+
+export const actions = [
+  {
+    "label": "+ New Quotation",
+    "route": "/sales-quotation",
+    "default": true
+  }
+];

--- a/artifacts/sales/generated/mockData.js
+++ b/artifacts/sales/generated/mockData.js
@@ -1,0 +1,158 @@
+// Auto-generated from aggregate-contract.json — DO NOT EDIT
+
+export const kpis = {
+  "totalQuoted": 125400,
+  "totalInvoiced": 98200,
+  "pendingCollection": 27300,
+  "ordersThisMonth": 23,
+  "trends": {
+    "totalQuoted": 15,
+    "totalInvoiced": 8,
+    "pendingCollection": -5,
+    "ordersThisMonth": 3
+  }
+};
+
+export const pipeline = [
+  {
+    "id": "QT-001",
+    "columnId": "draft",
+    "title": "QT-2026-0089",
+    "subtitle": "Empresa ABC S.L.",
+    "value": 8500,
+    "badges": [
+      "Priority"
+    ]
+  },
+  {
+    "id": "QT-002",
+    "columnId": "draft",
+    "title": "QT-2026-0090",
+    "subtitle": "Tech Solutions",
+    "value": 3200
+  },
+  {
+    "id": "QT-003",
+    "columnId": "sent",
+    "title": "QT-2026-0085",
+    "subtitle": "Global Trade Ltd",
+    "value": 15000,
+    "badges": [
+      "VIP"
+    ]
+  },
+  {
+    "id": "QT-004",
+    "columnId": "sent",
+    "title": "QT-2026-0087",
+    "subtitle": "Madrid Logistics",
+    "value": 4800
+  },
+  {
+    "id": "QT-005",
+    "columnId": "negotiation",
+    "title": "QT-2026-0082",
+    "subtitle": "Barcelona Foods",
+    "value": 22000,
+    "badges": [
+      "Priority",
+      "VIP"
+    ],
+    "priority": 3
+  },
+  {
+    "id": "QT-006",
+    "columnId": "negotiation",
+    "title": "QT-2026-0084",
+    "subtitle": "Sevilla Motors",
+    "value": 6700,
+    "priority": 2
+  },
+  {
+    "id": "QT-007",
+    "columnId": "won",
+    "title": "QT-2026-0078",
+    "subtitle": "Valencia Exports",
+    "value": 18500
+  },
+  {
+    "id": "QT-008",
+    "columnId": "won",
+    "title": "QT-2026-0080",
+    "subtitle": "Bilbao Tech",
+    "value": 9200
+  },
+  {
+    "id": "QT-009",
+    "columnId": "lost",
+    "title": "QT-2026-0076",
+    "subtitle": "Zaragoza Industrial",
+    "value": 5400
+  }
+];
+
+export const quotations = [
+  {
+    "documentNo": "QT-2026-0089",
+    "customer": "Empresa ABC S.L.",
+    "amount": 8500,
+    "status": "Draft",
+    "date": "2026-03-09"
+  },
+  {
+    "documentNo": "QT-2026-0090",
+    "customer": "Tech Solutions",
+    "amount": 3200,
+    "status": "Draft",
+    "date": "2026-03-09"
+  },
+  {
+    "documentNo": "QT-2026-0085",
+    "customer": "Global Trade Ltd",
+    "amount": 15000,
+    "status": "Sent",
+    "date": "2026-03-09"
+  },
+  {
+    "documentNo": "QT-2026-0087",
+    "customer": "Madrid Logistics",
+    "amount": 4800,
+    "status": "Sent",
+    "date": "2026-03-09"
+  },
+  {
+    "documentNo": "QT-2026-0082",
+    "customer": "Barcelona Foods",
+    "amount": 22000,
+    "status": "Negotiation",
+    "date": "2026-03-09"
+  },
+  {
+    "documentNo": "QT-2026-0084",
+    "customer": "Sevilla Motors",
+    "amount": 6700,
+    "status": "Negotiation",
+    "date": "2026-03-09"
+  },
+  {
+    "documentNo": "QT-2026-0078",
+    "customer": "Valencia Exports",
+    "amount": 18500,
+    "status": "Won",
+    "date": "2026-03-09"
+  },
+  {
+    "documentNo": "QT-2026-0080",
+    "customer": "Bilbao Tech",
+    "amount": 9200,
+    "status": "Won",
+    "date": "2026-03-09"
+  },
+  {
+    "documentNo": "QT-2026-0076",
+    "customer": "Zaragoza Industrial",
+    "amount": 5400,
+    "status": "Lost",
+    "date": "2026-03-09"
+  }
+];

--- a/artifacts/tax/generated/web/tax/TaxForm.jsx
+++ b/artifacts/tax/generated/web/tax/TaxForm.jsx
@@ -3,7 +3,7 @@ import { EntityForm } from '@/components/contract-ui';
 const fields = [
   { key: 'name', label: 'Name', type: 'text', required: true },
   { key: 'rate', label: 'Rate', type: 'number', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'validFrom', label: 'Valid From', type: 'date' },
 ];
 

--- a/artifacts/tax/generated/web/tax/index.jsx
+++ b/artifacts/tax/generated/web/tax/index.jsx
@@ -3,6 +3,8 @@ import TaxTable from './TaxTable';
 import TaxForm from './TaxForm';
 import catalogs from './mockCatalogs';
 
+const windowMeta = { category: 'reference', name: 'Tax' };
+
 export default function App(props) {
   return (
     <SingleEntityPage
@@ -11,6 +13,7 @@ export default function App(props) {
       Form={TaxForm}
       catalogs={catalogs}
       entityLabel="Tax"
+      window={windowMeta}
       {...props}
     />
   );

--- a/artifacts/uom/generated/web/uom/UomForm.jsx
+++ b/artifacts/uom/generated/web/uom/UomForm.jsx
@@ -3,7 +3,7 @@ import { EntityForm } from '@/components/contract-ui';
 const fields = [
   { key: 'name', label: 'Name', type: 'text', required: true },
   { key: 'symbol', label: 'Symbol', type: 'text', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
 ];
 
 export default function UomForm(props) {

--- a/artifacts/uom/generated/web/uom/index.jsx
+++ b/artifacts/uom/generated/web/uom/index.jsx
@@ -3,6 +3,8 @@ import UomTable from './UomTable';
 import UomForm from './UomForm';
 import catalogs from './mockCatalogs';
 
+const windowMeta = { category: 'reference', name: 'UOM' };
+
 export default function App(props) {
   return (
     <SingleEntityPage
@@ -11,6 +13,7 @@ export default function App(props) {
       Form={UomForm}
       catalogs={catalogs}
       entityLabel="Uom"
+      window={windowMeta}
       {...props}
     />
   );

--- a/artifacts/user/generated/web/user/UserForm.jsx
+++ b/artifacts/user/generated/web/user/UserForm.jsx
@@ -4,7 +4,7 @@ const fields = [
   { key: 'name', label: 'Name', type: 'text', required: true },
   { key: 'email', label: 'Email', type: 'text' },
   { key: 'phone', label: 'Phone', type: 'text' },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
 ];
 
 export default function UserForm(props) {

--- a/artifacts/user/generated/web/user/index.jsx
+++ b/artifacts/user/generated/web/user/index.jsx
@@ -3,6 +3,8 @@ import UserTable from './UserTable';
 import UserForm from './UserForm';
 import catalogs from './mockCatalogs';
 
+const windowMeta = { category: 'reference', name: 'User' };
+
 export default function App(props) {
   return (
     <SingleEntityPage
@@ -11,6 +13,7 @@ export default function App(props) {
       Form={UserForm}
       catalogs={catalogs}
       entityLabel="User"
+      window={windowMeta}
       {...props}
     />
   );

--- a/artifacts/warehouse-storage-bins/generated/web/warehouse-storage-bins/WarehouseForm.jsx
+++ b/artifacts/warehouse-storage-bins/generated/web/warehouse-storage-bins/WarehouseForm.jsx
@@ -3,7 +3,7 @@ import { EntityForm } from '@/components/contract-ui';
 const fields = [
   { key: 'searchKey', label: 'Search Key', type: 'text', required: true },
   { key: 'name', label: 'Name', type: 'text', required: true },
-  { key: 'description', label: 'Description', type: 'text' },
+  { key: 'description', label: 'Description', type: 'textarea' },
   { key: 'address1', label: 'Address1', type: 'text' },
   { key: 'address2', label: 'Address2', type: 'text' },
   { key: 'city', label: 'City', type: 'text' },

--- a/artifacts/warehouse-storage-bins/generated/web/warehouse-storage-bins/index.jsx
+++ b/artifacts/warehouse-storage-bins/generated/web/warehouse-storage-bins/index.jsx
@@ -1,5 +1,7 @@
 import WarehousePage from './WarehousePage';
 
+const windowMeta = { category: 'setup', name: 'Warehouse Storage Bins' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <WarehousePage token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <WarehousePage token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }

--- a/cli/src/generate-aggregate.js
+++ b/cli/src/generate-aggregate.js
@@ -1,0 +1,142 @@
+import { readFileSync, writeFileSync, mkdirSync, readdirSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+
+/**
+ * Convert a kebab-case section id to camelCase variable name.
+ * e.g., 'stock-levels' -> 'stockLevels'
+ */
+function toCamelCase(id) {
+  return id.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+/**
+ * Generate config.js and mockData.js from an aggregate contract.
+ *
+ * @param {object} contract - The aggregate-contract.json object
+ * @returns {{ 'config.js': string, 'mockData.js': string }}
+ */
+export function generateAggregateFiles(contract) {
+  return {
+    'config.js': generateConfig(contract),
+    'mockData.js': generateMockData(contract),
+  };
+}
+
+/**
+ * Generate the config.js file content.
+ */
+function generateConfig(contract) {
+  const { meta, sections: sectionsList, layout, actions } = contract;
+
+  // Find the kpi-header section and extract its kpis array
+  const kpiSection = sectionsList.find(s => s.id === 'kpi-header');
+  const kpisConfig = kpiSection?.kpis ?? [];
+
+  // Build sections object keyed by id, excluding kpi-header
+  const sectionsObj = {};
+  for (const section of sectionsList) {
+    if (section.id === 'kpi-header') continue;
+    const { id, ...config } = section;
+    sectionsObj[id] = config;
+  }
+
+  const lines = [
+    '// Auto-generated from aggregate-contract.json — DO NOT EDIT',
+    '',
+    `export const meta = ${JSON.stringify(meta, null, 2)};`,
+    '',
+    `export const kpisConfig = ${JSON.stringify(kpisConfig, null, 2)};`,
+    '',
+    `export const sections = ${JSON.stringify(sectionsObj, null, 2)};`,
+    '',
+    `export const layout = ${JSON.stringify(layout.areas, null, 2)};`,
+    '',
+    `export const actions = ${JSON.stringify(actions, null, 2)};`,
+    '',
+  ];
+
+  return lines.join('\n');
+}
+
+/**
+ * Generate the mockData.js file content.
+ * One named export per section id (skip quick-actions).
+ * kpi-header section exports as 'kpis'.
+ */
+function generateMockData(contract) {
+  const { sections: sectionsList, mockData } = contract;
+
+  const lines = [
+    '// Auto-generated from aggregate-contract.json — DO NOT EDIT',
+    '',
+  ];
+
+  for (const section of sectionsList) {
+    if (section.type === 'quick-actions') continue;
+
+    const data = mockData[section.id];
+    if (data === undefined) continue;
+
+    // kpi-header exports as 'kpis', others use camelCase of section id
+    const exportName = section.id === 'kpi-header'
+      ? 'kpis'
+      : toCamelCase(section.id);
+
+    lines.push(`export const ${exportName} = ${JSON.stringify(data, null, 2)};`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// CLI entry point — only runs when executed directly
+const isDirectRun = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/.*\//, ''));
+if (isDirectRun) {
+  const args = process.argv.slice(2);
+
+  if (args[0] === '--all') {
+    // Find all aggregate-contract.json files in artifacts/
+    const artifactsDir = resolve('artifacts');
+    let count = 0;
+    for (const moduleName of readdirSync(artifactsDir, { withFileTypes: true })) {
+      if (!moduleName.isDirectory()) continue;
+      const contractPath = resolve(artifactsDir, moduleName.name, 'aggregate-contract.json');
+      try {
+        const json = readFileSync(contractPath, 'utf-8');
+        const contract = JSON.parse(json);
+        writeGeneratedFiles(contract, moduleName.name);
+        count++;
+      } catch {
+        // No aggregate-contract.json in this directory, skip
+      }
+    }
+    console.log(`Generated files for ${count} modules`);
+  } else if (args[0]) {
+    const contractPath = resolve(args[0]);
+    const json = readFileSync(contractPath, 'utf-8');
+    const contract = JSON.parse(json);
+    const moduleName = contract.meta?.module ?? dirname(contractPath).split('/').pop();
+    writeGeneratedFiles(contract, moduleName);
+  } else {
+    console.error('Usage: node cli/src/generate-aggregate.js <aggregate-contract.json>');
+    console.error('       node cli/src/generate-aggregate.js --all');
+    process.exit(1);
+  }
+}
+
+/**
+ * Write generated config.js and mockData.js to the output directory.
+ */
+function writeGeneratedFiles(contract, moduleName) {
+  const files = generateAggregateFiles(contract);
+  const outDir = resolve(`artifacts/${moduleName}/generated`);
+  mkdirSync(outDir, { recursive: true });
+
+  for (const [filename, code] of Object.entries(files)) {
+    const filePath = resolve(outDir, filename);
+    writeFileSync(filePath, code, 'utf-8');
+    console.log(`  wrote ${filePath}`);
+  }
+
+  console.log(`Generated ${Object.keys(files).length} files in ${outDir}`);
+}

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -60,6 +60,7 @@ function mapFormFieldType(field) {
   if (field.type === 'boolean') return 'checkbox';
   if (field.tsType === 'number') return 'number';
   if (field.type === 'date') return 'date';
+  if (/notes|description|comments|remarks/i.test(field.name)) return 'textarea';
   return 'text';
 }
 
@@ -239,14 +240,18 @@ export default function ${compName}(props) {
  * Generate the entry point / index component.
  * Accepts { token, apiBaseUrl, window } props.
  */
-export function generateIndexComponent(headerEntity, detailEntity) {
+export function generateIndexComponent(headerEntity, detailEntity, contract) {
   const headerName = capitalize(headerEntity);
+  const category = contract?.frontendContract?.window?.category ?? 'general';
+  const windowName = contract?.frontendContract?.window?.name ?? toLabel(headerEntity);
 
   if (detailEntity) {
     return `import ${headerName}Page from './${headerName}Page';
 
+const windowMeta = { category: '${category}', name: '${windowName}' };
+
 export default function App({ token, apiBaseUrl, window }) {
-  return <${headerName}Page token={token} apiBaseUrl={apiBaseUrl} window={window} />;
+  return <${headerName}Page token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} />;
 }
 `;
   }
@@ -256,6 +261,8 @@ import ${headerName}Table from './${headerName}Table';
 import ${headerName}Form from './${headerName}Form';
 import catalogs from './mockCatalogs';
 
+const windowMeta = { category: '${category}', name: '${windowName}' };
+
 export default function App(props) {
   return (
     <SingleEntityPage
@@ -264,6 +271,7 @@ export default function App(props) {
       Form={${headerName}Form}
       catalogs={catalogs}
       entityLabel="${toLabel(headerEntity)}"
+      window={windowMeta}
       {...props}
     />
   );
@@ -326,6 +334,11 @@ const CATALOG_DATA = {
   UOM: Array.from({ length: 5 }, (_, i) => ({
     id: `uom-${String(i + 1).padStart(3, '0')}`,
     name: ['Each', 'Box', 'Kg', 'Meter', 'Liter'][i],
+  })),
+  StorageBin: Array.from({ length: 10 }, (_, i) => ({
+    id: `sb-${String(i + 1).padStart(3, '0')}`,
+    name: ['A-01-01', 'A-01-02', 'A-02-01', 'A-02-02', 'B-01-01', 'B-01-02', 'B-02-01', 'B-02-02', 'C-01-01', 'C-01-02'][i],
+    warehouseId: `wh-${String(Math.floor(i / 2) + 1).padStart(3, '0')}`,
   })),
   ProductCategory: Array.from({ length: 9 }, (_, i) => ({
     id: `cat-${String(i + 1).padStart(3, '0')}`,
@@ -414,7 +427,7 @@ export function generateAll(contract) {
   files['mockCatalogs.js'] = generateMockCatalogs(contract);
 
   // Always generate index
-  files['index.jsx'] = generateIndexComponent(primaryEntity, detailEntity);
+  files['index.jsx'] = generateIndexComponent(primaryEntity, detailEntity, contract);
 
   return files;
 }

--- a/cli/src/run-aggregate-tests.js
+++ b/cli/src/run-aggregate-tests.js
@@ -1,0 +1,276 @@
+/**
+ * Aggregate Contract Test Runner
+ *
+ * Validates structural integrity of aggregate-contract.json files.
+ * Pure functions, no I/O. Same pattern as run-contract-tests.js.
+ *
+ * 8 validation categories:
+ *   section-presence, kpi-integrity, table-column-match,
+ *   kanban-column-match, alert-severity, link-validity,
+ *   layout-coverage, mockData-shape
+ */
+
+const VALID_KPI_FORMATS = new Set(['currency', 'number', 'percent']);
+
+let testCounter = 0;
+function nextId(category) {
+  return `agg-${category}-${++testCounter}`;
+}
+
+/**
+ * Check that every section in sections[] has a corresponding entry in mockData.
+ * Skips quick-actions type sections.
+ */
+function checkSectionPresence(contract) {
+  const results = [];
+  const sections = contract.sections ?? [];
+  const mockData = contract.mockData ?? {};
+
+  for (const section of sections) {
+    if (section.type === 'quick-actions') continue;
+    const hasMock = section.id in mockData;
+    results.push({
+      id: nextId('sp'),
+      category: 'section-presence',
+      description: `Section '${section.id}' has mockData`,
+      passed: hasMock,
+      ...(hasMock ? {} : { reason: `No mockData entry for section '${section.id}'` }),
+    });
+  }
+  return results;
+}
+
+/**
+ * Check KPI sections: each KPI must have a label, a valid format, and a value in mockData.
+ */
+function checkKpiIntegrity(contract) {
+  const results = [];
+  const sections = (contract.sections ?? []).filter(s => s.type === 'kpi');
+  const mockData = contract.mockData ?? {};
+
+  for (const section of sections) {
+    const data = mockData[section.id] ?? {};
+    for (const kpi of section.kpis ?? []) {
+      // Check label
+      const hasLabel = Boolean(kpi.label);
+      results.push({
+        id: nextId('kpi'),
+        category: 'kpi-integrity',
+        description: `KPI '${kpi.key}' has a label`,
+        passed: hasLabel,
+        ...(hasLabel ? {} : { reason: `KPI '${kpi.key}' is missing a label` }),
+      });
+
+      // Check format
+      const validFormat = VALID_KPI_FORMATS.has(kpi.format);
+      results.push({
+        id: nextId('kpi'),
+        category: 'kpi-integrity',
+        description: `KPI '${kpi.key}' has valid format '${kpi.format}'`,
+        passed: validFormat,
+        ...(validFormat ? {} : { reason: `KPI '${kpi.key}' has invalid format '${kpi.format}', expected one of: currency, number, percent` }),
+      });
+
+      // Check value in mockData
+      const hasValue = kpi.key in data;
+      results.push({
+        id: nextId('kpi'),
+        category: 'kpi-integrity',
+        description: `KPI '${kpi.key}' has value in mockData`,
+        passed: hasValue,
+        ...(hasValue ? {} : { reason: `KPI '${kpi.key}' (key: '${kpi.key}') not found in mockData for section '${section.id}'` }),
+      });
+    }
+  }
+  return results;
+}
+
+/**
+ * Check data-table sections: first mockData row must contain all column keys.
+ */
+function checkTableColumnMatch(contract) {
+  const results = [];
+  const sections = (contract.sections ?? []).filter(s => s.type === 'data-table');
+  const mockData = contract.mockData ?? {};
+
+  for (const section of sections) {
+    const rows = mockData[section.id];
+    if (!Array.isArray(rows) || rows.length === 0) continue;
+    const firstRow = rows[0];
+    for (const col of section.columns ?? []) {
+      const hasKey = col.key in firstRow;
+      results.push({
+        id: nextId('tcm'),
+        category: 'table-column-match',
+        description: `Table '${section.id}' row has column '${col.key}'`,
+        passed: hasKey,
+        ...(hasKey ? {} : { reason: `Column '${col.key}' not found in first mockData row for table '${section.id}'` }),
+      });
+    }
+  }
+  return results;
+}
+
+/**
+ * Check kanban sections: each card's columnId must exist in the section's columns.
+ */
+function checkKanbanColumnMatch(contract) {
+  const results = [];
+  const sections = (contract.sections ?? []).filter(s => s.type === 'kanban');
+  const mockData = contract.mockData ?? {};
+
+  for (const section of sections) {
+    const validIds = new Set((section.columns ?? []).map(c => c.id));
+    const cards = mockData[section.id];
+    if (!Array.isArray(cards)) continue;
+    for (const card of cards) {
+      const valid = validIds.has(card.columnId);
+      results.push({
+        id: nextId('kcm'),
+        category: 'kanban-column-match',
+        description: `Kanban card '${card.title ?? 'untitled'}' has valid columnId`,
+        passed: valid,
+        ...(valid ? {} : { reason: `Card columnId '${card.columnId}' not found in kanban columns for '${section.id}'` }),
+      });
+    }
+  }
+  return results;
+}
+
+/**
+ * Check alerts sections: each alert's severity must be in the section's declared severities set.
+ */
+function checkAlertSeverity(contract) {
+  const results = [];
+  const sections = (contract.sections ?? []).filter(s => s.type === 'alerts');
+  const mockData = contract.mockData ?? {};
+
+  for (const section of sections) {
+    const validSeverities = new Set(section.severities ?? []);
+    const alerts = mockData[section.id];
+    if (!Array.isArray(alerts)) continue;
+    for (const alert of alerts) {
+      const valid = validSeverities.has(alert.severity);
+      results.push({
+        id: nextId('as'),
+        category: 'alert-severity',
+        description: `Alert severity '${alert.severity}' is valid`,
+        passed: valid,
+        ...(valid ? {} : { reason: `Alert severity '${alert.severity}' not in declared set [${[...validSeverities].join(', ')}] for section '${section.id}'` }),
+      });
+    }
+  }
+  return results;
+}
+
+/**
+ * Check that action routes exist in the provided menu items list.
+ */
+function checkLinkValidity(contract, menuItems) {
+  const results = [];
+  const actions = contract.actions ?? [];
+  const menuSet = new Set(menuItems.map(m => m.replace(/^\//, '')));
+
+  for (const action of actions) {
+    const route = (action.route ?? '').replace(/^\//, '');
+    const valid = menuSet.has(route);
+    results.push({
+      id: nextId('lv'),
+      category: 'link-validity',
+      description: `Action route '${action.route}' exists in menu`,
+      passed: valid,
+      ...(valid ? {} : { reason: `Route '${action.route}' not found in menu items` }),
+    });
+  }
+  return results;
+}
+
+/**
+ * Check that all section IDs are referenced in layout.areas.
+ */
+function checkLayoutCoverage(contract) {
+  const results = [];
+  const sections = contract.sections ?? [];
+  const areaSet = new Set((contract.layout?.areas ?? []).map(a => a.section));
+
+  for (const section of sections) {
+    const covered = areaSet.has(section.id);
+    results.push({
+      id: nextId('lc'),
+      category: 'layout-coverage',
+      description: `Section '${section.id}' is referenced in layout`,
+      passed: covered,
+      ...(covered ? {} : { reason: `Section '${section.id}' not found in layout.areas` }),
+    });
+  }
+  return results;
+}
+
+/**
+ * Check mockData shape: arrays must be non-empty, objects must have keys.
+ * Skips quick-actions sections.
+ */
+function checkMockDataShape(contract) {
+  const results = [];
+  const sections = contract.sections ?? [];
+  const mockData = contract.mockData ?? {};
+  const skipTypes = new Set(['quick-actions']);
+
+  for (const section of sections) {
+    if (skipTypes.has(section.type)) continue;
+    const data = mockData[section.id];
+    if (data === undefined) continue;
+
+    let valid = true;
+    let reason = '';
+
+    if (Array.isArray(data)) {
+      if (data.length === 0) {
+        valid = false;
+        reason = `mockData for '${section.id}' is an empty array`;
+      }
+    } else if (typeof data === 'object' && data !== null) {
+      if (Object.keys(data).length === 0) {
+        valid = false;
+        reason = `mockData for '${section.id}' is an empty object`;
+      }
+    }
+
+    results.push({
+      id: nextId('mds'),
+      category: 'mockData-shape',
+      description: `mockData for '${section.id}' has valid shape`,
+      passed: valid,
+      ...(valid ? {} : { reason }),
+    });
+  }
+  return results;
+}
+
+/**
+ * Run all aggregate contract tests and return a summary.
+ *
+ * @param {object} contract - The aggregate contract JSON
+ * @param {string[]} menuItems - List of valid menu routes
+ * @returns {{total: number, passed: number, failed: number, results: Array<{id: string, category: string, description: string, passed: boolean, reason?: string}>}}
+ */
+export function runAggregateTests(contract, menuItems = []) {
+  // Reset counter for each run so IDs are deterministic per invocation
+  testCounter = 0;
+
+  const results = [
+    ...checkSectionPresence(contract),
+    ...checkKpiIntegrity(contract),
+    ...checkTableColumnMatch(contract),
+    ...checkKanbanColumnMatch(contract),
+    ...checkAlertSeverity(contract),
+    ...checkLinkValidity(contract, menuItems),
+    ...checkLayoutCoverage(contract),
+    ...checkMockDataShape(contract),
+  ];
+
+  const passed = results.filter(r => r.passed).length;
+  const failed = results.filter(r => !r.passed).length;
+
+  return { total: passed + failed, passed, failed, results };
+}

--- a/cli/test/generate-aggregate.test.js
+++ b/cli/test/generate-aggregate.test.js
@@ -1,0 +1,157 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { generateAggregateFiles } from '../src/generate-aggregate.js';
+
+const sampleContract = {
+  meta: {
+    module: 'inventory',
+    label: 'Inventory Overview',
+    icon: 'Package',
+    route: '/inventory',
+  },
+  sections: [
+    {
+      id: 'kpi-header',
+      type: 'kpi',
+      title: 'Key Metrics',
+      kpis: [
+        { key: 'totalItems', label: 'Total Items', format: 'number' },
+        { key: 'totalValue', label: 'Total Value', format: 'currency' },
+        { key: 'lowStockPct', label: 'Low Stock %', format: 'percent' },
+      ],
+    },
+    {
+      id: 'stock-levels',
+      type: 'data-table',
+      title: 'Stock Levels',
+      columns: [
+        { key: 'product', label: 'Product' },
+        { key: 'warehouse', label: 'Warehouse' },
+        { key: 'quantity', label: 'Qty', type: 'number' },
+      ],
+    },
+    {
+      id: 'quick-actions',
+      type: 'quick-actions',
+      title: 'Actions',
+    },
+    {
+      id: 'recent-movements',
+      type: 'data-table',
+      title: 'Recent Movements',
+      columns: [
+        { key: 'date', label: 'Date' },
+        { key: 'product', label: 'Product' },
+        { key: 'qty', label: 'Qty', type: 'number' },
+      ],
+    },
+  ],
+  layout: {
+    areas: [
+      { section: 'kpi-header', span: 'full' },
+      { section: 'stock-levels', span: 'half' },
+      { section: 'recent-movements', span: 'half' },
+      { section: 'quick-actions', span: 'sidebar' },
+    ],
+  },
+  actions: [
+    { label: 'New Receipt', route: '/goods-receipt', icon: 'Plus' },
+    { label: 'New Shipment', route: '/goods-shipment', icon: 'Truck' },
+  ],
+  mockData: {
+    'kpi-header': {
+      totalItems: 1245,
+      totalValue: 328500,
+      lowStockPct: 12.3,
+    },
+    'stock-levels': [
+      { product: 'Laptop Pro 15', warehouse: 'Main Warehouse', quantity: 42 },
+      { product: 'USB-C Cable', warehouse: 'East DC', quantity: 350 },
+    ],
+    'recent-movements': [
+      { date: '2026-03-01', product: 'Laptop Pro 15', qty: 10 },
+      { date: '2026-03-02', product: 'USB-C Cable', qty: -25 },
+    ],
+  },
+};
+
+describe('generateAggregateFiles', () => {
+  const result = generateAggregateFiles(sampleContract);
+
+  it('returns config.js and mockData.js (2 files)', () => {
+    const keys = Object.keys(result);
+    assert.ok(keys.includes('config.js'), 'should have config.js');
+    assert.ok(keys.includes('mockData.js'), 'should have mockData.js');
+    assert.equal(keys.length, 2, 'should return exactly 2 files');
+  });
+
+  it('config.js exports meta with module, label, icon, route', () => {
+    const config = result['config.js'];
+    assert.ok(config.includes('export const meta'), 'should export meta');
+    assert.ok(config.includes('"module": "inventory"'), 'should include module');
+    assert.ok(config.includes('"label": "Inventory Overview"'), 'should include label');
+    assert.ok(config.includes('"icon": "Package"'), 'should include icon');
+    assert.ok(config.includes('"route": "/inventory"'), 'should include route');
+  });
+
+  it('config.js exports kpisConfig array from kpi-header section', () => {
+    const config = result['config.js'];
+    assert.ok(config.includes('export const kpisConfig'), 'should export kpisConfig');
+    assert.ok(config.includes('"key": "totalItems"'), 'should include totalItems kpi');
+    assert.ok(config.includes('"key": "totalValue"'), 'should include totalValue kpi');
+    assert.ok(config.includes('"key": "lowStockPct"'), 'should include lowStockPct kpi');
+  });
+
+  it('config.js exports sections object keyed by section id, excluding kpi-header', () => {
+    const config = result['config.js'];
+    assert.ok(config.includes('export const sections'), 'should export sections');
+    assert.ok(config.includes('"stock-levels"'), 'should include stock-levels section');
+    assert.ok(config.includes('"recent-movements"'), 'should include recent-movements section');
+    assert.ok(config.includes('"quick-actions"'), 'should include quick-actions section');
+    // kpi-header should NOT appear as a section key
+    // It should be in kpisConfig, not in sections
+    // We check that it's not a top-level key in the sections object
+    const sectionsMatch = config.match(/export const sections\s*=\s*(\{[\s\S]*?\n\};)/);
+    if (sectionsMatch) {
+      assert.ok(!sectionsMatch[1].includes('"kpi-header":'), 'should NOT include kpi-header in sections');
+    }
+  });
+
+  it('config.js exports layout array', () => {
+    const config = result['config.js'];
+    assert.ok(config.includes('export const layout'), 'should export layout');
+    assert.ok(config.includes('"section": "kpi-header"'), 'should include kpi-header area');
+    assert.ok(config.includes('"span": "full"'), 'should include span');
+  });
+
+  it('config.js exports actions array', () => {
+    const config = result['config.js'];
+    assert.ok(config.includes('export const actions'), 'should export actions');
+    assert.ok(config.includes('"label": "New Receipt"'), 'should include New Receipt action');
+    assert.ok(config.includes('"route": "/goods-shipment"'), 'should include shipment route');
+  });
+
+  it('mockData.js exports one named export per section (skips quick-actions)', () => {
+    const mock = result['mockData.js'];
+    assert.ok(mock.includes('export const kpis'), 'should export kpis (from kpi-header)');
+    assert.ok(mock.includes('export const stockLevels'), 'should export stockLevels');
+    assert.ok(mock.includes('export const recentMovements'), 'should export recentMovements');
+    // quick-actions should be skipped
+    assert.ok(!mock.includes('quickActions'), 'should NOT export quickActions');
+  });
+
+  it('mockData.js contains actual data values', () => {
+    const mock = result['mockData.js'];
+    assert.ok(mock.includes('1245'), 'should include totalItems value');
+    assert.ok(mock.includes('328500'), 'should include totalValue value');
+    assert.ok(mock.includes('Laptop Pro 15'), 'should include product name');
+    assert.ok(mock.includes('Main Warehouse'), 'should include warehouse name');
+  });
+
+  it('generated files have "DO NOT EDIT" header', () => {
+    const config = result['config.js'];
+    const mock = result['mockData.js'];
+    assert.ok(config.includes('DO NOT EDIT'), 'config.js should have DO NOT EDIT header');
+    assert.ok(mock.includes('DO NOT EDIT'), 'mockData.js should have DO NOT EDIT header');
+  });
+});

--- a/cli/test/run-aggregate-tests.test.js
+++ b/cli/test/run-aggregate-tests.test.js
@@ -1,0 +1,169 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { runAggregateTests } from '../src/run-aggregate-tests.js';
+
+/**
+ * Valid aggregate contract fixture with all section types covered.
+ */
+const validContract = {
+  sections: [
+    {
+      id: 'kpi-revenue',
+      type: 'kpi',
+      kpis: [
+        { key: 'totalRevenue', label: 'Total Revenue', format: 'currency' },
+        { key: 'orderCount', label: 'Order Count', format: 'number' },
+      ],
+    },
+    {
+      id: 'table-orders',
+      type: 'data-table',
+      columns: [
+        { key: 'documentNo', label: 'Document No' },
+        { key: 'total', label: 'Total' },
+      ],
+    },
+    {
+      id: 'alerts-section',
+      type: 'alerts',
+      severities: ['info', 'warning', 'error'],
+    },
+    {
+      id: 'quick-actions',
+      type: 'quick-actions',
+    },
+  ],
+  layout: {
+    areas: [
+      { section: 'kpi-revenue' },
+      { section: 'table-orders' },
+      { section: 'alerts-section' },
+      { section: 'quick-actions' },
+    ],
+  },
+  mockData: {
+    'kpi-revenue': { totalRevenue: 50000, orderCount: 120 },
+    'table-orders': [
+      { documentNo: 'SO-001', total: 1500 },
+      { documentNo: 'SO-002', total: 2300 },
+    ],
+    'alerts-section': [
+      { message: 'Low stock', severity: 'warning' },
+    ],
+    'quick-actions': [
+      { label: 'New Order', route: '/orders/new' },
+    ],
+  },
+  actions: [
+    { label: 'New Order', route: '/orders/new' },
+  ],
+};
+
+const menuItems = ['/orders/new', '/orders', '/dashboard'];
+
+describe('runAggregateTests', () => {
+  it('passes all checks on a valid contract', () => {
+    const result = runAggregateTests(validContract, menuItems);
+    assert.equal(result.failed, 0, `Failed tests: ${JSON.stringify(result.results.filter(r => !r.passed), null, 2)}`);
+    assert.ok(result.total > 0);
+    assert.equal(result.total, result.passed);
+  });
+
+  it('fails section-presence when mockData is missing for a section', () => {
+    const contract = structuredClone(validContract);
+    delete contract.mockData['table-orders'];
+    const result = runAggregateTests(contract, menuItems);
+    const fail = result.results.find(r => r.category === 'section-presence' && !r.passed);
+    assert.ok(fail, 'Expected a section-presence failure');
+    assert.ok(fail.reason.includes('table-orders'));
+  });
+
+  it('fails kpi-integrity on invalid format', () => {
+    const contract = structuredClone(validContract);
+    contract.sections[0].kpis[0].format = 'money';
+    const result = runAggregateTests(contract, menuItems);
+    const fail = result.results.find(r => r.category === 'kpi-integrity' && !r.passed);
+    assert.ok(fail, 'Expected a kpi-integrity failure for invalid format');
+    assert.ok(fail.reason.includes('money'));
+  });
+
+  it('fails kpi-integrity when mockData value is missing for a KPI key', () => {
+    const contract = structuredClone(validContract);
+    delete contract.mockData['kpi-revenue'].orderCount;
+    const result = runAggregateTests(contract, menuItems);
+    const fail = result.results.find(r => r.category === 'kpi-integrity' && !r.passed && r.reason.includes('orderCount'));
+    assert.ok(fail, 'Expected a kpi-integrity failure for missing mockData value');
+  });
+
+  it('fails table-column-match when row misses a column key', () => {
+    const contract = structuredClone(validContract);
+    contract.mockData['table-orders'] = [{ documentNo: 'SO-001' }]; // missing 'total'
+    const result = runAggregateTests(contract, menuItems);
+    const fail = result.results.find(r => r.category === 'table-column-match' && !r.passed);
+    assert.ok(fail, 'Expected a table-column-match failure');
+    assert.ok(fail.reason.includes('total'));
+  });
+
+  it('fails link-validity when route is not in menu items', () => {
+    const contract = structuredClone(validContract);
+    contract.actions = [{ label: 'Go Nowhere', route: '/nowhere' }];
+    const result = runAggregateTests(contract, menuItems);
+    const fail = result.results.find(r => r.category === 'link-validity' && !r.passed);
+    assert.ok(fail, 'Expected a link-validity failure');
+    assert.ok(fail.reason.includes('/nowhere'));
+  });
+
+  it('fails layout-coverage when a section is not in layout', () => {
+    const contract = structuredClone(validContract);
+    contract.layout.areas = contract.layout.areas.filter(a => a.section !== 'alerts-section');
+    const result = runAggregateTests(contract, menuItems);
+    const fail = result.results.find(r => r.category === 'layout-coverage' && !r.passed);
+    assert.ok(fail, 'Expected a layout-coverage failure');
+    assert.ok(fail.reason.includes('alerts-section'));
+  });
+
+  it('fails mockData-shape on empty array', () => {
+    const contract = structuredClone(validContract);
+    contract.mockData['table-orders'] = [];
+    const result = runAggregateTests(contract, menuItems);
+    const fail = result.results.find(r => r.category === 'mockData-shape' && !r.passed);
+    assert.ok(fail, 'Expected a mockData-shape failure for empty array');
+    assert.ok(fail.reason.includes('table-orders'));
+  });
+
+  it('skips kanban-column-match when no kanban sections exist', () => {
+    const result = runAggregateTests(validContract, menuItems);
+    const kanbanResults = result.results.filter(r => r.category === 'kanban-column-match');
+    assert.equal(kanbanResults.length, 0, 'Should produce no kanban checks when no kanban sections');
+  });
+
+  it('fails alert-severity on invalid severity', () => {
+    const contract = structuredClone(validContract);
+    contract.mockData['alerts-section'] = [{ message: 'Bad', severity: 'critical' }];
+    const result = runAggregateTests(contract, menuItems);
+    const fail = result.results.find(r => r.category === 'alert-severity' && !r.passed);
+    assert.ok(fail, 'Expected an alert-severity failure');
+    assert.ok(fail.reason.includes('critical'));
+  });
+
+  it('fails kanban-column-match when card has invalid columnId', () => {
+    const contract = structuredClone(validContract);
+    contract.sections.push({
+      id: 'kanban-pipeline',
+      type: 'kanban',
+      columns: [
+        { id: 'open', label: 'Open' },
+        { id: 'closed', label: 'Closed' },
+      ],
+    });
+    contract.layout.areas.push({ section: 'kanban-pipeline' });
+    contract.mockData['kanban-pipeline'] = [
+      { title: 'Deal A', columnId: 'open' },
+      { title: 'Deal B', columnId: 'invalid-col' },
+    ];
+    const result = runAggregateTests(contract, menuItems);
+    const fail = result.results.find(r => r.category === 'kanban-column-match' && !r.passed);
+    assert.ok(fail, 'Expected a kanban-column-match failure');
+    assert.ok(fail.reason.includes('invalid-col'));
+  });
+});

--- a/tools/app-shell/src/App.jsx
+++ b/tools/app-shell/src/App.jsx
@@ -8,6 +8,8 @@ import PreviewPage from './preview/PreviewPage.jsx';
 import DashboardPage from './pages/DashboardPage.jsx';
 import SalesPage from './pages/SalesPage.jsx';
 import ContactsPage from './pages/ContactsPage.jsx';
+import InventoryPage from './pages/InventoryPage.jsx';
+import PurchasesPage from './pages/PurchasesPage.jsx';
 import { buildMenuGroups, buildWindowMap } from './windows/registry.js';
 import { createMockFetch } from './lib/mockFetch.js';
 
@@ -96,6 +98,8 @@ function AppRoutes({ menuGroups, windowMap }) {
         <Route path="preview" element={<PreviewPage />} />
         <Route path="sales" element={<SalesPage />} />
         <Route path="contacts" element={<ContactsPage />} />
+        <Route path="inventory" element={<InventoryPage />} />
+        <Route path="purchases" element={<PurchasesPage />} />
         <Route
           path=":windowName"
           element={<WindowLoader windowMap={windowMap} apiBaseUrl={API_BASE_URL} />}

--- a/tools/app-shell/src/components/contract-ui/KanbanBoard.jsx
+++ b/tools/app-shell/src/components/contract-ui/KanbanBoard.jsx
@@ -10,14 +10,14 @@ import { Star, GripVertical } from 'lucide-react';
  * Maps color name strings to Tailwind border/bg classes.
  */
 const COLOR_MAP = {
-  blue: 'border-t-blue-500 bg-blue-50/50',
-  green: 'border-t-emerald-500 bg-emerald-50/50',
-  red: 'border-t-red-500 bg-red-50/50',
-  yellow: 'border-t-amber-500 bg-amber-50/50',
-  purple: 'border-t-purple-500 bg-purple-50/50',
-  orange: 'border-t-orange-500 bg-orange-50/50',
-  pink: 'border-t-pink-500 bg-pink-50/50',
-  gray: 'border-t-gray-400 bg-gray-50/50',
+  blue: 'border-t-blue-500 bg-blue-500/10',
+  green: 'border-t-emerald-500 bg-emerald-500/10',
+  red: 'border-t-red-500 bg-red-500/10',
+  yellow: 'border-t-amber-500 bg-amber-500/10',
+  purple: 'border-t-purple-500 bg-purple-500/10',
+  orange: 'border-t-orange-500 bg-orange-500/10',
+  pink: 'border-t-pink-500 bg-pink-500/10',
+  gray: 'border-t-gray-400 bg-gray-500/10',
 };
 
 const COLOR_DOT_MAP = {
@@ -57,7 +57,7 @@ function PriorityStars({ priority }) {
           key={i}
           className={cn(
             'h-3 w-3',
-            i < count ? 'fill-amber-400 text-amber-400' : 'text-gray-300'
+            i < count ? 'fill-amber-400 text-amber-400' : 'text-muted-foreground/30'
           )}
         />
       ))}

--- a/tools/app-shell/src/hooks/useEntity.js
+++ b/tools/app-shell/src/hooks/useEntity.js
@@ -19,9 +19,12 @@ export function useEntity(entity, childEntity, { token, apiBaseUrl }) {
   const refresh = useCallback(() => {
     setLoading(true);
     fetch(`${apiBaseUrl}/${entity}`, { headers })
-      .then(res => res.json())
-      .then(data => { setItems(data); setLoading(false); })
-      .catch(() => setLoading(false));
+      .then(res => {
+        if (!res.ok) throw new Error(`${res.status}`);
+        return res.json();
+      })
+      .then(data => { setItems(Array.isArray(data) ? data : []); setLoading(false); })
+      .catch(() => { setItems([]); setLoading(false); });
   }, [apiBaseUrl, entity, token]);
 
   useEffect(() => { refresh(); }, [refresh]);
@@ -29,8 +32,11 @@ export function useEntity(entity, childEntity, { token, apiBaseUrl }) {
   const fetchChildren = useCallback((parentId) => {
     if (!childEntity || !parentId) { setChildren([]); return; }
     fetch(`${apiBaseUrl}/${entity}/${parentId}/${childEntity}`, { headers })
-      .then(res => res.json())
-      .then(setChildren)
+      .then(res => {
+        if (!res.ok) throw new Error(`${res.status}`);
+        return res.json();
+      })
+      .then(data => setChildren(Array.isArray(data) ? data : []))
       .catch(() => setChildren([]));
   }, [apiBaseUrl, entity, childEntity, token]);
 

--- a/tools/app-shell/src/index.css
+++ b/tools/app-shell/src/index.css
@@ -3,6 +3,17 @@
 @tailwind utilities;
 
 @layer base {
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+    margin: 0;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+
   :root {
     --background: 210 20% 98%;
     --foreground: 222 47% 11%;
@@ -68,12 +79,4 @@
     --sidebar-border: 240 3.7% 15.9%;
     --sidebar-ring: 217.2 91.2% 59.8%;
   }
-}
-
-body {
-  margin: 0;
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  background-color: hsl(var(--background));
-  color: hsl(var(--foreground));
 }

--- a/tools/app-shell/src/menu.json
+++ b/tools/app-shell/src/menu.json
@@ -24,6 +24,7 @@
       "group": "Purchases",
       "icon": "Truck",
       "items": [
+        { "name": "purchases", "label": "Overview" },
         { "name": "purchase-order", "label": "Purchase Orders" },
         { "name": "goods-receipt", "label": "Goods Receipt" },
         { "name": "purchase-invoice", "label": "Invoices" },
@@ -35,6 +36,7 @@
       "group": "Inventory",
       "icon": "Package",
       "items": [
+        { "name": "inventory", "label": "Overview" },
         { "name": "physical-inventory", "label": "Physical Inventory" },
         { "name": "goods-movements", "label": "Goods Movements" }
       ]

--- a/tools/app-shell/src/pages/ContactsPage.jsx
+++ b/tools/app-shell/src/pages/ContactsPage.jsx
@@ -10,71 +10,38 @@ import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
 import { Users, Search, Mail, Phone, MapPin, X, Plus } from 'lucide-react';
 
-const COLUMNS = [
-  { id: 'customer', title: 'Customers', color: 'blue' },
-  { id: 'vendor', title: 'Vendors', color: 'green' },
-  { id: 'both', title: 'Customer & Vendor', color: 'purple' },
-  { id: 'prospect', title: 'Prospects', color: 'yellow' },
-];
+import { kpisConfig, sections, actions } from '@generated/contacts/generated/config';
+import * as mockData from '@generated/contacts/generated/mockData';
 
-const ALL_CONTACTS = [
-  { id: 'BP-001', columnId: 'customer', title: 'Empresa ABC S.L.', subtitle: 'Madrid, Spain', avatar: 'E', badges: ['VIP'], value: 52000 },
-  { id: 'BP-002', columnId: 'customer', title: 'Tech Solutions', subtitle: 'Barcelona, Spain', avatar: 'T', value: 28000 },
-  { id: 'BP-003', columnId: 'customer', title: 'Global Trade Ltd', subtitle: 'London, UK', avatar: 'G', badges: ['VIP'], value: 85000 },
-  { id: 'BP-004', columnId: 'vendor', title: 'Suministros Garcia', subtitle: 'Valencia, Spain', avatar: 'S' },
-  { id: 'BP-005', columnId: 'vendor', title: 'Nordic Components', subtitle: 'Stockholm, Sweden', avatar: 'N' },
-  { id: 'BP-006', columnId: 'both', title: 'Iberica Industrial', subtitle: 'Bilbao, Spain', avatar: 'I', value: 34000 },
-  { id: 'BP-007', columnId: 'both', title: 'Mediterranean Foods', subtitle: 'Sevilla, Spain', avatar: 'M', value: 15000 },
-  { id: 'BP-008', columnId: 'prospect', title: 'StartupXYZ', subtitle: 'Remote', avatar: 'S' },
-  { id: 'BP-009', columnId: 'prospect', title: 'New Retail Co', subtitle: 'Malaga, Spain', avatar: 'N' },
-  { id: 'BP-010', columnId: 'customer', title: 'Zaragoza Motors', subtitle: 'Zaragoza, Spain', avatar: 'Z', value: 19000 },
-];
+// -- Icon map (string name -> component) --------------------------------------
 
-const KPIS = [
-  { label: 'Total Contacts', value: 156, format: 'number', icon: Users },
-  { label: 'Customers', value: 89, format: 'number', trend: 5 },
-  { label: 'Vendors', value: 42, format: 'number' },
-  { label: 'Pending Balance', value: 27300, format: 'currency', trend: -8 },
-];
+const ICON_MAP = { Users };
 
-const MOCK_EMAILS = {
-  'BP-001': 'contact@empresaabc.es',
-  'BP-002': 'info@techsolutions.com',
-  'BP-003': 'sales@globaltrade.co.uk',
-  'BP-004': 'pedidos@suministrosgarcia.es',
-  'BP-005': 'order@nordiccomponents.se',
-  'BP-006': 'admin@ibericaindustrial.es',
-  'BP-007': 'hello@medfoods.es',
-  'BP-008': 'hi@startupxyz.io',
-  'BP-009': 'info@newretailco.es',
-  'BP-010': 'ventas@zaragozamotors.es',
-};
+// -- Derived data from aggregate contract -------------------------------------
 
-const MOCK_PHONES = {
-  'BP-001': '+34 91 555 1234',
-  'BP-002': '+34 93 444 5678',
-  'BP-003': '+44 20 7946 0958',
-  'BP-004': '+34 96 333 4567',
-  'BP-005': '+46 8 123 4567',
-  'BP-006': '+34 94 222 3456',
-  'BP-007': '+34 95 111 2345',
-  'BP-008': '+1 555 987 6543',
-  'BP-009': '+34 95 666 7890',
-  'BP-010': '+34 97 888 9012',
-};
+// kpisConfig is empty for contacts; KPIs live in sections.kpis.kpis
+const kpisDef = (kpisConfig.length > 0 ? kpisConfig : sections.kpis?.kpis) || [];
 
-const CHATTER_MESSAGES = [
-  { id: '1', author: 'Ana Garcia', text: 'Renewed annual contract for $52,000', timestamp: '2026-03-08T10:30:00', type: 'note' },
-  { id: '2', author: 'System', text: 'Invoice INV-0142 sent via email', timestamp: '2026-03-07T14:00:00', type: 'system' },
-  { id: '3', author: 'Pedro Lopez', text: 'Meeting scheduled for Q2 review', timestamp: '2026-03-05T09:00:00', type: 'note' },
-];
+const KPIS = kpisDef.map((k) => ({
+  ...k,
+  value: mockData.kpis[k.key],
+  trend: mockData.kpis.trends?.[k.key],
+  icon: ICON_MAP[k.icon],
+}));
 
-const CATEGORY_LABEL = {
-  customer: 'Customer',
-  vendor: 'Vendor',
-  both: 'Customer & Vendor',
-  prospect: 'Prospect',
-};
+const COLUMNS = sections.directory.columns;
+const ALL_CONTACTS = mockData.directory;
+const CHATTER_MESSAGES = mockData.notes;
+const CATEGORY_LABEL = Object.fromEntries(COLUMNS.map((c) => [c.id, c.title]));
+
+// Build email/phone maps by matching directory entries to contactList rows by name
+const contactByName = Object.fromEntries(mockData.contactList.map((c) => [c.name, c]));
+const MOCK_EMAILS = Object.fromEntries(
+  mockData.directory.map((d) => [d.id, contactByName[d.title]?.email || ''])
+);
+const MOCK_PHONES = Object.fromEntries(
+  mockData.directory.map((d) => [d.id, contactByName[d.title]?.phone || ''])
+);
 
 function formatCurrency(value) {
   if (value == null) return '-';
@@ -256,9 +223,9 @@ export default function ContactsPage() {
               />
             </div>
             <Button asChild>
-              <Link to="/business-partner">
+              <Link to={actions[0].route}>
                 <Plus className="h-4 w-4 mr-1.5" />
-                New Contact
+                {actions[0].label}
               </Link>
             </Button>
           </div>

--- a/tools/app-shell/src/pages/DashboardPage.jsx
+++ b/tools/app-shell/src/pages/DashboardPage.jsx
@@ -19,41 +19,34 @@ import {
   ChevronRight,
   Clock,
 } from 'lucide-react';
+import { kpisConfig, actions } from '@generated/dashboard/generated/config';
+import * as mockData from '@generated/dashboard/generated/mockData';
 
 /* ------------------------------------------------------------------
- * Mock data
+ * Data derived from aggregate contract
  * ----------------------------------------------------------------*/
 
-const kpis = [
-  { label: 'Revenue this month', value: 48250, format: 'currency', trend: 12.5, icon: DollarSign },
-  { label: 'Expenses this month', value: 31800, format: 'currency', trend: 3.2, icon: CreditCard },
-  { label: 'Net Profit', value: 16450, format: 'currency', trend: 28.7, icon: TrendingUp },
-  { label: 'Pending Invoices', value: 7, format: 'number', trend: -2, icon: Clock },
-];
+const ICON_MAP = { DollarSign, CreditCard, TrendingUp, Clock, FileText, ShoppingCart, Users, Box };
 
-const chartMonths = ['Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec', 'Jan', 'Feb', 'Mar'];
-const chartValues = [32000, 35000, 28000, 41000, 38000, 45000, 42000, 39000, 44000, 47000, 43000, 48250];
+const kpis = kpisConfig.map((k) => ({
+  ...k,
+  value: mockData.kpis[k.key].value,
+  trend: mockData.kpis[k.key].trend,
+  icon: ICON_MAP[k.icon] || DollarSign,
+}));
 
-const quickActions = [
-  { label: '+ Invoice', to: '/sales-invoice', icon: FileText },
-  { label: '+ Order', to: '/sales-order', icon: ShoppingCart },
-  { label: '+ Contact', to: '/business-partner', icon: Users },
-  { label: '+ Product', to: '/product', icon: Box },
-];
+const chartMonths = mockData.revenueTrend.labels;
+const chartValues = mockData.revenueTrend.values;
 
-const pendingTasks = [
-  { type: 'warning', text: '3 overdue invoices', link: '/sales-invoice', amount: '$12,400' },
-  { type: 'info', text: '2 orders pending shipment', link: '/goods-shipment' },
-  { type: 'info', text: '5 purchase orders to confirm', link: '/purchase-order' },
-  { type: 'warning', text: '1 low stock alert', link: '/physical-inventory', detail: 'Cerveza Ale 0.5L' },
-];
+const quickActions = actions.map((a) => ({
+  label: a.label,
+  to: a.route,
+  icon: ICON_MAP[a.icon] || FileText,
+}));
 
-const recentMessages = [
-  { id: '1', author: 'System', text: 'Invoice INV-2026-0142 was paid by Empresa ABC', timestamp: '2026-03-09T08:30:00', type: 'system' },
-  { id: '2', author: 'Ana Garcia', text: 'New quotation QT-0089 created for $8,500', timestamp: '2026-03-09T07:15:00', type: 'note' },
-  { id: '3', author: 'System', text: 'Purchase Order PO-0234 received (15 items)', timestamp: '2026-03-08T16:45:00', type: 'system' },
-  { id: '4', author: 'Pedro Lopez', text: 'Stock adjustment completed for warehouse Madrid', timestamp: '2026-03-08T14:20:00', type: 'note' },
-];
+const pendingTasks = mockData.pendingTasks;
+
+const recentMessages = mockData.recentMessages;
 
 /* ------------------------------------------------------------------
  * SVG Revenue Chart

--- a/tools/app-shell/src/pages/InventoryPage.jsx
+++ b/tools/app-shell/src/pages/InventoryPage.jsx
@@ -7,66 +7,27 @@ import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Package, AlertTriangle, ArrowUp, ArrowDown, Search } from 'lucide-react';
 
-// -- KPI data ------------------------------------------------------------------
+import { kpisConfig, sections, actions } from '@generated/inventory/generated/config';
+import * as mockData from '@generated/inventory/generated/mockData';
 
-const KPIS = [
-  { label: 'Total SKUs', value: 248, format: 'number', icon: Package },
-  { label: 'Stock Value', value: 1245000, format: 'currency', trend: 3.2 },
-  { label: 'Low Stock Alerts', value: 5, format: 'number', trend: 2, icon: AlertTriangle },
-  { label: 'Movements Today', value: 12, format: 'number' },
-];
+// -- Icon map for resolving string names from config to React components ------
 
-// -- Inventory table columns ---------------------------------------------------
+const ICON_MAP = { Package, AlertTriangle };
 
-const COLUMNS = [
-  { key: 'sku', label: 'SKU' },
-  { key: 'name', label: 'Product Name' },
-  { key: 'warehouse', label: 'Warehouse' },
-  { key: 'available', label: 'Available', type: 'amount' },
-  { key: 'reserved', label: 'Reserved', type: 'amount' },
-  { key: 'minimum', label: 'Minimum', type: 'amount' },
-  { key: 'status', label: 'Status', type: 'status' },
-];
+// -- Derived data from contract files -----------------------------------------
 
-const FILTERS = ['name', 'warehouse'];
+const KPIS = kpisConfig.map(k => ({
+  ...k,
+  value: mockData.kpis[k.key],
+  icon: k.icon ? ICON_MAP[k.icon] : undefined,
+}));
 
-// -- Mock inventory data (12 rows, Madrid & Barcelona) -------------------------
+const COLUMNS = sections['stock-levels'].columns;
+const FILTERS = sections['stock-levels'].filters;
 
-const INVENTORY_DATA = [
-  { id: 1, sku: 'PRD-001', name: 'Steel Bolts M8', warehouse: 'Madrid Central', available: 1200, reserved: 150, minimum: 200, status: 'In Stock' },
-  { id: 2, sku: 'PRD-002', name: 'Copper Wire 2.5mm', warehouse: 'Barcelona North', available: 340, reserved: 40, minimum: 100, status: 'In Stock' },
-  { id: 3, sku: 'PRD-003', name: 'Hydraulic Pump HP-50', warehouse: 'Madrid Central', available: 18, reserved: 5, minimum: 25, status: 'Low Stock' },
-  { id: 4, sku: 'PRD-004', name: 'LED Panel 60x60', warehouse: 'Barcelona North', available: 85, reserved: 20, minimum: 50, status: 'In Stock' },
-  { id: 5, sku: 'PRD-005', name: 'Rubber Gasket Set', warehouse: 'Madrid Central', available: 12, reserved: 8, minimum: 30, status: 'Low Stock' },
-  { id: 6, sku: 'PRD-006', name: 'Stainless Pipe DN50', warehouse: 'Barcelona North', available: 450, reserved: 60, minimum: 100, status: 'In Stock' },
-  { id: 7, sku: 'PRD-007', name: 'Circuit Breaker 32A', warehouse: 'Madrid Central', available: 95, reserved: 10, minimum: 40, status: 'In Stock' },
-  { id: 8, sku: 'PRD-008', name: 'Thermal Insulation Roll', warehouse: 'Barcelona North', available: 8, reserved: 3, minimum: 15, status: 'Low Stock' },
-  { id: 9, sku: 'PRD-009', name: 'PVC Conduit 25mm', warehouse: 'Madrid Central', available: 620, reserved: 80, minimum: 150, status: 'In Stock' },
-  { id: 10, sku: 'PRD-010', name: 'Bearing SKF 6205', warehouse: 'Barcelona North', available: 5, reserved: 2, minimum: 20, status: 'Low Stock' },
-  { id: 11, sku: 'PRD-011', name: 'Welding Rod E6013', warehouse: 'Madrid Central', available: 2000, reserved: 300, minimum: 500, status: 'In Stock' },
-  { id: 12, sku: 'PRD-012', name: 'Air Filter Element', warehouse: 'Barcelona North', available: 3, reserved: 1, minimum: 10, status: 'Low Stock' },
-];
-
-// -- Low stock alerts data -----------------------------------------------------
-
-const LOW_STOCK_ALERTS = [
-  { name: 'Hydraulic Pump HP-50', current: 18, minimum: 25, severity: 'amber' },
-  { name: 'Rubber Gasket Set', current: 12, minimum: 30, severity: 'red' },
-  { name: 'Thermal Insulation Roll', current: 8, minimum: 15, severity: 'red' },
-  { name: 'Bearing SKF 6205', current: 5, minimum: 20, severity: 'red' },
-  { name: 'Air Filter Element', current: 3, minimum: 10, severity: 'red' },
-];
-
-// -- Recent movements data -----------------------------------------------------
-
-const RECENT_MOVEMENTS = [
-  { id: 1, direction: 'in', product: 'Steel Bolts M8', qty: 500, warehouse: 'Madrid Central', time: '2 hours ago' },
-  { id: 2, direction: 'out', product: 'Copper Wire 2.5mm', qty: 120, warehouse: 'Barcelona North', time: '3 hours ago' },
-  { id: 3, direction: 'in', product: 'LED Panel 60x60', qty: 50, warehouse: 'Barcelona North', time: '5 hours ago' },
-  { id: 4, direction: 'out', product: 'Circuit Breaker 32A', qty: 15, warehouse: 'Madrid Central', time: '6 hours ago' },
-  { id: 5, direction: 'in', product: 'PVC Conduit 25mm', qty: 200, warehouse: 'Madrid Central', time: '8 hours ago' },
-  { id: 6, direction: 'out', product: 'Welding Rod E6013', qty: 300, warehouse: 'Madrid Central', time: '1 day ago' },
-];
+const INVENTORY_DATA = mockData.stockLevels;
+const LOW_STOCK_ALERTS = mockData.lowStock;
+const RECENT_MOVEMENTS = mockData.recentMovements;
 
 // -- Component -----------------------------------------------------------------
 
@@ -77,12 +38,11 @@ export default function InventoryPage() {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold tracking-tight">Inventory</h1>
         <div className="flex items-center gap-2">
-          <Button variant="outline" asChild>
-            <Link to="/physical-inventory">Physical Inventory</Link>
-          </Button>
-          <Button asChild>
-            <Link to="/goods-movements">Goods Movements</Link>
-          </Button>
+          {actions.map(action => (
+            <Button key={action.route} variant={action.variant} asChild>
+              <Link to={action.route}>{action.label}</Link>
+            </Button>
+          ))}
         </div>
       </div>
 

--- a/tools/app-shell/src/pages/InventoryPage.jsx
+++ b/tools/app-shell/src/pages/InventoryPage.jsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { KPIHeader, DataTable } from '@/components/contract-ui';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+import { Package, AlertTriangle, ArrowUp, ArrowDown, Search } from 'lucide-react';
+
+// -- KPI data ------------------------------------------------------------------
+
+const KPIS = [
+  { label: 'Total SKUs', value: 248, format: 'number', icon: Package },
+  { label: 'Stock Value', value: 1245000, format: 'currency', trend: 3.2 },
+  { label: 'Low Stock Alerts', value: 5, format: 'number', trend: 2, icon: AlertTriangle },
+  { label: 'Movements Today', value: 12, format: 'number' },
+];
+
+// -- Inventory table columns ---------------------------------------------------
+
+const COLUMNS = [
+  { key: 'sku', label: 'SKU' },
+  { key: 'name', label: 'Product Name' },
+  { key: 'warehouse', label: 'Warehouse' },
+  { key: 'available', label: 'Available', type: 'amount' },
+  { key: 'reserved', label: 'Reserved', type: 'amount' },
+  { key: 'minimum', label: 'Minimum', type: 'amount' },
+  { key: 'status', label: 'Status', type: 'status' },
+];
+
+const FILTERS = ['name', 'warehouse'];
+
+// -- Mock inventory data (12 rows, Madrid & Barcelona) -------------------------
+
+const INVENTORY_DATA = [
+  { id: 1, sku: 'PRD-001', name: 'Steel Bolts M8', warehouse: 'Madrid Central', available: 1200, reserved: 150, minimum: 200, status: 'In Stock' },
+  { id: 2, sku: 'PRD-002', name: 'Copper Wire 2.5mm', warehouse: 'Barcelona North', available: 340, reserved: 40, minimum: 100, status: 'In Stock' },
+  { id: 3, sku: 'PRD-003', name: 'Hydraulic Pump HP-50', warehouse: 'Madrid Central', available: 18, reserved: 5, minimum: 25, status: 'Low Stock' },
+  { id: 4, sku: 'PRD-004', name: 'LED Panel 60x60', warehouse: 'Barcelona North', available: 85, reserved: 20, minimum: 50, status: 'In Stock' },
+  { id: 5, sku: 'PRD-005', name: 'Rubber Gasket Set', warehouse: 'Madrid Central', available: 12, reserved: 8, minimum: 30, status: 'Low Stock' },
+  { id: 6, sku: 'PRD-006', name: 'Stainless Pipe DN50', warehouse: 'Barcelona North', available: 450, reserved: 60, minimum: 100, status: 'In Stock' },
+  { id: 7, sku: 'PRD-007', name: 'Circuit Breaker 32A', warehouse: 'Madrid Central', available: 95, reserved: 10, minimum: 40, status: 'In Stock' },
+  { id: 8, sku: 'PRD-008', name: 'Thermal Insulation Roll', warehouse: 'Barcelona North', available: 8, reserved: 3, minimum: 15, status: 'Low Stock' },
+  { id: 9, sku: 'PRD-009', name: 'PVC Conduit 25mm', warehouse: 'Madrid Central', available: 620, reserved: 80, minimum: 150, status: 'In Stock' },
+  { id: 10, sku: 'PRD-010', name: 'Bearing SKF 6205', warehouse: 'Barcelona North', available: 5, reserved: 2, minimum: 20, status: 'Low Stock' },
+  { id: 11, sku: 'PRD-011', name: 'Welding Rod E6013', warehouse: 'Madrid Central', available: 2000, reserved: 300, minimum: 500, status: 'In Stock' },
+  { id: 12, sku: 'PRD-012', name: 'Air Filter Element', warehouse: 'Barcelona North', available: 3, reserved: 1, minimum: 10, status: 'Low Stock' },
+];
+
+// -- Low stock alerts data -----------------------------------------------------
+
+const LOW_STOCK_ALERTS = [
+  { name: 'Hydraulic Pump HP-50', current: 18, minimum: 25, severity: 'amber' },
+  { name: 'Rubber Gasket Set', current: 12, minimum: 30, severity: 'red' },
+  { name: 'Thermal Insulation Roll', current: 8, minimum: 15, severity: 'red' },
+  { name: 'Bearing SKF 6205', current: 5, minimum: 20, severity: 'red' },
+  { name: 'Air Filter Element', current: 3, minimum: 10, severity: 'red' },
+];
+
+// -- Recent movements data -----------------------------------------------------
+
+const RECENT_MOVEMENTS = [
+  { id: 1, direction: 'in', product: 'Steel Bolts M8', qty: 500, warehouse: 'Madrid Central', time: '2 hours ago' },
+  { id: 2, direction: 'out', product: 'Copper Wire 2.5mm', qty: 120, warehouse: 'Barcelona North', time: '3 hours ago' },
+  { id: 3, direction: 'in', product: 'LED Panel 60x60', qty: 50, warehouse: 'Barcelona North', time: '5 hours ago' },
+  { id: 4, direction: 'out', product: 'Circuit Breaker 32A', qty: 15, warehouse: 'Madrid Central', time: '6 hours ago' },
+  { id: 5, direction: 'in', product: 'PVC Conduit 25mm', qty: 200, warehouse: 'Madrid Central', time: '8 hours ago' },
+  { id: 6, direction: 'out', product: 'Welding Rod E6013', qty: 300, warehouse: 'Madrid Central', time: '1 day ago' },
+];
+
+// -- Component -----------------------------------------------------------------
+
+export default function InventoryPage() {
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">Inventory</h1>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" asChild>
+            <Link to="/physical-inventory">Physical Inventory</Link>
+          </Button>
+          <Button asChild>
+            <Link to="/goods-movements">Goods Movements</Link>
+          </Button>
+        </div>
+      </div>
+
+      {/* KPIs */}
+      <KPIHeader kpis={KPIS} />
+
+      {/* Two-column layout */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Left column: DataTable (2/3 width) */}
+        <div className="lg:col-span-2">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Search className="h-5 w-5 text-muted-foreground" />
+                Stock Levels
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <DataTable
+                columns={COLUMNS}
+                filters={FILTERS}
+                data={INVENTORY_DATA}
+              />
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Right column: Alerts + Recent Movements (1/3 width) */}
+        <div className="space-y-6">
+          {/* Low Stock Alerts */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <AlertTriangle className="h-5 w-5 text-amber-500" />
+                Low Stock Alerts
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {LOW_STOCK_ALERTS.map((alert, idx) => (
+                <div key={idx}>
+                  {idx > 0 && <Separator className="mb-3" />}
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <p className="text-sm font-medium truncate">{alert.name}</p>
+                      <p className="text-xs text-muted-foreground mt-0.5">
+                        {alert.current} / {alert.minimum} minimum
+                      </p>
+                    </div>
+                    <Badge
+                      variant={alert.severity === 'red' ? 'destructive' : 'outline'}
+                      className={
+                        alert.severity === 'amber'
+                          ? 'border-amber-300 bg-amber-50 text-amber-700'
+                          : ''
+                      }
+                    >
+                      {alert.severity === 'red' ? 'Critical' : 'Warning'}
+                    </Badge>
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+
+          {/* Recent Movements */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Recent Movements</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {RECENT_MOVEMENTS.map((movement, idx) => (
+                <div key={movement.id}>
+                  {idx > 0 && <Separator className="mb-3" />}
+                  <div className="flex items-start gap-3">
+                    <div className={`mt-0.5 rounded-full p-1 ${
+                      movement.direction === 'in'
+                        ? 'bg-emerald-100 text-emerald-600'
+                        : 'bg-red-100 text-red-600'
+                    }`}>
+                      {movement.direction === 'in'
+                        ? <ArrowUp className="h-3.5 w-3.5" />
+                        : <ArrowDown className="h-3.5 w-3.5" />
+                      }
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium truncate">{movement.product}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {movement.qty} units &middot; {movement.warehouse}
+                      </p>
+                    </div>
+                    <span className="text-xs text-muted-foreground whitespace-nowrap">
+                      {movement.time}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tools/app-shell/src/pages/PurchasesPage.jsx
+++ b/tools/app-shell/src/pages/PurchasesPage.jsx
@@ -1,0 +1,174 @@
+import React, { useState, useCallback } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { KPIHeader, KanbanBoard } from '@/components/contract-ui';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Truck, FileText, Plus } from 'lucide-react';
+
+// -- KPI data ------------------------------------------------------------------
+
+const KPIS = [
+  { label: 'Total Ordered', value: 89500, format: 'currency', trend: 6, icon: FileText },
+  { label: 'Received On Time', value: 92, format: 'percent', trend: 2, icon: Truck },
+  { label: 'Pending Invoices', value: 8, format: 'number' },
+  { label: 'Overdue', value: 12400, format: 'currency', trend: -15 },
+];
+
+// -- Kanban columns & seed cards -----------------------------------------------
+
+const COLUMNS = [
+  { id: 'draft', title: 'Draft', color: 'gray' },
+  { id: 'confirmed', title: 'Confirmed', color: 'blue' },
+  { id: 'in-transit', title: 'In Transit', color: 'yellow' },
+  { id: 'received', title: 'Received', color: 'green' },
+  { id: 'invoiced', title: 'Invoiced', color: 'purple' },
+];
+
+const INITIAL_CARDS = [
+  { id: 'PO-001', columnId: 'draft', title: 'PO-2026-0234', subtitle: 'Suministros García', value: 12500 },
+  { id: 'PO-002', columnId: 'draft', title: 'PO-2026-0235', subtitle: 'Nordic Components', value: 8200 },
+  { id: 'PO-003', columnId: 'confirmed', title: 'PO-2026-0236', subtitle: 'China Imports Ltd', value: 45000, badges: ['Priority'] },
+  { id: 'PO-004', columnId: 'confirmed', title: 'PO-2026-0237', subtitle: 'Local Parts SL', value: 3400 },
+  { id: 'PO-005', columnId: 'in-transit', title: 'PO-2026-0238', subtitle: 'Euro Materials', value: 18700, badges: ['Delayed'] },
+  { id: 'PO-006', columnId: 'received', title: 'PO-2026-0239', subtitle: 'Steel Works AG', value: 6800 },
+  { id: 'PO-007', columnId: 'received', title: 'PO-2026-0240', subtitle: 'Paper Supply Co', value: 2100 },
+  { id: 'PO-008', columnId: 'invoiced', title: 'PO-2026-0241', subtitle: 'Ibérica Industrial', value: 15000 },
+];
+
+// -- Status label / color helpers for the list view ----------------------------
+
+const STATUS_LABEL = {
+  draft: 'Draft',
+  confirmed: 'Confirmed',
+  'in-transit': 'In Transit',
+  received: 'Received',
+  invoiced: 'Invoiced',
+};
+
+const STATUS_VARIANT = {
+  draft: 'secondary',
+  confirmed: 'default',
+  'in-transit': 'outline',
+  received: 'default',
+  invoiced: 'secondary',
+};
+
+function formatCurrency(value) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+// -- Component -----------------------------------------------------------------
+
+export default function PurchasesPage() {
+  const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState('kanban');
+  const [cards, setCards] = useState(INITIAL_CARDS);
+
+  const handleDragEnd = useCallback((cardId, _fromColumnId, toColumnId) => {
+    setCards((prev) =>
+      prev.map((c) => (c.id === cardId ? { ...c, columnId: toColumnId } : c))
+    );
+  }, []);
+
+  const handleCardClick = useCallback(
+    () => {
+      navigate('/purchase-order');
+    },
+    [navigate]
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Header bar */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">Purchases</h1>
+        <Button asChild>
+          <Link to="/purchase-order">
+            <Plus className="mr-2 h-4 w-4" />
+            New PO
+          </Link>
+        </Button>
+      </div>
+
+      {/* KPIs */}
+      <KPIHeader kpis={KPIS} />
+
+      {/* Tab switcher */}
+      <div className="flex items-center gap-2">
+        <Button
+          variant={activeTab === 'kanban' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setActiveTab('kanban')}
+        >
+          Kanban
+        </Button>
+        <Button
+          variant={activeTab === 'list' ? 'default' : 'outline'}
+          size="sm"
+          onClick={() => setActiveTab('list')}
+        >
+          List
+        </Button>
+      </div>
+
+      {/* Tab content */}
+      {activeTab === 'kanban' && (
+        <KanbanBoard
+          columns={COLUMNS}
+          cards={cards}
+          onDragEnd={handleDragEnd}
+          onCardClick={handleCardClick}
+          emptyMessage="No purchase orders"
+        />
+      )}
+
+      {activeTab === 'list' && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Purchase Orders</CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b bg-muted/50">
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">Doc No</th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">Vendor</th>
+                    <th className="px-4 py-3 text-right font-medium text-muted-foreground">Amount</th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">Status</th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">Date</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {cards.map((card) => (
+                    <tr
+                      key={card.id}
+                      className="border-b last:border-0 hover:bg-muted/30 cursor-pointer transition-colors"
+                      onClick={() => navigate('/purchase-order')}
+                    >
+                      <td className="px-4 py-3 font-medium">{card.title}</td>
+                      <td className="px-4 py-3 text-muted-foreground">{card.subtitle}</td>
+                      <td className="px-4 py-3 text-right tabular-nums">{formatCurrency(card.value)}</td>
+                      <td className="px-4 py-3">
+                        <Badge variant={STATUS_VARIANT[card.columnId] || 'secondary'}>
+                          {STATUS_LABEL[card.columnId] || card.columnId}
+                        </Badge>
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">2026-03-09</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/tools/app-shell/src/pages/PurchasesPage.jsx
+++ b/tools/app-shell/src/pages/PurchasesPage.jsx
@@ -6,45 +6,24 @@ import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Truck, FileText, Plus } from 'lucide-react';
 
-// -- KPI data ------------------------------------------------------------------
+import { kpisConfig, sections, actions } from '@generated/purchases/generated/config';
+import * as mockData from '@generated/purchases/generated/mockData';
 
-const KPIS = [
-  { label: 'Total Ordered', value: 89500, format: 'currency', trend: 6, icon: FileText },
-  { label: 'Received On Time', value: 92, format: 'percent', trend: 2, icon: Truck },
-  { label: 'Pending Invoices', value: 8, format: 'number' },
-  { label: 'Overdue', value: 12400, format: 'currency', trend: -15 },
-];
+// -- Icon map (string name -> component) --------------------------------------
 
-// -- Kanban columns & seed cards -----------------------------------------------
+const ICON_MAP = { FileText, Truck };
 
-const COLUMNS = [
-  { id: 'draft', title: 'Draft', color: 'gray' },
-  { id: 'confirmed', title: 'Confirmed', color: 'blue' },
-  { id: 'in-transit', title: 'In Transit', color: 'yellow' },
-  { id: 'received', title: 'Received', color: 'green' },
-  { id: 'invoiced', title: 'Invoiced', color: 'purple' },
-];
+// -- Derived data from aggregate contract -------------------------------------
 
-const INITIAL_CARDS = [
-  { id: 'PO-001', columnId: 'draft', title: 'PO-2026-0234', subtitle: 'Suministros García', value: 12500 },
-  { id: 'PO-002', columnId: 'draft', title: 'PO-2026-0235', subtitle: 'Nordic Components', value: 8200 },
-  { id: 'PO-003', columnId: 'confirmed', title: 'PO-2026-0236', subtitle: 'China Imports Ltd', value: 45000, badges: ['Priority'] },
-  { id: 'PO-004', columnId: 'confirmed', title: 'PO-2026-0237', subtitle: 'Local Parts SL', value: 3400 },
-  { id: 'PO-005', columnId: 'in-transit', title: 'PO-2026-0238', subtitle: 'Euro Materials', value: 18700, badges: ['Delayed'] },
-  { id: 'PO-006', columnId: 'received', title: 'PO-2026-0239', subtitle: 'Steel Works AG', value: 6800 },
-  { id: 'PO-007', columnId: 'received', title: 'PO-2026-0240', subtitle: 'Paper Supply Co', value: 2100 },
-  { id: 'PO-008', columnId: 'invoiced', title: 'PO-2026-0241', subtitle: 'Ibérica Industrial', value: 15000 },
-];
+const KPIS = kpisConfig.map((k) => ({
+  ...k,
+  value: mockData.kpis[k.key],
+  icon: ICON_MAP[k.icon],
+}));
 
-// -- Status label / color helpers for the list view ----------------------------
-
-const STATUS_LABEL = {
-  draft: 'Draft',
-  confirmed: 'Confirmed',
-  'in-transit': 'In Transit',
-  received: 'Received',
-  invoiced: 'Invoiced',
-};
+const COLUMNS = sections.pipeline.columns;
+const INITIAL_CARDS = mockData.pipeline;
+const STATUS_LABEL = Object.fromEntries(COLUMNS.map((c) => [c.id, c.title]));
 
 const STATUS_VARIANT = {
   draft: 'secondary',
@@ -89,9 +68,9 @@ export default function PurchasesPage() {
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold tracking-tight">Purchases</h1>
         <Button asChild>
-          <Link to="/purchase-order">
+          <Link to={actions[0].route}>
             <Plus className="mr-2 h-4 w-4" />
-            New PO
+            {actions[0].label}
           </Link>
         </Button>
       </div>

--- a/tools/app-shell/src/pages/SalesPage.jsx
+++ b/tools/app-shell/src/pages/SalesPage.jsx
@@ -6,47 +6,28 @@ import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { ShoppingCart, FileText, TrendingUp } from 'lucide-react';
 
-// -- KPI data ------------------------------------------------------------------
+import { sections, actions } from '@generated/sales/generated/config';
+import * as mockData from '@generated/sales/generated/mockData';
 
-const KPIS = [
-  { label: 'Total Quoted', value: 125400, format: 'currency', trend: 15, icon: FileText },
-  { label: 'Total Invoiced', value: 98200, format: 'currency', trend: 8, icon: TrendingUp },
-  { label: 'Pending Collection', value: 27300, format: 'currency', trend: -5, icon: ShoppingCart },
-  { label: 'Orders This Month', value: 23, format: 'number', trend: 3 },
-];
+// -- Icon resolution (config stores string names) -----------------------------
 
-// -- Kanban columns & seed cards -----------------------------------------------
+const ICON_MAP = { ShoppingCart, FileText, TrendingUp };
 
-const COLUMNS = [
-  { id: 'draft', title: 'Draft', color: 'gray' },
-  { id: 'sent', title: 'Sent', color: 'blue' },
-  { id: 'negotiation', title: 'Negotiation', color: 'yellow' },
-  { id: 'won', title: 'Won', color: 'green' },
-  { id: 'lost', title: 'Lost', color: 'red' },
-];
+// -- Derived data from contract -----------------------------------------------
 
-const INITIAL_CARDS = [
-  { id: 'QT-001', columnId: 'draft', title: 'QT-2026-0089', subtitle: 'Empresa ABC S.L.', value: 8500, badges: ['Priority'] },
-  { id: 'QT-002', columnId: 'draft', title: 'QT-2026-0090', subtitle: 'Tech Solutions', value: 3200 },
-  { id: 'QT-003', columnId: 'sent', title: 'QT-2026-0085', subtitle: 'Global Trade Ltd', value: 15000, badges: ['VIP'] },
-  { id: 'QT-004', columnId: 'sent', title: 'QT-2026-0087', subtitle: 'Madrid Logistics', value: 4800 },
-  { id: 'QT-005', columnId: 'negotiation', title: 'QT-2026-0082', subtitle: 'Barcelona Foods', value: 22000, badges: ['Priority', 'VIP'], priority: 3 },
-  { id: 'QT-006', columnId: 'negotiation', title: 'QT-2026-0084', subtitle: 'Sevilla Motors', value: 6700, priority: 2 },
-  { id: 'QT-007', columnId: 'won', title: 'QT-2026-0078', subtitle: 'Valencia Exports', value: 18500 },
-  { id: 'QT-008', columnId: 'won', title: 'QT-2026-0080', subtitle: 'Bilbao Tech', value: 9200 },
-  { id: 'QT-009', columnId: 'lost', title: 'QT-2026-0076', subtitle: 'Zaragoza Industrial', value: 5400 },
-];
+const KPIS = sections.kpis.kpis.map((k) => ({
+  ...k,
+  value: mockData.kpis[k.key],
+  trend: mockData.kpis.trends?.[k.key],
+  icon: ICON_MAP[k.icon],
+}));
 
-// -- Status label / color helpers for the list view ----------------------------
+const COLUMNS = sections.pipeline.columns;
+const INITIAL_CARDS = mockData.pipeline;
 
-const STATUS_LABEL = {
-  draft: 'Draft',
-  sent: 'Sent',
-  negotiation: 'Negotiation',
-  won: 'Won',
-  lost: 'Lost',
-};
+const STATUS_LABEL = Object.fromEntries(COLUMNS.map((c) => [c.id, c.title]));
 
+// UI-presentation mapping — kept inline because it's view logic, not data.
 const STATUS_VARIANT = {
   draft: 'secondary',
   sent: 'default',
@@ -89,9 +70,11 @@ export default function SalesPage() {
       {/* Header bar */}
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold tracking-tight">Sales</h1>
-        <Button asChild>
-          <Link to="/sales-quotation">+ New Quotation</Link>
-        </Button>
+        {actions.map((action) => (
+          <Button key={action.route} asChild>
+            <Link to={action.route}>{action.label}</Link>
+          </Button>
+        ))}
       </div>
 
       {/* KPIs */}


### PR DESCRIPTION
## Summary
- Introduce **aggregate contract system** for overview/dashboard pages (contract → generator → config.js + mockData.js → UI)
- New CLI: `generate-aggregate.js` (produces config + mockData) and `run-aggregate-tests.js` (8 validation categories)
- 5 aggregate contracts: dashboard, sales, purchases, inventory, contacts
- Migrate all 5 overview pages to import from contracts (zero hardcoded data)
- Add Inventory and Purchases overview pages with KPIs, Kanban, alerts
- Add aggregate-contracts skill for agent reference

## Test plan
- [x] 2,198 unit tests pass (0 failures, 103 suites)
- [x] 179 aggregate contract tests pass across 5 modules
- [x] Vite build clean (no errors, no warnings)
- [x] All 8 test categories validated: section-presence, kpi-integrity, table-column-match, kanban-column-match, alert-severity, link-validity, layout-coverage, mockData-shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)