### PR TITLE
feat: add Schema Inspector for visual schema editing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2196,6 +2196,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-tooltip": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
@@ -7869,6 +7898,7 @@
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tooltip": "^1.2.8",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.2.8",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.0",

--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Search, Inbox } from 'lucide-react';
+import { FieldHighlight } from '@/components/inspector/FieldHighlight.jsx';
 
 /**
  * Map a status string to a Badge variant and optional className override.
@@ -83,7 +84,7 @@ function EmptyState({ hasFilter, totalCount }) {
  *  - compact: boolean (reserved for narrower layout)
  *  - loading: boolean (shows skeleton when true)
  */
-export function DataTable({ columns = [], filters = [], data = [], onRowSelect, selectedId, compact, loading }) {
+export function DataTable({ entity, columns = [], filters = [], data = [], onRowSelect, selectedId, compact, loading }) {
   const [filterValues, setFilterValues] = useState({});
 
   const setFilter = (key, value) => {
@@ -155,7 +156,9 @@ export function DataTable({ columns = [], filters = [], data = [], onRowSelect, 
             <TableRow className="border-b-2 border-primary/20 bg-muted/40">
               {columns.map(col => (
                 <TableHead key={col.key} className="text-xs font-medium text-blue-800 uppercase tracking-wider">
-                  {col.label}
+                  <FieldHighlight entityName={entity} fieldName={col.key}>
+                    {col.label}
+                  </FieldHighlight>
                 </TableHead>
               ))}
             </TableRow>

--- a/tools/app-shell/src/components/contract-ui/EntityForm.jsx
+++ b/tools/app-shell/src/components/contract-ui/EntityForm.jsx
@@ -3,6 +3,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
 import { Search } from 'lucide-react';
+import { FieldHighlight } from '@/components/inspector/FieldHighlight.jsx';
 
 /**
  * Combobox-style search input for foreign key fields.
@@ -141,13 +142,14 @@ function DependentSelect({ field, value, onChange, catalogs, formData }) {
  *  - onChange: (fieldKey, value) => void
  *  - catalogs: Record<string, Array<{ id, name, ... }>> for FK reference data
  */
-export function EntityForm({ fields = [], data, onChange, catalogs }) {
+export function EntityForm({ entity, fields = [], data, onChange, catalogs }) {
   return (
     <div className="grid grid-cols-2 gap-3">
       {fields.map(f => {
         if (f.type === 'checkbox') {
           return (
-            <div key={f.key} className="flex items-center gap-2 pt-6">
+            <FieldHighlight key={f.key} entityName={entity} fieldName={f.key}>
+            <div className="flex items-center gap-2 pt-6">
               <button
                 type="button"
                 role="checkbox"
@@ -182,70 +184,79 @@ export function EntityForm({ fields = [], data, onChange, catalogs }) {
                 {f.label}{f.required ? ' *' : ''}
               </Label>
             </div>
+            </FieldHighlight>
           );
         }
         if (f.type === 'dependent') {
           return (
-            <div key={f.key} className="space-y-1.5">
-              <Label htmlFor={f.key} className="text-sm text-foreground font-medium">
-                {f.label}{f.required ? ' *' : ''}
-              </Label>
-              <DependentSelect
-                field={f}
-                value={data?.[f.key] ?? ''}
-                onChange={(val) => onChange?.(f.key, val)}
-                catalogs={catalogs}
-                formData={data}
-              />
-            </div>
+            <FieldHighlight key={f.key} entityName={entity} fieldName={f.key}>
+              <div className="space-y-1.5">
+                <Label htmlFor={f.key} className="text-sm text-foreground font-medium">
+                  {f.label}{f.required ? ' *' : ''}
+                </Label>
+                <DependentSelect
+                  field={f}
+                  value={data?.[f.key] ?? ''}
+                  onChange={(val) => onChange?.(f.key, val)}
+                  catalogs={catalogs}
+                  formData={data}
+                />
+              </div>
+            </FieldHighlight>
           );
         }
         if (f.type === 'selector') {
           return (
-            <div key={f.key} className="space-y-1.5">
-              <Label htmlFor={f.key} className="text-sm text-foreground font-medium">
-                {f.label}{f.required ? ' *' : ''}
-              </Label>
-              <SelectorInput
-                field={f}
-                value={data?.[f.key] ?? ''}
-                onChange={(val) => onChange?.(f.key, val)}
-                catalogs={catalogs}
-              />
-            </div>
+            <FieldHighlight key={f.key} entityName={entity} fieldName={f.key}>
+              <div className="space-y-1.5">
+                <Label htmlFor={f.key} className="text-sm text-foreground font-medium">
+                  {f.label}{f.required ? ' *' : ''}
+                </Label>
+                <SelectorInput
+                  field={f}
+                  value={data?.[f.key] ?? ''}
+                  onChange={(val) => onChange?.(f.key, val)}
+                  catalogs={catalogs}
+                />
+              </div>
+            </FieldHighlight>
           );
         }
         if (f.type === 'search') {
           return (
-            <div key={f.key} className="space-y-1.5">
-              <Label htmlFor={f.key} className="text-sm text-foreground font-medium">
-                {f.label}{f.required ? ' *' : ''}
-              </Label>
-              <SearchInput
-                field={f}
-                value={data?.[f.key] ?? ''}
-                onChange={(val) => onChange?.(f.key, val)}
-                catalogs={catalogs}
-              />
-            </div>
+            <FieldHighlight key={f.key} entityName={entity} fieldName={f.key}>
+              <div className="space-y-1.5">
+                <Label htmlFor={f.key} className="text-sm text-foreground font-medium">
+                  {f.label}{f.required ? ' *' : ''}
+                </Label>
+                <SearchInput
+                  field={f}
+                  value={data?.[f.key] ?? ''}
+                  onChange={(val) => onChange?.(f.key, val)}
+                  catalogs={catalogs}
+                />
+              </div>
+            </FieldHighlight>
           );
         }
         const inputType = f.type === 'number' ? 'number' : 'text';
         return (
-          <div key={f.key} className="space-y-1.5">
-            <Label htmlFor={f.key} className="text-sm text-foreground font-medium">
-              {f.label}{f.required ? ' *' : ''}
-            </Label>
-            <Input
-              id={f.key}
-              name={f.key}
-              type={inputType}
-              value={data?.[f.key] ?? ''}
-              onChange={(e) => onChange?.(f.key, e.target.value)}
-              className="focus:ring-2 focus:ring-primary focus:outline-none"
-              required={f.required}
-            />
-          </div>
+          <FieldHighlight key={f.key} entityName={entity} fieldName={f.key}>
+            <div className="space-y-1.5">
+              <Label htmlFor={f.key} className="text-sm text-foreground font-medium">
+                {f.label}{f.required ? ' *' : ''}
+              </Label>
+              <Input
+                id={f.key}
+                name={f.key}
+                type={inputType}
+                value={data?.[f.key] ?? ''}
+                onChange={(e) => onChange?.(f.key, e.target.value)}
+                className="focus:ring-2 focus:ring-primary focus:outline-none"
+                required={f.required}
+              />
+            </div>
+          </FieldHighlight>
         );
       })}
     </div>

--- a/tools/app-shell/src/components/contract-ui/MasterDetailPage.jsx
+++ b/tools/app-shell/src/components/contract-ui/MasterDetailPage.jsx
@@ -242,6 +242,7 @@ export function MasterDetailPage({
               </div>
             ) : (
               <Table
+                entity={entity}
                 data={hook.items}
                 onRowSelect={hook.handleSelect}
                 selectedId={hook.selected?.id}
@@ -320,6 +321,7 @@ export function MasterDetailPage({
             {/* Form zone: editable fields only */}
             <div className="px-5 pt-4 pb-3 border-b">
               <Form
+                entity={entity}
                 data={hook.editing}
                 onChange={hook.handleChange}
                 catalogs={catalogs}

--- a/tools/app-shell/src/components/inspector/AddFieldDialog.jsx
+++ b/tools/app-shell/src/components/inspector/AddFieldDialog.jsx
@@ -1,0 +1,219 @@
+import { useMemo, useState } from "react";
+import { Search, Plus } from "lucide-react";
+import { useInspector } from "./InspectorProvider";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+export function AddFieldDialog({ open, onOpenChange, entityName }) {
+  const { schema, schemaRaw, addField } = useInspector();
+  const [search, setSearch] = useState("");
+  const [selectedFieldName, setSelectedFieldName] = useState(null);
+  const [visibility, setVisibility] = useState("editable");
+  const [required, setRequired] = useState(false);
+  const [grid, setGrid] = useState(false);
+  const [form, setForm] = useState(true);
+  const [searchable, setSearchable] = useState(false);
+
+  const availableFields = useMemo(() => {
+    const rawEntity = schemaRaw?.entities?.find((e) => e.name === entityName);
+    const curatedEntity = schema?.entities?.find((e) => e.name === entityName);
+    if (!rawEntity?.fields) return [];
+    const curatedNames = new Set(
+      (curatedEntity?.fields ?? []).map((f) => f.name)
+    );
+    return rawEntity.fields.filter((f) => !curatedNames.has(f.name));
+  }, [schema, schemaRaw, entityName]);
+
+  const filteredFields = useMemo(() => {
+    if (!search.trim()) return availableFields;
+    const q = search.toLowerCase();
+    return availableFields.filter(
+      (f) =>
+        f.name?.toLowerCase().includes(q) ||
+        f.column?.toLowerCase().includes(q)
+    );
+  }, [availableFields, search]);
+
+  const selectedRawField = useMemo(
+    () => availableFields.find((f) => f.name === selectedFieldName) ?? null,
+    [availableFields, selectedFieldName]
+  );
+
+  function resetState() {
+    setSearch("");
+    setSelectedFieldName(null);
+    setVisibility("editable");
+    setRequired(false);
+    setGrid(false);
+    setForm(true);
+    setSearchable(false);
+  }
+
+  function handleOpenChange(nextOpen) {
+    if (!nextOpen) resetState();
+    onOpenChange(nextOpen);
+  }
+
+  function handleAdd() {
+    if (!selectedRawField) return;
+    addField(entityName, {
+      ...selectedRawField,
+      visibility,
+      required,
+      grid,
+      form,
+      searchable,
+    });
+    handleOpenChange(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-h-[85vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>Add Field</DialogTitle>
+          <DialogDescription>
+            Select a field from the raw schema to add to {entityName}.
+          </DialogDescription>
+        </DialogHeader>
+
+        {/* Search */}
+        <div className="relative">
+          <Search className="absolute left-2.5 top-2.5 h-4 w-4 text-muted-foreground" />
+          <Input
+            placeholder="Search by name or column..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+
+        {/* Field list */}
+        <div className="flex-1 min-h-0 overflow-y-auto border rounded-md max-h-48">
+          {filteredFields.length === 0 ? (
+            <p className="p-4 text-sm text-muted-foreground text-center">
+              No available fields found.
+            </p>
+          ) : (
+            <ul className="divide-y">
+              {filteredFields.map((field) => (
+                <li
+                  key={field.name}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => setSelectedFieldName(field.name)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      setSelectedFieldName(field.name);
+                    }
+                  }}
+                  className={`px-3 py-2 cursor-pointer text-sm transition-colors hover:bg-accent ${
+                    selectedFieldName === field.name ? "bg-primary/10" : ""
+                  }`}
+                >
+                  <span className="font-medium">{field.name}</span>
+                  <span className="mx-1.5 text-muted-foreground">·</span>
+                  <span className="text-muted-foreground">{field.column}</span>
+                  <span className="mx-1.5 text-muted-foreground">·</span>
+                  <span className="text-muted-foreground text-xs">
+                    {field.type}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Configuration panel */}
+        {selectedRawField && (
+          <div className="space-y-3 border rounded-md p-3">
+            <p className="text-sm font-medium">
+              Configure: {selectedRawField.name}
+            </p>
+
+            {/* Visibility */}
+            <div className="flex items-center justify-between">
+              <Label htmlFor="add-visibility">Visibility</Label>
+              <Select value={visibility} onValueChange={setVisibility}>
+                <SelectTrigger id="add-visibility" className="w-36">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="editable">Editable</SelectItem>
+                  <SelectItem value="readOnly">Read Only</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Required */}
+            <div className="flex items-center justify-between">
+              <Label htmlFor="add-required">Required</Label>
+              <Switch
+                id="add-required"
+                checked={required}
+                onCheckedChange={setRequired}
+              />
+            </div>
+
+            {/* Grid */}
+            <div className="flex items-center justify-between">
+              <Label htmlFor="add-grid">Grid</Label>
+              <Switch
+                id="add-grid"
+                checked={grid}
+                onCheckedChange={setGrid}
+              />
+            </div>
+
+            {/* Form */}
+            <div className="flex items-center justify-between">
+              <Label htmlFor="add-form">Form</Label>
+              <Switch
+                id="add-form"
+                checked={form}
+                onCheckedChange={setForm}
+              />
+            </div>
+
+            {/* Searchable */}
+            <div className="flex items-center justify-between">
+              <Label htmlFor="add-searchable">Searchable</Label>
+              <Switch
+                id="add-searchable"
+                checked={searchable}
+                onCheckedChange={setSearchable}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Add button */}
+        <Button
+          onClick={handleAdd}
+          disabled={!selectedRawField}
+          className="w-full"
+        >
+          <Plus className="h-4 w-4 mr-1" />
+          {selectedRawField ? `Add ${selectedRawField.name}` : "Select a field"}
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/tools/app-shell/src/components/inspector/FieldHighlight.jsx
+++ b/tools/app-shell/src/components/inspector/FieldHighlight.jsx
@@ -1,0 +1,33 @@
+import { useInspector } from './InspectorProvider.jsx';
+
+/**
+ * Wrapper that highlights a field when the inspector is in edit mode.
+ * Clicking a highlighted field selects it in the inspector panel.
+ *
+ * Must be rendered inside an InspectorProvider (which lives in AppLayout).
+ */
+export function FieldHighlight({ entityName, fieldName, children }) {
+  const inspector = useInspector();
+
+  if (!inspector?.editMode) {
+    return children;
+  }
+
+  const isSelected = inspector.selectedField === fieldName && inspector.selectedEntity === entityName;
+
+  return (
+    <div
+      className={`relative cursor-pointer rounded transition-all ${
+        isSelected
+          ? 'ring-2 ring-primary ring-offset-1'
+          : 'hover:ring-2 hover:ring-primary/40 hover:ring-offset-1'
+      }`}
+      onClick={(e) => {
+        e.stopPropagation();
+        inspector.selectField(entityName, fieldName);
+      }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/tools/app-shell/src/components/inspector/InspectorProvider.jsx
+++ b/tools/app-shell/src/components/inspector/InspectorProvider.jsx
@@ -1,0 +1,137 @@
+import { createContext, useCallback, useContext, useMemo, useState } from "react";
+
+const InspectorContext = createContext(null);
+
+export function InspectorProvider({ children }) {
+  const [editMode, setEditMode] = useState(false);
+  const [schema, setSchema] = useState(null);
+  const [schemaRaw, setSchemaRaw] = useState(null);
+  const [dirty, setDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [selectedField, setSelectedField] = useState(null);
+  const [selectedEntity, setSelectedEntity] = useState(null);
+  const [windowSlug, setWindowSlug] = useState(null);
+
+  const loadSchema = useCallback(async (slug) => {
+    setWindowSlug(slug);
+    const [curatedRes, rawRes] = await Promise.all([
+      fetch(`/api/schema/${slug}`),
+      fetch(`/api/schema-raw/${slug}`),
+    ]);
+    if (!curatedRes.ok) throw new Error(`Failed to load schema: ${curatedRes.status}`);
+    if (!rawRes.ok) throw new Error(`Failed to load raw schema: ${rawRes.status}`);
+    const curated = await curatedRes.json();
+    const raw = await rawRes.json();
+    setSchema(curated);
+    setSchemaRaw(raw);
+    setDirty(false);
+    setSelectedField(null);
+    setSelectedEntity(null);
+  }, []);
+
+  const updateField = useCallback((entityName, fieldName, updates) => {
+    setSchema((prev) => {
+      const next = structuredClone(prev);
+      const entity = next.entities.find((e) => e.name === entityName);
+      if (!entity) return prev;
+      const field = entity.fields.find((f) => f.name === fieldName);
+      if (!field) return prev;
+      Object.assign(field, updates);
+      return next;
+    });
+    setDirty(true);
+  }, []);
+
+  const removeField = useCallback((entityName, fieldName) => {
+    setSchema((prev) => {
+      const next = structuredClone(prev);
+      const entity = next.entities.find((e) => e.name === entityName);
+      if (!entity) return prev;
+      entity.fields = entity.fields.filter((f) => f.name !== fieldName);
+      return next;
+    });
+    setDirty(true);
+  }, []);
+
+  const addField = useCallback((entityName, field) => {
+    setSchema((prev) => {
+      const next = structuredClone(prev);
+      const entity = next.entities.find((e) => e.name === entityName);
+      if (!entity) return prev;
+      entity.fields.push(field);
+      return next;
+    });
+    setDirty(true);
+  }, []);
+
+  const save = useCallback(async () => {
+    if (!windowSlug || !schema) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/schema/${windowSlug}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ schema }),
+      });
+      if (!res.ok) throw new Error(`Save failed: ${res.status}`);
+      setDirty(false);
+    } finally {
+      setSaving(false);
+    }
+  }, [windowSlug, schema]);
+
+  const selectField = useCallback((entityName, fieldName) => {
+    setSelectedEntity(entityName);
+    setSelectedField(fieldName);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      editMode,
+      setEditMode,
+      schema,
+      schemaRaw,
+      dirty,
+      saving,
+      selectedField,
+      selectedEntity,
+      windowSlug,
+      loadSchema,
+      updateField,
+      removeField,
+      addField,
+      save,
+      selectField,
+    }),
+    [
+      editMode,
+      schema,
+      schemaRaw,
+      dirty,
+      saving,
+      selectedField,
+      selectedEntity,
+      windowSlug,
+      loadSchema,
+      updateField,
+      removeField,
+      addField,
+      save,
+      selectField,
+    ],
+  );
+
+  return (
+    <InspectorContext.Provider value={value}>
+      {children}
+    </InspectorContext.Provider>
+  );
+}
+
+export function useInspector() {
+  const ctx = useContext(InspectorContext);
+  if (!ctx) {
+    throw new Error("useInspector must be used within an InspectorProvider");
+  }
+  return ctx;
+}

--- a/tools/app-shell/src/components/inspector/SchemaInspector.jsx
+++ b/tools/app-shell/src/components/inspector/SchemaInspector.jsx
@@ -1,5 +1,7 @@
-import { Trash2 } from "lucide-react";
+import { useState } from "react";
+import { Plus, Trash2 } from "lucide-react";
 import { useInspector } from "./InspectorProvider";
+import { AddFieldDialog } from "./AddFieldDialog.jsx";
 import {
   Sheet,
   SheetContent,
@@ -28,6 +30,8 @@ export function SchemaInspector() {
     updateField,
     removeField,
   } = useInspector();
+
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
 
   if (!selectedField) return null;
 
@@ -125,6 +129,23 @@ export function SchemaInspector() {
             <Trash2 className="mr-2 h-4 w-4" />
             Remove Field
           </Button>
+
+          {/* Add Field */}
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full"
+            onClick={() => setAddDialogOpen(true)}
+          >
+            <Plus className="h-4 w-4 mr-2" />
+            Add Field
+          </Button>
+
+          <AddFieldDialog
+            open={addDialogOpen}
+            onOpenChange={setAddDialogOpen}
+            entityName={selectedEntity}
+          />
         </div>
       </SheetContent>
     </Sheet>

--- a/tools/app-shell/src/components/inspector/SchemaInspector.jsx
+++ b/tools/app-shell/src/components/inspector/SchemaInspector.jsx
@@ -1,0 +1,132 @@
+import { Trash2 } from "lucide-react";
+import { useInspector } from "./InspectorProvider";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+
+export function SchemaInspector() {
+  const {
+    schema,
+    selectedField,
+    selectedEntity,
+    selectField,
+    updateField,
+    removeField,
+  } = useInspector();
+
+  if (!selectedField) return null;
+
+  const entity = schema?.entities?.find((e) => e.name === selectedEntity);
+  const field = entity?.fields?.find((f) => f.name === selectedField);
+
+  if (!field) return null;
+
+  const handleClose = () => selectField(null, null);
+
+  const handleUpdate = (key, value) => {
+    updateField(selectedEntity, selectedField, { [key]: value });
+  };
+
+  const handleRemove = () => {
+    removeField(selectedEntity, selectedField);
+    handleClose();
+  };
+
+  return (
+    <Sheet open={!!selectedField} onOpenChange={(open) => !open && handleClose()}>
+      <SheetContent>
+        <SheetHeader>
+          <SheetTitle>{field.name}</SheetTitle>
+          <SheetDescription>
+            {field.column} &middot; {selectedEntity}
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex flex-col gap-6 py-6">
+          {/* Visibility */}
+          <div className="flex flex-col gap-2">
+            <Label>Visibility</Label>
+            <Select
+              value={field.visibility}
+              onValueChange={(value) => handleUpdate("visibility", value)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select visibility" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="editable">Editable</SelectItem>
+                <SelectItem value="readOnly">Read Only</SelectItem>
+                <SelectItem value="discarded">Discarded</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <Separator />
+
+          {/* Required */}
+          <div className="flex items-center justify-between">
+            <Label htmlFor="required-switch">Required</Label>
+            <Switch
+              id="required-switch"
+              checked={field.required}
+              onCheckedChange={(checked) => handleUpdate("required", checked)}
+            />
+          </div>
+
+          {/* Grid */}
+          <div className="flex items-center justify-between">
+            <Label htmlFor="grid-switch">Grid</Label>
+            <Switch
+              id="grid-switch"
+              checked={field.grid}
+              onCheckedChange={(checked) => handleUpdate("grid", checked)}
+            />
+          </div>
+
+          {/* Form */}
+          <div className="flex items-center justify-between">
+            <Label htmlFor="form-switch">Form</Label>
+            <Switch
+              id="form-switch"
+              checked={field.form}
+              onCheckedChange={(checked) => handleUpdate("form", checked)}
+            />
+          </div>
+
+          {/* Searchable */}
+          <div className="flex items-center justify-between">
+            <Label htmlFor="searchable-switch">Searchable</Label>
+            <Switch
+              id="searchable-switch"
+              checked={field.searchable}
+              onCheckedChange={(checked) => handleUpdate("searchable", checked)}
+            />
+          </div>
+
+          <Separator />
+
+          {/* Remove Field */}
+          <Button variant="destructive" onClick={handleRemove}>
+            <Trash2 className="mr-2 h-4 w-4" />
+            Remove Field
+          </Button>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/tools/app-shell/src/components/ui/switch.jsx
+++ b/tools/app-shell/src/components/ui/switch.jsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import * as SwitchPrimitives from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+const Switch = React.forwardRef(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}>
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+      )} />
+  </SwitchPrimitives.Root>
+))
+Switch.displayName = SwitchPrimitives.Root.displayName
+
+export { Switch }

--- a/tools/app-shell/src/layout/AppLayout.jsx
+++ b/tools/app-shell/src/layout/AppLayout.jsx
@@ -3,18 +3,23 @@ import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar.jsx';
 import AppSidebar from './Sidebar.jsx';
 import TopBar from './TopBar.jsx';
 import { CopilotWidget } from '@/components/CopilotWidget.jsx';
+import { InspectorProvider } from '@/components/inspector/InspectorProvider.jsx';
+import { SchemaInspector } from '@/components/inspector/SchemaInspector.jsx';
 
 export default function AppLayout({ menuGroups }) {
   return (
-    <SidebarProvider>
-      <AppSidebar menuGroups={menuGroups} />
-      <SidebarInset>
-        <TopBar />
-        <div className="flex-1 overflow-auto p-6">
-          <Outlet />
-        </div>
-      </SidebarInset>
-      <CopilotWidget />
-    </SidebarProvider>
+    <InspectorProvider>
+      <SidebarProvider>
+        <AppSidebar menuGroups={menuGroups} />
+        <SidebarInset>
+          <TopBar />
+          <div className="flex-1 overflow-auto p-6">
+            <Outlet />
+          </div>
+        </SidebarInset>
+        <CopilotWidget />
+        <SchemaInspector />
+      </SidebarProvider>
+    </InspectorProvider>
   );
 }

--- a/tools/app-shell/src/layout/TopBar.jsx
+++ b/tools/app-shell/src/layout/TopBar.jsx
@@ -1,12 +1,37 @@
 import { SidebarTrigger } from '@/components/ui/sidebar.jsx';
 import { Separator } from '@/components/ui/separator.jsx';
+import { useInspector } from '@/components/inspector/InspectorProvider.jsx';
+import { Pencil, PencilOff, Save, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button.jsx';
+import { Badge } from '@/components/ui/badge.jsx';
 
 export default function TopBar() {
+  const inspector = useInspector();
+
   return (
     <header className="flex h-14 shrink-0 items-center gap-2 border-b bg-background px-4">
       <SidebarTrigger className="-ml-1" />
       <Separator orientation="vertical" className="mr-2 h-4" />
+      {inspector.editMode && (
+        <Badge variant="outline" className="text-xs border-amber-500 text-amber-600">
+          Edit Mode
+        </Badge>
+      )}
       <div className="flex-1" />
+      {inspector.editMode && inspector.dirty && (
+        <Button size="sm" onClick={inspector.save} disabled={inspector.saving}>
+          {inspector.saving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Save className="h-4 w-4 mr-2" />}
+          Save &amp; Regenerate
+        </Button>
+      )}
+      <Button
+        variant={inspector.editMode ? 'default' : 'outline'}
+        size="icon"
+        onClick={() => inspector.setEditMode(!inspector.editMode)}
+      >
+        {inspector.editMode ? <PencilOff className="h-4 w-4" /> : <Pencil className="h-4 w-4" />}
+        <span className="sr-only">Toggle edit mode</span>
+      </Button>
     </header>
   );
 }

--- a/tools/app-shell/src/windows/WindowLoader.jsx
+++ b/tools/app-shell/src/windows/WindowLoader.jsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useAuth } from '@/auth/AuthContext.jsx';
+import { useInspector } from '@/components/inspector/InspectorProvider.jsx';
 
 export default function WindowLoader({ windowMap, apiBaseUrl }) {
   const { windowName } = useParams();
   const { token } = useAuth();
+  const inspector = useInspector();
   const [Component, setComponent] = useState(null);
   const [error, setError] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -31,6 +33,14 @@ export default function WindowLoader({ windowMap, apiBaseUrl }) {
         setLoading(false);
       });
   }, [windowName, windowMap]);
+
+  useEffect(() => {
+    if (windowName) {
+      inspector.loadSchema(windowName).catch(() => {
+        // Schema may not exist for all windows — that's OK
+      });
+    }
+  }, [windowName]);
 
   if (loading) {
     return <div className="flex items-center justify-center h-64 text-muted-foreground">Loading...</div>;

--- a/tools/app-shell/vite-plugins/schema-api.js
+++ b/tools/app-shell/vite-plugins/schema-api.js
@@ -5,6 +5,8 @@ const ARTIFACTS_DIR = resolve(import.meta.dirname, '../../../artifacts');
 const CONTRACT_GENERATOR = resolve(import.meta.dirname, '../../../cli/src/generate-contract.js');
 const FRONTEND_GENERATOR = resolve(import.meta.dirname, '../../../cli/src/generate-frontend.js');
 
+const SAFE_WINDOW_RE = /^[a-z0-9-]+$/;
+
 /**
  * Vite plugin that exposes REST endpoints for the Schema Inspector.
  *
@@ -20,19 +22,40 @@ export default function schemaApiPlugin() {
         // GET /api/schema-raw/:window
         const rawMatch = req.url?.match(/^\/api\/schema-raw\/([^/?]+)/);
         if (rawMatch && req.method === 'GET') {
-          return serveJson(res, rawMatch[1], 'schema-raw.json');
+          const windowName = rawMatch[1];
+          if (!SAFE_WINDOW_RE.test(windowName)) {
+            res.statusCode = 400;
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify({ error: 'Invalid window name' }));
+            return;
+          }
+          return serveJson(res, windowName, 'schema-raw.json');
         }
 
         // GET /api/schema/:window
         const getMatch = req.url?.match(/^\/api\/schema\/([^/?]+)/);
         if (getMatch && req.method === 'GET') {
-          return serveJson(res, getMatch[1], 'schema-curated.json');
+          const windowName = getMatch[1];
+          if (!SAFE_WINDOW_RE.test(windowName)) {
+            res.statusCode = 400;
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify({ error: 'Invalid window name' }));
+            return;
+          }
+          return serveJson(res, windowName, 'schema-curated.json');
         }
 
         // POST /api/schema/:window
         const postMatch = req.url?.match(/^\/api\/schema\/([^/?]+)/);
         if (postMatch && req.method === 'POST') {
-          return handlePost(req, res, postMatch[1]);
+          const windowName = postMatch[1];
+          if (!SAFE_WINDOW_RE.test(windowName)) {
+            res.statusCode = 400;
+            res.setHeader('Content-Type', 'application/json');
+            res.end(JSON.stringify({ error: 'Invalid window name' }));
+            return;
+          }
+          return handlePost(req, res, windowName);
         }
 
         next();
@@ -110,10 +133,19 @@ async function handlePost(req, res, window) {
   }
 }
 
-function readBody(req) {
+function readBody(req, limit = 5 * 1024 * 1024) {
   return new Promise((resolve, reject) => {
     const chunks = [];
-    req.on('data', (chunk) => chunks.push(chunk));
+    let size = 0;
+    req.on('data', (chunk) => {
+      size += chunk.length;
+      if (size > limit) {
+        reject(new Error('Request body too large'));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
     req.on('end', () => resolve(Buffer.concat(chunks).toString()));
     req.on('error', reject);
   });

--- a/tools/app-shell/vite-plugins/schema-api.js
+++ b/tools/app-shell/vite-plugins/schema-api.js
@@ -1,0 +1,120 @@
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+const ARTIFACTS_DIR = resolve(import.meta.dirname, '../../../artifacts');
+const CONTRACT_GENERATOR = resolve(import.meta.dirname, '../../../cli/src/generate-contract.js');
+const FRONTEND_GENERATOR = resolve(import.meta.dirname, '../../../cli/src/generate-frontend.js');
+
+/**
+ * Vite plugin that exposes REST endpoints for the Schema Inspector.
+ *
+ * GET  /api/schema/:window      — read schema-curated.json
+ * GET  /api/schema-raw/:window  — read schema-raw.json
+ * POST /api/schema/:window      — write schema, regenerate contract + frontend
+ */
+export default function schemaApiPlugin() {
+  return {
+    name: 'schema-api',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        // GET /api/schema-raw/:window
+        const rawMatch = req.url?.match(/^\/api\/schema-raw\/([^/?]+)/);
+        if (rawMatch && req.method === 'GET') {
+          return serveJson(res, rawMatch[1], 'schema-raw.json');
+        }
+
+        // GET /api/schema/:window
+        const getMatch = req.url?.match(/^\/api\/schema\/([^/?]+)/);
+        if (getMatch && req.method === 'GET') {
+          return serveJson(res, getMatch[1], 'schema-curated.json');
+        }
+
+        // POST /api/schema/:window
+        const postMatch = req.url?.match(/^\/api\/schema\/([^/?]+)/);
+        if (postMatch && req.method === 'POST') {
+          return handlePost(req, res, postMatch[1]);
+        }
+
+        next();
+      });
+    },
+  };
+}
+
+function serveJson(res, window, filename) {
+  try {
+    const filePath = join(ARTIFACTS_DIR, window, filename);
+    const data = readFileSync(filePath, 'utf-8');
+    res.setHeader('Content-Type', 'application/json');
+    res.end(data);
+  } catch (err) {
+    res.statusCode = err.code === 'ENOENT' ? 404 : 500;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: err.message }));
+  }
+}
+
+async function handlePost(req, res, window) {
+  const start = performance.now();
+
+  try {
+    const body = await readBody(req);
+    const { schema } = JSON.parse(body);
+
+    if (!schema) {
+      res.statusCode = 400;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({ error: 'Missing "schema" in request body' }));
+      return;
+    }
+
+    const windowDir = join(ARTIFACTS_DIR, window);
+    mkdirSync(windowDir, { recursive: true });
+
+    // 1. Write schema-curated.json
+    const schemaPath = join(windowDir, 'schema-curated.json');
+    writeFileSync(schemaPath, JSON.stringify(schema, null, 2));
+
+    // 2. Generate contract
+    const { generateContract } = await import(CONTRACT_GENERATOR);
+    const contract = generateContract(schema);
+    const contractPath = join(windowDir, 'contract.json');
+    writeFileSync(contractPath, JSON.stringify(contract, null, 2));
+
+    // 3. Generate frontend files
+    const { generateAll } = await import(FRONTEND_GENERATOR);
+    const files = generateAll(contract);
+    const webDir = join(windowDir, 'generated', 'web', window);
+    mkdirSync(webDir, { recursive: true });
+
+    const writtenFiles = [];
+    for (const [filename, code] of Object.entries(files)) {
+      const filePath = join(webDir, filename);
+      writeFileSync(filePath, code);
+      writtenFiles.push(filename);
+    }
+
+    const duration = ((performance.now() - start) / 1000).toFixed(1);
+
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({
+      ok: true,
+      regenerated: true,
+      duration: `${duration}s`,
+      files: writtenFiles,
+    }));
+  } catch (err) {
+    res.statusCode = 500;
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ error: err.message }));
+  }
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on('data', (chunk) => chunks.push(chunk));
+    req.on('end', () => resolve(Buffer.concat(chunks).toString()));
+    req.on('error', reject);
+  });
+}

--- a/tools/app-shell/vite.config.js
+++ b/tools/app-shell/vite.config.js
@@ -1,10 +1,11 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { resolve } from 'path';
+import schemaApiPlugin from './vite-plugins/schema-api.js';
 
 export default defineConfig({
   base: './',
-  plugins: [react()],
+  plugins: [react(), schemaApiPlugin()],
   resolve: {
     alias: {
       '@': resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- Adds an inspector mode to the app-shell that lets functional users click fields in the generated UI, edit their schema properties (visibility, required, grid, form, searchable), and add/remove fields
- Changes are previewed in-memory instantly; "Save & Regenerate" persists to schema-curated.json and auto-regenerates the full pipeline (contract + frontend + HMR reload)
- Vite dev middleware handles read/write/regenerate — zero extra infrastructure

## Components
- **Vite plugin** (`vite-plugins/schema-api.js`): REST endpoints for schema CRUD + regeneration
- **InspectorProvider**: React context with schema state, dirty tracking, CRUD operations
- **SchemaInspector**: Sheet panel with field property editors
- **AddFieldDialog**: Dialog to add fields from schema-raw to schema-curated
- **FieldHighlight**: Clickable overlay on DataTable headers and EntityForm fields
- **TopBar**: Edit mode toggle + Save & Regenerate button

## Test plan
- [ ] Navigate to a window (e.g., Sales Order), click Pencil icon — Edit Mode badge appears
- [ ] Click on a field in the grid or form — inspector Sheet opens with correct properties
- [ ] Change visibility/required/grid/form/searchable — preview updates instantly
- [ ] Click "Save & Regenerate" — schema is persisted, contract + frontend regenerated, page hot-reloads
- [ ] Click "Add Field" — dialog shows fields from schema-raw not in curated
- [ ] Add a field, save — field appears in regenerated UI
- [ ] Remove a field, save — field disappears from regenerated UI
- [ ] Build passes: `cd tools/app-shell && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)