### PR TITLE
feat: Phase 6 — HR & Projects module

### DIFF
--- a/artifacts/absence/contract.json
+++ b/artifacts/absence/contract.json
@@ -1,0 +1,302 @@
+{
+  "version": "0.1.0",
+  "generatedAt": "2026-03-09T10:00:00.000Z",
+  "checksum": "hr-absence-001",
+  "frontendContract": {
+    "window": {
+      "id": "HR-ABSENCE",
+      "name": "Absence",
+      "primaryEntity": "absence",
+      "category": "hr"
+    },
+    "entities": {
+      "absence": {
+        "fields": [
+          {
+            "name": "employee",
+            "column": "Employee_ID",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "User",
+            "inputMode": "selector"
+          },
+          {
+            "name": "type",
+            "column": "AbsenceType",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "AbsenceType",
+            "inputMode": "selector"
+          },
+          {
+            "name": "startDate",
+            "column": "StartDate",
+            "type": "date",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "endDate",
+            "column": "EndDate",
+            "type": "date",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "days",
+            "column": "Days",
+            "type": "number",
+            "tsType": "number",
+            "visibility": "readOnly",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "status",
+            "column": "Status",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "AbsenceStatus",
+            "inputMode": "selector"
+          },
+          {
+            "name": "reason",
+            "column": "Reason",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": false,
+            "form": true
+          },
+          {
+            "name": "approvedBy",
+            "column": "ApprovedBy_ID",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "readOnly",
+            "required": false,
+            "grid": true,
+            "form": true,
+            "reference": "User",
+            "inputMode": "selector"
+          }
+        ],
+        "searchableFields": [
+          "employee",
+          "type",
+          "status"
+        ],
+        "computedFields": []
+      }
+    }
+  },
+  "backendContract": {
+    "window": {
+      "id": "HR-ABSENCE",
+      "name": "Absence",
+      "primaryEntity": "absence",
+      "category": "hr"
+    },
+    "entities": {
+      "absence": {
+        "fields": [
+          {
+            "name": "employee",
+            "column": "Employee_ID",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "type",
+            "column": "AbsenceType",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "startDate",
+            "column": "StartDate",
+            "type": "date",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "endDate",
+            "column": "EndDate",
+            "type": "date",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "days",
+            "column": "Days",
+            "type": "number",
+            "visibility": "readOnly",
+            "required": true
+          },
+          {
+            "name": "status",
+            "column": "Status",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "reason",
+            "column": "Reason",
+            "type": "string",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "approvedBy",
+            "column": "ApprovedBy_ID",
+            "type": "foreignKey",
+            "visibility": "readOnly",
+            "required": false
+          },
+          {
+            "name": "adClientId",
+            "column": "AD_Client_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "adOrgId",
+            "column": "AD_Org_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "createdBy",
+            "column": "CreatedBy",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updatedBy",
+            "column": "UpdatedBy",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "created",
+            "column": "Created",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updated",
+            "column": "Updated",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          }
+        ]
+      }
+    },
+    "endpoints": [
+      {
+        "entity": "absence",
+        "method": "GET",
+        "path": "/absence",
+        "supportedFilters": ["employee", "type", "status"]
+      },
+      {
+        "entity": "absence",
+        "method": "GET",
+        "path": "/absence/:id",
+        "supportedFilters": []
+      },
+      {
+        "entity": "absence",
+        "method": "POST",
+        "path": "/absence",
+        "supportedFilters": []
+      },
+      {
+        "entity": "absence",
+        "method": "PUT",
+        "path": "/absence/:id",
+        "supportedFilters": []
+      },
+      {
+        "entity": "absence",
+        "method": "DELETE",
+        "path": "/absence/:id",
+        "supportedFilters": []
+      }
+    ],
+    "processEndpoints": []
+  },
+  "testManifest": {
+    "tests": [
+      { "id": "t-1", "category": "field-presence", "entity": "absence", "field": "employee", "runner": "node", "description": "Field 'employee' should be present in absence" },
+      { "id": "t-2", "category": "field-presence", "entity": "absence", "field": "type", "runner": "node", "description": "Field 'type' should be present in absence" },
+      { "id": "t-3", "category": "field-presence", "entity": "absence", "field": "startDate", "runner": "node", "description": "Field 'startDate' should be present in absence" },
+      { "id": "t-4", "category": "field-presence", "entity": "absence", "field": "endDate", "runner": "node", "description": "Field 'endDate' should be present in absence" },
+      { "id": "t-5", "category": "field-presence", "entity": "absence", "field": "days", "runner": "node", "description": "Field 'days' should be present in absence" },
+      { "id": "t-6", "category": "field-presence", "entity": "absence", "field": "status", "runner": "node", "description": "Field 'status' should be present in absence" },
+      { "id": "t-7", "category": "field-presence", "entity": "absence", "field": "reason", "runner": "node", "description": "Field 'reason' should be present in absence" },
+      { "id": "t-8", "category": "field-presence", "entity": "absence", "field": "approvedBy", "runner": "node", "description": "Field 'approvedBy' should be present in absence" },
+      { "id": "t-9", "category": "field-type", "entity": "absence", "field": "employee", "runner": "node", "description": "Field 'employee' should have type 'foreignKey' in absence" },
+      { "id": "t-10", "category": "field-type", "entity": "absence", "field": "type", "runner": "node", "description": "Field 'type' should have type 'foreignKey' in absence" },
+      { "id": "t-11", "category": "field-type", "entity": "absence", "field": "startDate", "runner": "node", "description": "Field 'startDate' should have type 'date' in absence" },
+      { "id": "t-12", "category": "field-type", "entity": "absence", "field": "endDate", "runner": "node", "description": "Field 'endDate' should have type 'date' in absence" },
+      { "id": "t-13", "category": "field-type", "entity": "absence", "field": "days", "runner": "node", "description": "Field 'days' should have type 'number' in absence" },
+      { "id": "t-14", "category": "field-type", "entity": "absence", "field": "status", "runner": "node", "description": "Field 'status' should have type 'foreignKey' in absence" },
+      { "id": "t-15", "category": "field-type", "entity": "absence", "field": "reason", "runner": "node", "description": "Field 'reason' should have type 'string' in absence" },
+      { "id": "t-16", "category": "field-type", "entity": "absence", "field": "approvedBy", "runner": "node", "description": "Field 'approvedBy' should have type 'foreignKey' in absence" },
+      { "id": "t-17", "category": "searchable-filters", "entity": "absence", "field": "employee", "runner": "node", "description": "Field 'employee' should be a supported filter for absence" },
+      { "id": "t-18", "category": "searchable-filters", "entity": "absence", "field": "type", "runner": "node", "description": "Field 'type' should be a supported filter for absence" },
+      { "id": "t-19", "category": "searchable-filters", "entity": "absence", "field": "status", "runner": "node", "description": "Field 'status' should be a supported filter for absence" },
+      { "id": "t-20", "category": "visibility", "entity": "absence", "runner": "node", "description": "Entity 'absence' should only expose visible fields in frontend" },
+      { "id": "t-21", "category": "system-field", "entity": "absence", "field": "adClientId", "runner": "node", "description": "System field 'adClientId' should exist in backend but not frontend for absence" },
+      { "id": "t-22", "category": "system-field", "entity": "absence", "field": "adOrgId", "runner": "node", "description": "System field 'adOrgId' should exist in backend but not frontend for absence" },
+      { "id": "t-23", "category": "system-field", "entity": "absence", "field": "createdBy", "runner": "node", "description": "System field 'createdBy' should exist in backend but not frontend for absence" },
+      { "id": "t-24", "category": "system-field", "entity": "absence", "field": "updatedBy", "runner": "node", "description": "System field 'updatedBy' should exist in backend but not frontend for absence" },
+      { "id": "t-25", "category": "system-field", "entity": "absence", "field": "created", "runner": "node", "description": "System field 'created' should exist in backend but not frontend for absence" },
+      { "id": "t-26", "category": "system-field", "entity": "absence", "field": "updated", "runner": "node", "description": "System field 'updated' should exist in backend but not frontend for absence" }
+    ],
+    "summary": {
+      "total": 26,
+      "byCategory": {
+        "field-presence": 8,
+        "field-type": 8,
+        "searchable-filters": 3,
+        "visibility": 1,
+        "system-field": 6
+      },
+      "byRunner": {
+        "node": 26,
+        "junit": 0
+      }
+    }
+  }
+}

--- a/artifacts/absence/generated/web/absence/AbsenceForm.jsx
+++ b/artifacts/absence/generated/web/absence/AbsenceForm.jsx
@@ -1,0 +1,14 @@
+import { EntityForm } from '@/components/contract-ui';
+
+const fields = [
+  { key: 'employee', label: 'Employee', type: 'selector', required: true, reference: 'User', inputMode: 'selector' },
+  { key: 'type', label: 'Type', type: 'selector', required: true, reference: 'AbsenceType', inputMode: 'selector' },
+  { key: 'startDate', label: 'Start Date', type: 'date', required: true },
+  { key: 'endDate', label: 'End Date', type: 'date', required: true },
+  { key: 'status', label: 'Status', type: 'selector', required: true, reference: 'AbsenceStatus', inputMode: 'selector' },
+  { key: 'reason', label: 'Reason', type: 'text' },
+];
+
+export default function AbsenceForm(props) {
+  return <EntityForm fields={fields} {...props} />;
+}

--- a/artifacts/absence/generated/web/absence/AbsenceTable.jsx
+++ b/artifacts/absence/generated/web/absence/AbsenceTable.jsx
@@ -1,0 +1,17 @@
+import { DataTable } from '@/components/contract-ui';
+
+const columns = [
+  { key: 'employee', label: 'Employee', type: 'string' },
+  { key: 'type', label: 'Type', type: 'string' },
+  { key: 'startDate', label: 'Start Date', type: 'date' },
+  { key: 'endDate', label: 'End Date', type: 'date' },
+  { key: 'days', label: 'Days', type: 'number' },
+  { key: 'status', label: 'Status', type: 'status' },
+  { key: 'approvedBy', label: 'Approved By', type: 'string' },
+];
+
+const filters = ['employee', 'type', 'status'];
+
+export default function AbsenceTable(props) {
+  return <DataTable columns={columns} filters={filters} {...props} />;
+}

--- a/artifacts/absence/generated/web/absence/index.jsx
+++ b/artifacts/absence/generated/web/absence/index.jsx
@@ -1,0 +1,20 @@
+import { SingleEntityPage } from '@/components/contract-ui';
+import AbsenceTable from './AbsenceTable';
+import AbsenceForm from './AbsenceForm';
+import catalogs from './mockCatalogs';
+
+const windowMeta = { category: 'hr', name: 'Absence' };
+
+export default function App(props) {
+  return (
+    <SingleEntityPage
+      entity="absence"
+      Table={AbsenceTable}
+      Form={AbsenceForm}
+      catalogs={catalogs}
+      entityLabel="Absence"
+      window={windowMeta}
+      {...props}
+    />
+  );
+}

--- a/artifacts/absence/generated/web/absence/mockCatalogs.js
+++ b/artifacts/absence/generated/web/absence/mockCatalogs.js
@@ -1,0 +1,40 @@
+// Auto-generated mock catalogs for FK reference data - do not edit manually
+
+const catalogs = {};
+
+catalogs['User'] = [
+  {
+    "id": "user-001",
+    "name": "Alice Johnson"
+  },
+  {
+    "id": "user-002",
+    "name": "Bob Smith"
+  },
+  {
+    "id": "user-003",
+    "name": "Carol Williams"
+  },
+  {
+    "id": "user-004",
+    "name": "David Brown"
+  },
+  {
+    "id": "user-005",
+    "name": "Eva Martinez"
+  },
+  {
+    "id": "user-006",
+    "name": "Frank Lee"
+  },
+  {
+    "id": "user-007",
+    "name": "Grace Kim"
+  },
+  {
+    "id": "user-008",
+    "name": "Henry Davis"
+  }
+];
+
+export default catalogs;

