### PR TITLE
ci: add test workflow for PRs and main pushes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - name: Run all tests
+        run: node --test --test-reporter=spec 'cli/test/*.test.js'
+
+      - name: Build app-shell
+        run: npm run build --workspace=tools/app-shell


### PR DESCRIPTION
## Summary
- Runs all CLI tests (`node --test 'cli/test/*.test.js'`) on every PR and push to main
- Builds app-shell to catch compilation errors
- Node 22, npm cache for speed

## Test plan
- [ ] Workflow triggers on this PR itself
- [ ] Tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)