### PR TITLE
feat: Phase 5 — CRM module

### DIFF
--- a/artifacts/activity/contract.json
+++ b/artifacts/activity/contract.json
@@ -1,0 +1,522 @@
+{
+  "version": "0.1.0",
+  "generatedAt": "2026-03-09T10:00:00.000Z",
+  "checksum": "crm-activity-001",
+  "frontendContract": {
+    "window": {
+      "id": "CRM-ACTIVITY",
+      "name": "Activity",
+      "primaryEntity": "activity",
+      "category": "crm"
+    },
+    "entities": {
+      "activity": {
+        "fields": [
+          {
+            "name": "type",
+            "column": "Type",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "ActivityType",
+            "inputMode": "selector"
+          },
+          {
+            "name": "subject",
+            "column": "Subject",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "deal",
+            "column": "CRM_Deal_ID",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true,
+            "reference": "Deal",
+            "inputMode": "search"
+          },
+          {
+            "name": "contact",
+            "column": "C_BPartner_ID",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true,
+            "reference": "BusinessPartner",
+            "inputMode": "search"
+          },
+          {
+            "name": "assignedTo",
+            "column": "AssignedTo_ID",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true,
+            "reference": "User",
+            "inputMode": "selector"
+          },
+          {
+            "name": "dueDate",
+            "column": "DueDate",
+            "type": "date",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "status",
+            "column": "Status",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "ActivityStatus",
+            "inputMode": "selector"
+          },
+          {
+            "name": "notes",
+            "column": "Notes",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": false,
+            "form": true
+          },
+          {
+            "name": "duration",
+            "column": "Duration",
+            "type": "number",
+            "tsType": "number",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true
+          }
+        ],
+        "searchableFields": [
+          "subject",
+          "contact",
+          "type"
+        ],
+        "computedFields": []
+      }
+    }
+  },
+  "backendContract": {
+    "window": {
+      "id": "CRM-ACTIVITY",
+      "name": "Activity",
+      "primaryEntity": "activity",
+      "category": "crm"
+    },
+    "entities": {
+      "activity": {
+        "fields": [
+          {
+            "name": "type",
+            "column": "Type",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "subject",
+            "column": "Subject",
+            "type": "string",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "deal",
+            "column": "CRM_Deal_ID",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "contact",
+            "column": "C_BPartner_ID",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "assignedTo",
+            "column": "AssignedTo_ID",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "dueDate",
+            "column": "DueDate",
+            "type": "date",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "status",
+            "column": "Status",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "notes",
+            "column": "Notes",
+            "type": "string",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "duration",
+            "column": "Duration",
+            "type": "number",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "adClientId",
+            "column": "AD_Client_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "adOrgId",
+            "column": "AD_Org_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "createdBy",
+            "column": "CreatedBy",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updatedBy",
+            "column": "UpdatedBy",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "created",
+            "column": "Created",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updated",
+            "column": "Updated",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          }
+        ]
+      }
+    },
+    "endpoints": [
+      {
+        "entity": "activity",
+        "method": "GET",
+        "path": "/activity",
+        "supportedFilters": [
+          "subject",
+          "contact",
+          "type"
+        ]
+      },
+      {
+        "entity": "activity",
+        "method": "GET",
+        "path": "/activity/:id",
+        "supportedFilters": []
+      },
+      {
+        "entity": "activity",
+        "method": "POST",
+        "path": "/activity",
+        "supportedFilters": []
+      },
+      {
+        "entity": "activity",
+        "method": "PUT",
+        "path": "/activity/:id",
+        "supportedFilters": []
+      },
+      {
+        "entity": "activity",
+        "method": "DELETE",
+        "path": "/activity/:id",
+        "supportedFilters": []
+      }
+    ],
+    "processEndpoints": []
+  },
+  "testManifest": {
+    "tests": [
+      {
+        "id": "t-1",
+        "category": "field-presence",
+        "entity": "activity",
+        "field": "type",
+        "runner": "node",
+        "description": "Field 'type' should be present in activity"
+      },
+      {
+        "id": "t-2",
+        "category": "field-presence",
+        "entity": "activity",
+        "field": "subject",
+        "runner": "node",
+        "description": "Field 'subject' should be present in activity"
+      },
+      {
+        "id": "t-3",
+        "category": "field-presence",
+        "entity": "activity",
+        "field": "deal",
+        "runner": "node",
+        "description": "Field 'deal' should be present in activity"
+      },
+      {
+        "id": "t-4",
+        "category": "field-presence",
+        "entity": "activity",
+        "field": "contact",
+        "runner": "node",
+        "description": "Field 'contact' should be present in activity"
+      },
+      {
+        "id": "t-5",
+        "category": "field-presence",
+        "entity": "activity",
+        "field": "assignedTo",
+        "runner": "node",
+        "description": "Field 'assignedTo' should be present in activity"
+      },
+      {
+        "id": "t-6",
+        "category": "field-presence",
+        "entity": "activity",
+        "field": "dueDate",
+        "runner": "node",
+        "description": "Field 'dueDate' should be present in activity"
+      },
+      {
+        "id": "t-7",
+        "category": "field-presence",
+        "entity": "activity",
+        "field": "status",
+        "runner": "node",
+        "description": "Field 'status' should be present in activity"
+      },
+      {
+        "id": "t-8",
+        "category": "field-presence",
+        "entity": "activity",
+        "field": "notes",
+        "runner": "node",
+        "description": "Field 'notes' should be present in activity"
+      },
+      {
+        "id": "t-9",
+        "category": "field-presence",
+        "entity": "activity",
+        "field": "duration",
+        "runner": "node",
+        "description": "Field 'duration' should be present in activity"
+      },
+      {
+        "id": "t-10",
+        "category": "field-type",
+        "entity": "activity",
+        "field": "type",
+        "runner": "node",
+        "description": "Field 'type' should have type 'foreignKey' in activity"
+      },
+      {
+        "id": "t-11",
+        "category": "field-type",
+        "entity": "activity",
+        "field": "subject",
+        "runner": "node",
+        "description": "Field 'subject' should have type 'string' in activity"
+      },
+      {
+        "id": "t-12",
+        "category": "field-type",
+        "entity": "activity",
+        "field": "deal",
+        "runner": "node",
+        "description": "Field 'deal' should have type 'foreignKey' in activity"
+      },
+      {
+        "id": "t-13",
+        "category": "field-type",
+        "entity": "activity",
+        "field": "contact",
+        "runner": "node",
+        "description": "Field 'contact' should have type 'foreignKey' in activity"
+      },
+      {
+        "id": "t-14",
+        "category": "field-type",
+        "entity": "activity",
+        "field": "assignedTo",
+        "runner": "node",
+        "description": "Field 'assignedTo' should have type 'foreignKey' in activity"
+      },
+      {
+        "id": "t-15",
+        "category": "field-type",
+        "entity": "activity",
+        "field": "dueDate",
+        "runner": "node",
+        "description": "Field 'dueDate' should have type 'date' in activity"
+      },
+      {
+        "id": "t-16",
+        "category": "field-type",
+        "entity": "activity",
+        "field": "status",
+        "runner": "node",
+        "description": "Field 'status' should have type 'foreignKey' in activity"
+      },
+      {
+        "id": "t-17",
+        "category": "field-type",
+        "entity": "activity",
+        "field": "notes",
+        "runner": "node",
+        "description": "Field 'notes' should have type 'string' in activity"
+      },
+      {
+        "id": "t-18",
+        "category": "field-type",
+        "entity": "activity",
+        "field": "duration",
+        "runner": "node",
+        "description": "Field 'duration' should have type 'number' in activity"
+      },
+      {
+        "id": "t-19",
+        "category": "searchable-filters",
+        "entity": "activity",
+        "field": "subject",
+        "runner": "node",
+        "description": "Field 'subject' should be a supported filter for activity"
+      },
+      {
+        "id": "t-20",
+        "category": "searchable-filters",
+        "entity": "activity",
+        "field": "contact",
+        "runner": "node",
+        "description": "Field 'contact' should be a supported filter for activity"
+      },
+      {
+        "id": "t-21",
+        "category": "searchable-filters",
+        "entity": "activity",
+        "field": "type",
+        "runner": "node",
+        "description": "Field 'type' should be a supported filter for activity"
+      },
+      {
+        "id": "t-22",
+        "category": "visibility",
+        "entity": "activity",
+        "runner": "node",
+        "description": "Entity 'activity' should only expose visible fields in frontend"
+      },
+      {
+        "id": "t-23",
+        "category": "system-field",
+        "entity": "activity",
+        "field": "adClientId",
+        "runner": "node",
+        "description": "System field 'adClientId' should exist in backend but not frontend for activity"
+      },
+      {
+        "id": "t-24",
+        "category": "system-field",
+        "entity": "activity",
+        "field": "adOrgId",
+        "runner": "node",
+        "description": "System field 'adOrgId' should exist in backend but not frontend for activity"
+      },
+      {
+        "id": "t-25",
+        "category": "system-field",
+        "entity": "activity",
+        "field": "createdBy",
+        "runner": "node",
+        "description": "System field 'createdBy' should exist in backend but not frontend for activity"
+      },
+      {
+        "id": "t-26",
+        "category": "system-field",
+        "entity": "activity",
+        "field": "updatedBy",
+        "runner": "node",
+        "description": "System field 'updatedBy' should exist in backend but not frontend for activity"
+      },
+      {
+        "id": "t-27",
+        "category": "system-field",
+        "entity": "activity",
+        "field": "created",
+        "runner": "node",
+        "description": "System field 'created' should exist in backend but not frontend for activity"
+      },
+      {
+        "id": "t-28",
+        "category": "system-field",
+        "entity": "activity",
+        "field": "updated",
+        "runner": "node",
+        "description": "System field 'updated' should exist in backend but not frontend for activity"
+      }
+    ],
+    "summary": {
+      "total": 28,
+      "byCategory": {
+        "field-presence": 9,
+        "field-type": 9,
+        "searchable-filters": 3,
+        "visibility": 1,
+        "system-field": 6
+      },
+      "byRunner": {
+        "node": 28,
+        "junit": 0
+      }
+    }
+  }
+}