--- a/artifacts/document/contract.json
+++ b/artifacts/document/contract.json
@@ -1,0 +1,321 @@
+{
+  "version": "0.1.0",
+  "generatedAt": "2026-03-09T10:00:00.000Z",
+  "checksum": "dm-document-001",
+  "frontendContract": {
+    "window": {
+      "id": "DM-DOCUMENT",
+      "name": "Document",
+      "primaryEntity": "document",
+      "category": "documents"
+    },
+    "entities": {
+      "document": {
+        "fields": [
+          {
+            "name": "name",
+            "column": "Name",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "category",
+            "column": "Category",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "DocumentCategory",
+            "inputMode": "selector"
+          },
+          {
+            "name": "project",
+            "column": "Project_ID",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true,
+            "reference": "Project",
+            "inputMode": "selector"
+          },
+          {
+            "name": "uploadedBy",
+            "column": "UploadedBy_ID",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "readOnly",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "User",
+            "inputMode": "selector"
+          },
+          {
+            "name": "uploadDate",
+            "column": "UploadDate",
+            "type": "date",
+            "tsType": "string",
+            "visibility": "readOnly",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "fileSize",
+            "column": "FileSize",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "readOnly",
+            "required": false,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "version",
+            "column": "Version",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "readOnly",
+            "required": false,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "status",
+            "column": "Status",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "DocumentStatus",
+            "inputMode": "selector"
+          },
+          {
+            "name": "tags",
+            "column": "Tags",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true
+          }
+        ],
+        "searchableFields": [
+          "name",
+          "category",
+          "status"
+        ],
+        "computedFields": []
+      }
+    }
+  },
+  "backendContract": {
+    "window": {
+      "id": "DM-DOCUMENT",
+      "name": "Document",
+      "primaryEntity": "document",
+      "category": "documents"
+    },
+    "entities": {
+      "document": {
+        "fields": [
+          {
+            "name": "name",
+            "column": "Name",
+            "type": "string",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "category",
+            "column": "Category",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "project",
+            "column": "Project_ID",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "uploadedBy",
+            "column": "UploadedBy_ID",
+            "type": "foreignKey",
+            "visibility": "readOnly",
+            "required": true
+          },
+          {
+            "name": "uploadDate",
+            "column": "UploadDate",
+            "type": "date",
+            "visibility": "readOnly",
+            "required": true
+          },
+          {
+            "name": "fileSize",
+            "column": "FileSize",
+            "type": "string",
+            "visibility": "readOnly",
+            "required": false
+          },
+          {
+            "name": "version",
+            "column": "Version",
+            "type": "string",
+            "visibility": "readOnly",
+            "required": false
+          },
+          {
+            "name": "status",
+            "column": "Status",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "tags",
+            "column": "Tags",
+            "type": "string",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "adClientId",
+            "column": "AD_Client_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "adOrgId",
+            "column": "AD_Org_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "createdBy",
+            "column": "CreatedBy",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updatedBy",
+            "column": "UpdatedBy",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "created",
+            "column": "Created",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updated",
+            "column": "Updated",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          }
+        ]
+      }
+    },
+    "endpoints": [
+      {
+        "entity": "document",
+        "method": "GET",
+        "path": "/document",
+        "supportedFilters": ["name", "category", "status"]
+      },
+      {
+        "entity": "document",
+        "method": "GET",
+        "path": "/document/:id",
+        "supportedFilters": []
+      },
+      {
+        "entity": "document",
+        "method": "POST",
+        "path": "/document",
+        "supportedFilters": []
+      },
+      {
+        "entity": "document",
+        "method": "PUT",
+        "path": "/document/:id",
+        "supportedFilters": []
+      },
+      {
+        "entity": "document",
+        "method": "DELETE",
+        "path": "/document/:id",
+        "supportedFilters": []
+      }
+    ],
+    "processEndpoints": []
+  },
+  "testManifest": {
+    "tests": [
+      { "id": "t-1", "category": "field-presence", "entity": "document", "field": "name", "runner": "node", "description": "Field 'name' should be present in document" },
+      { "id": "t-2", "category": "field-presence", "entity": "document", "field": "category", "runner": "node", "description": "Field 'category' should be present in document" },
+      { "id": "t-3", "category": "field-presence", "entity": "document", "field": "project", "runner": "node", "description": "Field 'project' should be present in document" },
+      { "id": "t-4", "category": "field-presence", "entity": "document", "field": "uploadedBy", "runner": "node", "description": "Field 'uploadedBy' should be present in document" },
+      { "id": "t-5", "category": "field-presence", "entity": "document", "field": "uploadDate", "runner": "node", "description": "Field 'uploadDate' should be present in document" },
+      { "id": "t-6", "category": "field-presence", "entity": "document", "field": "fileSize", "runner": "node", "description": "Field 'fileSize' should be present in document" },
+      { "id": "t-7", "category": "field-presence", "entity": "document", "field": "version", "runner": "node", "description": "Field 'version' should be present in document" },
+      { "id": "t-8", "category": "field-presence", "entity": "document", "field": "status", "runner": "node", "description": "Field 'status' should be present in document" },
+      { "id": "t-9", "category": "field-presence", "entity": "document", "field": "tags", "runner": "node", "description": "Field 'tags' should be present in document" },
+      { "id": "t-10", "category": "field-type", "entity": "document", "field": "name", "runner": "node", "description": "Field 'name' should have type 'string' in document" },
+      { "id": "t-11", "category": "field-type", "entity": "document", "field": "category", "runner": "node", "description": "Field 'category' should have type 'foreignKey' in document" },
+      { "id": "t-12", "category": "field-type", "entity": "document", "field": "project", "runner": "node", "description": "Field 'project' should have type 'foreignKey' in document" },
+      { "id": "t-13", "category": "field-type", "entity": "document", "field": "uploadedBy", "runner": "node", "description": "Field 'uploadedBy' should have type 'foreignKey' in document" },
+      { "id": "t-14", "category": "field-type", "entity": "document", "field": "uploadDate", "runner": "node", "description": "Field 'uploadDate' should have type 'date' in document" },
+      { "id": "t-15", "category": "field-type", "entity": "document", "field": "fileSize", "runner": "node", "description": "Field 'fileSize' should have type 'string' in document" },
+      { "id": "t-16", "category": "field-type", "entity": "document", "field": "version", "runner": "node", "description": "Field 'version' should have type 'string' in document" },
+      { "id": "t-17", "category": "field-type", "entity": "document", "field": "status", "runner": "node", "description": "Field 'status' should have type 'foreignKey' in document" },
+      { "id": "t-18", "category": "field-type", "entity": "document", "field": "tags", "runner": "node", "description": "Field 'tags' should have type 'string' in document" },
+      { "id": "t-19", "category": "searchable-filters", "entity": "document", "field": "name", "runner": "node", "description": "Field 'name' should be a supported filter for document" },
+      { "id": "t-20", "category": "searchable-filters", "entity": "document", "field": "category", "runner": "node", "description": "Field 'category' should be a supported filter for document" },
+      { "id": "t-21", "category": "searchable-filters", "entity": "document", "field": "status", "runner": "node", "description": "Field 'status' should be a supported filter for document" },
+      { "id": "t-22", "category": "visibility", "entity": "document", "runner": "node", "description": "Entity 'document' should only expose visible fields in frontend" },
+      { "id": "t-23", "category": "system-field", "entity": "document", "field": "adClientId", "runner": "node", "description": "System field 'adClientId' should exist in backend but not frontend for document" },
+      { "id": "t-24", "category": "system-field", "entity": "document", "field": "adOrgId", "runner": "node", "description": "System field 'adOrgId' should exist in backend but not frontend for document" },
+      { "id": "t-25", "category": "system-field", "entity": "document", "field": "createdBy", "runner": "node", "description": "System field 'createdBy' should exist in backend but not frontend for document" },
+      { "id": "t-26", "category": "system-field", "entity": "document", "field": "updatedBy", "runner": "node", "description": "System field 'updatedBy' should exist in backend but not frontend for document" },
+      { "id": "t-27", "category": "system-field", "entity": "document", "field": "created", "runner": "node", "description": "System field 'created' should exist in backend but not frontend for document" },
+      { "id": "t-28", "category": "system-field", "entity": "document", "field": "updated", "runner": "node", "description": "System field 'updated' should exist in backend but not frontend for document" }
+    ],
+    "summary": {
+      "total": 28,
+      "byCategory": {
+        "field-presence": 9,
+        "field-type": 9,
+        "searchable-filters": 3,
+        "visibility": 1,
+        "system-field": 6
+      },
+      "byRunner": {
+        "node": 28,
+        "junit": 0
+      }
+    }
+  }
+}

--- a/artifacts/document/generated/web/document/DocumentForm.jsx
+++ b/artifacts/document/generated/web/document/DocumentForm.jsx
@@ -1,0 +1,13 @@
+import { EntityForm } from '@/components/contract-ui';
+
+const fields = [
+  { key: 'name', label: 'Name', type: 'text', required: true },
+  { key: 'category', label: 'Category', type: 'selector', required: true, reference: 'DocumentCategory', inputMode: 'selector' },
+  { key: 'project', label: 'Project', type: 'selector', reference: 'Project', inputMode: 'selector' },
+  { key: 'status', label: 'Status', type: 'selector', required: true, reference: 'DocumentStatus', inputMode: 'selector' },
+  { key: 'tags', label: 'Tags', type: 'text' },
+];
+
+export default function DocumentForm(props) {
+  return <EntityForm fields={fields} {...props} />;
+}

--- a/artifacts/document/generated/web/document/DocumentTable.jsx
+++ b/artifacts/document/generated/web/document/DocumentTable.jsx
@@ -1,0 +1,19 @@
+import { DataTable } from '@/components/contract-ui';
+
+const columns = [
+  { key: 'name', label: 'Name', type: 'string' },
+  { key: 'category', label: 'Category', type: 'string' },
+  { key: 'project', label: 'Project', type: 'string' },
+  { key: 'uploadedBy', label: 'Uploaded By', type: 'string' },
+  { key: 'uploadDate', label: 'Upload Date', type: 'date' },
+  { key: 'fileSize', label: 'File Size', type: 'string' },
+  { key: 'version', label: 'Version', type: 'string' },
+  { key: 'status', label: 'Status', type: 'status' },
+  { key: 'tags', label: 'Tags', type: 'string' },
+];
+
+const filters = ['name', 'category', 'status'];
+
+export default function DocumentTable(props) {
+  return <DataTable columns={columns} filters={filters} {...props} />;
+}

--- a/artifacts/document/generated/web/document/index.jsx
+++ b/artifacts/document/generated/web/document/index.jsx
@@ -1,0 +1,20 @@
+import { SingleEntityPage } from '@/components/contract-ui';
+import DocumentTable from './DocumentTable';
+import DocumentForm from './DocumentForm';
+import catalogs from './mockCatalogs';
+
+const windowMeta = { category: 'documents', name: 'Document' };
+
+export default function App(props) {
+  return (
+    <SingleEntityPage
+      entity="document"
+      Table={DocumentTable}
+      Form={DocumentForm}
+      catalogs={catalogs}
+      entityLabel="Document"
+      window={windowMeta}
+      {...props}
+    />
+  );
+}

--- a/artifacts/document/generated/web/document/mockCatalogs.js
+++ b/artifacts/document/generated/web/document/mockCatalogs.js
@@ -1,0 +1,40 @@
+// Auto-generated mock catalogs for FK reference data - do not edit manually
+
+const catalogs = {};
+
+catalogs['User'] = [
+  {
+    "id": "user-001",
+    "name": "Alice Johnson"
+  },
+  {
+    "id": "user-002",
+    "name": "Bob Smith"
+  },
+  {
+    "id": "user-003",
+    "name": "Carol Williams"
+  },
+  {
+    "id": "user-004",
+    "name": "David Brown"
+  },
+  {
+    "id": "user-005",
+    "name": "Eva Martinez"
+  },
+  {
+    "id": "user-006",
+    "name": "Frank Lee"
+  },
+  {
+    "id": "user-007",
+    "name": "Grace Kim"
+  },
+  {
+    "id": "user-008",
+    "name": "Henry Davis"
+  }
+];
+
+export default catalogs;

