### PR TITLE
feat: add Artifact Viewer for browsing JSON artifacts with git history

### DIFF
--- a/tools/app-shell/src/App.jsx
+++ b/tools/app-shell/src/App.jsx
@@ -18,6 +18,8 @@ import ProjectsPage from './pages/ProjectsPage.jsx';
 import { buildMenuGroups, buildWindowMap } from './windows/registry.js';
 import { createMockFetch } from './lib/mockFetch.js';
 
+import ArtifactViewerPage from './pages/ArtifactViewerPage.jsx';
+
 const OnboardingPage = lazy(() => import('./pages/OnboardingPage.jsx'));
 const SmartScanPage = lazy(() => import('./pages/SmartScanPage.jsx'));
 
@@ -128,6 +130,8 @@ function AppRoutes({ menuGroups, windowMap }) {
         <Route path="projects" element={<ProjectsPage />} />
         <Route path="onboarding" element={<Suspense fallback={<div className="p-8 text-muted-foreground">Loading...</div>}><OnboardingPage /></Suspense>} />
         <Route path="smart-scan" element={<Suspense fallback={<div className="p-8 text-muted-foreground">Loading...</div>}><SmartScanPage /></Suspense>} />
+        <Route path="artifacts" element={<ArtifactViewerPage />} />
+        <Route path="artifacts/:windowName" element={<ArtifactViewerPage />} />
         <Route
           path=":windowName"
           element={<WindowLoader windowMap={windowMap} apiBaseUrl={API_BASE_URL} />}

--- a/tools/app-shell/src/layout/Sidebar.jsx
+++ b/tools/app-shell/src/layout/Sidebar.jsx
@@ -32,6 +32,7 @@ import {
   FolderKanban,
   Target,
   LogOut,
+  FileJson,
 } from 'lucide-react';
 
 const ICON_MAP = {
@@ -122,6 +123,14 @@ export default function AppSidebar({ menuGroups }) {
               <NavLink to="/preview">
                 <Eye className="h-4 w-4" />
                 <span>Preview</span>
+              </NavLink>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton asChild tooltip="Artifacts">
+              <NavLink to="/artifacts">
+                <FileJson className="h-4 w-4" />
+                <span>Artifacts</span>
               </NavLink>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/tools/app-shell/src/pages/ArtifactViewerPage.jsx
+++ b/tools/app-shell/src/pages/ArtifactViewerPage.jsx
@@ -1,0 +1,295 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { FileJson, Search, History, Loader2, FolderOpen } from 'lucide-react';
+
+const ARTIFACT_FILES = [
+  { key: 'schema-raw.json', label: 'Schema Raw' },
+  { key: 'schema-curated.json', label: 'Schema Curated' },
+  { key: 'contract.json', label: 'Contract' },
+];
+
+/**
+ * Syntax-highlighted JSON viewer.
+ * Colorizes keys, strings, numbers, booleans, and nulls with Tailwind classes.
+ */
+function JsonView({ data }) {
+  const highlighted = useMemo(() => {
+    if (!data) return '';
+    const raw = typeof data === 'string' ? data : JSON.stringify(data, null, 2);
+    // Escape HTML first
+    const escaped = raw
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+
+    // Apply syntax coloring via regex replacements
+    return escaped
+      // Keys (quoted strings followed by colon)
+      .replace(
+        /^(\s*)(&quot;|")([^"]+)(&quot;|")(\s*:)/gm,
+        '$1<span class="text-blue-600">"$3"</span>$5'
+      )
+      // String values
+      .replace(
+        /:\s*(&quot;|")([^"]*?)(&quot;|")/g,
+        ': <span class="text-green-600">"$2"</span>'
+      )
+      // Numbers
+      .replace(
+        /:\s*(-?\d+\.?\d*([eE][+-]?\d+)?)/g,
+        ': <span class="text-amber-600">$1</span>'
+      )
+      // Booleans
+      .replace(
+        /:\s*(true|false)/g,
+        ': <span class="text-purple-600">$1</span>'
+      )
+      // Null
+      .replace(
+        /:\s*(null)/g,
+        ': <span class="text-gray-400">$1</span>'
+      );
+  }, [data]);
+
+  const lines = highlighted.split('\n');
+
+  return (
+    <div className="relative overflow-auto rounded-lg border border-gray-200 bg-gray-50 font-mono text-sm">
+      <table className="w-full border-collapse">
+        <tbody>
+          {lines.map((line, i) => (
+            <tr key={i} className="hover:bg-gray-100/50">
+              <td className="select-none border-r border-gray-200 px-3 py-0 text-right text-xs text-gray-400 align-top">
+                {i + 1}
+              </td>
+              <td
+                className="px-4 py-0 whitespace-pre"
+                dangerouslySetInnerHTML={{ __html: line || ' ' }}
+              />
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export default function ArtifactViewerPage() {
+  const { windowName: paramWindow } = useParams();
+  const navigate = useNavigate();
+
+  const [windows, setWindows] = useState([]);
+  const [search, setSearch] = useState('');
+  const [selectedWindow, setSelectedWindow] = useState(paramWindow || null);
+  const [selectedFile, setSelectedFile] = useState('schema-curated.json');
+  const [selectedRef, setSelectedRef] = useState(null);
+  const [commits, setCommits] = useState([]);
+  const [jsonData, setJsonData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Sync URL param to state
+  useEffect(() => {
+    if (paramWindow && paramWindow !== selectedWindow) {
+      setSelectedWindow(paramWindow);
+    }
+  }, [paramWindow]);
+
+  // Fetch window list on mount
+  useEffect(() => {
+    fetch('/api/artifacts')
+      .then((r) => r.json())
+      .then((data) => setWindows(data.windows || []))
+      .catch(() => setWindows([]));
+  }, []);
+
+  // Fetch history when window changes
+  useEffect(() => {
+    if (!selectedWindow) {
+      setCommits([]);
+      return;
+    }
+    fetch(`/api/artifacts/${selectedWindow}/history`)
+      .then((r) => r.json())
+      .then((data) => setCommits(data.commits || []))
+      .catch(() => setCommits([]));
+  }, [selectedWindow]);
+
+  // Fetch JSON data when window/file/ref changes
+  useEffect(() => {
+    if (!selectedWindow) {
+      setJsonData(null);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+
+    const refParam = selectedRef ? `?ref=${selectedRef}` : '';
+    fetch(`/api/artifacts/${selectedWindow}/${selectedFile}${refParam}`)
+      .then((r) => {
+        if (!r.ok) throw new Error(r.status === 404 ? 'File not found at this version' : 'Failed to load');
+        return r.text();
+      })
+      .then((text) => {
+        // Try to parse for pretty printing
+        try {
+          setJsonData(JSON.parse(text));
+        } catch {
+          setJsonData(text);
+        }
+        setError(null);
+      })
+      .catch((err) => {
+        setJsonData(null);
+        setError(err.message);
+      })
+      .finally(() => setLoading(false));
+  }, [selectedWindow, selectedFile, selectedRef]);
+
+  const handleSelectWindow = useCallback(
+    (name) => {
+      setSelectedWindow(name);
+      setSelectedRef(null);
+      navigate(`/artifacts/${name}`, { replace: true });
+    },
+    [navigate]
+  );
+
+  const filteredWindows = useMemo(() => {
+    if (!search) return windows;
+    const q = search.toLowerCase();
+    return windows.filter((w) => w.includes(q));
+  }, [windows, search]);
+
+  return (
+    <div className="flex h-full">
+      {/* Left sidebar — window list */}
+      <aside className="flex w-[220px] shrink-0 flex-col border-r border-gray-200 bg-white">
+        <div className="border-b border-gray-200 p-3">
+          <div className="flex items-center gap-2 mb-2">
+            <FileJson className="h-4 w-4 text-gray-500" />
+            <h2 className="text-sm font-semibold text-gray-700">Artifacts</h2>
+            <span className="ml-auto rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500">
+              {windows.length}
+            </span>
+          </div>
+          <div className="relative">
+            <Search className="absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
+            <input
+              type="text"
+              placeholder="Search windows..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="w-full rounded-md border border-gray-200 bg-gray-50 py-1.5 pl-7 pr-2 text-xs placeholder:text-gray-400 focus:border-blue-300 focus:outline-none focus:ring-1 focus:ring-blue-200"
+            />
+          </div>
+        </div>
+
+        <nav className="flex-1 overflow-y-auto p-1">
+          {filteredWindows.map((name) => (
+            <button
+              key={name}
+              onClick={() => handleSelectWindow(name)}
+              className={`w-full rounded-md px-2.5 py-1.5 text-left text-xs transition-colors ${
+                name === selectedWindow
+                  ? 'bg-blue-50 font-medium text-blue-700'
+                  : 'text-gray-600 hover:bg-gray-50'
+              }`}
+            >
+              {name}
+            </button>
+          ))}
+          {filteredWindows.length === 0 && (
+            <p className="px-3 py-4 text-xs text-gray-400">No windows found</p>
+          )}
+        </nav>
+      </aside>
+
+      {/* Main content */}
+      <main className="flex flex-1 flex-col overflow-hidden">
+        {!selectedWindow ? (
+          <div className="flex flex-1 items-center justify-center text-gray-400">
+            <div className="text-center">
+              <FolderOpen className="mx-auto mb-3 h-12 w-12 text-gray-300" />
+              <p className="text-sm">Select a window from the list</p>
+            </div>
+          </div>
+        ) : (
+          <>
+            {/* Top bar — tabs + version selector */}
+            <div className="flex items-center gap-4 border-b border-gray-200 bg-white px-4 py-2">
+              {/* File tabs */}
+              <div className="flex gap-1">
+                {ARTIFACT_FILES.map(({ key, label }) => (
+                  <button
+                    key={key}
+                    onClick={() => {
+                      setSelectedFile(key);
+                      setSelectedRef(null);
+                    }}
+                    className={`rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                      key === selectedFile
+                        ? 'bg-gray-900 text-white'
+                        : 'text-gray-600 hover:bg-gray-100'
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+
+              {/* Separator */}
+              <div className="h-5 w-px bg-gray-200" />
+
+              {/* Version selector */}
+              <div className="flex items-center gap-2">
+                <History className="h-3.5 w-3.5 text-gray-400" />
+                <select
+                  value={selectedRef || ''}
+                  onChange={(e) => setSelectedRef(e.target.value || null)}
+                  className="rounded-md border border-gray-200 bg-white px-2 py-1 text-xs text-gray-700 focus:border-blue-300 focus:outline-none focus:ring-1 focus:ring-blue-200"
+                >
+                  <option value="">Current version</option>
+                  {commits.map((c) => (
+                    <option key={c.hash} value={c.hash}>
+                      {c.hash} — {c.date?.substring(0, 10)} — {c.subject?.substring(0, 50)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Window name badge */}
+              <span className="ml-auto rounded-md bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-600">
+                {selectedWindow}
+              </span>
+            </div>
+
+            {/* JSON viewer */}
+            <div className="flex-1 overflow-auto p-4">
+              {loading && (
+                <div className="flex items-center justify-center py-16">
+                  <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+                  <span className="ml-2 text-sm text-gray-500">Loading...</span>
+                </div>
+              )}
+
+              {error && !loading && (
+                <div className="rounded-lg border border-amber-200 bg-amber-50 p-6 text-center">
+                  <p className="text-sm text-amber-700">{error}</p>
+                </div>
+              )}
+
+              {jsonData && !loading && !error && <JsonView data={jsonData} />}
+
+              {!jsonData && !loading && !error && (
+                <div className="flex items-center justify-center py-16 text-gray-400">
+                  <p className="text-sm">No data to display</p>
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/tools/app-shell/test/artifact-api.test.js
+++ b/tools/app-shell/test/artifact-api.test.js
@@ -1,0 +1,94 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+const ARTIFACTS_DIR = resolve(import.meta.dirname, '../../../artifacts');
+const SAFE_WINDOW_RE = /^[a-z0-9-]+$/;
+const SAFE_REF_RE = /^[a-f0-9]{7,40}$/;
+const ALLOWED_ARTIFACT_FILES = ['schema-raw.json', 'schema-curated.json', 'contract.json'];
+
+describe('artifact-api validation', () => {
+  it('SAFE_WINDOW_RE accepts valid window names', () => {
+    assert.ok(SAFE_WINDOW_RE.test('sales-order'));
+    assert.ok(SAFE_WINDOW_RE.test('business-partner'));
+    assert.ok(SAFE_WINDOW_RE.test('uom'));
+    assert.ok(SAFE_WINDOW_RE.test('chart-of-accounts'));
+  });
+
+  it('SAFE_WINDOW_RE rejects dangerous window names', () => {
+    assert.ok(!SAFE_WINDOW_RE.test('../etc'));
+    assert.ok(!SAFE_WINDOW_RE.test('foo;rm -rf'));
+    assert.ok(!SAFE_WINDOW_RE.test('sales order'));
+    assert.ok(!SAFE_WINDOW_RE.test('Sales_Order'));
+    assert.ok(!SAFE_WINDOW_RE.test(''));
+  });
+
+  it('SAFE_REF_RE accepts valid git hashes', () => {
+    assert.ok(SAFE_REF_RE.test('abc1234'));
+    assert.ok(SAFE_REF_RE.test('deadbeef'));
+    assert.ok(SAFE_REF_RE.test('a'.repeat(40)));
+  });
+
+  it('SAFE_REF_RE rejects invalid git refs', () => {
+    assert.ok(!SAFE_REF_RE.test('abc123'));   // too short (6 chars)
+    assert.ok(!SAFE_REF_RE.test('ABCDEF0'));  // uppercase
+    assert.ok(!SAFE_REF_RE.test('abc;rm'));   // injection
+    assert.ok(!SAFE_REF_RE.test('main'));     // branch name
+    assert.ok(!SAFE_REF_RE.test(''));
+  });
+
+  it('ALLOWED_ARTIFACT_FILES whitelist contains exactly 3 files', () => {
+    assert.equal(ALLOWED_ARTIFACT_FILES.length, 3);
+    assert.ok(ALLOWED_ARTIFACT_FILES.includes('schema-raw.json'));
+    assert.ok(ALLOWED_ARTIFACT_FILES.includes('schema-curated.json'));
+    assert.ok(ALLOWED_ARTIFACT_FILES.includes('contract.json'));
+  });
+
+  it('ALLOWED_ARTIFACT_FILES rejects unauthorized files', () => {
+    assert.ok(!ALLOWED_ARTIFACT_FILES.includes('rules-raw.json'));
+    assert.ok(!ALLOWED_ARTIFACT_FILES.includes('processes.json'));
+    assert.ok(!ALLOWED_ARTIFACT_FILES.includes('../../../etc/passwd'));
+  });
+});
+
+describe('artifact-api filesystem', () => {
+  it('artifacts directory exists', () => {
+    assert.ok(existsSync(ARTIFACTS_DIR), 'artifacts/ dir must exist');
+  });
+
+  it('at least one window has artifact files', () => {
+    const entries = readdirSync(ARTIFACTS_DIR, { withFileTypes: true });
+    const windowsWithArtifacts = entries
+      .filter((e) => e.isDirectory())
+      .filter((e) => {
+        const dir = join(ARTIFACTS_DIR, e.name);
+        return ALLOWED_ARTIFACT_FILES.some((f) => existsSync(join(dir, f)));
+      });
+
+    assert.ok(windowsWithArtifacts.length > 0, 'Should have at least one window with artifacts');
+  });
+
+  it('sales-order has all 3 artifact files', () => {
+    const windowDir = join(ARTIFACTS_DIR, 'sales-order');
+    for (const f of ALLOWED_ARTIFACT_FILES) {
+      assert.ok(existsSync(join(windowDir, f)), `sales-order should have ${f}`);
+    }
+  });
+
+  it('artifact files are valid JSON', () => {
+    const windowDir = join(ARTIFACTS_DIR, 'sales-order');
+    for (const f of ALLOWED_ARTIFACT_FILES) {
+      const content = readFileSync(join(windowDir, f), 'utf-8');
+      assert.doesNotThrow(() => JSON.parse(content), `${f} should be valid JSON`);
+    }
+  });
+
+  it('window names match SAFE_WINDOW_RE pattern', () => {
+    const entries = readdirSync(ARTIFACTS_DIR, { withFileTypes: true });
+    const dirs = entries.filter((e) => e.isDirectory());
+    for (const d of dirs) {
+      assert.ok(SAFE_WINDOW_RE.test(d.name), `Window "${d.name}" should match safe pattern`);
+    }
+  });
+});

--- a/tools/app-shell/vite-plugins/schema-api.js
+++ b/tools/app-shell/vite-plugins/schema-api.js
@@ -1,46 +1,91 @@
-import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, readdirSync, existsSync } from 'node:fs';
 import { resolve, join } from 'node:path';
+import { execSync } from 'node:child_process';
 
 const ARTIFACTS_DIR = resolve(import.meta.dirname, '../../../artifacts');
+const REPO_ROOT = resolve(ARTIFACTS_DIR, '..');
 const CONTRACT_GENERATOR = resolve(import.meta.dirname, '../../../cli/src/generate-contract.js');
 const FRONTEND_GENERATOR = resolve(import.meta.dirname, '../../../cli/src/generate-frontend.js');
 
 const SAFE_WINDOW_RE = /^[a-z0-9-]+$/;
+const SAFE_REF_RE = /^[a-f0-9]{7,40}$/;
+const ALLOWED_ARTIFACT_FILES = ['schema-raw.json', 'schema-curated.json', 'contract.json'];
 
 /**
- * Vite plugin that exposes REST endpoints for the Schema Inspector.
+ * Vite plugin that exposes REST endpoints for the Schema Inspector
+ * and the Artifact Viewer.
  *
- * GET  /api/schema/:window      — read schema-curated.json
- * GET  /api/schema-raw/:window  — read schema-raw.json
- * POST /api/schema/:window      — write schema, regenerate contract + frontend
+ * Schema Inspector:
+ *   GET  /api/schema/:window           — read schema-curated.json
+ *   GET  /api/schema-raw/:window       — read schema-raw.json
+ *   POST /api/schema/:window           — write schema, regenerate contract + frontend
+ *
+ * Artifact Viewer:
+ *   GET  /api/artifacts                 — list windows with artifact files
+ *   GET  /api/artifacts/:window/history — git history for a window's files
+ *   GET  /api/artifacts/:window/:file   — read artifact file (optional ?ref= for git version)
  */
 export default function schemaApiPlugin() {
   return {
     name: 'schema-api',
     configureServer(server) {
       server.middlewares.use((req, res, next) => {
+        const parsedUrl = new URL(req.url, 'http://localhost');
+        const pathname = parsedUrl.pathname;
+
+        // --- Artifact Viewer endpoints ---
+
+        // GET /api/artifacts (list windows)
+        if (pathname === '/api/artifacts' && req.method === 'GET') {
+          return handleListArtifacts(res);
+        }
+
+        // GET /api/artifacts/:window/history
+        const historyMatch = pathname.match(/^\/api\/artifacts\/([^/]+)\/history$/);
+        if (historyMatch && req.method === 'GET') {
+          const windowName = historyMatch[1];
+          if (!SAFE_WINDOW_RE.test(windowName)) {
+            return sendError(res, 400, 'Invalid window name');
+          }
+          return handleArtifactHistory(res, windowName);
+        }
+
+        // GET /api/artifacts/:window/:file?ref=hash
+        const fileMatch = pathname.match(/^\/api\/artifacts\/([^/]+)\/([^/]+)$/);
+        if (fileMatch && req.method === 'GET') {
+          const windowName = fileMatch[1];
+          const fileName = fileMatch[2];
+          if (!SAFE_WINDOW_RE.test(windowName)) {
+            return sendError(res, 400, 'Invalid window name');
+          }
+          if (!ALLOWED_ARTIFACT_FILES.includes(fileName)) {
+            return sendError(res, 400, 'File not allowed. Must be one of: ' + ALLOWED_ARTIFACT_FILES.join(', '));
+          }
+          const ref = parsedUrl.searchParams.get('ref') || null;
+          if (ref && !SAFE_REF_RE.test(ref)) {
+            return sendError(res, 400, 'Invalid git ref format');
+          }
+          return handleArtifactFile(res, windowName, fileName, ref);
+        }
+
+        // --- Schema Inspector endpoints ---
+
         // GET /api/schema-raw/:window
-        const rawMatch = req.url?.match(/^\/api\/schema-raw\/([^/?]+)/);
+        const rawMatch = pathname.match(/^\/api\/schema-raw\/([^/?]+)/);
         if (rawMatch && req.method === 'GET') {
           const windowName = rawMatch[1];
           if (!SAFE_WINDOW_RE.test(windowName)) {
-            res.statusCode = 400;
-            res.setHeader('Content-Type', 'application/json');
-            res.end(JSON.stringify({ error: 'Invalid window name' }));
-            return;
+            return sendError(res, 400, 'Invalid window name');
           }
           return serveJson(res, windowName, 'schema-raw.json');
         }
 
         // GET /api/schema/:window
-        const getMatch = req.url?.match(/^\/api\/schema\/([^/?]+)/);
+        const getMatch = pathname.match(/^\/api\/schema\/([^/?]+)/);
         if (getMatch && req.method === 'GET') {
           const windowName = getMatch[1];
           if (!SAFE_WINDOW_RE.test(windowName)) {
-            res.statusCode = 400;
-            res.setHeader('Content-Type', 'application/json');
-            res.end(JSON.stringify({ error: 'Invalid window name' }));
-            return;
+            return sendError(res, 400, 'Invalid window name');
           }
           return serveJson(res, windowName, 'schema-curated.json');
         }
@@ -50,10 +95,7 @@ export default function schemaApiPlugin() {
         if (postMatch && req.method === 'POST') {
           const windowName = postMatch[1];
           if (!SAFE_WINDOW_RE.test(windowName)) {
-            res.statusCode = 400;
-            res.setHeader('Content-Type', 'application/json');
-            res.end(JSON.stringify({ error: 'Invalid window name' }));
-            return;
+            return sendError(res, 400, 'Invalid window name');
           }
           return handlePost(req, res, windowName);
         }
@@ -62,6 +104,80 @@ export default function schemaApiPlugin() {
       });
     },
   };
+}
+
+function sendError(res, status, message) {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify({ error: message }));
+}
+
+/** List all windows that have at least one of the 3 artifact files. */
+function handleListArtifacts(res) {
+  try {
+    const entries = readdirSync(ARTIFACTS_DIR, { withFileTypes: true });
+    const windows = entries
+      .filter((e) => e.isDirectory())
+      .filter((e) => {
+        const dir = join(ARTIFACTS_DIR, e.name);
+        return ALLOWED_ARTIFACT_FILES.some((f) => existsSync(join(dir, f)));
+      })
+      .map((e) => e.name)
+      .sort();
+
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ windows }));
+  } catch (err) {
+    sendError(res, 500, err.message);
+  }
+}
+
+/** Git history for a window's artifact files (last 50 commits). */
+function handleArtifactHistory(res, windowName) {
+  try {
+    const filePaths = ALLOWED_ARTIFACT_FILES.map(
+      (f) => `artifacts/${windowName}/${f}`
+    ).join(' ');
+
+    const cmd = `git log -50 --pretty=format:'%h||%ci||%s' --follow -- ${filePaths}`;
+    const output = execSync(cmd, { cwd: REPO_ROOT, encoding: 'utf-8', timeout: 10000 });
+
+    const commits = output
+      .split('\n')
+      .filter((line) => line.trim())
+      .map((line) => {
+        const [hash, date, ...subjectParts] = line.split('||');
+        return { hash, date, subject: subjectParts.join('||') };
+      });
+
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ commits }));
+  } catch (err) {
+    sendError(res, 500, err.message);
+  }
+}
+
+/** Read an artifact file, optionally at a specific git ref. */
+function handleArtifactFile(res, windowName, fileName, ref) {
+  try {
+    let data;
+    if (ref) {
+      const gitPath = `artifacts/${windowName}/${fileName}`;
+      const cmd = `git show ${ref}:${gitPath}`;
+      data = execSync(cmd, { cwd: REPO_ROOT, encoding: 'utf-8', timeout: 10000 });
+    } else {
+      const filePath = join(ARTIFACTS_DIR, windowName, fileName);
+      data = readFileSync(filePath, 'utf-8');
+    }
+    res.setHeader('Content-Type', 'application/json');
+    res.end(data);
+  } catch (err) {
+    if (err.code === 'ENOENT' || (err.stderr && err.stderr.includes('does not exist'))) {
+      sendError(res, 404, 'File not found at this version');
+    } else {
+      sendError(res, 500, err.message);
+    }
+  }
 }
 
 function serveJson(res, window, filename) {


### PR DESCRIPTION
## Summary
- Extends `schema-api.js` Vite plugin with 3 new endpoints: list windows, git history, and file-at-ref reading
- Adds `ArtifactViewerPage` with searchable window sidebar, file tabs (Schema Raw / Schema Curated / Contract), version selector via git history, and syntax-highlighted JSON display with line numbers
- Adds route at `/artifacts` and `/artifacts/:windowName`, plus sidebar navigation link
- All inputs validated: window names via SAFE_WINDOW_RE, file names via whitelist, git refs via hex pattern

## Test plan
- [x] 11 new tests covering validation rules, filesystem assertions, and whitelist enforcement
- [x] Full existing test suite passes (2922 tests, 0 failures)
- [x] Vite build succeeds with no errors
- [ ] Manual: navigate to /artifacts, select a window, switch tabs, select a historical version

Generated with [Claude Code](https://claude.com/claude-code)