### PR TITLE
feat: sidebar icon rail + flyouts + Command Palette

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3521,6 +3521,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/code-block-writer": {
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
@@ -7872,6 +7888,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.0",
+        "cmdk": "^1.1.1",
         "lucide-react": "^0.400.0",
         "next-themes": "^0.4.6",
         "react": "^18.3.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.0",
+    "cmdk": "^1.1.1",
     "lucide-react": "^0.400.0",
     "next-themes": "^0.4.6",
     "react": "^18.3.0",

--- a/tools/app-shell/src/components/CommandPalette.jsx
+++ b/tools/app-shell/src/components/CommandPalette.jsx
@@ -1,0 +1,80 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command.jsx';
+import menuConfig from '../menu.json';
+
+import {
+  LayoutDashboard,
+  ShoppingCart,
+  Truck,
+  Calculator,
+  Package,
+  Users,
+  FolderKanban,
+  Settings,
+} from 'lucide-react';
+
+const ICON_MAP = {
+  LayoutDashboard,
+  ShoppingCart,
+  Truck,
+  Calculator,
+  Package,
+  Users,
+  FolderKanban,
+  Settings,
+};
+
+export function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const down = (e) => {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setOpen((o) => !o);
+      }
+    };
+    document.addEventListener('keydown', down);
+    return () => document.removeEventListener('keydown', down);
+  }, []);
+
+  const handleSelect = (name) => {
+    navigate(`/${name}`);
+    setOpen(false);
+  };
+
+  return (
+    <CommandDialog open={open} onOpenChange={setOpen}>
+      <CommandInput placeholder="Search pages..." />
+      <CommandList>
+        <CommandEmpty>No results found.</CommandEmpty>
+        {menuConfig.menu.map((group) => {
+          const Icon = ICON_MAP[group.icon] || Package;
+          return (
+            <CommandGroup key={group.group} heading={group.group}>
+              {group.items.map((item) => (
+                <CommandItem
+                  key={item.name}
+                  value={`${group.group} ${item.label} ${item.name}`}
+                  onSelect={() => handleSelect(item.name)}
+                >
+                  <Icon className="mr-2 h-4 w-4" />
+                  <span>{item.label}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          );
+        })}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/tools/app-shell/src/components/ui/command.jsx
+++ b/tools/app-shell/src/components/ui/command.jsx
@@ -1,0 +1,109 @@
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog.jsx";
+
+const Command = React.forwardRef(({ className, ...props }, ref) => (
+  <CommandPrimitive
+    ref={ref}
+    className={cn(
+      "flex h-full w-full flex-col overflow-hidden rounded-md bg-popover text-popover-foreground",
+      className
+    )}
+    {...props}
+  />
+));
+Command.displayName = "Command";
+
+const CommandDialog = ({ children, ...props }) => {
+  return (
+    <Dialog {...props}>
+      <DialogContent className="overflow-hidden p-0 shadow-lg">
+        <DialogTitle className="sr-only">Command palette</DialogTitle>
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+const CommandInput = React.forwardRef(({ className, ...props }, ref) => (
+  <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
+    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <CommandPrimitive.Input
+      ref={ref}
+      className={cn(
+        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  </div>
+));
+CommandInput.displayName = "CommandInput";
+
+const CommandList = React.forwardRef(({ className, ...props }, ref) => (
+  <CommandPrimitive.List
+    ref={ref}
+    className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+    {...props}
+  />
+));
+CommandList.displayName = "CommandList";
+
+const CommandEmpty = React.forwardRef((props, ref) => (
+  <CommandPrimitive.Empty ref={ref} className="py-6 text-center text-sm" {...props} />
+));
+CommandEmpty.displayName = "CommandEmpty";
+
+const CommandGroup = React.forwardRef(({ className, ...props }, ref) => (
+  <CommandPrimitive.Group
+    ref={ref}
+    className={cn(
+      "overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground",
+      className
+    )}
+    {...props}
+  />
+));
+CommandGroup.displayName = "CommandGroup";
+
+const CommandSeparator = React.forwardRef(({ className, ...props }, ref) => (
+  <CommandPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 h-px bg-border", className)}
+    {...props}
+  />
+));
+CommandSeparator.displayName = "CommandSeparator";
+
+const CommandItem = React.forwardRef(({ className, ...props }, ref) => (
+  <CommandPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      className
+    )}
+    {...props}
+  />
+));
+CommandItem.displayName = "CommandItem";
+
+const CommandShortcut = ({ className, ...props }) => (
+  <span className={cn("ml-auto text-xs tracking-widest text-muted-foreground", className)} {...props} />
+);
+CommandShortcut.displayName = "CommandShortcut";
+
+export {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+  CommandShortcut,
+};

--- a/tools/app-shell/src/layout/AppLayout.jsx
+++ b/tools/app-shell/src/layout/AppLayout.jsx
@@ -3,10 +3,11 @@ import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar.jsx';
 import AppSidebar from './Sidebar.jsx';
 import TopBar from './TopBar.jsx';
 import { CopilotWidget } from '@/components/CopilotWidget.jsx';
+import { CommandPalette } from '@/components/CommandPalette.jsx';
 
 export default function AppLayout({ menuGroups }) {
   return (
-    <SidebarProvider>
+    <SidebarProvider defaultOpen={false}>
       <AppSidebar menuGroups={menuGroups} />
       <SidebarInset>
         <TopBar />
@@ -15,6 +16,7 @@ export default function AppLayout({ menuGroups }) {
         </div>
       </SidebarInset>
       <CopilotWidget />
+      <CommandPalette />
     </SidebarProvider>
   );
 }

--- a/tools/app-shell/src/layout/Sidebar.jsx
+++ b/tools/app-shell/src/layout/Sidebar.jsx
@@ -1,16 +1,16 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 import { useAuth } from '@/auth/AuthContext.jsx';
 import {
   Sidebar,
   SidebarContent,
   SidebarFooter,
-  SidebarGroup,
-  SidebarGroupContent,
-  SidebarGroupLabel,
   SidebarHeader,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
   SidebarRail,
 } from '@/components/ui/sidebar.jsx';
 import {
@@ -24,10 +24,13 @@ import {
   LayoutDashboard,
   ShoppingCart,
   Truck,
+  Calculator,
   Package,
   Box,
   Users,
   Settings,
+  FolderKanban,
+  Target,
   LogOut,
 } from 'lucide-react';
 
@@ -35,52 +38,53 @@ const ICON_MAP = {
   LayoutDashboard,
   ShoppingCart,
   Truck,
+  Calculator,
   Package,
   Box,
   Users,
   Settings,
+  FolderKanban,
+  Target,
 };
 
-function NavMenuGroup({ group, icon, items }) {
+function NavMenuGroup({ group, icon, items, isActive }) {
   const Icon = ICON_MAP[icon] || Package;
 
   return (
-    <Collapsible defaultOpen className="group/collapsible">
-      <SidebarGroup className="p-0">
-        <SidebarGroupLabel asChild>
-          <CollapsibleTrigger className="flex w-full items-center gap-2">
+    <Collapsible asChild defaultOpen={isActive} className="group/collapsible">
+      <SidebarMenuItem>
+        <CollapsibleTrigger asChild>
+          <SidebarMenuButton tooltip={group}>
             <Icon className="h-4 w-4" />
-            <span className="flex-1 text-left">{group}</span>
-            <ChevronRight className="h-3 w-3 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
-          </CollapsibleTrigger>
-        </SidebarGroupLabel>
+            <span>{group}</span>
+            <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+          </SidebarMenuButton>
+        </CollapsibleTrigger>
         <CollapsibleContent>
-          <SidebarGroupContent>
-            <SidebarMenu>
-              {items.map((item) => (
-                <SidebarMenuItem key={item.name}>
-                  <SidebarMenuButton asChild tooltip={item.label}>
-                    <NavLink
-                      to={`/${item.name}`}
-                      className={({ isActive }) => (isActive ? 'font-medium' : '')}
-                    >
-                      {({ isActive }) => (
-                        <span data-active={isActive || undefined}>{item.label}</span>
-                      )}
-                    </NavLink>
-                  </SidebarMenuButton>
-                </SidebarMenuItem>
-              ))}
-            </SidebarMenu>
-          </SidebarGroupContent>
+          <SidebarMenuSub>
+            {items.map((item) => (
+              <SidebarMenuSubItem key={item.name}>
+                <SidebarMenuSubButton asChild>
+                  <NavLink
+                    to={`/${item.name}`}
+                    className={({ isActive: active }) => (active ? 'font-medium' : '')}
+                  >
+                    {item.label}
+                  </NavLink>
+                </SidebarMenuSubButton>
+              </SidebarMenuSubItem>
+            ))}
+          </SidebarMenuSub>
         </CollapsibleContent>
-      </SidebarGroup>
+      </SidebarMenuItem>
     </Collapsible>
   );
 }
 
 export default function AppSidebar({ menuGroups }) {
   const { username, logout } = useAuth();
+  const location = useLocation();
+  const currentPath = location.pathname.replace(/^\//, '');
 
   return (
     <Sidebar collapsible="icon">
@@ -97,14 +101,17 @@ export default function AppSidebar({ menuGroups }) {
       </SidebarHeader>
 
       <SidebarContent>
-        {menuGroups.map((g) => (
-          <NavMenuGroup
-            key={g.group}
-            group={g.group}
-            icon={g.icon}
-            items={g.items}
-          />
-        ))}
+        <SidebarMenu>
+          {menuGroups.map((g) => (
+            <NavMenuGroup
+              key={g.group}
+              group={g.group}
+              icon={g.icon}
+              items={g.items}
+              isActive={g.items.some((item) => item.name === currentPath)}
+            />
+          ))}
+        </SidebarMenu>
       </SidebarContent>
 
       <SidebarFooter className="border-t border-sidebar-border">

--- a/tools/app-shell/src/layout/TopBar.jsx
+++ b/tools/app-shell/src/layout/TopBar.jsx
@@ -1,5 +1,7 @@
 import { SidebarTrigger } from '@/components/ui/sidebar.jsx';
 import { Separator } from '@/components/ui/separator.jsx';
+import { Search } from 'lucide-react';
+import { Button } from '@/components/ui/button.jsx';
 
 export default function TopBar() {
   return (
@@ -7,6 +9,19 @@ export default function TopBar() {
       <SidebarTrigger className="-ml-1" />
       <Separator orientation="vertical" className="mr-2 h-4" />
       <div className="flex-1" />
+      <Button
+        variant="outline"
+        className="relative h-8 w-full justify-start rounded-[0.5rem] bg-muted/50 text-sm font-normal text-muted-foreground shadow-none sm:pr-12 md:w-40 lg:w-64"
+        onClick={() => {
+          document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }));
+        }}
+      >
+        <Search className="mr-2 h-4 w-4" />
+        Search...
+        <kbd className="pointer-events-none absolute right-[0.3rem] top-[0.3rem] hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex">
+          <span className="text-xs">&#8984;</span>K
+        </kbd>
+      </Button>
     </header>
   );
 }

--- a/tools/app-shell/src/menu.json
+++ b/tools/app-shell/src/menu.json
@@ -1,17 +1,11 @@
 {
   "menu": [
     {
-      "group": "Get Started",
-      "icon": "Rocket",
-      "items": [
-        { "name": "onboarding", "label": "Setup Wizard" }
-      ]
-    },
-    {
       "group": "Home",
       "icon": "LayoutDashboard",
       "items": [
-        { "name": "dashboard", "label": "Dashboard" }
+        { "name": "dashboard", "label": "Dashboard" },
+        { "name": "onboarding", "label": "Setup Wizard" }
       ]
     },
     {
@@ -40,7 +34,7 @@
       ]
     },
     {
-      "group": "Accounting",
+      "group": "Finance",
       "icon": "Calculator",
       "items": [
         { "name": "accounting", "label": "Overview" },
@@ -48,8 +42,8 @@
         { "name": "payment-out", "label": "Payments Out" },
         { "name": "bank-reconciliation", "label": "Bank Reconciliation" },
         { "name": "chart-of-accounts", "label": "Chart of Accounts" },
-        { "name": "reports", "label": "Reports" },
-        { "name": "recurring-invoice", "label": "Recurring Invoices" }
+        { "name": "recurring-invoice", "label": "Recurring Invoices" },
+        { "name": "reports", "label": "Reports" }
       ]
     },
     {
@@ -57,33 +51,25 @@
       "icon": "Package",
       "items": [
         { "name": "inventory", "label": "Overview" },
+        { "name": "product", "label": "Products" },
+        { "name": "product-category", "label": "Categories" },
         { "name": "physical-inventory", "label": "Physical Inventory" },
-        { "name": "goods-movements", "label": "Goods Movements" }
+        { "name": "goods-movements", "label": "Goods Movements" },
+        { "name": "warehouse", "label": "Warehouses" },
+        { "name": "warehouse-storage-bins", "label": "Storage Bins" }
       ]
     },
     {
-      "group": "Contacts",
+      "group": "People",
       "icon": "Users",
       "items": [
-        { "name": "contacts", "label": "Overview" },
-        { "name": "business-partner", "label": "Contacts" }
-      ]
-    },
-    {
-      "group": "CRM",
-      "icon": "Target",
-      "items": [
-        { "name": "crm", "label": "Overview" },
+        { "name": "contacts", "label": "Contacts" },
+        { "name": "business-partner", "label": "Business Partners" },
+        { "name": "crm", "label": "CRM" },
         { "name": "deal", "label": "Deals" },
         { "name": "activity", "label": "Activities" },
-        { "name": "lead", "label": "Leads" }
-      ]
-    },
-    {
-      "group": "HR",
-      "icon": "Users",
-      "items": [
-        { "name": "hr", "label": "Overview" },
+        { "name": "lead", "label": "Leads" },
+        { "name": "hr", "label": "HR" },
         { "name": "employee", "label": "Employees" },
         { "name": "absence", "label": "Absences" }
       ]
@@ -99,31 +85,15 @@
       ]
     },
     {
-      "group": "Products",
-      "icon": "Box",
-      "items": [
-        { "name": "product", "label": "Products" },
-        { "name": "product-category", "label": "Categories" }
-      ]
-    },
-    {
       "group": "Settings",
       "icon": "Settings",
       "items": [
-        { "name": "warehouse", "label": "Warehouses" },
-        { "name": "warehouse-storage-bins", "label": "Storage Bins" },
         { "name": "price-list", "label": "Price Lists" },
         { "name": "payment-term", "label": "Payment Terms" },
         { "name": "payment-method", "label": "Payment Methods" },
         { "name": "tax", "label": "Taxes" },
         { "name": "uom", "label": "Units of Measure" },
-        { "name": "user", "label": "Users" }
-      ]
-    },
-    {
-      "group": "Tools",
-      "icon": "Wrench",
-      "items": [
+        { "name": "user", "label": "Users" },
         { "name": "smart-scan", "label": "Smart Scan" }
       ]
     }


### PR DESCRIPTION
## Summary
- Merge 12 sidebar menu groups into 8 cleaner categories (Home, Sales, Purchases, Finance, Inventory, People, Projects, Settings)
- Sidebar now collapses to an icon rail by default using shadcn sidebar-07 pattern with `SidebarMenuSub` flyouts
- Active group auto-expands based on current route via `useLocation()`
- Add Command Palette (Cmd+K / Ctrl+K) using `cmdk` for quick page navigation across all menu items
- Add search trigger button in TopBar for discoverability

## Test plan
- [x] Wiring completeness tests pass (306 tests, 0 failures)
- [x] Vite build succeeds
- [ ] Visual verification: sidebar renders as icon rail when collapsed
- [ ] Visual verification: clicking group icon shows flyout with sub-items
- [ ] Cmd+K opens command palette, search works, selecting navigates

Generated with [Claude Code](https://claude.com/claude-code)