--- a/artifacts/employee/contract.json
+++ b/artifacts/employee/contract.json
@@ -1,0 +1,319 @@
+{
+  "version": "0.1.0",
+  "generatedAt": "2026-03-09T10:00:00.000Z",
+  "checksum": "hr-employee-001",
+  "frontendContract": {
+    "window": {
+      "id": "HR-EMPLOYEE",
+      "name": "Employee",
+      "primaryEntity": "employee",
+      "category": "hr"
+    },
+    "entities": {
+      "employee": {
+        "fields": [
+          {
+            "name": "name",
+            "column": "Name",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "employeeId",
+            "column": "EmployeeId",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "readOnly",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "department",
+            "column": "Department",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "Department",
+            "inputMode": "selector"
+          },
+          {
+            "name": "position",
+            "column": "Position",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "email",
+            "column": "Email",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "phone",
+            "column": "Phone",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "startDate",
+            "column": "StartDate",
+            "type": "date",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "status",
+            "column": "Status",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "EmployeeStatus",
+            "inputMode": "selector"
+          },
+          {
+            "name": "manager",
+            "column": "Manager_ID",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true,
+            "reference": "User",
+            "inputMode": "selector"
+          }
+        ],
+        "searchableFields": [
+          "name",
+          "department",
+          "status"
+        ],
+        "computedFields": []
+      }
+    }
+  },
+  "backendContract": {
+    "window": {
+      "id": "HR-EMPLOYEE",
+      "name": "Employee",
+      "primaryEntity": "employee",
+      "category": "hr"
+    },
+    "entities": {
+      "employee": {
+        "fields": [
+          {
+            "name": "name",
+            "column": "Name",
+            "type": "string",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "employeeId",
+            "column": "EmployeeId",
+            "type": "string",
+            "visibility": "readOnly",
+            "required": true
+          },
+          {
+            "name": "department",
+            "column": "Department",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "position",
+            "column": "Position",
+            "type": "string",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "email",
+            "column": "Email",
+            "type": "string",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "phone",
+            "column": "Phone",
+            "type": "string",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "startDate",
+            "column": "StartDate",
+            "type": "date",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "status",
+            "column": "Status",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "manager",
+            "column": "Manager_ID",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "adClientId",
+            "column": "AD_Client_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "adOrgId",
+            "column": "AD_Org_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "createdBy",
+            "column": "CreatedBy",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updatedBy",
+            "column": "UpdatedBy",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "created",
+            "column": "Created",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updated",
+            "column": "Updated",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          }
+        ]
+      }
+    },
+    "endpoints": [
+      {
+        "entity": "employee",
+        "method": "GET",
+        "path": "/employee",
+        "supportedFilters": ["name", "department", "status"]
+      },
+      {
+        "entity": "employee",
+        "method": "GET",
+        "path": "/employee/:id",
+        "supportedFilters": []
+      },
+      {
+        "entity": "employee",
+        "method": "POST",
+        "path": "/employee",
+        "supportedFilters": []
+      },
+      {
+        "entity": "employee",
+        "method": "PUT",
+        "path": "/employee/:id",
+        "supportedFilters": []
+      },
+      {
+        "entity": "employee",
+        "method": "DELETE",
+        "path": "/employee/:id",
+        "supportedFilters": []
+      }
+    ],
+    "processEndpoints": []
+  },
+  "testManifest": {
+    "tests": [
+      { "id": "t-1", "category": "field-presence", "entity": "employee", "field": "name", "runner": "node", "description": "Field 'name' should be present in employee" },
+      { "id": "t-2", "category": "field-presence", "entity": "employee", "field": "employeeId", "runner": "node", "description": "Field 'employeeId' should be present in employee" },
+      { "id": "t-3", "category": "field-presence", "entity": "employee", "field": "department", "runner": "node", "description": "Field 'department' should be present in employee" },
+      { "id": "t-4", "category": "field-presence", "entity": "employee", "field": "position", "runner": "node", "description": "Field 'position' should be present in employee" },
+      { "id": "t-5", "category": "field-presence", "entity": "employee", "field": "email", "runner": "node", "description": "Field 'email' should be present in employee" },
+      { "id": "t-6", "category": "field-presence", "entity": "employee", "field": "phone", "runner": "node", "description": "Field 'phone' should be present in employee" },
+      { "id": "t-7", "category": "field-presence", "entity": "employee", "field": "startDate", "runner": "node", "description": "Field 'startDate' should be present in employee" },
+      { "id": "t-8", "category": "field-presence", "entity": "employee", "field": "status", "runner": "node", "description": "Field 'status' should be present in employee" },
+      { "id": "t-9", "category": "field-presence", "entity": "employee", "field": "manager", "runner": "node", "description": "Field 'manager' should be present in employee" },
+      { "id": "t-10", "category": "field-type", "entity": "employee", "field": "name", "runner": "node", "description": "Field 'name' should have type 'string' in employee" },
+      { "id": "t-11", "category": "field-type", "entity": "employee", "field": "employeeId", "runner": "node", "description": "Field 'employeeId' should have type 'string' in employee" },
+      { "id": "t-12", "category": "field-type", "entity": "employee", "field": "department", "runner": "node", "description": "Field 'department' should have type 'foreignKey' in employee" },
+      { "id": "t-13", "category": "field-type", "entity": "employee", "field": "position", "runner": "node", "description": "Field 'position' should have type 'string' in employee" },
+      { "id": "t-14", "category": "field-type", "entity": "employee", "field": "email", "runner": "node", "description": "Field 'email' should have type 'string' in employee" },
+      { "id": "t-15", "category": "field-type", "entity": "employee", "field": "phone", "runner": "node", "description": "Field 'phone' should have type 'string' in employee" },
+      { "id": "t-16", "category": "field-type", "entity": "employee", "field": "startDate", "runner": "node", "description": "Field 'startDate' should have type 'date' in employee" },
+      { "id": "t-17", "category": "field-type", "entity": "employee", "field": "status", "runner": "node", "description": "Field 'status' should have type 'foreignKey' in employee" },
+      { "id": "t-18", "category": "field-type", "entity": "employee", "field": "manager", "runner": "node", "description": "Field 'manager' should have type 'foreignKey' in employee" },
+      { "id": "t-19", "category": "searchable-filters", "entity": "employee", "field": "name", "runner": "node", "description": "Field 'name' should be a supported filter for employee" },
+      { "id": "t-20", "category": "searchable-filters", "entity": "employee", "field": "department", "runner": "node", "description": "Field 'department' should be a supported filter for employee" },
+      { "id": "t-21", "category": "searchable-filters", "entity": "employee", "field": "status", "runner": "node", "description": "Field 'status' should be a supported filter for employee" },
+      { "id": "t-22", "category": "visibility", "entity": "employee", "runner": "node", "description": "Entity 'employee' should only expose visible fields in frontend" },
+      { "id": "t-23", "category": "system-field", "entity": "employee", "field": "adClientId", "runner": "node", "description": "System field 'adClientId' should exist in backend but not frontend for employee" },
+      { "id": "t-24", "category": "system-field", "entity": "employee", "field": "adOrgId", "runner": "node", "description": "System field 'adOrgId' should exist in backend but not frontend for employee" },
+      { "id": "t-25", "category": "system-field", "entity": "employee", "field": "createdBy", "runner": "node", "description": "System field 'createdBy' should exist in backend but not frontend for employee" },
+      { "id": "t-26", "category": "system-field", "entity": "employee", "field": "updatedBy", "runner": "node", "description": "System field 'updatedBy' should exist in backend but not frontend for employee" },
+      { "id": "t-27", "category": "system-field", "entity": "employee", "field": "created", "runner": "node", "description": "System field 'created' should exist in backend but not frontend for employee" },
+      { "id": "t-28", "category": "system-field", "entity": "employee", "field": "updated", "runner": "node", "description": "System field 'updated' should exist in backend but not frontend for employee" }
+    ],
+    "summary": {
+      "total": 28,
+      "byCategory": {
+        "field-presence": 9,
+        "field-type": 9,
+        "searchable-filters": 3,
+        "visibility": 1,
+        "system-field": 6
+      },
+      "byRunner": {
+        "node": 28,
+        "junit": 0
+      }
+    }
+  }
+}

--- a/artifacts/employee/generated/web/employee/EmployeeForm.jsx
+++ b/artifacts/employee/generated/web/employee/EmployeeForm.jsx
@@ -1,0 +1,16 @@
+import { EntityForm } from '@/components/contract-ui';
+
+const fields = [
+  { key: 'name', label: 'Name', type: 'text', required: true },
+  { key: 'department', label: 'Department', type: 'selector', required: true, reference: 'Department', inputMode: 'selector' },
+  { key: 'position', label: 'Position', type: 'text', required: true },
+  { key: 'email', label: 'Email', type: 'text', required: true },
+  { key: 'phone', label: 'Phone', type: 'text' },
+  { key: 'startDate', label: 'Start Date', type: 'date', required: true },
+  { key: 'status', label: 'Status', type: 'selector', required: true, reference: 'EmployeeStatus', inputMode: 'selector' },
+  { key: 'manager', label: 'Manager', type: 'selector', reference: 'User', inputMode: 'selector' },
+];
+
+export default function EmployeeForm(props) {
+  return <EntityForm fields={fields} {...props} />;
+}

--- a/artifacts/employee/generated/web/employee/EmployeeTable.jsx
+++ b/artifacts/employee/generated/web/employee/EmployeeTable.jsx
@@ -1,0 +1,19 @@
+import { DataTable } from '@/components/contract-ui';
+
+const columns = [
+  { key: 'name', label: 'Name', type: 'string' },
+  { key: 'employeeId', label: 'Employee Id', type: 'string' },
+  { key: 'department', label: 'Department', type: 'string' },
+  { key: 'position', label: 'Position', type: 'string' },
+  { key: 'email', label: 'Email', type: 'string' },
+  { key: 'phone', label: 'Phone', type: 'string' },
+  { key: 'startDate', label: 'Start Date', type: 'date' },
+  { key: 'status', label: 'Status', type: 'status' },
+  { key: 'manager', label: 'Manager', type: 'string' },
+];
+
+const filters = ['name', 'department', 'status'];
+
+export default function EmployeeTable(props) {
+  return <DataTable columns={columns} filters={filters} {...props} />;
+}

--- a/artifacts/employee/generated/web/employee/index.jsx
+++ b/artifacts/employee/generated/web/employee/index.jsx
@@ -1,0 +1,20 @@
+import { SingleEntityPage } from '@/components/contract-ui';
+import EmployeeTable from './EmployeeTable';
+import EmployeeForm from './EmployeeForm';
+import catalogs from './mockCatalogs';
+
+const windowMeta = { category: 'hr', name: 'Employee' };
+
+export default function App(props) {
+  return (
+    <SingleEntityPage
+      entity="employee"
+      Table={EmployeeTable}
+      Form={EmployeeForm}
+      catalogs={catalogs}
+      entityLabel="Employee"
+      window={windowMeta}
+      {...props}
+    />
+  );
+}

--- a/artifacts/employee/generated/web/employee/mockCatalogs.js
+++ b/artifacts/employee/generated/web/employee/mockCatalogs.js
@@ -1,0 +1,40 @@
+// Auto-generated mock catalogs for FK reference data - do not edit manually
+
+const catalogs = {};
+
+catalogs['User'] = [
+  {
+    "id": "user-001",
+    "name": "Alice Johnson"
+  },
+  {
+    "id": "user-002",
+    "name": "Bob Smith"
+  },
+  {
+    "id": "user-003",
+    "name": "Carol Williams"
+  },
+  {
+    "id": "user-004",
+    "name": "David Brown"
+  },
+  {
+    "id": "user-005",
+    "name": "Eva Martinez"
+  },
+  {
+    "id": "user-006",
+    "name": "Frank Lee"
+  },
+  {
+    "id": "user-007",
+    "name": "Grace Kim"
+  },
+  {
+    "id": "user-008",
+    "name": "Henry Davis"
+  }
+];
+
+export default catalogs;

