### PR TITLE
feat: add useLabel hook and LocaleProvider for i18n

### DIFF
--- a/tools/app-shell/src/i18n/LocaleProvider.jsx
+++ b/tools/app-shell/src/i18n/LocaleProvider.jsx
@@ -1,0 +1,30 @@
+import React, { createContext, useContext, useMemo } from 'react';
+
+const LocaleContext = createContext(null);
+
+// Import all locale files statically (Vite handles JSON imports)
+const localeModules = import.meta.glob('../locales/*.json', { eager: true });
+
+/**
+ * Provides locale dictionary to the component tree via React context.
+ * Accepts a locale prop (e.g., "en_US") and resolves the matching JSON file.
+ */
+export function LocaleProvider({ locale = 'en_US', children }) {
+  const dictionary = useMemo(() => {
+    const key = `../locales/${locale}.json`;
+    return localeModules[key]?.default ?? localeModules[key] ?? {};
+  }, [locale]);
+
+  return (
+    <LocaleContext.Provider value={dictionary}>
+      {children}
+    </LocaleContext.Provider>
+  );
+}
+
+/**
+ * Returns the raw locale dictionary from context.
+ */
+export function useLocale() {
+  return useContext(LocaleContext);
+}

--- a/tools/app-shell/src/i18n/__tests__/resolveLabel-edge.test.js
+++ b/tools/app-shell/src/i18n/__tests__/resolveLabel-edge.test.js
@@ -1,0 +1,107 @@
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveLabel } from '../resolveLabel.js';
+
+describe('resolveLabel edge cases', () => {
+  it('returns null when columnName is empty string', () => {
+    const dict = { fields: { '': { label: 'Empty Key' } } };
+    // Empty string IS a valid key — should resolve if present
+    assert.equal(resolveLabel(dict, ''), 'Empty Key');
+  });
+
+  it('returns null when field entry exists but has no label property', () => {
+    const dict = { fields: { SomeField: { description: 'No label here' } } };
+    assert.equal(resolveLabel(dict, 'SomeField'), null);
+  });
+
+  it('returns null when field entry is null', () => {
+    const dict = { fields: { SomeField: null } };
+    assert.equal(resolveLabel(dict, 'SomeField'), null);
+  });
+
+  it('returns null when fields value is null', () => {
+    const dict = { fields: null };
+    assert.equal(resolveLabel(dict, 'C_BPartner_ID'), null);
+  });
+
+  it('returns empty string label when label is explicitly empty', () => {
+    const dict = { fields: { EmptyLabel: { label: '' } } };
+    // Empty string is falsy but should still be returned (not coerced to null)
+    // With ?? operator, empty string is NOT nullish, so it passes through
+    assert.equal(resolveLabel(dict, 'EmptyLabel'), '');
+  });
+
+  it('returns label when label value is zero (number)', () => {
+    const dict = { fields: { NumericLabel: { label: 0 } } };
+    // 0 is NOT nullish, so ?? should pass it through
+    assert.equal(resolveLabel(dict, 'NumericLabel'), 0);
+  });
+
+  it('returns null when columnName is null', () => {
+    const dict = { fields: { C_BPartner_ID: { label: 'BP' } } };
+    assert.equal(resolveLabel(dict, null), null);
+  });
+
+  it('returns null when columnName is undefined', () => {
+    const dict = { fields: { C_BPartner_ID: { label: 'BP' } } };
+    assert.equal(resolveLabel(dict, undefined), null);
+  });
+
+  it('is case-sensitive for column names', () => {
+    const dict = { fields: { DocStatus: { label: 'Document Status' } } };
+    assert.equal(resolveLabel(dict, 'docstatus'), null);
+    assert.equal(resolveLabel(dict, 'DOCSTATUS'), null);
+    assert.equal(resolveLabel(dict, 'DocStatus'), 'Document Status');
+  });
+
+  it('handles dictionary that is a non-object primitive (number)', () => {
+    assert.equal(resolveLabel(42, 'SomeField'), null);
+  });
+
+  it('handles dictionary that is a boolean', () => {
+    assert.equal(resolveLabel(true, 'SomeField'), null);
+  });
+
+  it('handles dictionary that is a string', () => {
+    assert.equal(resolveLabel('not-a-dict', 'SomeField'), null);
+  });
+});
+
+describe('resolveLabel en_US.json contract', () => {
+  // Verify the actual en_US.json matches expected labels from the DB
+  let enUS;
+
+  // Load the actual locale file
+  before(async () => {
+    const url = new URL('../../locales/en_US.json', import.meta.url);
+    const fs = await import('node:fs');
+    enUS = JSON.parse(fs.readFileSync(url, 'utf8'));
+  });
+
+  it('en_US.json is valid and has fields key', () => {
+    assert.ok(enUS.fields, 'en_US.json must have a fields key');
+    assert.equal(typeof enUS.fields, 'object');
+  });
+
+  it('C_BPartner_ID resolves to Business Partner', () => {
+    assert.equal(resolveLabel(enUS, 'C_BPartner_ID'), 'Business Partner');
+  });
+
+  it('DatePromised resolves to Scheduled Delivery Date', () => {
+    assert.equal(resolveLabel(enUS, 'DatePromised'), 'Scheduled Delivery Date');
+  });
+
+  it('GrandTotal resolves to Total Gross Amount', () => {
+    assert.equal(resolveLabel(enUS, 'GrandTotal'), 'Total Gross Amount');
+  });
+
+  it('DocStatus resolves to Document Status', () => {
+    assert.equal(resolveLabel(enUS, 'DocStatus'), 'Document Status');
+  });
+
+  it('en_US.json has windows, tabs, and menus sections', () => {
+    assert.ok(enUS.windows, 'must have windows key');
+    assert.ok(enUS.tabs, 'must have tabs key');
+    assert.ok(enUS.menus, 'must have menus key');
+  });
+});