--- a/artifacts/activity/generated/web/activity/ActivityForm.jsx
+++ b/artifacts/activity/generated/web/activity/ActivityForm.jsx
@@ -1,0 +1,17 @@
+import { EntityForm } from '@/components/contract-ui';
+
+const fields = [
+  { key: 'type', label: 'Type', type: 'selector', required: true, reference: 'ActivityType', inputMode: 'selector' },
+  { key: 'subject', label: 'Subject', type: 'text', required: true },
+  { key: 'deal', label: 'Deal', type: 'search', reference: 'Deal', inputMode: 'search' },
+  { key: 'contact', label: 'Contact', type: 'search', reference: 'BusinessPartner', inputMode: 'search' },
+  { key: 'assignedTo', label: 'Assigned To', type: 'selector', reference: 'User', inputMode: 'selector' },
+  { key: 'dueDate', label: 'Due Date', type: 'date' },
+  { key: 'status', label: 'Status', type: 'selector', required: true, reference: 'ActivityStatus', inputMode: 'selector' },
+  { key: 'notes', label: 'Notes', type: 'textarea' },
+  { key: 'duration', label: 'Duration', type: 'number' },
+];
+
+export default function ActivityForm(props) {
+  return <EntityForm fields={fields} {...props} />;
+}

--- a/artifacts/activity/generated/web/activity/ActivityTable.jsx
+++ b/artifacts/activity/generated/web/activity/ActivityTable.jsx
@@ -1,0 +1,18 @@
+import { DataTable } from '@/components/contract-ui';
+
+const columns = [
+  { key: 'type', label: 'Type', type: 'string' },
+  { key: 'subject', label: 'Subject', type: 'string' },
+  { key: 'deal', label: 'Deal', type: 'string' },
+  { key: 'contact', label: 'Contact', type: 'string' },
+  { key: 'assignedTo', label: 'Assigned To', type: 'string' },
+  { key: 'dueDate', label: 'Due Date', type: 'date' },
+  { key: 'status', label: 'Status', type: 'status' },
+  { key: 'duration', label: 'Duration', type: 'number' },
+];
+
+const filters = ['subject', 'contact', 'type'];
+
+export default function ActivityTable(props) {
+  return <DataTable columns={columns} filters={filters} {...props} />;
+}

--- a/artifacts/activity/generated/web/activity/index.jsx
+++ b/artifacts/activity/generated/web/activity/index.jsx
@@ -1,0 +1,20 @@
+import { SingleEntityPage } from '@/components/contract-ui';
+import ActivityTable from './ActivityTable';
+import ActivityForm from './ActivityForm';
+import catalogs from './mockCatalogs';
+
+const windowMeta = { category: 'crm', name: 'Activity' };
+
+export default function App(props) {
+  return (
+    <SingleEntityPage
+      entity="activity"
+      Table={ActivityTable}
+      Form={ActivityForm}
+      catalogs={catalogs}
+      entityLabel="Activity"
+      window={windowMeta}
+      {...props}
+    />
+  );
+}

--- a/artifacts/activity/generated/web/activity/mockCatalogs.js
+++ b/artifacts/activity/generated/web/activity/mockCatalogs.js
@@ -1,0 +1,103 @@
+// Auto-generated mock catalogs for FK reference data - do not edit manually
+
+const catalogs = {};
+
+catalogs['BusinessPartner'] = [
+  {
+    "id": "bp-001",
+    "name": "Acme Corp"
+  },
+  {
+    "id": "bp-002",
+    "name": "TechFlow Inc"
+  },
+  {
+    "id": "bp-003",
+    "name": "Global Trade Ltd"
+  },
+  {
+    "id": "bp-004",
+    "name": "Summit Industries"
+  },
+  {
+    "id": "bp-005",
+    "name": "Pacific Partners"
+  },
+  {
+    "id": "bp-006",
+    "name": "Alpine Solutions"
+  },
+  {
+    "id": "bp-007",
+    "name": "Meridian Group"
+  },
+  {
+    "id": "bp-008",
+    "name": "Vertex Systems"
+  },
+  {
+    "id": "bp-009",
+    "name": "Atlas Manufacturing"
+  },
+  {
+    "id": "bp-010",
+    "name": "Nova Enterprises"
+  },
+  {
+    "id": "bp-011",
+    "name": "Pinnacle Services"
+  },
+  {
+    "id": "bp-012",
+    "name": "Horizon Labs"
+  },
+  {
+    "id": "bp-013",
+    "name": "Cedar Holdings"
+  },
+  {
+    "id": "bp-014",
+    "name": "Sterling & Co"
+  },
+  {
+    "id": "bp-015",
+    "name": "Quantum Logistics"
+  }
+];
+
+catalogs['User'] = [
+  {
+    "id": "user-001",
+    "name": "Alice Johnson"
+  },
+  {
+    "id": "user-002",
+    "name": "Bob Smith"
+  },
+  {
+    "id": "user-003",
+    "name": "Carol Williams"
+  },
+  {
+    "id": "user-004",
+    "name": "David Brown"
+  },
+  {
+    "id": "user-005",
+    "name": "Eva Martinez"
+  },
+  {
+    "id": "user-006",
+    "name": "Frank Lee"
+  },
+  {
+    "id": "user-007",
+    "name": "Grace Kim"
+  },
+  {
+    "id": "user-008",
+    "name": "Henry Davis"
+  }
+];
+
+export default catalogs;