--- a/artifacts/hr/aggregate-contract.json
+++ b/artifacts/hr/aggregate-contract.json
@@ -1,0 +1,112 @@
+{
+  "version": "0.1.0",
+  "type": "aggregate",
+  "meta": {
+    "module": "hr",
+    "label": "HR",
+    "icon": "Users",
+    "route": "/hr"
+  },
+  "sections": [
+    {
+      "id": "kpis",
+      "type": "kpi",
+      "kpis": [
+        { "key": "totalEmployees", "label": "Total Employees", "format": "number", "icon": "Users", "trend": "up" },
+        { "key": "activeAbsences", "label": "On Leave Today", "format": "number", "icon": "Calendar", "trend": "neutral" },
+        { "key": "openPositions", "label": "Open Positions", "format": "number", "icon": "UserPlus", "trend": "up" },
+        { "key": "avgTenure", "label": "Avg. Tenure", "format": "number", "icon": "Clock", "trend": "up" }
+      ]
+    },
+    {
+      "id": "employeeDirectory",
+      "type": "data-table",
+      "title": "Employee Directory",
+      "icon": "Users",
+      "columns": [
+        { "key": "name", "label": "Name", "align": "left" },
+        { "key": "department", "label": "Department", "align": "left" },
+        { "key": "position", "label": "Position", "align": "left" },
+        { "key": "email", "label": "Email", "align": "left" },
+        { "key": "status", "label": "Status", "align": "left" }
+      ],
+      "filters": ["department", "status"]
+    },
+    {
+      "id": "absenceCalendar",
+      "type": "kanban",
+      "title": "Current Absences",
+      "icon": "Calendar",
+      "columns": [
+        { "id": "pending", "title": "Pending", "color": "yellow" },
+        { "id": "approved", "title": "Approved", "color": "green" },
+        { "id": "on-leave", "title": "On Leave", "color": "blue" },
+        { "id": "returned", "title": "Returned", "color": "gray" }
+      ]
+    },
+    {
+      "id": "hrUpdates",
+      "type": "activity-feed",
+      "title": "HR Updates",
+      "icon": "Bell",
+      "fields": {
+        "direction": "direction",
+        "label": "label",
+        "detail": "detail",
+        "time": "time"
+      }
+    }
+  ],
+  "layout": {
+    "type": "grid",
+    "areas": [
+      { "section": "kpis", "span": "full" },
+      { "section": "employeeDirectory", "span": "2/3" },
+      { "section": "absenceCalendar", "span": "1/3" },
+      { "section": "hrUpdates", "span": "full" }
+    ]
+  },
+  "actions": [
+    { "label": "Add Employee", "route": "/employee", "variant": "default" },
+    { "label": "Request Absence", "route": "/absence", "variant": "outline" }
+  ],
+  "mockData": {
+    "kpis": {
+      "totalEmployees": 156,
+      "activeAbsences": 8,
+      "openPositions": 12,
+      "avgTenure": 3.4,
+      "trends": {
+        "totalEmployees": 5,
+        "activeAbsences": 0,
+        "openPositions": 3,
+        "avgTenure": 0.2
+      }
+    },
+    "employeeDirectory": [
+      { "name": "Maria Garcia", "department": "Engineering", "position": "Senior Developer", "email": "m.garcia@company.com", "status": "Active" },
+      { "name": "Carlos Lopez", "department": "Sales", "position": "Account Executive", "email": "c.lopez@company.com", "status": "Active" },
+      { "name": "Ana Martinez", "department": "Marketing", "position": "Content Manager", "email": "a.martinez@company.com", "status": "On Leave" },
+      { "name": "Pedro Sanchez", "department": "Engineering", "position": "Tech Lead", "email": "p.sanchez@company.com", "status": "Active" },
+      { "name": "Laura Torres", "department": "HR", "position": "HR Specialist", "email": "l.torres@company.com", "status": "Active" },
+      { "name": "Diego Rivera", "department": "Finance", "position": "Financial Analyst", "email": "d.rivera@company.com", "status": "Active" },
+      { "name": "Sofia Herrera", "department": "Engineering", "position": "QA Engineer", "email": "s.herrera@company.com", "status": "On Leave" },
+      { "name": "Juan Morales", "department": "Operations", "position": "Operations Manager", "email": "j.morales@company.com", "status": "Active" }
+    ],
+    "absenceCalendar": [
+      { "id": "AB-001", "columnId": "pending", "title": "Vacation Request", "subtitle": "Juan Morales", "badges": ["5 days"] },
+      { "id": "AB-002", "columnId": "approved", "title": "Medical Leave", "subtitle": "Sofia Herrera", "badges": ["3 days"] },
+      { "id": "AB-003", "columnId": "on-leave", "title": "Parental Leave", "subtitle": "Ana Martinez", "badges": ["30 days"] },
+      { "id": "AB-004", "columnId": "pending", "title": "Personal Day", "subtitle": "Diego Rivera", "badges": ["1 day"] },
+      { "id": "AB-005", "columnId": "approved", "title": "Conference", "subtitle": "Pedro Sanchez", "badges": ["2 days"] },
+      { "id": "AB-006", "columnId": "returned", "title": "Sick Leave", "subtitle": "Carlos Lopez", "badges": ["2 days"] }
+    ],
+    "hrUpdates": [
+      { "id": 1, "direction": "in", "label": "New hire: Elena Ruiz joined Engineering", "detail": "Frontend Developer — starts Monday", "time": "2 hours ago" },
+      { "id": 2, "direction": "out", "label": "Absence approved for Sofia Herrera", "detail": "Medical leave — 3 days", "time": "3 hours ago" },
+      { "id": 3, "label": "Performance review cycle opened", "detail": "Q1 2026 reviews due by March 31", "time": "5 hours ago" },
+      { "id": 4, "direction": "in", "label": "Job posting published: Product Manager", "detail": "3 applications received", "time": "1 day ago" },
+      { "id": 5, "label": "Training completed: Data Privacy Workshop", "detail": "24 employees certified", "time": "2 days ago" }
+    ]
+  }
+}

--- a/artifacts/hr/generated/config.js
+++ b/artifacts/hr/generated/config.js
@@ -1,0 +1,152 @@
+// Auto-generated from aggregate-contract.json — DO NOT EDIT
+
+export const meta = {
+  "module": "hr",
+  "label": "HR",
+  "icon": "Users",
+  "route": "/hr"
+};
+
+export const kpisConfig = [];
+
+export const sections = {
+  "kpis": {
+    "type": "kpi",
+    "kpis": [
+      {
+        "key": "totalEmployees",
+        "label": "Total Employees",
+        "format": "number",
+        "icon": "Users",
+        "trend": "up"
+      },
+      {
+        "key": "activeAbsences",
+        "label": "On Leave Today",
+        "format": "number",
+        "icon": "Calendar",
+        "trend": "neutral"
+      },
+      {
+        "key": "openPositions",
+        "label": "Open Positions",
+        "format": "number",
+        "icon": "UserPlus",
+        "trend": "up"
+      },
+      {
+        "key": "avgTenure",
+        "label": "Avg. Tenure",
+        "format": "number",
+        "icon": "Clock",
+        "trend": "up"
+      }
+    ]
+  },
+  "employeeDirectory": {
+    "type": "data-table",
+    "title": "Employee Directory",
+    "icon": "Users",
+    "columns": [
+      {
+        "key": "name",
+        "label": "Name",
+        "align": "left"
+      },
+      {
+        "key": "department",
+        "label": "Department",
+        "align": "left"
+      },
+      {
+        "key": "position",
+        "label": "Position",
+        "align": "left"
+      },
+      {
+        "key": "email",
+        "label": "Email",
+        "align": "left"
+      },
+      {
+        "key": "status",
+        "label": "Status",
+        "align": "left"
+      }
+    ],
+    "filters": [
+      "department",
+      "status"
+    ]
+  },
+  "absenceCalendar": {
+    "type": "kanban",
+    "title": "Current Absences",
+    "icon": "Calendar",
+    "columns": [
+      {
+        "id": "pending",
+        "title": "Pending",
+        "color": "yellow"
+      },
+      {
+        "id": "approved",
+        "title": "Approved",
+        "color": "green"
+      },
+      {
+        "id": "on-leave",
+        "title": "On Leave",
+        "color": "blue"
+      },
+      {
+        "id": "returned",
+        "title": "Returned",
+        "color": "gray"
+      }
+    ]
+  },
+  "hrUpdates": {
+    "type": "activity-feed",
+    "title": "HR Updates",
+    "icon": "Bell",
+    "fields": {
+      "direction": "direction",
+      "label": "label",
+      "detail": "detail",
+      "time": "time"
+    }
+  }
+};
+
+export const layout = [
+  {
+    "section": "kpis",
+    "span": "full"
+  },
+  {
+    "section": "employeeDirectory",
+    "span": "2/3"
+  },
+  {
+    "section": "absenceCalendar",
+    "span": "1/3"
+  },
+  {
+    "section": "hrUpdates",
+    "span": "full"
+  }
+];
+
+export const actions = [
+  {
+    "label": "Add Employee",
+    "route": "/employee",
+    "variant": "default"
+  },
+  {
+    "label": "Request Absence",
+    "route": "/absence",
+    "variant": "outline"
+  }
+];

--- a/artifacts/hr/generated/mockData.js
+++ b/artifacts/hr/generated/mockData.js
@@ -1,0 +1,166 @@
+// Auto-generated from aggregate-contract.json — DO NOT EDIT
+
+export const kpis = {
+  "totalEmployees": 156,
+  "activeAbsences": 8,
+  "openPositions": 12,
+  "avgTenure": 3.4,
+  "trends": {
+    "totalEmployees": 5,
+    "activeAbsences": 0,
+    "openPositions": 3,
+    "avgTenure": 0.2
+  }
+};
+
+export const employeeDirectory = [
+  {
+    "name": "Maria Garcia",
+    "department": "Engineering",
+    "position": "Senior Developer",
+    "email": "m.garcia@company.com",
+    "status": "Active"
+  },
+  {
+    "name": "Carlos Lopez",
+    "department": "Sales",
+    "position": "Account Executive",
+    "email": "c.lopez@company.com",
+    "status": "Active"
+  },
+  {
+    "name": "Ana Martinez",
+    "department": "Marketing",
+    "position": "Content Manager",
+    "email": "a.martinez@company.com",
+    "status": "On Leave"
+  },
+  {
+    "name": "Pedro Sanchez",
+    "department": "Engineering",
+    "position": "Tech Lead",
+    "email": "p.sanchez@company.com",
+    "status": "Active"
+  },
+  {
+    "name": "Laura Torres",
+    "department": "HR",
+    "position": "HR Specialist",
+    "email": "l.torres@company.com",
+    "status": "Active"
+  },
+  {
+    "name": "Diego Rivera",
+    "department": "Finance",
+    "position": "Financial Analyst",
+    "email": "d.rivera@company.com",
+    "status": "Active"
+  },
+  {
+    "name": "Sofia Herrera",
+    "department": "Engineering",
+    "position": "QA Engineer",
+    "email": "s.herrera@company.com",
+    "status": "On Leave"
+  },
+  {
+    "name": "Juan Morales",
+    "department": "Operations",
+    "position": "Operations Manager",
+    "email": "j.morales@company.com",
+    "status": "Active"
+  }
+];
+
+export const absenceCalendar = [
+  {
+    "id": "AB-001",
+    "columnId": "pending",
+    "title": "Vacation Request",
+    "subtitle": "Juan Morales",
+    "badges": [
+      "5 days"
+    ]
+  },
+  {
+    "id": "AB-002",
+    "columnId": "approved",
+    "title": "Medical Leave",
+    "subtitle": "Sofia Herrera",
+    "badges": [
+      "3 days"
+    ]
+  },
+  {
+    "id": "AB-003",
+    "columnId": "on-leave",
+    "title": "Parental Leave",
+    "subtitle": "Ana Martinez",
+    "badges": [
+      "30 days"
+    ]
+  },
+  {
+    "id": "AB-004",
+    "columnId": "pending",
+    "title": "Personal Day",
+    "subtitle": "Diego Rivera",
+    "badges": [
+      "1 day"
+    ]
+  },
+  {
+    "id": "AB-005",
+    "columnId": "approved",
+    "title": "Conference",
+    "subtitle": "Pedro Sanchez",
+    "badges": [
+      "2 days"
+    ]
+  },
+  {
+    "id": "AB-006",
+    "columnId": "returned",
+    "title": "Sick Leave",
+    "subtitle": "Carlos Lopez",
+    "badges": [
+      "2 days"
+    ]
+  }
+];
+
+export const hrUpdates = [
+  {
+    "id": 1,
+    "direction": "in",
+    "label": "New hire: Elena Ruiz joined Engineering",
+    "detail": "Frontend Developer — starts Monday",
+    "time": "2 hours ago"
+  },
+  {
+    "id": 2,
+    "direction": "out",
+    "label": "Absence approved for Sofia Herrera",
+    "detail": "Medical leave — 3 days",
+    "time": "3 hours ago"
+  },
+  {
+    "id": 3,
+    "label": "Performance review cycle opened",
+    "detail": "Q1 2026 reviews due by March 31",
+    "time": "5 hours ago"
+  },
+  {
+    "id": 4,
+    "direction": "in",
+    "label": "Job posting published: Product Manager",
+    "detail": "3 applications received",
+    "time": "1 day ago"
+  },
+  {
+    "id": 5,
+    "label": "Training completed: Data Privacy Workshop",
+    "detail": "24 employees certified",
+    "time": "2 days ago"
+  }
+];