--- a/tools/app-shell/src/i18n/__tests__/useLabel.test.js
+++ b/tools/app-shell/src/i18n/__tests__/useLabel.test.js
@@ -1,0 +1,48 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveLabel } from '../resolveLabel.js';
+
+const sampleDictionary = {
+  fields: {
+    C_BPartner_ID: { label: 'Business Partner', description: 'A Business Partner is anyone with whom you transact.' },
+    DateOrdered: { label: 'Order Date' },
+    DatePromised: { label: 'Scheduled Delivery Date' },
+    GrandTotal: { label: 'Total Gross Amount' },
+    DocumentNo: { label: 'Document No.' },
+  },
+  windows: { 'Sales Order': { label: 'Sales Order' } },
+};
+
+describe('resolveLabel', () => {
+  it('returns correct label for a known column', () => {
+    assert.equal(resolveLabel(sampleDictionary, 'C_BPartner_ID'), 'Business Partner');
+  });
+
+  it('returns correct label for another known column', () => {
+    assert.equal(resolveLabel(sampleDictionary, 'DatePromised'), 'Scheduled Delivery Date');
+  });
+
+  it('returns label with special characters', () => {
+    assert.equal(resolveLabel(sampleDictionary, 'DocumentNo'), 'Document No.');
+  });
+
+  it('returns null for an unknown column', () => {
+    assert.equal(resolveLabel(sampleDictionary, 'NonExistent'), null);
+  });
+
+  it('returns null for an empty dictionary', () => {
+    assert.equal(resolveLabel({}, 'C_BPartner_ID'), null);
+  });
+
+  it('returns null for a dictionary with no fields key', () => {
+    assert.equal(resolveLabel({ windows: {} }, 'C_BPartner_ID'), null);
+  });
+
+  it('returns null when dictionary is null', () => {
+    assert.equal(resolveLabel(null, 'C_BPartner_ID'), null);
+  });
+
+  it('returns null when dictionary is undefined', () => {
+    assert.equal(resolveLabel(undefined, 'C_BPartner_ID'), null);
+  });
+});

--- a/tools/app-shell/src/i18n/index.js
+++ b/tools/app-shell/src/i18n/index.js
@@ -1,0 +1,3 @@
+export { LocaleProvider, useLocale } from './LocaleProvider.jsx';
+export { useLabel } from './useLabel.js';
+export { resolveLabel } from './resolveLabel.js';

--- a/tools/app-shell/src/i18n/resolveLabel.js
+++ b/tools/app-shell/src/i18n/resolveLabel.js
@@ -1,0 +1,11 @@
+/**
+ * Resolves a field label from the locale dictionary.
+ * Pure function — no React dependency, safe for direct testing.
+ *
+ * @param {object|null} dictionary - The locale dictionary
+ * @param {string} columnName - The column name to look up
+ * @returns {string|null} The label, or null if not found
+ */
+export function resolveLabel(dictionary, columnName) {
+  return dictionary?.fields?.[columnName]?.label ?? null;
+}

--- a/tools/app-shell/src/i18n/useLabel.js
+++ b/tools/app-shell/src/i18n/useLabel.js
@@ -1,0 +1,17 @@
+import { useLocale } from './LocaleProvider.jsx';
+import { resolveLabel } from './resolveLabel.js';
+
+/**
+ * Hook that returns a label resolver function.
+ * t(columnName) returns the localized label string, or null if not found.
+ *
+ * Usage:
+ *   const t = useLabel();
+ *   t('C_BPartner_ID')   // "Business Partner"
+ *   t('DatePromised')     // "Scheduled Delivery Date"
+ *   t('NonExistent')      // null (caller should fallback)
+ */
+export function useLabel() {
+  const dictionary = useLocale();
+  return (columnName) => resolveLabel(dictionary, columnName);
+}

--- a/tools/app-shell/src/locales/en_US.json
+++ b/tools/app-shell/src/locales/en_US.json
@@ -1,0 +1,23 @@
+{
+  "fields": {
+    "C_BPartner_ID": { "label": "Business Partner", "description": "A Business Partner is anyone with whom you transact." },
+    "DateOrdered": { "label": "Order Date", "description": "The time listed on the order." },
+    "DatePromised": { "label": "Scheduled Delivery Date", "description": "The date that a task is to be completed by." },
+    "GrandTotal": { "label": "Total Gross Amount" },
+    "TotalLines": { "label": "Total Net Amount" },
+    "DocStatus": { "label": "Document Status" },
+    "DocumentNo": { "label": "Document No." },
+    "SalesRep_ID": { "label": "Sales Representative" },
+    "POReference": { "label": "Order Reference" }
+  },
+  "windows": {
+    "Sales Order": { "label": "Sales Order" }
+  },
+  "tabs": {
+    "Header": { "label": "Header" },
+    "Lines": { "label": "Lines" }
+  },
+  "menus": {
+    "Sales Order": { "label": "Sales Order" }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `LocaleProvider` React context that loads locale JSON via `import.meta.glob`
- Add `useLabel()` hook that resolves field labels by column name
- Extract `resolveLabel()` as pure function for testability
- Add placeholder `en_US.json` locale with 9 field entries
- 8/8 tests passing

## Test plan
- [x] Unit tests for `resolveLabel` (known column, unknown column, empty/null dictionary)
- [ ] Manual: verify `LocaleProvider` loads locale in app-shell dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)