--- a/artifacts/crm/aggregate-contract.json
+++ b/artifacts/crm/aggregate-contract.json
@@ -1,0 +1,121 @@
+{
+  "version": "0.1.0",
+  "type": "aggregate",
+  "meta": {
+    "module": "crm",
+    "label": "CRM",
+    "icon": "Target",
+    "route": "/crm"
+  },
+  "sections": [
+    {
+      "id": "kpis",
+      "type": "kpi",
+      "kpis": [
+        { "key": "openDeals", "label": "Open Deals", "format": "number", "icon": "Target", "trend": "up" },
+        { "key": "pipelineValue", "label": "Pipeline Value", "format": "currency", "icon": "DollarSign", "trend": "up" },
+        { "key": "wonThisMonth", "label": "Won This Month", "format": "number", "icon": "Trophy", "trend": "up" },
+        { "key": "conversionRate", "label": "Conversion Rate", "format": "percent", "icon": "TrendingUp", "trend": "up" }
+      ]
+    },
+    {
+      "id": "dealPipeline",
+      "type": "kanban",
+      "title": "Deal Pipeline",
+      "icon": "Kanban",
+      "columns": [
+        { "id": "lead", "title": "Lead", "color": "gray" },
+        { "id": "qualification", "title": "Qualification", "color": "blue" },
+        { "id": "proposal", "title": "Proposal", "color": "yellow" },
+        { "id": "negotiation", "title": "Negotiation", "color": "orange" },
+        { "id": "closed-won", "title": "Closed Won", "color": "green" },
+        { "id": "closed-lost", "title": "Closed Lost", "color": "red" }
+      ]
+    },
+    {
+      "id": "recentActivities",
+      "type": "data-table",
+      "title": "Recent Activities",
+      "icon": "Activity",
+      "columns": [
+        { "key": "type", "label": "Type", "align": "left" },
+        { "key": "subject", "label": "Subject", "align": "left" },
+        { "key": "contact", "label": "Contact", "align": "left" },
+        { "key": "deal", "label": "Deal", "align": "left" },
+        { "key": "dueDate", "label": "Due Date", "align": "left" },
+        { "key": "status", "label": "Status", "align": "left" }
+      ],
+      "filters": ["type", "status"]
+    },
+    {
+      "id": "teamFeed",
+      "type": "activity-feed",
+      "title": "Team Activity",
+      "icon": "Users",
+      "fields": {
+        "direction": "direction",
+        "label": "label",
+        "detail": "detail",
+        "time": "time"
+      }
+    }
+  ],
+  "layout": {
+    "type": "grid",
+    "areas": [
+      { "section": "kpis", "span": "full" },
+      { "section": "dealPipeline", "span": "full" },
+      { "section": "recentActivities", "span": "2/3" },
+      { "section": "teamFeed", "span": "1/3" }
+    ]
+  },
+  "actions": [
+    { "label": "New Deal", "route": "/deal", "variant": "default" },
+    { "label": "Log Activity", "route": "/activity", "variant": "outline" },
+    { "label": "Add Lead", "route": "/lead", "variant": "outline" }
+  ],
+  "mockData": {
+    "kpis": {
+      "openDeals": 24,
+      "pipelineValue": 487500,
+      "wonThisMonth": 7,
+      "conversionRate": 32,
+      "trends": {
+        "openDeals": 4,
+        "pipelineValue": 15,
+        "wonThisMonth": 2,
+        "conversionRate": 5
+      }
+    },
+    "dealPipeline": [
+      { "id": "DL-001", "columnId": "lead", "title": "ERP Modernization", "subtitle": "Acme Corp", "value": 45000, "badges": ["Hot"] },
+      { "id": "DL-002", "columnId": "lead", "title": "Cloud Migration", "subtitle": "TechStart Inc", "value": 28000 },
+      { "id": "DL-003", "columnId": "qualification", "title": "Supply Chain Suite", "subtitle": "Global Logistics", "value": 120000, "badges": ["Enterprise"] },
+      { "id": "DL-004", "columnId": "qualification", "title": "Analytics Platform", "subtitle": "DataDriven Co", "value": 35000 },
+      { "id": "DL-005", "columnId": "proposal", "title": "CRM Implementation", "subtitle": "Retail Plus", "value": 67000, "badges": ["Priority"] },
+      { "id": "DL-006", "columnId": "negotiation", "title": "Warehouse Automation", "subtitle": "MegaStore Ltd", "value": 95000, "badges": ["Enterprise", "Priority"] },
+      { "id": "DL-007", "columnId": "negotiation", "title": "POS Integration", "subtitle": "QuickShop", "value": 22000 },
+      { "id": "DL-008", "columnId": "closed-won", "title": "Inventory Module", "subtitle": "FreshFoods Co", "value": 38000 },
+      { "id": "DL-009", "columnId": "closed-won", "title": "Billing System", "subtitle": "ServicePro", "value": 52000 },
+      { "id": "DL-010", "columnId": "closed-lost", "title": "HR Platform", "subtitle": "PeopleFirst", "value": 31000 }
+    ],
+    "recentActivities": [
+      { "type": "Call", "subject": "Discovery call with Acme Corp", "contact": "John Smith", "deal": "ERP Modernization", "dueDate": "2026-03-09", "status": "Completed" },
+      { "type": "Email", "subject": "Proposal follow-up", "contact": "Sarah Johnson", "deal": "CRM Implementation", "dueDate": "2026-03-09", "status": "Pending" },
+      { "type": "Meeting", "subject": "Technical review session", "contact": "Mike Chen", "deal": "Warehouse Automation", "dueDate": "2026-03-10", "status": "Scheduled" },
+      { "type": "Task", "subject": "Prepare pricing document", "contact": "Lisa Park", "deal": "Supply Chain Suite", "dueDate": "2026-03-10", "status": "In Progress" },
+      { "type": "Call", "subject": "Contract negotiation", "contact": "David Lee", "deal": "POS Integration", "dueDate": "2026-03-08", "status": "Completed" },
+      { "type": "Email", "subject": "Send case study references", "contact": "Anna Rodriguez", "deal": "Analytics Platform", "dueDate": "2026-03-11", "status": "Pending" },
+      { "type": "Meeting", "subject": "Quarterly business review", "contact": "Tom Wilson", "deal": "Inventory Module", "dueDate": "2026-03-07", "status": "Completed" },
+      { "type": "Task", "subject": "Update deal stage in CRM", "contact": "Karen White", "deal": "Cloud Migration", "dueDate": "2026-03-09", "status": "Overdue" }
+    ],
+    "teamFeed": [
+      { "id": 1, "direction": "out", "label": "Ana closed deal with FreshFoods Co", "detail": "$38,000 won", "time": "1 hour ago" },
+      { "id": 2, "direction": "in", "label": "New lead from website form", "detail": "TechStart Inc — Cloud Migration", "time": "2 hours ago" },
+      { "id": 3, "label": "Pedro moved Warehouse Automation to Negotiation", "detail": "MegaStore Ltd", "time": "3 hours ago" },
+      { "id": 4, "direction": "out", "label": "Proposal sent to Retail Plus", "detail": "CRM Implementation — $67,000", "time": "5 hours ago" },
+      { "id": 5, "direction": "in", "label": "Meeting scheduled with Global Logistics", "detail": "Supply Chain Suite review", "time": "6 hours ago" },
+      { "id": 6, "label": "Maria updated pipeline forecast", "detail": "Q1 target: $450,000", "time": "1 day ago" }
+    ]
+  }
+}

--- a/artifacts/crm/generated/config.js
+++ b/artifacts/crm/generated/config.js
@@ -1,0 +1,172 @@
+// Auto-generated from aggregate-contract.json — DO NOT EDIT
+
+export const meta = {
+  "module": "crm",
+  "label": "CRM",
+  "icon": "Target",
+  "route": "/crm"
+};
+
+export const kpisConfig = [];
+
+export const sections = {
+  "kpis": {
+    "type": "kpi",
+    "kpis": [
+      {
+        "key": "openDeals",
+        "label": "Open Deals",
+        "format": "number",
+        "icon": "Target",
+        "trend": "up"
+      },
+      {
+        "key": "pipelineValue",
+        "label": "Pipeline Value",
+        "format": "currency",
+        "icon": "DollarSign",
+        "trend": "up"
+      },
+      {
+        "key": "wonThisMonth",
+        "label": "Won This Month",
+        "format": "number",
+        "icon": "Trophy",
+        "trend": "up"
+      },
+      {
+        "key": "conversionRate",
+        "label": "Conversion Rate",
+        "format": "percent",
+        "icon": "TrendingUp",
+        "trend": "up"
+      }
+    ]
+  },
+  "dealPipeline": {
+    "type": "kanban",
+    "title": "Deal Pipeline",
+    "icon": "Kanban",
+    "columns": [
+      {
+        "id": "lead",
+        "title": "Lead",
+        "color": "gray"
+      },
+      {
+        "id": "qualification",
+        "title": "Qualification",
+        "color": "blue"
+      },
+      {
+        "id": "proposal",
+        "title": "Proposal",
+        "color": "yellow"
+      },
+      {
+        "id": "negotiation",
+        "title": "Negotiation",
+        "color": "orange"
+      },
+      {
+        "id": "closed-won",
+        "title": "Closed Won",
+        "color": "green"
+      },
+      {
+        "id": "closed-lost",
+        "title": "Closed Lost",
+        "color": "red"
+      }
+    ]
+  },
+  "recentActivities": {
+    "type": "data-table",
+    "title": "Recent Activities",
+    "icon": "Activity",
+    "columns": [
+      {
+        "key": "type",
+        "label": "Type",
+        "align": "left"
+      },
+      {
+        "key": "subject",
+        "label": "Subject",
+        "align": "left"
+      },
+      {
+        "key": "contact",
+        "label": "Contact",
+        "align": "left"
+      },
+      {
+        "key": "deal",
+        "label": "Deal",
+        "align": "left"
+      },
+      {
+        "key": "dueDate",
+        "label": "Due Date",
+        "align": "left"
+      },
+      {
+        "key": "status",
+        "label": "Status",
+        "align": "left"
+      }
+    ],
+    "filters": [
+      "type",
+      "status"
+    ]
+  },
+  "teamFeed": {
+    "type": "activity-feed",
+    "title": "Team Activity",
+    "icon": "Users",
+    "fields": {
+      "direction": "direction",
+      "label": "label",
+      "detail": "detail",
+      "time": "time"
+    }
+  }
+};
+
+export const layout = [
+  {
+    "section": "kpis",
+    "span": "full"
+  },
+  {
+    "section": "dealPipeline",
+    "span": "full"
+  },
+  {
+    "section": "recentActivities",
+    "span": "2/3"
+  },
+  {
+    "section": "teamFeed",
+    "span": "1/3"
+  }
+];
+
+export const actions = [
+  {
+    "label": "New Deal",
+    "route": "/deal",
+    "variant": "default"
+  },
+  {
+    "label": "Log Activity",
+    "route": "/activity",
+    "variant": "outline"
+  },
+  {
+    "label": "Add Lead",
+    "route": "/lead",
+    "variant": "outline"
+  }
+];