--- a/artifacts/project/contract.json
+++ b/artifacts/project/contract.json
@@ -1,0 +1,321 @@
+{
+  "version": "0.1.0",
+  "generatedAt": "2026-03-09T10:00:00.000Z",
+  "checksum": "pm-project-001",
+  "frontendContract": {
+    "window": {
+      "id": "PM-PROJECT",
+      "name": "Project",
+      "primaryEntity": "project",
+      "category": "projects"
+    },
+    "entities": {
+      "project": {
+        "fields": [
+          {
+            "name": "name",
+            "column": "Name",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "code",
+            "column": "Code",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "client",
+            "column": "C_BPartner_ID",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true,
+            "reference": "BusinessPartner",
+            "inputMode": "search"
+          },
+          {
+            "name": "manager",
+            "column": "Manager_ID",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "User",
+            "inputMode": "selector"
+          },
+          {
+            "name": "status",
+            "column": "Status",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "ProjectStatus",
+            "inputMode": "selector"
+          },
+          {
+            "name": "startDate",
+            "column": "StartDate",
+            "type": "date",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "endDate",
+            "column": "EndDate",
+            "type": "date",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "budget",
+            "column": "Budget",
+            "type": "amount",
+            "tsType": "number",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "priority",
+            "column": "Priority",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "Priority",
+            "inputMode": "selector"
+          }
+        ],
+        "searchableFields": [
+          "name",
+          "client",
+          "status"
+        ],
+        "computedFields": []
+      }
+    }
+  },
+  "backendContract": {
+    "window": {
+      "id": "PM-PROJECT",
+      "name": "Project",
+      "primaryEntity": "project",
+      "category": "projects"
+    },
+    "entities": {
+      "project": {
+        "fields": [
+          {
+            "name": "name",
+            "column": "Name",
+            "type": "string",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "code",
+            "column": "Code",
+            "type": "string",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "client",
+            "column": "C_BPartner_ID",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "manager",
+            "column": "Manager_ID",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "status",
+            "column": "Status",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "startDate",
+            "column": "StartDate",
+            "type": "date",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "endDate",
+            "column": "EndDate",
+            "type": "date",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "budget",
+            "column": "Budget",
+            "type": "amount",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "priority",
+            "column": "Priority",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "adClientId",
+            "column": "AD_Client_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "adOrgId",
+            "column": "AD_Org_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "createdBy",
+            "column": "CreatedBy",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updatedBy",
+            "column": "UpdatedBy",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "created",
+            "column": "Created",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updated",
+            "column": "Updated",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          }
+        ]
+      }
+    },
+    "endpoints": [
+      {
+        "entity": "project",
+        "method": "GET",
+        "path": "/project",
+        "supportedFilters": ["name", "client", "status"]
+      },
+      {
+        "entity": "project",
+        "method": "GET",
+        "path": "/project/:id",
+        "supportedFilters": []
+      },
+      {
+        "entity": "project",
+        "method": "POST",
+        "path": "/project",
+        "supportedFilters": []
+      },
+      {
+        "entity": "project",
+        "method": "PUT",
+        "path": "/project/:id",
+        "supportedFilters": []
+      },
+      {
+        "entity": "project",
+        "method": "DELETE",
+        "path": "/project/:id",
+        "supportedFilters": []
+      }
+    ],
+    "processEndpoints": []
+  },
+  "testManifest": {
+    "tests": [
+      { "id": "t-1", "category": "field-presence", "entity": "project", "field": "name", "runner": "node", "description": "Field 'name' should be present in project" },
+      { "id": "t-2", "category": "field-presence", "entity": "project", "field": "code", "runner": "node", "description": "Field 'code' should be present in project" },
+      { "id": "t-3", "category": "field-presence", "entity": "project", "field": "client", "runner": "node", "description": "Field 'client' should be present in project" },
+      { "id": "t-4", "category": "field-presence", "entity": "project", "field": "manager", "runner": "node", "description": "Field 'manager' should be present in project" },
+      { "id": "t-5", "category": "field-presence", "entity": "project", "field": "status", "runner": "node", "description": "Field 'status' should be present in project" },
+      { "id": "t-6", "category": "field-presence", "entity": "project", "field": "startDate", "runner": "node", "description": "Field 'startDate' should be present in project" },
+      { "id": "t-7", "category": "field-presence", "entity": "project", "field": "endDate", "runner": "node", "description": "Field 'endDate' should be present in project" },
+      { "id": "t-8", "category": "field-presence", "entity": "project", "field": "budget", "runner": "node", "description": "Field 'budget' should be present in project" },
+      { "id": "t-9", "category": "field-presence", "entity": "project", "field": "priority", "runner": "node", "description": "Field 'priority' should be present in project" },
+      { "id": "t-10", "category": "field-type", "entity": "project", "field": "name", "runner": "node", "description": "Field 'name' should have type 'string' in project" },
+      { "id": "t-11", "category": "field-type", "entity": "project", "field": "code", "runner": "node", "description": "Field 'code' should have type 'string' in project" },
+      { "id": "t-12", "category": "field-type", "entity": "project", "field": "client", "runner": "node", "description": "Field 'client' should have type 'foreignKey' in project" },
+      { "id": "t-13", "category": "field-type", "entity": "project", "field": "manager", "runner": "node", "description": "Field 'manager' should have type 'foreignKey' in project" },
+      { "id": "t-14", "category": "field-type", "entity": "project", "field": "status", "runner": "node", "description": "Field 'status' should have type 'foreignKey' in project" },
+      { "id": "t-15", "category": "field-type", "entity": "project", "field": "startDate", "runner": "node", "description": "Field 'startDate' should have type 'date' in project" },
+      { "id": "t-16", "category": "field-type", "entity": "project", "field": "endDate", "runner": "node", "description": "Field 'endDate' should have type 'date' in project" },
+      { "id": "t-17", "category": "field-type", "entity": "project", "field": "budget", "runner": "node", "description": "Field 'budget' should have type 'amount' in project" },
+      { "id": "t-18", "category": "field-type", "entity": "project", "field": "priority", "runner": "node", "description": "Field 'priority' should have type 'foreignKey' in project" },
+      { "id": "t-19", "category": "searchable-filters", "entity": "project", "field": "name", "runner": "node", "description": "Field 'name' should be a supported filter for project" },
+      { "id": "t-20", "category": "searchable-filters", "entity": "project", "field": "client", "runner": "node", "description": "Field 'client' should be a supported filter for project" },
+      { "id": "t-21", "category": "searchable-filters", "entity": "project", "field": "status", "runner": "node", "description": "Field 'status' should be a supported filter for project" },
+      { "id": "t-22", "category": "visibility", "entity": "project", "runner": "node", "description": "Entity 'project' should only expose visible fields in frontend" },
+      { "id": "t-23", "category": "system-field", "entity": "project", "field": "adClientId", "runner": "node", "description": "System field 'adClientId' should exist in backend but not frontend for project" },
+      { "id": "t-24", "category": "system-field", "entity": "project", "field": "adOrgId", "runner": "node", "description": "System field 'adOrgId' should exist in backend but not frontend for project" },
+      { "id": "t-25", "category": "system-field", "entity": "project", "field": "createdBy", "runner": "node", "description": "System field 'createdBy' should exist in backend but not frontend for project" },
+      { "id": "t-26", "category": "system-field", "entity": "project", "field": "updatedBy", "runner": "node", "description": "System field 'updatedBy' should exist in backend but not frontend for project" },
+      { "id": "t-27", "category": "system-field", "entity": "project", "field": "created", "runner": "node", "description": "System field 'created' should exist in backend but not frontend for project" },
+      { "id": "t-28", "category": "system-field", "entity": "project", "field": "updated", "runner": "node", "description": "System field 'updated' should exist in backend but not frontend for project" }
+    ],
+    "summary": {
+      "total": 28,
+      "byCategory": {
+        "field-presence": 9,
+        "field-type": 9,
+        "searchable-filters": 3,
+        "visibility": 1,
+        "system-field": 6
+      },
+      "byRunner": {
+        "node": 28,
+        "junit": 0
+      }
+    }
+  }
+}

--- a/artifacts/project/generated/web/project/ProjectForm.jsx
+++ b/artifacts/project/generated/web/project/ProjectForm.jsx
@@ -1,0 +1,17 @@
+import { EntityForm } from '@/components/contract-ui';
+
+const fields = [
+  { key: 'name', label: 'Name', type: 'text', required: true },
+  { key: 'code', label: 'Code', type: 'text', required: true },
+  { key: 'client', label: 'Client', type: 'search', reference: 'BusinessPartner', inputMode: 'search' },
+  { key: 'manager', label: 'Manager', type: 'selector', required: true, reference: 'User', inputMode: 'selector' },
+  { key: 'status', label: 'Status', type: 'selector', required: true, reference: 'ProjectStatus', inputMode: 'selector' },
+  { key: 'startDate', label: 'Start Date', type: 'date', required: true },
+  { key: 'endDate', label: 'End Date', type: 'date' },
+  { key: 'budget', label: 'Budget', type: 'number' },
+  { key: 'priority', label: 'Priority', type: 'selector', required: true, reference: 'Priority', inputMode: 'selector' },
+];
+
+export default function ProjectForm(props) {
+  return <EntityForm fields={fields} {...props} />;
+}

--- a/artifacts/project/generated/web/project/ProjectTable.jsx
+++ b/artifacts/project/generated/web/project/ProjectTable.jsx
@@ -1,0 +1,19 @@
+import { DataTable } from '@/components/contract-ui';
+
+const columns = [
+  { key: 'name', label: 'Name', type: 'string' },
+  { key: 'code', label: 'Code', type: 'string' },
+  { key: 'client', label: 'Client', type: 'string' },
+  { key: 'manager', label: 'Manager', type: 'string' },
+  { key: 'status', label: 'Status', type: 'status' },
+  { key: 'startDate', label: 'Start Date', type: 'date' },
+  { key: 'endDate', label: 'End Date', type: 'date' },
+  { key: 'budget', label: 'Budget', type: 'amount' },
+  { key: 'priority', label: 'Priority', type: 'string' },
+];
+
+const filters = ['name', 'client', 'status'];
+
+export default function ProjectTable(props) {
+  return <DataTable columns={columns} filters={filters} {...props} />;
+}

--- a/artifacts/project/generated/web/project/index.jsx
+++ b/artifacts/project/generated/web/project/index.jsx
@@ -1,0 +1,20 @@
+import { SingleEntityPage } from '@/components/contract-ui';
+import ProjectTable from './ProjectTable';
+import ProjectForm from './ProjectForm';
+import catalogs from './mockCatalogs';
+
+const windowMeta = { category: 'projects', name: 'Project' };
+
+export default function App(props) {
+  return (
+    <SingleEntityPage
+      entity="project"
+      Table={ProjectTable}
+      Form={ProjectForm}
+      catalogs={catalogs}
+      entityLabel="Project"
+      window={windowMeta}
+      {...props}
+    />
+  );
+}

--- a/artifacts/project/generated/web/project/mockCatalogs.js
+++ b/artifacts/project/generated/web/project/mockCatalogs.js
@@ -1,0 +1,103 @@
+// Auto-generated mock catalogs for FK reference data - do not edit manually
+
+const catalogs = {};
+
+catalogs['BusinessPartner'] = [
+  {
+    "id": "bp-001",
+    "name": "Acme Corp"
+  },
+  {
+    "id": "bp-002",
+    "name": "TechFlow Inc"
+  },
+  {
+    "id": "bp-003",
+    "name": "Global Trade Ltd"
+  },
+  {
+    "id": "bp-004",
+    "name": "Summit Industries"
+  },
+  {
+    "id": "bp-005",
+    "name": "Pacific Partners"
+  },
+  {
+    "id": "bp-006",
+    "name": "Alpine Solutions"
+  },
+  {
+    "id": "bp-007",
+    "name": "Meridian Group"
+  },
+  {
+    "id": "bp-008",
+    "name": "Vertex Systems"
+  },
+  {
+    "id": "bp-009",
+    "name": "Atlas Manufacturing"
+  },
+  {
+    "id": "bp-010",
+    "name": "Nova Enterprises"
+  },
+  {
+    "id": "bp-011",
+    "name": "Pinnacle Services"
+  },
+  {
+    "id": "bp-012",
+    "name": "Horizon Labs"
+  },
+  {
+    "id": "bp-013",
+    "name": "Cedar Holdings"
+  },
+  {
+    "id": "bp-014",
+    "name": "Sterling & Co"
+  },
+  {
+    "id": "bp-015",
+    "name": "Quantum Logistics"
+  }
+];
+
+catalogs['User'] = [
+  {
+    "id": "user-001",
+    "name": "Alice Johnson"
+  },
+  {
+    "id": "user-002",
+    "name": "Bob Smith"
+  },
+  {
+    "id": "user-003",
+    "name": "Carol Williams"
+  },
+  {
+    "id": "user-004",
+    "name": "David Brown"
+  },
+  {
+    "id": "user-005",
+    "name": "Eva Martinez"
+  },
+  {
+    "id": "user-006",
+    "name": "Frank Lee"
+  },
+  {
+    "id": "user-007",
+    "name": "Grace Kim"
+  },
+  {
+    "id": "user-008",
+    "name": "Henry Davis"
+  }
+];
+
+export default catalogs;

