### PR TITLE
feat: redesign sidebar (icon rail) and topbar (section tabs)

### DIFF
--- a/tools/app-shell/src/layout/AppLayout.jsx
+++ b/tools/app-shell/src/layout/AppLayout.jsx
@@ -1,5 +1,4 @@
 import { Outlet } from 'react-router-dom';
-import { SidebarProvider, SidebarInset } from '@/components/ui/sidebar.jsx';
 import AppSidebar from './Sidebar.jsx';
 import TopBar from './TopBar.jsx';
 import { CopilotWidget } from '@/components/CopilotWidget.jsx';
@@ -10,18 +9,16 @@ import { SchemaInspector } from '@/components/inspector/SchemaInspector.jsx';
 export default function AppLayout({ menuGroups }) {
   return (
     <InspectorProvider>
-      <SidebarProvider defaultOpen={false}>
-        <AppSidebar menuGroups={menuGroups} />
-        <SidebarInset>
-          <TopBar />
-          <div className="flex-1 overflow-auto p-6">
-            <Outlet />
-          </div>
-        </SidebarInset>
-        <CopilotWidget />
-        <CommandPalette />
-        <SchemaInspector />
-      </SidebarProvider>
+      <AppSidebar menuGroups={menuGroups} />
+      <div className="ml-[60px] flex h-screen flex-col">
+        <TopBar menuGroups={menuGroups} />
+        <div className="flex-1 overflow-auto p-6">
+          <Outlet />
+        </div>
+      </div>
+      <CopilotWidget />
+      <CommandPalette />
+      <SchemaInspector />
     </InspectorProvider>
   );
 }