--- a/artifacts/crm/generated/mockData.js
+++ b/artifacts/crm/generated/mockData.js
@@ -1,0 +1,210 @@
+// Auto-generated from aggregate-contract.json — DO NOT EDIT
+
+export const kpis = {
+  "openDeals": 24,
+  "pipelineValue": 487500,
+  "wonThisMonth": 7,
+  "conversionRate": 32,
+  "trends": {
+    "openDeals": 4,
+    "pipelineValue": 15,
+    "wonThisMonth": 2,
+    "conversionRate": 5
+  }
+};
+
+export const dealPipeline = [
+  {
+    "id": "DL-001",
+    "columnId": "lead",
+    "title": "ERP Modernization",
+    "subtitle": "Acme Corp",
+    "value": 45000,
+    "badges": [
+      "Hot"
+    ]
+  },
+  {
+    "id": "DL-002",
+    "columnId": "lead",
+    "title": "Cloud Migration",
+    "subtitle": "TechStart Inc",
+    "value": 28000
+  },
+  {
+    "id": "DL-003",
+    "columnId": "qualification",
+    "title": "Supply Chain Suite",
+    "subtitle": "Global Logistics",
+    "value": 120000,
+    "badges": [
+      "Enterprise"
+    ]
+  },
+  {
+    "id": "DL-004",
+    "columnId": "qualification",
+    "title": "Analytics Platform",
+    "subtitle": "DataDriven Co",
+    "value": 35000
+  },
+  {
+    "id": "DL-005",
+    "columnId": "proposal",
+    "title": "CRM Implementation",
+    "subtitle": "Retail Plus",
+    "value": 67000,
+    "badges": [
+      "Priority"
+    ]
+  },
+  {
+    "id": "DL-006",
+    "columnId": "negotiation",
+    "title": "Warehouse Automation",
+    "subtitle": "MegaStore Ltd",
+    "value": 95000,
+    "badges": [
+      "Enterprise",
+      "Priority"
+    ]
+  },
+  {
+    "id": "DL-007",
+    "columnId": "negotiation",
+    "title": "POS Integration",
+    "subtitle": "QuickShop",
+    "value": 22000
+  },
+  {
+    "id": "DL-008",
+    "columnId": "closed-won",
+    "title": "Inventory Module",
+    "subtitle": "FreshFoods Co",
+    "value": 38000
+  },
+  {
+    "id": "DL-009",
+    "columnId": "closed-won",
+    "title": "Billing System",
+    "subtitle": "ServicePro",
+    "value": 52000
+  },
+  {
+    "id": "DL-010",
+    "columnId": "closed-lost",
+    "title": "HR Platform",
+    "subtitle": "PeopleFirst",
+    "value": 31000
+  }
+];
+
+export const recentActivities = [
+  {
+    "type": "Call",
+    "subject": "Discovery call with Acme Corp",
+    "contact": "John Smith",
+    "deal": "ERP Modernization",
+    "dueDate": "2026-03-09",
+    "status": "Completed"
+  },
+  {
+    "type": "Email",
+    "subject": "Proposal follow-up",
+    "contact": "Sarah Johnson",
+    "deal": "CRM Implementation",
+    "dueDate": "2026-03-09",
+    "status": "Pending"
+  },
+  {
+    "type": "Meeting",
+    "subject": "Technical review session",
+    "contact": "Mike Chen",
+    "deal": "Warehouse Automation",
+    "dueDate": "2026-03-10",
+    "status": "Scheduled"
+  },
+  {
+    "type": "Task",
+    "subject": "Prepare pricing document",
+    "contact": "Lisa Park",
+    "deal": "Supply Chain Suite",
+    "dueDate": "2026-03-10",
+    "status": "In Progress"
+  },
+  {
+    "type": "Call",
+    "subject": "Contract negotiation",
+    "contact": "David Lee",
+    "deal": "POS Integration",
+    "dueDate": "2026-03-08",
+    "status": "Completed"
+  },
+  {
+    "type": "Email",
+    "subject": "Send case study references",
+    "contact": "Anna Rodriguez",
+    "deal": "Analytics Platform",
+    "dueDate": "2026-03-11",
+    "status": "Pending"
+  },
+  {
+    "type": "Meeting",
+    "subject": "Quarterly business review",
+    "contact": "Tom Wilson",
+    "deal": "Inventory Module",
+    "dueDate": "2026-03-07",
+    "status": "Completed"
+  },
+  {
+    "type": "Task",
+    "subject": "Update deal stage in CRM",
+    "contact": "Karen White",
+    "deal": "Cloud Migration",
+    "dueDate": "2026-03-09",
+    "status": "Overdue"
+  }
+];
+
+export const teamFeed = [
+  {
+    "id": 1,
+    "direction": "out",
+    "label": "Ana closed deal with FreshFoods Co",
+    "detail": "$38,000 won",
+    "time": "1 hour ago"
+  },
+  {
+    "id": 2,
+    "direction": "in",
+    "label": "New lead from website form",
+    "detail": "TechStart Inc — Cloud Migration",
+    "time": "2 hours ago"
+  },
+  {
+    "id": 3,
+    "label": "Pedro moved Warehouse Automation to Negotiation",
+    "detail": "MegaStore Ltd",
+    "time": "3 hours ago"
+  },
+  {
+    "id": 4,
+    "direction": "out",
+    "label": "Proposal sent to Retail Plus",
+    "detail": "CRM Implementation — $67,000",
+    "time": "5 hours ago"
+  },
+  {
+    "id": 5,
+    "direction": "in",
+    "label": "Meeting scheduled with Global Logistics",
+    "detail": "Supply Chain Suite review",
+    "time": "6 hours ago"
+  },
+  {
+    "id": 6,
+    "label": "Maria updated pipeline forecast",
+    "detail": "Q1 target: $450,000",
+    "time": "1 day ago"
+  }
+];