--- a/artifacts/projects/aggregate-contract.json
+++ b/artifacts/projects/aggregate-contract.json
@@ -1,0 +1,120 @@
+{
+  "version": "0.1.0",
+  "type": "aggregate",
+  "meta": {
+    "module": "projects",
+    "label": "Projects",
+    "icon": "FolderKanban",
+    "route": "/projects"
+  },
+  "sections": [
+    {
+      "id": "kpis",
+      "type": "kpi",
+      "kpis": [
+        { "key": "activeProjects", "label": "Active Projects", "format": "number", "icon": "FolderKanban", "trend": "up" },
+        { "key": "totalHoursMonth", "label": "Hours This Month", "format": "number", "icon": "Clock", "trend": "up" },
+        { "key": "budgetUtilization", "label": "Budget Used", "format": "percent", "icon": "PieChart", "trend": "neutral" },
+        { "key": "documentsCount", "label": "Documents", "format": "number", "icon": "FileText", "trend": "up" }
+      ]
+    },
+    {
+      "id": "projectBoard",
+      "type": "kanban",
+      "title": "Project Board",
+      "icon": "FolderKanban",
+      "columns": [
+        { "id": "planning", "title": "Planning", "color": "gray" },
+        { "id": "in-progress", "title": "In Progress", "color": "blue" },
+        { "id": "on-hold", "title": "On Hold", "color": "yellow" },
+        { "id": "completed", "title": "Completed", "color": "green" }
+      ]
+    },
+    {
+      "id": "recentTimeEntries",
+      "type": "data-table",
+      "title": "Recent Time Entries",
+      "icon": "Clock",
+      "columns": [
+        { "key": "employee", "label": "Employee", "align": "left" },
+        { "key": "project", "label": "Project", "align": "left" },
+        { "key": "date", "label": "Date", "align": "left" },
+        { "key": "hours", "label": "Hours", "align": "right" },
+        { "key": "category", "label": "Category", "align": "left" },
+        { "key": "status", "label": "Status", "align": "left" }
+      ],
+      "filters": ["project", "category"]
+    },
+    {
+      "id": "recentDocuments",
+      "type": "data-table",
+      "title": "Recent Documents",
+      "icon": "FileText",
+      "columns": [
+        { "key": "name", "label": "Name", "align": "left" },
+        { "key": "category", "label": "Category", "align": "left" },
+        { "key": "project", "label": "Project", "align": "left" },
+        { "key": "uploadedBy", "label": "Uploaded By", "align": "left" },
+        { "key": "uploadDate", "label": "Upload Date", "align": "left" },
+        { "key": "status", "label": "Status", "align": "left" }
+      ],
+      "filters": ["category", "status"]
+    }
+  ],
+  "layout": {
+    "type": "grid",
+    "areas": [
+      { "section": "kpis", "span": "full" },
+      { "section": "projectBoard", "span": "full" },
+      { "section": "recentTimeEntries", "span": "1/2" },
+      { "section": "recentDocuments", "span": "1/2" }
+    ]
+  },
+  "actions": [
+    { "label": "New Project", "route": "/project", "variant": "default" },
+    { "label": "Log Time", "route": "/time-tracking", "variant": "outline" },
+    { "label": "Upload Document", "route": "/document", "variant": "outline" }
+  ],
+  "mockData": {
+    "kpis": {
+      "activeProjects": 14,
+      "totalHoursMonth": 1248,
+      "budgetUtilization": 73,
+      "documentsCount": 89,
+      "trends": {
+        "activeProjects": 2,
+        "totalHoursMonth": 180,
+        "budgetUtilization": 0,
+        "documentsCount": 12
+      }
+    },
+    "projectBoard": [
+      { "id": "PJ-001", "columnId": "planning", "title": "Mobile App Redesign", "subtitle": "Q2 Initiative", "badges": ["High Priority"] },
+      { "id": "PJ-002", "columnId": "planning", "title": "API Gateway Migration", "subtitle": "Infrastructure", "badges": ["Technical"] },
+      { "id": "PJ-003", "columnId": "in-progress", "title": "ERP Integration", "subtitle": "Phase 2", "badges": ["Enterprise", "On Track"] },
+      { "id": "PJ-004", "columnId": "in-progress", "title": "Customer Portal", "subtitle": "Client-facing", "badges": ["Priority"] },
+      { "id": "PJ-005", "columnId": "on-hold", "title": "Data Warehouse", "subtitle": "Analytics", "badges": ["Blocked"] },
+      { "id": "PJ-006", "columnId": "in-progress", "title": "Security Audit", "subtitle": "Compliance", "badges": ["Urgent"] },
+      { "id": "PJ-007", "columnId": "completed", "title": "Website Refresh", "subtitle": "Marketing", "badges": ["Delivered"] },
+      { "id": "PJ-008", "columnId": "completed", "title": "CI/CD Pipeline", "subtitle": "DevOps", "badges": ["Delivered"] }
+    ],
+    "recentTimeEntries": [
+      { "employee": "Maria Garcia", "project": "ERP Integration", "date": "2026-03-09", "hours": 7.5, "category": "Development", "status": "Approved" },
+      { "employee": "Pedro Sanchez", "project": "Customer Portal", "date": "2026-03-09", "hours": 6.0, "category": "Code Review", "status": "Pending" },
+      { "employee": "Sofia Herrera", "project": "Security Audit", "date": "2026-03-08", "hours": 8.0, "category": "Testing", "status": "Approved" },
+      { "employee": "Carlos Lopez", "project": "Mobile App Redesign", "date": "2026-03-08", "hours": 4.5, "category": "Design", "status": "Approved" },
+      { "employee": "Ana Martinez", "project": "ERP Integration", "date": "2026-03-08", "hours": 5.0, "category": "Documentation", "status": "Pending" },
+      { "employee": "Diego Rivera", "project": "Customer Portal", "date": "2026-03-07", "hours": 7.0, "category": "Development", "status": "Approved" },
+      { "employee": "Laura Torres", "project": "Data Warehouse", "date": "2026-03-07", "hours": 3.5, "category": "Analysis", "status": "Rejected" },
+      { "employee": "Juan Morales", "project": "Security Audit", "date": "2026-03-07", "hours": 6.5, "category": "Development", "status": "Approved" }
+    ],
+    "recentDocuments": [
+      { "name": "ERP Phase 2 Requirements.pdf", "category": "Requirements", "project": "ERP Integration", "uploadedBy": "Maria Garcia", "uploadDate": "2026-03-09", "status": "Final" },
+      { "name": "Security Audit Report Q1.docx", "category": "Report", "project": "Security Audit", "uploadedBy": "Sofia Herrera", "uploadDate": "2026-03-08", "status": "Draft" },
+      { "name": "Customer Portal Wireframes.fig", "category": "Design", "project": "Customer Portal", "uploadedBy": "Carlos Lopez", "uploadDate": "2026-03-08", "status": "Review" },
+      { "name": "API Migration Plan.md", "category": "Technical", "project": "API Gateway Migration", "uploadedBy": "Pedro Sanchez", "uploadDate": "2026-03-07", "status": "Final" },
+      { "name": "Sprint Retrospective Notes.pdf", "category": "Meeting Notes", "project": "Mobile App Redesign", "uploadedBy": "Ana Martinez", "uploadDate": "2026-03-06", "status": "Final" },
+      { "name": "Data Model Diagram.png", "category": "Technical", "project": "Data Warehouse", "uploadedBy": "Diego Rivera", "uploadDate": "2026-03-05", "status": "Draft" }
+    ]
+  }
+}

--- a/artifacts/projects/generated/config.js
+++ b/artifacts/projects/generated/config.js
@@ -1,0 +1,192 @@
+// Auto-generated from aggregate-contract.json — DO NOT EDIT
+
+export const meta = {
+  "module": "projects",
+  "label": "Projects",
+  "icon": "FolderKanban",
+  "route": "/projects"
+};
+
+export const kpisConfig = [];
+
+export const sections = {
+  "kpis": {
+    "type": "kpi",
+    "kpis": [
+      {
+        "key": "activeProjects",
+        "label": "Active Projects",
+        "format": "number",
+        "icon": "FolderKanban",
+        "trend": "up"
+      },
+      {
+        "key": "totalHoursMonth",
+        "label": "Hours This Month",
+        "format": "number",
+        "icon": "Clock",
+        "trend": "up"
+      },
+      {
+        "key": "budgetUtilization",
+        "label": "Budget Used",
+        "format": "percent",
+        "icon": "PieChart",
+        "trend": "neutral"
+      },
+      {
+        "key": "documentsCount",
+        "label": "Documents",
+        "format": "number",
+        "icon": "FileText",
+        "trend": "up"
+      }
+    ]
+  },
+  "projectBoard": {
+    "type": "kanban",
+    "title": "Project Board",
+    "icon": "FolderKanban",
+    "columns": [
+      {
+        "id": "planning",
+        "title": "Planning",
+        "color": "gray"
+      },
+      {
+        "id": "in-progress",
+        "title": "In Progress",
+        "color": "blue"
+      },
+      {
+        "id": "on-hold",
+        "title": "On Hold",
+        "color": "yellow"
+      },
+      {
+        "id": "completed",
+        "title": "Completed",
+        "color": "green"
+      }
+    ]
+  },
+  "recentTimeEntries": {
+    "type": "data-table",
+    "title": "Recent Time Entries",
+    "icon": "Clock",
+    "columns": [
+      {
+        "key": "employee",
+        "label": "Employee",
+        "align": "left"
+      },
+      {
+        "key": "project",
+        "label": "Project",
+        "align": "left"
+      },
+      {
+        "key": "date",
+        "label": "Date",
+        "align": "left"
+      },
+      {
+        "key": "hours",
+        "label": "Hours",
+        "align": "right"
+      },
+      {
+        "key": "category",
+        "label": "Category",
+        "align": "left"
+      },
+      {
+        "key": "status",
+        "label": "Status",
+        "align": "left"
+      }
+    ],
+    "filters": [
+      "project",
+      "category"
+    ]
+  },
+  "recentDocuments": {
+    "type": "data-table",
+    "title": "Recent Documents",
+    "icon": "FileText",
+    "columns": [
+      {
+        "key": "name",
+        "label": "Name",
+        "align": "left"
+      },
+      {
+        "key": "category",
+        "label": "Category",
+        "align": "left"
+      },
+      {
+        "key": "project",
+        "label": "Project",
+        "align": "left"
+      },
+      {
+        "key": "uploadedBy",
+        "label": "Uploaded By",
+        "align": "left"
+      },
+      {
+        "key": "uploadDate",
+        "label": "Upload Date",
+        "align": "left"
+      },
+      {
+        "key": "status",
+        "label": "Status",
+        "align": "left"
+      }
+    ],
+    "filters": [
+      "category",
+      "status"
+    ]
+  }
+};
+
+export const layout = [
+  {
+    "section": "kpis",
+    "span": "full"
+  },
+  {
+    "section": "projectBoard",
+    "span": "full"
+  },
+  {
+    "section": "recentTimeEntries",
+    "span": "1/2"
+  },
+  {
+    "section": "recentDocuments",
+    "span": "1/2"
+  }
+];
+
+export const actions = [
+  {
+    "label": "New Project",
+    "route": "/project",
+    "variant": "default"
+  },
+  {
+    "label": "Log Time",
+    "route": "/time-tracking",
+    "variant": "outline"
+  },
+  {
+    "label": "Upload Document",
+    "route": "/document",
+    "variant": "outline"
+  }
+];

--- a/artifacts/projects/generated/mockData.js
+++ b/artifacts/projects/generated/mockData.js
@@ -1,0 +1,208 @@
+// Auto-generated from aggregate-contract.json — DO NOT EDIT
+
+export const kpis = {
+  "activeProjects": 14,
+  "totalHoursMonth": 1248,
+  "budgetUtilization": 73,
+  "documentsCount": 89,
+  "trends": {
+    "activeProjects": 2,
+    "totalHoursMonth": 180,
+    "budgetUtilization": 0,
+    "documentsCount": 12
+  }
+};
+
+export const projectBoard = [
+  {
+    "id": "PJ-001",
+    "columnId": "planning",
+    "title": "Mobile App Redesign",
+    "subtitle": "Q2 Initiative",
+    "badges": [
+      "High Priority"
+    ]
+  },
+  {
+    "id": "PJ-002",
+    "columnId": "planning",
+    "title": "API Gateway Migration",
+    "subtitle": "Infrastructure",
+    "badges": [
+      "Technical"
+    ]
+  },
+  {
+    "id": "PJ-003",
+    "columnId": "in-progress",
+    "title": "ERP Integration",
+    "subtitle": "Phase 2",
+    "badges": [
+      "Enterprise",
+      "On Track"
+    ]
+  },
+  {
+    "id": "PJ-004",
+    "columnId": "in-progress",
+    "title": "Customer Portal",
+    "subtitle": "Client-facing",
+    "badges": [
+      "Priority"
+    ]
+  },
+  {
+    "id": "PJ-005",
+    "columnId": "on-hold",
+    "title": "Data Warehouse",
+    "subtitle": "Analytics",
+    "badges": [
+      "Blocked"
+    ]
+  },
+  {
+    "id": "PJ-006",
+    "columnId": "in-progress",
+    "title": "Security Audit",
+    "subtitle": "Compliance",
+    "badges": [
+      "Urgent"
+    ]
+  },
+  {
+    "id": "PJ-007",
+    "columnId": "completed",
+    "title": "Website Refresh",
+    "subtitle": "Marketing",
+    "badges": [
+      "Delivered"
+    ]
+  },
+  {
+    "id": "PJ-008",
+    "columnId": "completed",
+    "title": "CI/CD Pipeline",
+    "subtitle": "DevOps",
+    "badges": [
+      "Delivered"
+    ]
+  }
+];
+
+export const recentTimeEntries = [
+  {
+    "employee": "Maria Garcia",
+    "project": "ERP Integration",
+    "date": "2026-03-09",
+    "hours": 7.5,
+    "category": "Development",
+    "status": "Approved"
+  },
+  {
+    "employee": "Pedro Sanchez",
+    "project": "Customer Portal",
+    "date": "2026-03-09",
+    "hours": 6,
+    "category": "Code Review",
+    "status": "Pending"
+  },
+  {
+    "employee": "Sofia Herrera",
+    "project": "Security Audit",
+    "date": "2026-03-08",
+    "hours": 8,
+    "category": "Testing",
+    "status": "Approved"
+  },
+  {
+    "employee": "Carlos Lopez",
+    "project": "Mobile App Redesign",
+    "date": "2026-03-08",
+    "hours": 4.5,
+    "category": "Design",
+    "status": "Approved"
+  },
+  {
+    "employee": "Ana Martinez",
+    "project": "ERP Integration",
+    "date": "2026-03-08",
+    "hours": 5,
+    "category": "Documentation",
+    "status": "Pending"
+  },
+  {
+    "employee": "Diego Rivera",
+    "project": "Customer Portal",
+    "date": "2026-03-07",
+    "hours": 7,
+    "category": "Development",
+    "status": "Approved"
+  },
+  {
+    "employee": "Laura Torres",
+    "project": "Data Warehouse",
+    "date": "2026-03-07",
+    "hours": 3.5,
+    "category": "Analysis",
+    "status": "Rejected"
+  },
+  {
+    "employee": "Juan Morales",
+    "project": "Security Audit",
+    "date": "2026-03-07",
+    "hours": 6.5,
+    "category": "Development",
+    "status": "Approved"
+  }
+];
+
+export const recentDocuments = [
+  {
+    "name": "ERP Phase 2 Requirements.pdf",
+    "category": "Requirements",
+    "project": "ERP Integration",
+    "uploadedBy": "Maria Garcia",
+    "uploadDate": "2026-03-09",
+    "status": "Final"
+  },
+  {
+    "name": "Security Audit Report Q1.docx",
+    "category": "Report",
+    "project": "Security Audit",
+    "uploadedBy": "Sofia Herrera",
+    "uploadDate": "2026-03-08",
+    "status": "Draft"
+  },
+  {
+    "name": "Customer Portal Wireframes.fig",
+    "category": "Design",
+    "project": "Customer Portal",
+    "uploadedBy": "Carlos Lopez",
+    "uploadDate": "2026-03-08",
+    "status": "Review"
+  },
+  {
+    "name": "API Migration Plan.md",
+    "category": "Technical",
+    "project": "API Gateway Migration",
+    "uploadedBy": "Pedro Sanchez",
+    "uploadDate": "2026-03-07",
+    "status": "Final"
+  },
+  {
+    "name": "Sprint Retrospective Notes.pdf",
+    "category": "Meeting Notes",
+    "project": "Mobile App Redesign",
+    "uploadedBy": "Ana Martinez",
+    "uploadDate": "2026-03-06",
+    "status": "Final"
+  },
+  {
+    "name": "Data Model Diagram.png",
+    "category": "Technical",
+    "project": "Data Warehouse",
+    "uploadedBy": "Diego Rivera",
+    "uploadDate": "2026-03-05",
+    "status": "Draft"
+  }
+];