--- a/tools/app-shell/src/layout/Sidebar.jsx
+++ b/tools/app-shell/src/layout/Sidebar.jsx
@@ -1,32 +1,18 @@
 import { NavLink, useLocation } from 'react-router-dom';
 import { useAuth } from '@/auth/AuthContext.jsx';
 import {
-  Sidebar,
-  SidebarContent,
-  SidebarFooter,
-  SidebarHeader,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-  SidebarMenuSub,
-  SidebarMenuSubButton,
-  SidebarMenuSubItem,
-  SidebarRail,
-} from '@/components/ui/sidebar.jsx';
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible.jsx';
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip.jsx';
 import {
   Eye,
-  ChevronRight,
   LayoutDashboard,
   ShoppingCart,
   Truck,
   Calculator,
   Package,
-  Box,
   Users,
   Settings,
   FolderKanban,
@@ -34,6 +20,7 @@ import {
   LogOut,
   FileJson,
 } from 'lucide-react';
+import { cn } from '@/lib/utils.js';
 
 const ICON_MAP = {
   LayoutDashboard,
@@ -41,117 +28,125 @@ const ICON_MAP = {
   Truck,
   Calculator,
   Package,
-  Box,
   Users,
   Settings,
   FolderKanban,
   Target,
+  Eye,
+  FileJson,
 };
 
-function NavMenuGroup({ group, icon, items, isActive }) {
+/**
+ * Determines which menu group is active based on current route.
+ * Returns the group object or null.
+ */
+export function findActiveGroup(menuGroups, pathname) {
+  const currentPath = pathname.replace(/^\//, '');
+  return menuGroups.find((g) =>
+    g.items.some((item) => item.name === currentPath)
+  ) || null;
+}
+
+function SidebarIcon({ icon, label, to, isActive }) {
   const Icon = ICON_MAP[icon] || Package;
 
   return (
-    <Collapsible asChild defaultOpen={isActive} className="group/collapsible">
-      <SidebarMenuItem>
-        <CollapsibleTrigger asChild>
-          <SidebarMenuButton tooltip={group}>
-            <Icon className="h-4 w-4" />
-            <span>{group}</span>
-            <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
-          </SidebarMenuButton>
-        </CollapsibleTrigger>
-        <CollapsibleContent>
-          <SidebarMenuSub>
-            {items.map((item) => (
-              <SidebarMenuSubItem key={item.name}>
-                <SidebarMenuSubButton asChild>
-                  <NavLink
-                    to={`/${item.name}`}
-                    className={({ isActive: active }) => (active ? 'font-medium' : '')}
-                  >
-                    {item.label}
-                  </NavLink>
-                </SidebarMenuSubButton>
-              </SidebarMenuSubItem>
-            ))}
-          </SidebarMenuSub>
-        </CollapsibleContent>
-      </SidebarMenuItem>
-    </Collapsible>
+    <Tooltip delayDuration={0}>
+      <TooltipTrigger asChild>
+        <NavLink
+          to={to}
+          className={cn(
+            'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
+            isActive
+              ? 'bg-white/15 text-white'
+              : 'text-white/60 hover:bg-white/10 hover:text-white'
+          )}
+        >
+          <Icon className="h-5 w-5" />
+          <span className="sr-only">{label}</span>
+        </NavLink>
+      </TooltipTrigger>
+      <TooltipContent side="right">
+        {label}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
 export default function AppSidebar({ menuGroups }) {
   const { username, logout } = useAuth();
   const location = useLocation();
-  const currentPath = location.pathname.replace(/^\//, '');
+  const activeGroup = findActiveGroup(menuGroups, location.pathname);
 
   return (
-    <Sidebar collapsible="icon">
-      <SidebarHeader className="border-b border-sidebar-border px-4 py-4">
-        <div className="flex items-center gap-2">
+    <TooltipProvider>
+      <nav className="fixed inset-y-0 left-0 z-50 flex w-[60px] flex-col items-center bg-[hsl(222,47%,11%)] py-3">
+        {/* Logo */}
+        <div className="mb-4 flex h-10 w-10 shrink-0 items-center justify-center">
           <img
-            src="/logo-etendo-white.png"
+            src="/favicon.png"
             alt="Etendo"
-            className="h-6 group-data-[collapsible=icon]:hidden"
+            className="h-9 w-9 rounded-lg"
           />
-          <div className="hidden group-data-[collapsible=icon]:flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-sidebar-primary text-sidebar-primary-foreground">
-            <Package className="h-4 w-4" />
-          </div>
         </div>
-      </SidebarHeader>
 
-      <SidebarContent>
-        <SidebarMenu>
+        {/* Menu groups */}
+        <div className="flex flex-1 flex-col items-center gap-1.5">
           {menuGroups.map((g) => (
-            <NavMenuGroup
+            <SidebarIcon
               key={g.group}
-              group={g.group}
               icon={g.icon}
-              items={g.items}
-              isActive={g.items.some((item) => item.name === currentPath)}
+              label={g.group}
+              to={`/${g.items[0].name}`}
+              isActive={activeGroup?.group === g.group}
             />
           ))}
-        </SidebarMenu>
-      </SidebarContent>
+        </div>
 
-      <SidebarFooter className="border-t border-sidebar-border">
-        <SidebarMenu>
-          <SidebarMenuItem>
-            <SidebarMenuButton asChild tooltip="Preview">
-              <NavLink to="/preview">
-                <Eye className="h-4 w-4" />
-                <span>Preview</span>
-              </NavLink>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem>
-            <SidebarMenuButton asChild tooltip="Artifacts">
-              <NavLink to="/artifacts">
-                <FileJson className="h-4 w-4" />
-                <span>Artifacts</span>
-              </NavLink>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem>
-            <SidebarMenuButton tooltip={username}>
-              <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-sidebar-primary/20 text-sidebar-primary-foreground">
-                <span className="text-[10px] font-semibold">{username?.charAt(0).toUpperCase()}</span>
+        {/* Footer */}
+        <div className="flex flex-col items-center gap-1.5 border-t border-white/10 pt-3">
+          <SidebarIcon
+            icon="Eye"
+            label="Preview"
+            to="/preview"
+            isActive={location.pathname === '/preview'}
+          />
+          <SidebarIcon
+            icon="FileJson"
+            label="Artifacts"
+            to="/artifacts"
+            isActive={location.pathname.startsWith('/artifacts')}
+          />
+
+          {/* User avatar */}
+          <Tooltip delayDuration={0}>
+            <TooltipTrigger asChild>
+              <div className="flex h-10 w-10 items-center justify-center">
+                <div className="flex h-7 w-7 items-center justify-center rounded-full bg-white/20 text-white">
+                  <span className="text-xs font-semibold">
+                    {username?.charAt(0).toUpperCase()}
+                  </span>
+                </div>
               </div>
-              <span className="truncate">{username}</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-          <SidebarMenuItem>
-            <SidebarMenuButton tooltip="Logout" onClick={logout}>
-              <LogOut className="h-4 w-4" />
-              <span>Logout</span>
-            </SidebarMenuButton>
-          </SidebarMenuItem>
-        </SidebarMenu>
-      </SidebarFooter>
+            </TooltipTrigger>
+            <TooltipContent side="right">{username}</TooltipContent>
+          </Tooltip>
 
-      <SidebarRail />
-    </Sidebar>
+          {/* Logout */}
+          <Tooltip delayDuration={0}>
+            <TooltipTrigger asChild>
+              <button
+                onClick={logout}
+                className="flex h-10 w-10 items-center justify-center rounded-lg text-white/60 transition-colors hover:bg-white/10 hover:text-white"
+              >
+                <LogOut className="h-5 w-5" />
+                <span className="sr-only">Logout</span>
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="right">Logout</TooltipContent>
+          </Tooltip>
+        </div>
+      </nav>
+    </TooltipProvider>
   );
 }

--- a/tools/app-shell/src/layout/TopBar.jsx
+++ b/tools/app-shell/src/layout/TopBar.jsx
@@ -1,52 +1,145 @@
-import { SidebarTrigger } from '@/components/ui/sidebar.jsx';
-import { Separator } from '@/components/ui/separator.jsx';
+import { NavLink, useLocation } from 'react-router-dom';
 import { useInspector } from '@/components/inspector/InspectorProvider.jsx';
-import { Pencil, PencilOff, Save, Loader2, Search } from 'lucide-react';
+import {
+  Pencil,
+  PencilOff,
+  Save,
+  Loader2,
+  Search,
+  LayoutGrid,
+  Plus,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button.jsx';
 import { Badge } from '@/components/ui/badge.jsx';
+import { Separator } from '@/components/ui/separator.jsx';
 import LocaleSwitcher from '@/components/LocaleSwitcher.jsx';
+import { cn } from '@/lib/utils.js';
+import { findActiveGroup } from './Sidebar.jsx';
 
-export default function TopBar() {
+export default function TopBar({ menuGroups }) {
   const inspector = useInspector();
+  const location = useLocation();
+  const activeGroup = findActiveGroup(menuGroups, location.pathname);
+  const currentPath = location.pathname.replace(/^\//, '');
+
+  // First item in the group is the "overview" page
+  const overviewItem = activeGroup?.items[0];
+  const isOnOverview = overviewItem?.name === currentPath;
+  // Remaining items become tabs
+  const tabItems = activeGroup?.items.slice(1) || [];
 
   return (
-    <header className="flex h-14 shrink-0 items-center gap-2 border-b bg-background px-4">
-      <SidebarTrigger className="-ml-1" />
-      <Separator orientation="vertical" className="mr-2 h-4" />
-      {inspector.editMode && (
-        <Badge variant="outline" className="text-xs border-amber-500 text-amber-600">
-          Edit Mode
-        </Badge>
-      )}
-      <div className="flex-1" />
-      <Button
-        variant="outline"
-        className="relative h-8 w-full justify-start rounded-[0.5rem] bg-muted/50 text-sm font-normal text-muted-foreground shadow-none sm:pr-12 md:w-40 lg:w-64"
-        onClick={() => {
-          document.dispatchEvent(new KeyboardEvent('keydown', { key: 'k', metaKey: true }));
-        }}
-      >
-        <Search className="mr-2 h-4 w-4" />
-        Search...
-        <kbd className="pointer-events-none absolute right-[0.3rem] top-[0.3rem] hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex">
-          <span className="text-xs">&#8984;</span>K
-        </kbd>
-      </Button>
-      <LocaleSwitcher />
-      {inspector.editMode && inspector.dirty && (
-        <Button size="sm" onClick={inspector.save} disabled={inspector.saving}>
-          {inspector.saving ? <Loader2 className="h-4 w-4 mr-2 animate-spin" /> : <Save className="h-4 w-4 mr-2" />}
-          Save &amp; Regenerate
+    <header className="flex h-14 shrink-0 items-center border-b bg-background">
+      {/* Left: section name + overview + tabs */}
+      <div className="flex min-w-0 flex-1 items-center gap-2 px-4">
+        {activeGroup && (
+          <>
+            <span className="shrink-0 text-sm font-bold">{activeGroup.group}</span>
+            <Separator orientation="vertical" className="mx-1 h-4" />
+
+            {/* Overview badge */}
+            {overviewItem && (
+              <NavLink to={`/${overviewItem.name}`}>
+                <Badge
+                  variant={isOnOverview ? 'default' : 'outline'}
+                  className={cn(
+                    'shrink-0 cursor-pointer',
+                    isOnOverview
+                      ? ''
+                      : 'bg-transparent hover:bg-muted'
+                  )}
+                >
+                  Overview
+                </Badge>
+              </NavLink>
+            )}
+
+            {tabItems.length > 0 && (
+              <Separator orientation="vertical" className="mx-1 h-4" />
+            )}
+
+            {/* Horizontal scrollable tabs */}
+            <div className="flex min-w-0 flex-1 items-center gap-0.5 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+              {tabItems.map((item) => {
+                const isTabActive = item.name === currentPath;
+                return (
+                  <NavLink
+                    key={item.name}
+                    to={`/${item.name}`}
+                    className={cn(
+                      'group relative flex shrink-0 items-center gap-1.5 px-3 py-1 text-sm transition-colors',
+                      isTabActive
+                        ? 'text-primary font-medium'
+                        : 'text-muted-foreground hover:text-foreground'
+                    )}
+                  >
+                    <LayoutGrid className="h-3.5 w-3.5" />
+                    <span>{item.label}</span>
+                    <Plus className="h-3 w-3 text-muted-foreground/50 opacity-0 transition-opacity group-hover:opacity-100" />
+                    {/* Active indicator */}
+                    {isTabActive && (
+                      <span className="absolute bottom-0 left-2 right-2 h-0.5 rounded-full bg-primary" />
+                    )}
+                  </NavLink>
+                );
+              })}
+            </div>
+          </>
+        )}
+
+        {!activeGroup && (
+          <span className="text-sm text-muted-foreground">
+            {currentPath || 'Home'}
+          </span>
+        )}
+      </div>
+
+      {/* Right: inspector controls, search, locale */}
+      <div className="flex shrink-0 items-center gap-2 px-4">
+        {inspector.editMode && (
+          <Badge variant="outline" className="text-xs border-amber-500 text-amber-600">
+            Edit Mode
+          </Badge>
+        )}
+        <Button
+          variant="outline"
+          className="relative h-8 w-full justify-start rounded-[0.5rem] bg-muted/50 text-sm font-normal text-muted-foreground shadow-none sm:pr-12 md:w-40 lg:w-64"
+          onClick={() => {
+            document.dispatchEvent(
+              new KeyboardEvent('keydown', { key: 'k', metaKey: true })
+            );
+          }}
+        >
+          <Search className="mr-2 h-4 w-4" />
+          Search...
+          <kbd className="pointer-events-none absolute right-[0.3rem] top-[0.3rem] hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex">
+            <span className="text-xs">&#8984;</span>K
+          </kbd>
         </Button>
-      )}
-      <Button
-        variant={inspector.editMode ? 'default' : 'outline'}
-        size="icon"
-        onClick={() => inspector.setEditMode(!inspector.editMode)}
-      >
-        {inspector.editMode ? <PencilOff className="h-4 w-4" /> : <Pencil className="h-4 w-4" />}
-        <span className="sr-only">Toggle edit mode</span>
-      </Button>
+        <LocaleSwitcher />
+        {inspector.editMode && inspector.dirty && (
+          <Button size="sm" onClick={inspector.save} disabled={inspector.saving}>
+            {inspector.saving ? (
+              <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            ) : (
+              <Save className="h-4 w-4 mr-2" />
+            )}
+            Save &amp; Regenerate
+          </Button>
+        )}
+        <Button
+          variant={inspector.editMode ? 'default' : 'outline'}
+          size="icon"
+          onClick={() => inspector.setEditMode(!inspector.editMode)}
+        >
+          {inspector.editMode ? (
+            <PencilOff className="h-4 w-4" />
+          ) : (
+            <Pencil className="h-4 w-4" />
+          )}
+          <span className="sr-only">Toggle edit mode</span>
+        </Button>
+      </div>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- **Sidebar**: Replaced collapsible shadcn Sidebar with a fixed 60px icon-only nav rail. Each menu group is a single icon with tooltip on hover. Active section gets a subtle highlight. Logo at top, user avatar + logout at bottom.
- **TopBar**: Shows active section name in bold, an "Overview" badge linking to the group's first item, and horizontal scrollable tabs for all sub-items. Each tab has a grid icon, label, and hover-visible "+" button. Active tab gets a blue bottom border.
- **AppLayout**: Removed SidebarProvider/SidebarInset. Simple flex layout with `ml-[60px]` for the main content area.
- All existing functionality preserved: inspector edit mode, save button, search/command palette, LocaleSwitcher.

## Test plan
- [x] `npm run build` passes in tools/app-shell/
- [ ] Visual verification: sidebar shows icons only, tooltips on hover
- [ ] Visual verification: topbar shows section name, overview badge, tabs
- [ ] Route navigation works via sidebar icons and topbar tabs
- [ ] Inspector edit mode, save, and search still function

🤖 Generated with [Claude Code](https://claude.com/claude-code)