--- a/artifacts/deal/contract.json
+++ b/artifacts/deal/contract.json
@@ -1,0 +1,522 @@
+{
+  "version": "0.1.0",
+  "generatedAt": "2026-03-09T10:00:00.000Z",
+  "checksum": "crm-deal-001",
+  "frontendContract": {
+    "window": {
+      "id": "CRM-DEAL",
+      "name": "Deal",
+      "primaryEntity": "deal",
+      "category": "crm"
+    },
+    "entities": {
+      "deal": {
+        "fields": [
+          {
+            "name": "name",
+            "column": "Name",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "businessPartner",
+            "column": "C_BPartner_ID",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "BusinessPartner",
+            "inputMode": "search"
+          },
+          {
+            "name": "stage",
+            "column": "Stage",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "DealStage",
+            "inputMode": "selector"
+          },
+          {
+            "name": "amount",
+            "column": "Amount",
+            "type": "amount",
+            "tsType": "number",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "currency",
+            "column": "C_Currency_ID",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "Currency",
+            "inputMode": "selector"
+          },
+          {
+            "name": "probability",
+            "column": "Probability",
+            "type": "number",
+            "tsType": "number",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "expectedCloseDate",
+            "column": "ExpectedCloseDate",
+            "type": "date",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "assignedTo",
+            "column": "AssignedTo_ID",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true,
+            "reference": "User",
+            "inputMode": "selector"
+          },
+          {
+            "name": "source",
+            "column": "Source",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true,
+            "reference": "LeadSource",
+            "inputMode": "selector"
+          }
+        ],
+        "searchableFields": [
+          "name",
+          "businessPartner",
+          "stage"
+        ],
+        "computedFields": []
+      }
+    }
+  },
+  "backendContract": {
+    "window": {
+      "id": "CRM-DEAL",
+      "name": "Deal",
+      "primaryEntity": "deal",
+      "category": "crm"
+    },
+    "entities": {
+      "deal": {
+        "fields": [
+          {
+            "name": "name",
+            "column": "Name",
+            "type": "string",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "businessPartner",
+            "column": "C_BPartner_ID",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "stage",
+            "column": "Stage",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "amount",
+            "column": "Amount",
+            "type": "amount",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "currency",
+            "column": "C_Currency_ID",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "probability",
+            "column": "Probability",
+            "type": "number",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "expectedCloseDate",
+            "column": "ExpectedCloseDate",
+            "type": "date",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "assignedTo",
+            "column": "AssignedTo_ID",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "source",
+            "column": "Source",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "adClientId",
+            "column": "AD_Client_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "adOrgId",
+            "column": "AD_Org_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "createdBy",
+            "column": "CreatedBy",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updatedBy",
+            "column": "UpdatedBy",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "created",
+            "column": "Created",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updated",
+            "column": "Updated",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          }
+        ]
+      }
+    },
+    "endpoints": [
+      {
+        "entity": "deal",
+        "method": "GET",
+        "path": "/deal",
+        "supportedFilters": [
+          "name",
+          "businessPartner",
+          "stage"
+        ]
+      },
+      {
+        "entity": "deal",
+        "method": "GET",
+        "path": "/deal/:id",
+        "supportedFilters": []
+      },
+      {
+        "entity": "deal",
+        "method": "POST",
+        "path": "/deal",
+        "supportedFilters": []
+      },
+      {
+        "entity": "deal",
+        "method": "PUT",
+        "path": "/deal/:id",
+        "supportedFilters": []
+      },
+      {
+        "entity": "deal",
+        "method": "DELETE",
+        "path": "/deal/:id",
+        "supportedFilters": []
+      }
+    ],
+    "processEndpoints": []
+  },
+  "testManifest": {
+    "tests": [
+      {
+        "id": "t-1",
+        "category": "field-presence",
+        "entity": "deal",
+        "field": "name",
+        "runner": "node",
+        "description": "Field 'name' should be present in deal"
+      },
+      {
+        "id": "t-2",
+        "category": "field-presence",
+        "entity": "deal",
+        "field": "businessPartner",
+        "runner": "node",
+        "description": "Field 'businessPartner' should be present in deal"
+      },
+      {
+        "id": "t-3",
+        "category": "field-presence",
+        "entity": "deal",
+        "field": "stage",
+        "runner": "node",
+        "description": "Field 'stage' should be present in deal"
+      },
+      {
+        "id": "t-4",
+        "category": "field-presence",
+        "entity": "deal",
+        "field": "amount",
+        "runner": "node",
+        "description": "Field 'amount' should be present in deal"
+      },
+      {
+        "id": "t-5",
+        "category": "field-presence",
+        "entity": "deal",
+        "field": "currency",
+        "runner": "node",
+        "description": "Field 'currency' should be present in deal"
+      },
+      {
+        "id": "t-6",
+        "category": "field-presence",
+        "entity": "deal",
+        "field": "probability",
+        "runner": "node",
+        "description": "Field 'probability' should be present in deal"
+      },
+      {
+        "id": "t-7",
+        "category": "field-presence",
+        "entity": "deal",
+        "field": "expectedCloseDate",
+        "runner": "node",
+        "description": "Field 'expectedCloseDate' should be present in deal"
+      },
+      {
+        "id": "t-8",
+        "category": "field-presence",
+        "entity": "deal",
+        "field": "assignedTo",
+        "runner": "node",
+        "description": "Field 'assignedTo' should be present in deal"
+      },
+      {
+        "id": "t-9",
+        "category": "field-presence",
+        "entity": "deal",
+        "field": "source",
+        "runner": "node",
+        "description": "Field 'source' should be present in deal"
+      },
+      {
+        "id": "t-10",
+        "category": "field-type",
+        "entity": "deal",
+        "field": "name",
+        "runner": "node",
+        "description": "Field 'name' should have type 'string' in deal"
+      },
+      {
+        "id": "t-11",
+        "category": "field-type",
+        "entity": "deal",
+        "field": "businessPartner",
+        "runner": "node",
+        "description": "Field 'businessPartner' should have type 'foreignKey' in deal"
+      },
+      {
+        "id": "t-12",
+        "category": "field-type",
+        "entity": "deal",
+        "field": "stage",
+        "runner": "node",
+        "description": "Field 'stage' should have type 'foreignKey' in deal"
+      },
+      {
+        "id": "t-13",
+        "category": "field-type",
+        "entity": "deal",
+        "field": "amount",
+        "runner": "node",
+        "description": "Field 'amount' should have type 'amount' in deal"
+      },
+      {
+        "id": "t-14",
+        "category": "field-type",
+        "entity": "deal",
+        "field": "currency",
+        "runner": "node",
+        "description": "Field 'currency' should have type 'foreignKey' in deal"
+      },
+      {
+        "id": "t-15",
+        "category": "field-type",
+        "entity": "deal",
+        "field": "probability",
+        "runner": "node",
+        "description": "Field 'probability' should have type 'number' in deal"
+      },
+      {
+        "id": "t-16",
+        "category": "field-type",
+        "entity": "deal",
+        "field": "expectedCloseDate",
+        "runner": "node",
+        "description": "Field 'expectedCloseDate' should have type 'date' in deal"
+      },
+      {
+        "id": "t-17",
+        "category": "field-type",
+        "entity": "deal",
+        "field": "assignedTo",
+        "runner": "node",
+        "description": "Field 'assignedTo' should have type 'foreignKey' in deal"
+      },
+      {
+        "id": "t-18",
+        "category": "field-type",
+        "entity": "deal",
+        "field": "source",
+        "runner": "node",
+        "description": "Field 'source' should have type 'foreignKey' in deal"
+      },
+      {
+        "id": "t-19",
+        "category": "searchable-filters",
+        "entity": "deal",
+        "field": "name",
+        "runner": "node",
+        "description": "Field 'name' should be a supported filter for deal"
+      },
+      {
+        "id": "t-20",
+        "category": "searchable-filters",
+        "entity": "deal",
+        "field": "businessPartner",
+        "runner": "node",
+        "description": "Field 'businessPartner' should be a supported filter for deal"
+      },
+      {
+        "id": "t-21",
+        "category": "searchable-filters",
+        "entity": "deal",
+        "field": "stage",
+        "runner": "node",
+        "description": "Field 'stage' should be a supported filter for deal"
+      },
+      {
+        "id": "t-22",
+        "category": "visibility",
+        "entity": "deal",
+        "runner": "node",
+        "description": "Entity 'deal' should only expose visible fields in frontend"
+      },
+      {
+        "id": "t-23",
+        "category": "system-field",
+        "entity": "deal",
+        "field": "adClientId",
+        "runner": "node",
+        "description": "System field 'adClientId' should exist in backend but not frontend for deal"
+      },
+      {
+        "id": "t-24",
+        "category": "system-field",
+        "entity": "deal",
+        "field": "adOrgId",
+        "runner": "node",
+        "description": "System field 'adOrgId' should exist in backend but not frontend for deal"
+      },
+      {
+        "id": "t-25",
+        "category": "system-field",
+        "entity": "deal",
+        "field": "createdBy",
+        "runner": "node",
+        "description": "System field 'createdBy' should exist in backend but not frontend for deal"
+      },
+      {
+        "id": "t-26",
+        "category": "system-field",
+        "entity": "deal",
+        "field": "updatedBy",
+        "runner": "node",
+        "description": "System field 'updatedBy' should exist in backend but not frontend for deal"
+      },
+      {
+        "id": "t-27",
+        "category": "system-field",
+        "entity": "deal",
+        "field": "created",
+        "runner": "node",
+        "description": "System field 'created' should exist in backend but not frontend for deal"
+      },
+      {
+        "id": "t-28",
+        "category": "system-field",
+        "entity": "deal",
+        "field": "updated",
+        "runner": "node",
+        "description": "System field 'updated' should exist in backend but not frontend for deal"
+      }
+    ],
+    "summary": {
+      "total": 28,
+      "byCategory": {
+        "field-presence": 9,
+        "field-type": 9,
+        "searchable-filters": 3,
+        "visibility": 1,
+        "system-field": 6
+      },
+      "byRunner": {
+        "node": 28,
+        "junit": 0
+      }
+    }
+  }
+}