--- a/artifacts/time-tracking/contract.json
+++ b/artifacts/time-tracking/contract.json
@@ -1,0 +1,304 @@
+{
+  "version": "0.1.0",
+  "generatedAt": "2026-03-09T10:00:00.000Z",
+  "checksum": "hr-time-tracking-001",
+  "frontendContract": {
+    "window": {
+      "id": "HR-TIME-TRACKING",
+      "name": "Time Tracking",
+      "primaryEntity": "timeTracking",
+      "category": "hr"
+    },
+    "entities": {
+      "timeTracking": {
+        "fields": [
+          {
+            "name": "employee",
+            "column": "Employee_ID",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "User",
+            "inputMode": "selector"
+          },
+          {
+            "name": "project",
+            "column": "Project_ID",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "Project",
+            "inputMode": "selector"
+          },
+          {
+            "name": "date",
+            "column": "WorkDate",
+            "type": "date",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "hours",
+            "column": "Hours",
+            "type": "number",
+            "tsType": "number",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "description",
+            "column": "Description",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": true,
+            "form": true
+          },
+          {
+            "name": "category",
+            "column": "Category",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "TimeCategory",
+            "inputMode": "selector"
+          },
+          {
+            "name": "billable",
+            "column": "Billable",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "YesNo",
+            "inputMode": "selector"
+          },
+          {
+            "name": "status",
+            "column": "Status",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "reference": "TimeStatus",
+            "inputMode": "selector"
+          }
+        ],
+        "searchableFields": [
+          "employee",
+          "project",
+          "status"
+        ],
+        "computedFields": []
+      }
+    }
+  },
+  "backendContract": {
+    "window": {
+      "id": "HR-TIME-TRACKING",
+      "name": "Time Tracking",
+      "primaryEntity": "timeTracking",
+      "category": "hr"
+    },
+    "entities": {
+      "timeTracking": {
+        "fields": [
+          {
+            "name": "employee",
+            "column": "Employee_ID",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "project",
+            "column": "Project_ID",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "date",
+            "column": "WorkDate",
+            "type": "date",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "hours",
+            "column": "Hours",
+            "type": "number",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "description",
+            "column": "Description",
+            "type": "string",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "category",
+            "column": "Category",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "billable",
+            "column": "Billable",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "status",
+            "column": "Status",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "adClientId",
+            "column": "AD_Client_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "adOrgId",
+            "column": "AD_Org_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "createdBy",
+            "column": "CreatedBy",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updatedBy",
+            "column": "UpdatedBy",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "created",
+            "column": "Created",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updated",
+            "column": "Updated",
+            "type": "datetime",
+            "visibility": "system",
+            "required": true
+          }
+        ]
+      }
+    },
+    "endpoints": [
+      {
+        "entity": "timeTracking",
+        "method": "GET",
+        "path": "/time-tracking",
+        "supportedFilters": ["employee", "project", "status"]
+      },
+      {
+        "entity": "timeTracking",
+        "method": "GET",
+        "path": "/time-tracking/:id",
+        "supportedFilters": []
+      },
+      {
+        "entity": "timeTracking",
+        "method": "POST",
+        "path": "/time-tracking",
+        "supportedFilters": []
+      },
+      {
+        "entity": "timeTracking",
+        "method": "PUT",
+        "path": "/time-tracking/:id",
+        "supportedFilters": []
+      },
+      {
+        "entity": "timeTracking",
+        "method": "DELETE",
+        "path": "/time-tracking/:id",
+        "supportedFilters": []
+      }
+    ],
+    "processEndpoints": []
+  },
+  "testManifest": {
+    "tests": [
+      { "id": "t-1", "category": "field-presence", "entity": "timeTracking", "field": "employee", "runner": "node", "description": "Field 'employee' should be present in timeTracking" },
+      { "id": "t-2", "category": "field-presence", "entity": "timeTracking", "field": "project", "runner": "node", "description": "Field 'project' should be present in timeTracking" },
+      { "id": "t-3", "category": "field-presence", "entity": "timeTracking", "field": "date", "runner": "node", "description": "Field 'date' should be present in timeTracking" },
+      { "id": "t-4", "category": "field-presence", "entity": "timeTracking", "field": "hours", "runner": "node", "description": "Field 'hours' should be present in timeTracking" },
+      { "id": "t-5", "category": "field-presence", "entity": "timeTracking", "field": "description", "runner": "node", "description": "Field 'description' should be present in timeTracking" },
+      { "id": "t-6", "category": "field-presence", "entity": "timeTracking", "field": "category", "runner": "node", "description": "Field 'category' should be present in timeTracking" },
+      { "id": "t-7", "category": "field-presence", "entity": "timeTracking", "field": "billable", "runner": "node", "description": "Field 'billable' should be present in timeTracking" },
+      { "id": "t-8", "category": "field-presence", "entity": "timeTracking", "field": "status", "runner": "node", "description": "Field 'status' should be present in timeTracking" },
+      { "id": "t-9", "category": "field-type", "entity": "timeTracking", "field": "employee", "runner": "node", "description": "Field 'employee' should have type 'foreignKey' in timeTracking" },
+      { "id": "t-10", "category": "field-type", "entity": "timeTracking", "field": "project", "runner": "node", "description": "Field 'project' should have type 'foreignKey' in timeTracking" },
+      { "id": "t-11", "category": "field-type", "entity": "timeTracking", "field": "date", "runner": "node", "description": "Field 'date' should have type 'date' in timeTracking" },
+      { "id": "t-12", "category": "field-type", "entity": "timeTracking", "field": "hours", "runner": "node", "description": "Field 'hours' should have type 'number' in timeTracking" },
+      { "id": "t-13", "category": "field-type", "entity": "timeTracking", "field": "description", "runner": "node", "description": "Field 'description' should have type 'string' in timeTracking" },
+      { "id": "t-14", "category": "field-type", "entity": "timeTracking", "field": "category", "runner": "node", "description": "Field 'category' should have type 'foreignKey' in timeTracking" },
+      { "id": "t-15", "category": "field-type", "entity": "timeTracking", "field": "billable", "runner": "node", "description": "Field 'billable' should have type 'foreignKey' in timeTracking" },
+      { "id": "t-16", "category": "field-type", "entity": "timeTracking", "field": "status", "runner": "node", "description": "Field 'status' should have type 'foreignKey' in timeTracking" },
+      { "id": "t-17", "category": "searchable-filters", "entity": "timeTracking", "field": "employee", "runner": "node", "description": "Field 'employee' should be a supported filter for timeTracking" },
+      { "id": "t-18", "category": "searchable-filters", "entity": "timeTracking", "field": "project", "runner": "node", "description": "Field 'project' should be a supported filter for timeTracking" },
+      { "id": "t-19", "category": "searchable-filters", "entity": "timeTracking", "field": "status", "runner": "node", "description": "Field 'status' should be a supported filter for timeTracking" },
+      { "id": "t-20", "category": "visibility", "entity": "timeTracking", "runner": "node", "description": "Entity 'timeTracking' should only expose visible fields in frontend" },
+      { "id": "t-21", "category": "system-field", "entity": "timeTracking", "field": "adClientId", "runner": "node", "description": "System field 'adClientId' should exist in backend but not frontend for timeTracking" },
+      { "id": "t-22", "category": "system-field", "entity": "timeTracking", "field": "adOrgId", "runner": "node", "description": "System field 'adOrgId' should exist in backend but not frontend for timeTracking" },
+      { "id": "t-23", "category": "system-field", "entity": "timeTracking", "field": "createdBy", "runner": "node", "description": "System field 'createdBy' should exist in backend but not frontend for timeTracking" },
+      { "id": "t-24", "category": "system-field", "entity": "timeTracking", "field": "updatedBy", "runner": "node", "description": "System field 'updatedBy' should exist in backend but not frontend for timeTracking" },
+      { "id": "t-25", "category": "system-field", "entity": "timeTracking", "field": "created", "runner": "node", "description": "System field 'created' should exist in backend but not frontend for timeTracking" },
+      { "id": "t-26", "category": "system-field", "entity": "timeTracking", "field": "updated", "runner": "node", "description": "System field 'updated' should exist in backend but not frontend for timeTracking" }
+    ],
+    "summary": {
+      "total": 26,
+      "byCategory": {
+        "field-presence": 8,
+        "field-type": 8,
+        "searchable-filters": 3,
+        "visibility": 1,
+        "system-field": 6
+      },
+      "byRunner": {
+        "node": 26,
+        "junit": 0
+      }
+    }
+  }
+}

--- a/artifacts/time-tracking/generated/web/time-tracking/TimeTrackingForm.jsx
+++ b/artifacts/time-tracking/generated/web/time-tracking/TimeTrackingForm.jsx
@@ -1,0 +1,16 @@
+import { EntityForm } from '@/components/contract-ui';
+
+const fields = [
+  { key: 'employee', label: 'Employee', type: 'selector', required: true, reference: 'User', inputMode: 'selector' },
+  { key: 'project', label: 'Project', type: 'selector', required: true, reference: 'Project', inputMode: 'selector' },
+  { key: 'date', label: 'Date', type: 'date', required: true },
+  { key: 'hours', label: 'Hours', type: 'number', required: true },
+  { key: 'description', label: 'Description', type: 'textarea' },
+  { key: 'category', label: 'Category', type: 'selector', required: true, reference: 'TimeCategory', inputMode: 'selector' },
+  { key: 'billable', label: 'Billable', type: 'selector', required: true, reference: 'YesNo', inputMode: 'selector' },
+  { key: 'status', label: 'Status', type: 'selector', required: true, reference: 'TimeStatus', inputMode: 'selector' },
+];
+
+export default function TimeTrackingForm(props) {
+  return <EntityForm fields={fields} {...props} />;
+}

--- a/artifacts/time-tracking/generated/web/time-tracking/TimeTrackingTable.jsx
+++ b/artifacts/time-tracking/generated/web/time-tracking/TimeTrackingTable.jsx
@@ -1,0 +1,18 @@
+import { DataTable } from '@/components/contract-ui';
+
+const columns = [
+  { key: 'employee', label: 'Employee', type: 'string' },
+  { key: 'project', label: 'Project', type: 'string' },
+  { key: 'date', label: 'Date', type: 'date' },
+  { key: 'hours', label: 'Hours', type: 'number' },
+  { key: 'description', label: 'Description', type: 'string' },
+  { key: 'category', label: 'Category', type: 'string' },
+  { key: 'billable', label: 'Billable', type: 'string' },
+  { key: 'status', label: 'Status', type: 'status' },
+];
+
+const filters = ['employee', 'project', 'status'];
+
+export default function TimeTrackingTable(props) {
+  return <DataTable columns={columns} filters={filters} {...props} />;
+}