--- a/artifacts/deal/generated/web/deal/DealForm.jsx
+++ b/artifacts/deal/generated/web/deal/DealForm.jsx
@@ -1,0 +1,17 @@
+import { EntityForm } from '@/components/contract-ui';
+
+const fields = [
+  { key: 'name', label: 'Name', type: 'text', required: true },
+  { key: 'businessPartner', label: 'Business Partner', type: 'search', required: true, reference: 'BusinessPartner', inputMode: 'search' },
+  { key: 'stage', label: 'Stage', type: 'selector', required: true, reference: 'DealStage', inputMode: 'selector' },
+  { key: 'amount', label: 'Amount', type: 'number', required: true },
+  { key: 'currency', label: 'Currency', type: 'selector', required: true, reference: 'Currency', inputMode: 'selector' },
+  { key: 'probability', label: 'Probability', type: 'number' },
+  { key: 'expectedCloseDate', label: 'Expected Close Date', type: 'date' },
+  { key: 'assignedTo', label: 'Assigned To', type: 'selector', reference: 'User', inputMode: 'selector' },
+  { key: 'source', label: 'Source', type: 'selector', reference: 'LeadSource', inputMode: 'selector' },
+];
+
+export default function DealForm(props) {
+  return <EntityForm fields={fields} {...props} />;
+}

--- a/artifacts/deal/generated/web/deal/DealTable.jsx
+++ b/artifacts/deal/generated/web/deal/DealTable.jsx
@@ -1,0 +1,19 @@
+import { DataTable } from '@/components/contract-ui';
+
+const columns = [
+  { key: 'name', label: 'Name', type: 'string' },
+  { key: 'businessPartner', label: 'Business Partner', type: 'string' },
+  { key: 'stage', label: 'Stage', type: 'string' },
+  { key: 'amount', label: 'Amount', type: 'amount' },
+  { key: 'currency', label: 'Currency', type: 'string' },
+  { key: 'probability', label: 'Probability', type: 'number' },
+  { key: 'expectedCloseDate', label: 'Expected Close Date', type: 'date' },
+  { key: 'assignedTo', label: 'Assigned To', type: 'string' },
+  { key: 'source', label: 'Source', type: 'string' },
+];
+
+const filters = ['name', 'businessPartner', 'stage'];
+
+export default function DealTable(props) {
+  return <DataTable columns={columns} filters={filters} {...props} />;
+}

--- a/artifacts/deal/generated/web/deal/index.jsx
+++ b/artifacts/deal/generated/web/deal/index.jsx
@@ -1,0 +1,20 @@
+import { SingleEntityPage } from '@/components/contract-ui';
+import DealTable from './DealTable';
+import DealForm from './DealForm';
+import catalogs from './mockCatalogs';
+
+const windowMeta = { category: 'crm', name: 'Deal' };
+
+export default function App(props) {
+  return (
+    <SingleEntityPage
+      entity="deal"
+      Table={DealTable}
+      Form={DealForm}
+      catalogs={catalogs}
+      entityLabel="Deal"
+      window={windowMeta}
+      {...props}
+    />
+  );
+}

--- a/artifacts/deal/generated/web/deal/mockCatalogs.js
+++ b/artifacts/deal/generated/web/deal/mockCatalogs.js
@@ -1,0 +1,103 @@
+// Auto-generated mock catalogs for FK reference data - do not edit manually
+
+const catalogs = {};
+
+catalogs['BusinessPartner'] = [
+  {
+    "id": "bp-001",
+    "name": "Acme Corp"
+  },
+  {
+    "id": "bp-002",
+    "name": "TechFlow Inc"
+  },
+  {
+    "id": "bp-003",
+    "name": "Global Trade Ltd"
+  },
+  {
+    "id": "bp-004",
+    "name": "Summit Industries"
+  },
+  {
+    "id": "bp-005",
+    "name": "Pacific Partners"
+  },
+  {
+    "id": "bp-006",
+    "name": "Alpine Solutions"
+  },
+  {
+    "id": "bp-007",
+    "name": "Meridian Group"
+  },
+  {
+    "id": "bp-008",
+    "name": "Vertex Systems"
+  },
+  {
+    "id": "bp-009",
+    "name": "Atlas Manufacturing"
+  },
+  {
+    "id": "bp-010",
+    "name": "Nova Enterprises"
+  },
+  {
+    "id": "bp-011",
+    "name": "Pinnacle Services"
+  },
+  {
+    "id": "bp-012",
+    "name": "Horizon Labs"
+  },
+  {
+    "id": "bp-013",
+    "name": "Cedar Holdings"
+  },
+  {
+    "id": "bp-014",
+    "name": "Sterling & Co"
+  },
+  {
+    "id": "bp-015",
+    "name": "Quantum Logistics"
+  }
+];
+
+catalogs['User'] = [
+  {
+    "id": "user-001",
+    "name": "Alice Johnson"
+  },
+  {
+    "id": "user-002",
+    "name": "Bob Smith"
+  },
+  {
+    "id": "user-003",
+    "name": "Carol Williams"
+  },
+  {
+    "id": "user-004",
+    "name": "David Brown"
+  },
+  {
+    "id": "user-005",
+    "name": "Eva Martinez"
+  },
+  {
+    "id": "user-006",
+    "name": "Frank Lee"
+  },
+  {
+    "id": "user-007",
+    "name": "Grace Kim"
+  },
+  {
+    "id": "user-008",
+    "name": "Henry Davis"
+  }
+];
+
+export default catalogs;

--- a/artifacts/lead/contract.json
+++ b/artifacts/lead/contract.json
@@ -1,0 +1,518 @@
+{
+  "version": "0.1.0",
+  "generatedAt": "2026-03-09T10:00:00.000Z",
+  "checksum": "crm-lead-001",
+  "frontendContract": {
+    "window": {
+      "id": "CRM-LEAD",
+      "name": "Lead",
+      "primaryEntity": "lead",
+      "category": "crm"
+    },
+    "entities": {
+      "lead": {
+        "fields": [
+          {
+            "name": "name",
+            "column": "Name",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "company",
+            "column": "Company",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "email",
+            "column": "Email",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "phone",
+            "column": "Phone",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "source",
+            "column": "Source",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true,
+            "reference": "LeadSource",
+            "inputMode": "selector"
+          },
+          {
+            "name": "status",
+            "column": "Status",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "LeadStatus",
+            "inputMode": "selector"
+          },
+          {
+            "name": "assignedTo",
+            "column": "AssignedTo_ID",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true,
+            "reference": "User",
+            "inputMode": "selector"
+          },
+          {
+            "name": "estimatedValue",
+            "column": "EstimatedValue",
+            "type": "amount",
+            "tsType": "number",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "notes",
+            "column": "Notes",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": false,
+            "form": true
+          }
+        ],
+        "searchableFields": [
+          "name",
+          "company",
+          "status"
+        ],
+        "computedFields": []
+      }
+    }
+  },
+  "backendContract": {
+    "window": {
+      "id": "CRM-LEAD",
+      "name": "Lead",
+      "primaryEntity": "lead",
+      "category": "crm"
+    },
+    "entities": {
+      "lead": {
+        "fields": [
+          {
+            "name": "name",
+            "column": "Name",
+            "type": "string",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "company",
+            "column": "Company",
+            "type": "string",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "email",
+            "column": "Email",
+            "type": "string",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "phone",
+            "column": "Phone",
+            "type": "string",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "source",
+            "column": "Source",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "status",
+            "column": "Status",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "assignedTo",
+            "column": "AssignedTo_ID",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "estimatedValue",
+            "column": "EstimatedValue",
+            "type": "amount",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "notes",
+            "column": "Notes",
+            "type": "string",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "adClientId",
+            "column": "AD_Client_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "adOrgId",
+            "column": "AD_Org_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "createdBy",
+            "column": "CreatedBy",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updatedBy",
+            "column": "UpdatedBy",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "created",
+            "column": "Created",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updated",
+            "column": "Updated",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          }
+        ]
+      }
+    },
+    "endpoints": [
+      {
+        "entity": "lead",
+        "method": "GET",
+        "path": "/lead",
+        "supportedFilters": [
+          "name",
+          "company",
+          "status"
+        ]
+      },
+      {
+        "entity": "lead",
+        "method": "GET",
+        "path": "/lead/:id",
+        "supportedFilters": []
+      },
+      {
+        "entity": "lead",
+        "method": "POST",
+        "path": "/lead",
+        "supportedFilters": []
+      },
+      {
+        "entity": "lead",
+        "method": "PUT",
+        "path": "/lead/:id",
+        "supportedFilters": []
+      },
+      {
+        "entity": "lead",
+        "method": "DELETE",
+        "path": "/lead/:id",
+        "supportedFilters": []
+      }
+    ],
+    "processEndpoints": []
+  },
+  "testManifest": {
+    "tests": [
+      {
+        "id": "t-1",
+        "category": "field-presence",
+        "entity": "lead",
+        "field": "name",
+        "runner": "node",
+        "description": "Field 'name' should be present in lead"
+      },
+      {
+        "id": "t-2",
+        "category": "field-presence",
+        "entity": "lead",
+        "field": "company",
+        "runner": "node",
+        "description": "Field 'company' should be present in lead"
+      },
+      {
+        "id": "t-3",
+        "category": "field-presence",
+        "entity": "lead",
+        "field": "email",
+        "runner": "node",
+        "description": "Field 'email' should be present in lead"
+      },
+      {
+        "id": "t-4",
+        "category": "field-presence",
+        "entity": "lead",
+        "field": "phone",
+        "runner": "node",
+        "description": "Field 'phone' should be present in lead"
+      },
+      {
+        "id": "t-5",
+        "category": "field-presence",
+        "entity": "lead",
+        "field": "source",
+        "runner": "node",
+        "description": "Field 'source' should be present in lead"
+      },
+      {
+        "id": "t-6",
+        "category": "field-presence",
+        "entity": "lead",
+        "field": "status",
+        "runner": "node",
+        "description": "Field 'status' should be present in lead"
+      },
+      {
+        "id": "t-7",
+        "category": "field-presence",
+        "entity": "lead",
+        "field": "assignedTo",
+        "runner": "node",
+        "description": "Field 'assignedTo' should be present in lead"
+      },
+      {
+        "id": "t-8",
+        "category": "field-presence",
+        "entity": "lead",
+        "field": "estimatedValue",
+        "runner": "node",
+        "description": "Field 'estimatedValue' should be present in lead"
+      },
+      {
+        "id": "t-9",
+        "category": "field-presence",
+        "entity": "lead",
+        "field": "notes",
+        "runner": "node",
+        "description": "Field 'notes' should be present in lead"
+      },
+      {
+        "id": "t-10",
+        "category": "field-type",
+        "entity": "lead",
+        "field": "name",
+        "runner": "node",
+        "description": "Field 'name' should have type 'string' in lead"
+      },
+      {
+        "id": "t-11",
+        "category": "field-type",
+        "entity": "lead",
+        "field": "company",
+        "runner": "node",
+        "description": "Field 'company' should have type 'string' in lead"
+      },
+      {
+        "id": "t-12",
+        "category": "field-type",
+        "entity": "lead",
+        "field": "email",
+        "runner": "node",
+        "description": "Field 'email' should have type 'string' in lead"
+      },
+      {
+        "id": "t-13",
+        "category": "field-type",
+        "entity": "lead",
+        "field": "phone",
+        "runner": "node",
+        "description": "Field 'phone' should have type 'string' in lead"
+      },
+      {
+        "id": "t-14",
+        "category": "field-type",
+        "entity": "lead",
+        "field": "source",
+        "runner": "node",
+        "description": "Field 'source' should have type 'foreignKey' in lead"
+      },
+      {
+        "id": "t-15",
+        "category": "field-type",
+        "entity": "lead",
+        "field": "status",
+        "runner": "node",
+        "description": "Field 'status' should have type 'foreignKey' in lead"
+      },
+      {
+        "id": "t-16",
+        "category": "field-type",
+        "entity": "lead",
+        "field": "assignedTo",
+        "runner": "node",
+        "description": "Field 'assignedTo' should have type 'foreignKey' in lead"
+      },
+      {
+        "id": "t-17",
+        "category": "field-type",
+        "entity": "lead",
+        "field": "estimatedValue",
+        "runner": "node",
+        "description": "Field 'estimatedValue' should have type 'amount' in lead"
+      },
+      {
+        "id": "t-18",
+        "category": "field-type",
+        "entity": "lead",
+        "field": "notes",
+        "runner": "node",
+        "description": "Field 'notes' should have type 'string' in lead"
+      },
+      {
+        "id": "t-19",
+        "category": "searchable-filters",
+        "entity": "lead",
+        "field": "name",
+        "runner": "node",
+        "description": "Field 'name' should be a supported filter for lead"
+      },
+      {
+        "id": "t-20",
+        "category": "searchable-filters",
+        "entity": "lead",
+        "field": "company",
+        "runner": "node",
+        "description": "Field 'company' should be a supported filter for lead"
+      },
+      {
+        "id": "t-21",
+        "category": "searchable-filters",
+        "entity": "lead",
+        "field": "status",
+        "runner": "node",
+        "description": "Field 'status' should be a supported filter for lead"
+      },
+      {
+        "id": "t-22",
+        "category": "visibility",
+        "entity": "lead",
+        "runner": "node",
+        "description": "Entity 'lead' should only expose visible fields in frontend"
+      },
+      {
+        "id": "t-23",
+        "category": "system-field",
+        "entity": "lead",
+        "field": "adClientId",
+        "runner": "node",
+        "description": "System field 'adClientId' should exist in backend but not frontend for lead"
+      },
+      {
+        "id": "t-24",
+        "category": "system-field",
+        "entity": "lead",
+        "field": "adOrgId",
+        "runner": "node",
+        "description": "System field 'adOrgId' should exist in backend but not frontend for lead"
+      },
+      {
+        "id": "t-25",
+        "category": "system-field",
+        "entity": "lead",
+        "field": "createdBy",
+        "runner": "node",
+        "description": "System field 'createdBy' should exist in backend but not frontend for lead"
+      },
+      {
+        "id": "t-26",
+        "category": "system-field",
+        "entity": "lead",
+        "field": "updatedBy",
+        "runner": "node",
+        "description": "System field 'updatedBy' should exist in backend but not frontend for lead"
+      },
+      {
+        "id": "t-27",
+        "category": "system-field",
+        "entity": "lead",
+        "field": "created",
+        "runner": "node",
+        "description": "System field 'created' should exist in backend but not frontend for lead"
+      },
+      {
+        "id": "t-28",
+        "category": "system-field",
+        "entity": "lead",
+        "field": "updated",
+        "runner": "node",
+        "description": "System field 'updated' should exist in backend but not frontend for lead"
+      }
+    ],
+    "summary": {
+      "total": 28,
+      "byCategory": {
+        "field-presence": 9,
+        "field-type": 9,
+        "searchable-filters": 3,
+        "visibility": 1,
+        "system-field": 6
+      },
+      "byRunner": {
+        "node": 28,
+        "junit": 0
+      }
+    }
+  }
+}

--- a/artifacts/lead/generated/web/lead/LeadForm.jsx
+++ b/artifacts/lead/generated/web/lead/LeadForm.jsx
@@ -1,0 +1,17 @@
+import { EntityForm } from '@/components/contract-ui';
+
+const fields = [
+  { key: 'name', label: 'Name', type: 'text', required: true },
+  { key: 'company', label: 'Company', type: 'text' },
+  { key: 'email', label: 'Email', type: 'text' },
+  { key: 'phone', label: 'Phone', type: 'text' },
+  { key: 'source', label: 'Source', type: 'selector', reference: 'LeadSource', inputMode: 'selector' },
+  { key: 'status', label: 'Status', type: 'selector', required: true, reference: 'LeadStatus', inputMode: 'selector' },
+  { key: 'assignedTo', label: 'Assigned To', type: 'selector', reference: 'User', inputMode: 'selector' },
+  { key: 'estimatedValue', label: 'Estimated Value', type: 'number' },
+  { key: 'notes', label: 'Notes', type: 'textarea' },
+];
+
+export default function LeadForm(props) {
+  return <EntityForm fields={fields} {...props} />;
+}

--- a/artifacts/lead/generated/web/lead/LeadTable.jsx
+++ b/artifacts/lead/generated/web/lead/LeadTable.jsx
@@ -1,0 +1,18 @@
+import { DataTable } from '@/components/contract-ui';
+
+const columns = [
+  { key: 'name', label: 'Name', type: 'string' },
+  { key: 'company', label: 'Company', type: 'string' },
+  { key: 'email', label: 'Email', type: 'string' },
+  { key: 'phone', label: 'Phone', type: 'string' },
+  { key: 'source', label: 'Source', type: 'string' },
+  { key: 'status', label: 'Status', type: 'status' },
+  { key: 'assignedTo', label: 'Assigned To', type: 'string' },
+  { key: 'estimatedValue', label: 'Estimated Value', type: 'amount' },
+];
+
+const filters = ['name', 'company', 'status'];
+
+export default function LeadTable(props) {
+  return <DataTable columns={columns} filters={filters} {...props} />;
+}

--- a/artifacts/lead/generated/web/lead/index.jsx
+++ b/artifacts/lead/generated/web/lead/index.jsx
@@ -1,0 +1,20 @@
+import { SingleEntityPage } from '@/components/contract-ui';
+import LeadTable from './LeadTable';
+import LeadForm from './LeadForm';
+import catalogs from './mockCatalogs';
+
+const windowMeta = { category: 'crm', name: 'Lead' };
+
+export default function App(props) {
+  return (
+    <SingleEntityPage
+      entity="lead"
+      Table={LeadTable}
+      Form={LeadForm}
+      catalogs={catalogs}
+      entityLabel="Lead"
+      window={windowMeta}
+      {...props}
+    />
+  );
+}