--- a/artifacts/time-tracking/generated/web/time-tracking/index.jsx
+++ b/artifacts/time-tracking/generated/web/time-tracking/index.jsx
@@ -1,0 +1,20 @@
+import { SingleEntityPage } from '@/components/contract-ui';
+import TimeTrackingTable from './TimeTrackingTable';
+import TimeTrackingForm from './TimeTrackingForm';
+import catalogs from './mockCatalogs';
+
+const windowMeta = { category: 'hr', name: 'Time Tracking' };
+
+export default function App(props) {
+  return (
+    <SingleEntityPage
+      entity="timeTracking"
+      Table={TimeTrackingTable}
+      Form={TimeTrackingForm}
+      catalogs={catalogs}
+      entityLabel="Time Tracking"
+      window={windowMeta}
+      {...props}
+    />
+  );
+}

--- a/artifacts/time-tracking/generated/web/time-tracking/mockCatalogs.js
+++ b/artifacts/time-tracking/generated/web/time-tracking/mockCatalogs.js
@@ -1,0 +1,40 @@
+// Auto-generated mock catalogs for FK reference data - do not edit manually
+
+const catalogs = {};
+
+catalogs['User'] = [
+  {
+    "id": "user-001",
+    "name": "Alice Johnson"
+  },
+  {
+    "id": "user-002",
+    "name": "Bob Smith"
+  },
+  {
+    "id": "user-003",
+    "name": "Carol Williams"
+  },
+  {
+    "id": "user-004",
+    "name": "David Brown"
+  },
+  {
+    "id": "user-005",
+    "name": "Eva Martinez"
+  },
+  {
+    "id": "user-006",
+    "name": "Frank Lee"
+  },
+  {
+    "id": "user-007",
+    "name": "Grace Kim"
+  },
+  {
+    "id": "user-008",
+    "name": "Henry Davis"
+  }
+];
+
+export default catalogs;

--- a/tools/app-shell/src/App.jsx
+++ b/tools/app-shell/src/App.jsx
@@ -13,6 +13,8 @@ import PurchasesPage from './pages/PurchasesPage.jsx';
 import AccountingPage from './pages/AccountingPage.jsx';
 import ReportsPage from './pages/ReportsPage.jsx';
 import CrmPage from './pages/CrmPage.jsx';
+import HrPage from './pages/HrPage.jsx';
+import ProjectsPage from './pages/ProjectsPage.jsx';
 import { buildMenuGroups, buildWindowMap } from './windows/registry.js';
 import { createMockFetch } from './lib/mockFetch.js';
 
@@ -110,6 +112,8 @@ function AppRoutes({ menuGroups, windowMap }) {
         <Route path="accounting" element={<AccountingPage />} />
         <Route path="reports" element={<ReportsPage />} />
         <Route path="crm" element={<CrmPage />} />
+        <Route path="hr" element={<HrPage />} />
+        <Route path="projects" element={<ProjectsPage />} />
         <Route
           path=":windowName"
           element={<WindowLoader windowMap={windowMap} apiBaseUrl={API_BASE_URL} />}

--- a/tools/app-shell/src/menu.json
+++ b/tools/app-shell/src/menu.json
@@ -73,6 +73,25 @@
       ]
     },
     {
+      "group": "HR",
+      "icon": "Users",
+      "items": [
+        { "name": "hr", "label": "Overview" },
+        { "name": "employee", "label": "Employees" },
+        { "name": "absence", "label": "Absences" }
+      ]
+    },
+    {
+      "group": "Projects",
+      "icon": "FolderKanban",
+      "items": [
+        { "name": "projects", "label": "Overview" },
+        { "name": "project", "label": "Projects" },
+        { "name": "time-tracking", "label": "Time Tracking" },
+        { "name": "document", "label": "Documents" }
+      ]
+    },
+    {
       "group": "Products",
       "icon": "Box",
       "items": [

--- a/tools/app-shell/src/pages/HrPage.jsx
+++ b/tools/app-shell/src/pages/HrPage.jsx
@@ -1,0 +1,144 @@
+import React, { useState, useCallback } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { KPIHeader, KanbanBoard, DataTable } from '@/components/contract-ui';
+import { Button } from '@/components/ui/button';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Separator } from '@/components/ui/separator';
+import { Users, Calendar, UserPlus, Clock, Bell, ArrowUp, ArrowDown } from 'lucide-react';
+
+import { sections, actions } from '@generated/hr/generated/config';
+import * as mockData from '@generated/hr/generated/mockData';
+
+// -- Icon resolution (config stores string names) -----------------------------
+
+const ICON_MAP = { Users, Calendar, UserPlus, Clock, Bell };
+
+// -- Derived data from contract -----------------------------------------------
+
+const KPIS = sections.kpis.kpis.map((k) => ({
+  ...k,
+  value: mockData.kpis[k.key],
+  trend: mockData.kpis.trends?.[k.key],
+  icon: ICON_MAP[k.icon],
+}));
+
+const TABLE_COLUMNS = sections.employeeDirectory.columns;
+const TABLE_FILTERS = sections.employeeDirectory.filters;
+const TABLE_DATA = mockData.employeeDirectory;
+
+const KANBAN_COLUMNS = sections.absenceCalendar.columns;
+const INITIAL_CARDS = mockData.absenceCalendar;
+
+const HR_FEED = mockData.hrUpdates;
+
+// -- Component -----------------------------------------------------------------
+
+export default function HrPage() {
+  const navigate = useNavigate();
+  const [cards, setCards] = useState(INITIAL_CARDS);
+
+  const handleDragEnd = useCallback((cardId, _fromColumnId, toColumnId) => {
+    setCards((prev) =>
+      prev.map((c) => (c.id === cardId ? { ...c, columnId: toColumnId } : c))
+    );
+  }, []);
+
+  const handleCardClick = useCallback(
+    () => {
+      navigate('/absence');
+    },
+    [navigate]
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Header bar */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">HR</h1>
+        <div className="flex items-center gap-2">
+          {actions.map((action) => (
+            <Button key={action.route} variant={action.variant} asChild>
+              <Link to={action.route}>{action.label}</Link>
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {/* KPIs */}
+      <KPIHeader kpis={KPIS} />
+
+      {/* Two-column layout: Employee Directory (2/3) + Absences (1/3) */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Employee Directory Table */}
+        <div className="lg:col-span-2">
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Users className="h-5 w-5 text-muted-foreground" />
+                Employee Directory
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <DataTable
+                columns={TABLE_COLUMNS}
+                filters={TABLE_FILTERS}
+                data={TABLE_DATA}
+              />
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Absence Kanban */}
+        <div>
+          <KanbanBoard
+            columns={KANBAN_COLUMNS}
+            cards={cards}
+            onDragEnd={handleDragEnd}
+            onCardClick={handleCardClick}
+            emptyMessage="No absences"
+          />
+        </div>
+      </div>
+
+      {/* HR Updates Feed */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Bell className="h-5 w-5 text-muted-foreground" />
+            HR Updates
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {HR_FEED.map((entry, idx) => (
+            <div key={entry.id}>
+              {idx > 0 && <Separator className="mb-3" />}
+              <div className="flex items-start gap-3">
+                {entry.direction && (
+                  <div className={`mt-0.5 rounded-full p-1 ${
+                    entry.direction === 'in'
+                      ? 'bg-emerald-100 text-emerald-600'
+                      : 'bg-blue-100 text-blue-600'
+                  }`}>
+                    {entry.direction === 'in'
+                      ? <ArrowUp className="h-3.5 w-3.5" />
+                      : <ArrowDown className="h-3.5 w-3.5" />
+                    }
+                  </div>
+                )}
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium truncate">{entry.label}</p>
+                  {entry.detail && (
+                    <p className="text-xs text-muted-foreground">{entry.detail}</p>
+                  )}
+                </div>
+                <span className="text-xs text-muted-foreground whitespace-nowrap">
+                  {entry.time}
+                </span>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/tools/app-shell/src/pages/ProjectsPage.jsx
+++ b/tools/app-shell/src/pages/ProjectsPage.jsx
@@ -1,0 +1,118 @@
+import React, { useState, useCallback } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { KPIHeader, KanbanBoard, DataTable } from '@/components/contract-ui';
+import { Button } from '@/components/ui/button';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { FolderKanban, Clock, PieChart, FileText } from 'lucide-react';
+
+import { sections, actions } from '@generated/projects/generated/config';
+import * as mockData from '@generated/projects/generated/mockData';
+
+// -- Icon resolution (config stores string names) -----------------------------
+
+const ICON_MAP = { FolderKanban, Clock, PieChart, FileText };
+
+// -- Derived data from contract -----------------------------------------------
+
+const KPIS = sections.kpis.kpis.map((k) => ({
+  ...k,
+  value: mockData.kpis[k.key],
+  trend: mockData.kpis.trends?.[k.key],
+  icon: ICON_MAP[k.icon],
+}));
+
+const KANBAN_COLUMNS = sections.projectBoard.columns;
+const INITIAL_CARDS = mockData.projectBoard;
+
+const TIME_COLUMNS = sections.recentTimeEntries.columns;
+const TIME_FILTERS = sections.recentTimeEntries.filters;
+const TIME_DATA = mockData.recentTimeEntries;
+
+const DOC_COLUMNS = sections.recentDocuments.columns;
+const DOC_FILTERS = sections.recentDocuments.filters;
+const DOC_DATA = mockData.recentDocuments;
+
+// -- Component -----------------------------------------------------------------
+
+export default function ProjectsPage() {
+  const navigate = useNavigate();
+  const [cards, setCards] = useState(INITIAL_CARDS);
+
+  const handleDragEnd = useCallback((cardId, _fromColumnId, toColumnId) => {
+    setCards((prev) =>
+      prev.map((c) => (c.id === cardId ? { ...c, columnId: toColumnId } : c))
+    );
+  }, []);
+
+  const handleCardClick = useCallback(
+    () => {
+      navigate('/project');
+    },
+    [navigate]
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Header bar */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">Projects</h1>
+        <div className="flex items-center gap-2">
+          {actions.map((action) => (
+            <Button key={action.route} variant={action.variant} asChild>
+              <Link to={action.route}>{action.label}</Link>
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {/* KPIs */}
+      <KPIHeader kpis={KPIS} />
+
+      {/* Project Board Kanban */}
+      <KanbanBoard
+        columns={KANBAN_COLUMNS}
+        cards={cards}
+        onDragEnd={handleDragEnd}
+        onCardClick={handleCardClick}
+        emptyMessage="No projects"
+      />
+
+      {/* Two-column layout: Time Entries (1/2) + Documents (1/2) */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        {/* Recent Time Entries */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Clock className="h-5 w-5 text-muted-foreground" />
+              Recent Time Entries
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <DataTable
+              columns={TIME_COLUMNS}
+              filters={TIME_FILTERS}
+              data={TIME_DATA}
+            />
+          </CardContent>
+        </Card>
+
+        {/* Recent Documents */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <FileText className="h-5 w-5 text-muted-foreground" />
+              Recent Documents
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <DataTable
+              columns={DOC_COLUMNS}
+              filters={DOC_FILTERS}
+              data={DOC_DATA}
+            />
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/tools/app-shell/src/windows/registry.js
+++ b/tools/app-shell/src/windows/registry.js
@@ -36,6 +36,11 @@ const windowLoaders = {
   'deal': () => import('@generated/deal/generated/web/deal/index.jsx'),
   'activity': () => import('@generated/activity/generated/web/activity/index.jsx'),
   'lead': () => import('@generated/lead/generated/web/lead/index.jsx'),
+  'employee': () => import('@generated/employee/generated/web/employee/index.jsx'),
+  'absence': () => import('@generated/absence/generated/web/absence/index.jsx'),
+  'project': () => import('@generated/project/generated/web/project/index.jsx'),
+  'time-tracking': () => import('@generated/time-tracking/generated/web/time-tracking/index.jsx'),
+  'document': () => import('@generated/document/generated/web/document/index.jsx'),
 };
 
 /**


### PR DESCRIPTION
## Summary
- Add **HR Overview** page with aggregate contract (KPIs: total employees, on leave today, open positions, avg tenure) + employee directory table + absence kanban + HR updates feed
- Add **Projects Overview** page with aggregate contract (KPIs: active projects, hours this month, budget used, documents) + project board kanban + time entries table + documents table
- Add **Employee** entity window (9 fields) — 28 contract tests
- Add **Time Tracking** entity window (8 fields) — 26 contract tests
- Add **Absence** entity window (8 fields) — 26 contract tests
- Add **Project** entity window (9 fields) — 28 contract tests
- Add **Document** entity window (9 fields) — 28 contract tests
- Add HR group (3 items) and Projects group (4 items) to menu
- Register all routes and entity windows

## Test plan
- [x] 2,537 unit tests pass (0 failures)
- [x] HR aggregate tests pass
- [x] Projects aggregate tests pass
- [x] 136 entity contract tests pass (5 entities)
- [x] Vite build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)