--- a/artifacts/lead/generated/web/lead/mockCatalogs.js
+++ b/artifacts/lead/generated/web/lead/mockCatalogs.js
@@ -1,0 +1,40 @@
+// Auto-generated mock catalogs for FK reference data - do not edit manually
+
+const catalogs = {};
+
+catalogs['User'] = [
+  {
+    "id": "user-001",
+    "name": "Alice Johnson"
+  },
+  {
+    "id": "user-002",
+    "name": "Bob Smith"
+  },
+  {
+    "id": "user-003",
+    "name": "Carol Williams"
+  },
+  {
+    "id": "user-004",
+    "name": "David Brown"
+  },
+  {
+    "id": "user-005",
+    "name": "Eva Martinez"
+  },
+  {
+    "id": "user-006",
+    "name": "Frank Lee"
+  },
+  {
+    "id": "user-007",
+    "name": "Grace Kim"
+  },
+  {
+    "id": "user-008",
+    "name": "Henry Davis"
+  }
+];
+
+export default catalogs;

--- a/tools/app-shell/src/App.jsx
+++ b/tools/app-shell/src/App.jsx
@@ -12,6 +12,7 @@ import InventoryPage from './pages/InventoryPage.jsx';
 import PurchasesPage from './pages/PurchasesPage.jsx';
 import AccountingPage from './pages/AccountingPage.jsx';
 import ReportsPage from './pages/ReportsPage.jsx';
+import CrmPage from './pages/CrmPage.jsx';
 import { buildMenuGroups, buildWindowMap } from './windows/registry.js';
 import { createMockFetch } from './lib/mockFetch.js';
 
@@ -108,6 +109,7 @@ function AppRoutes({ menuGroups, windowMap }) {
         <Route path="purchases" element={<PurchasesPage />} />
         <Route path="accounting" element={<AccountingPage />} />
         <Route path="reports" element={<ReportsPage />} />
+        <Route path="crm" element={<CrmPage />} />
         <Route
           path=":windowName"
           element={<WindowLoader windowMap={windowMap} apiBaseUrl={API_BASE_URL} />}

--- a/tools/app-shell/src/menu.json
+++ b/tools/app-shell/src/menu.json
@@ -63,6 +63,16 @@
       ]
     },
     {
+      "group": "CRM",
+      "icon": "Target",
+      "items": [
+        { "name": "crm", "label": "Overview" },
+        { "name": "deal", "label": "Deals" },
+        { "name": "activity", "label": "Activities" },
+        { "name": "lead", "label": "Leads" }
+      ]
+    },
+    {
       "group": "Products",
       "icon": "Box",
       "items": [

--- a/tools/app-shell/src/pages/CrmPage.jsx
+++ b/tools/app-shell/src/pages/CrmPage.jsx
@@ -1,0 +1,153 @@
+import React, { useState, useCallback } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { KPIHeader, KanbanBoard, DataTable } from '@/components/contract-ui';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import { Target, DollarSign, Trophy, TrendingUp, Users, Activity, ArrowUp, ArrowDown } from 'lucide-react';
+
+import { sections, actions } from '@generated/crm/generated/config';
+import * as mockData from '@generated/crm/generated/mockData';
+
+// -- Icon resolution (config stores string names) -----------------------------
+
+const ICON_MAP = { Target, DollarSign, Trophy, TrendingUp, Users, Activity };
+
+// -- Derived data from contract -----------------------------------------------
+
+const KPIS = sections.kpis.kpis.map((k) => ({
+  ...k,
+  value: mockData.kpis[k.key],
+  trend: mockData.kpis.trends?.[k.key],
+  icon: ICON_MAP[k.icon],
+}));
+
+const COLUMNS = sections.dealPipeline.columns;
+const INITIAL_CARDS = mockData.dealPipeline;
+
+const TABLE_COLUMNS = sections.recentActivities.columns;
+const TABLE_FILTERS = sections.recentActivities.filters;
+const TABLE_DATA = mockData.recentActivities;
+
+const TEAM_FEED = mockData.teamFeed;
+
+const STATUS_VARIANT = {
+  Completed: 'default',
+  Pending: 'secondary',
+  Scheduled: 'outline',
+  'In Progress': 'default',
+  Overdue: 'destructive',
+};
+
+// -- Component -----------------------------------------------------------------
+
+export default function CrmPage() {
+  const navigate = useNavigate();
+  const [cards, setCards] = useState(INITIAL_CARDS);
+
+  const handleDragEnd = useCallback((cardId, _fromColumnId, toColumnId) => {
+    setCards((prev) =>
+      prev.map((c) => (c.id === cardId ? { ...c, columnId: toColumnId } : c))
+    );
+  }, []);
+
+  const handleCardClick = useCallback(
+    () => {
+      navigate('/deal');
+    },
+    [navigate]
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Header bar */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">CRM</h1>
+        <div className="flex items-center gap-2">
+          {actions.map((action) => (
+            <Button key={action.route} variant={action.variant} asChild>
+              <Link to={action.route}>{action.label}</Link>
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {/* KPIs */}
+      <KPIHeader kpis={KPIS} />
+
+      {/* Deal Pipeline Kanban */}
+      <KanbanBoard
+        columns={COLUMNS}
+        cards={cards}
+        onDragEnd={handleDragEnd}
+        onCardClick={handleCardClick}
+        emptyMessage="No deals in pipeline"
+      />
+
+      {/* Two-column layout: Activities (2/3) + Team Feed (1/3) */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Recent Activities Table */}
+        <div className="lg:col-span-2">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Activity className="h-5 w-5 text-muted-foreground" />
+                Recent Activities
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <DataTable
+                columns={TABLE_COLUMNS}
+                filters={TABLE_FILTERS}
+                data={TABLE_DATA}
+              />
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Team Activity Feed */}
+        <div>
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Users className="h-5 w-5 text-muted-foreground" />
+                Team Activity
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {TEAM_FEED.map((entry, idx) => (
+                <div key={entry.id}>
+                  {idx > 0 && <Separator className="mb-3" />}
+                  <div className="flex items-start gap-3">
+                    {entry.direction && (
+                      <div className={`mt-0.5 rounded-full p-1 ${
+                        entry.direction === 'in'
+                          ? 'bg-emerald-100 text-emerald-600'
+                          : 'bg-blue-100 text-blue-600'
+                      }`}>
+                        {entry.direction === 'in'
+                          ? <ArrowUp className="h-3.5 w-3.5" />
+                          : <ArrowDown className="h-3.5 w-3.5" />
+                        }
+                      </div>
+                    )}
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm font-medium truncate">{entry.label}</p>
+                      {entry.detail && (
+                        <p className="text-xs text-muted-foreground">{entry.detail}</p>
+                      )}
+                    </div>
+                    <span className="text-xs text-muted-foreground whitespace-nowrap">
+                      {entry.time}
+                    </span>
+                  </div>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tools/app-shell/src/windows/registry.js
+++ b/tools/app-shell/src/windows/registry.js
@@ -33,6 +33,9 @@ const windowLoaders = {
   'return-from-customer': () => import('@generated/return-from-customer/generated/web/return-from-customer/index.jsx'),
   'return-material-receipt': () => import('@generated/return-material-receipt/generated/web/return-material-receipt/index.jsx'),
   'sales-invoice': () => import('@generated/sales-invoice/generated/web/sales-invoice/index.jsx'),
+  'deal': () => import('@generated/deal/generated/web/deal/index.jsx'),
+  'activity': () => import('@generated/activity/generated/web/activity/index.jsx'),
+  'lead': () => import('@generated/lead/generated/web/lead/index.jsx'),
 };
 
 /**


### PR DESCRIPTION
## Summary
- Add **CRM Overview** page with aggregate contract (KPIs: open deals, pipeline value, won this month, conversion rate) + deal pipeline kanban + recent activities table + team activity feed
- Add **Deal** entity window (9 fields: name, businessPartner, stage, amount, currency, probability, expectedCloseDate, assignedTo, source) — 28 contract tests
- Add **Activity** entity window (9 fields: type, subject, deal, contact, assignedTo, dueDate, status, notes, duration) — 28 contract tests
- Add **Lead** entity window (9 fields: name, company, email, phone, source, status, assignedTo, estimatedValue, notes) — 28 contract tests
- Add CRM group to menu with 4 items (Overview, Deals, Activities, Leads)
- Register routes and entity windows in App.jsx

## Test plan
- [x] 2,401 unit tests pass (0 failures)
- [x] 43 CRM aggregate tests pass
- [x] 84 entity contract tests pass (deal: 28, activity: 28, lead: 28)
- [x] Vite build clean (6.80s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)