### PR TITLE
feat: UI polish — section colors, transitions, remove duplicate headers

### DIFF
--- a/tools/app-shell/src/index.css
+++ b/tools/app-shell/src/index.css
@@ -2,6 +2,21 @@
 @tailwind components;
 @tailwind utilities;
 
+@keyframes page-enter {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.page-transition {
+  animation: page-enter 0.2s ease-out;
+}
+
 @layer base {
   * {
     @apply border-border;

--- a/tools/app-shell/src/layout/AppLayout.jsx
+++ b/tools/app-shell/src/layout/AppLayout.jsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import AppSidebar from './Sidebar.jsx';
 import TopBar from './TopBar.jsx';
 import { CopilotWidget } from '@/components/CopilotWidget.jsx';
@@ -7,12 +7,14 @@ import { InspectorProvider } from '@/components/inspector/InspectorProvider.jsx'
 import { SchemaInspector } from '@/components/inspector/SchemaInspector.jsx';
 
 export default function AppLayout({ menuGroups }) {
+  const location = useLocation();
+
   return (
     <InspectorProvider>
       <AppSidebar menuGroups={menuGroups} />
       <div className="ml-[60px] flex h-screen flex-col">
         <TopBar menuGroups={menuGroups} />
-        <div className="flex-1 overflow-auto p-6">
+        <div key={location.pathname} className="flex-1 overflow-auto p-6 page-transition">
           <Outlet />
         </div>
       </div>

--- a/tools/app-shell/src/layout/Sidebar.jsx
+++ b/tools/app-shell/src/layout/Sidebar.jsx
@@ -21,6 +21,7 @@ import {
   FileJson,
 } from 'lucide-react';
 import { cn } from '@/lib/utils.js';
+import { getSectionColor } from '@/lib/sectionColors.js';
 
 const ICON_MAP = {
   LayoutDashboard,
@@ -49,6 +50,7 @@ export function findActiveGroup(menuGroups, pathname) {
 
 function SidebarIcon({ icon, label, to, isActive }) {
   const Icon = ICON_MAP[icon] || Package;
+  const color = getSectionColor(label);
 
   return (
     <Tooltip delayDuration={0}>
@@ -58,9 +60,13 @@ function SidebarIcon({ icon, label, to, isActive }) {
           className={cn(
             'flex h-10 w-10 items-center justify-center rounded-lg transition-colors',
             isActive
-              ? 'bg-white/15 text-white'
+              ? 'text-white'
               : 'text-white/60 hover:bg-white/10 hover:text-white'
           )}
+          style={isActive ? {
+            borderLeft: `3px solid ${color.accent}`,
+            backgroundColor: color.accent + '25',
+          } : undefined}
         >
           <Icon className="h-5 w-5" />
           <span className="sr-only">{label}</span>

--- a/tools/app-shell/src/layout/TopBar.jsx
+++ b/tools/app-shell/src/layout/TopBar.jsx
@@ -14,6 +14,7 @@ import { Badge } from '@/components/ui/badge.jsx';
 import { Separator } from '@/components/ui/separator.jsx';
 import LocaleSwitcher from '@/components/LocaleSwitcher.jsx';
 import { cn } from '@/lib/utils.js';
+import { getSectionColor } from '@/lib/sectionColors.js';
 import { findActiveGroup } from './Sidebar.jsx';
 
 export default function TopBar({ menuGroups }) {
@@ -21,6 +22,7 @@ export default function TopBar({ menuGroups }) {
   const location = useLocation();
   const activeGroup = findActiveGroup(menuGroups, location.pathname);
   const currentPath = location.pathname.replace(/^\//, '');
+  const sectionColor = getSectionColor(activeGroup?.group);
 
   // First item in the group is the "overview" page
   const overviewItem = activeGroup?.items[0];
@@ -29,7 +31,10 @@ export default function TopBar({ menuGroups }) {
   const tabItems = activeGroup?.items.slice(1) || [];
 
   return (
-    <header className="flex h-14 shrink-0 items-center border-b bg-background">
+    <header
+      className="flex h-14 shrink-0 items-center border-b-[3px] bg-background"
+      style={{ borderBottomColor: sectionColor.accent }}
+    >
       {/* Left: section name + overview + tabs */}
       <div className="flex min-w-0 flex-1 items-center gap-2 px-4">
         {activeGroup && (

--- a/tools/app-shell/src/lib/sectionColors.js
+++ b/tools/app-shell/src/lib/sectionColors.js
@@ -1,0 +1,15 @@
+// Section accent colors — distinguishes Sales from Purchases visually
+export const SECTION_COLORS = {
+  Home: { accent: '#6366f1', bg: 'bg-indigo-50', border: 'border-indigo-400', text: 'text-indigo-600' },
+  Sales: { accent: '#2563eb', bg: 'bg-blue-50', border: 'border-blue-500', text: 'text-blue-600' },
+  Purchases: { accent: '#7c3aed', bg: 'bg-violet-50', border: 'border-violet-500', text: 'text-violet-600' },
+  Finance: { accent: '#059669', bg: 'bg-emerald-50', border: 'border-emerald-500', text: 'text-emerald-600' },
+  Inventory: { accent: '#d97706', bg: 'bg-amber-50', border: 'border-amber-500', text: 'text-amber-600' },
+  People: { accent: '#db2777', bg: 'bg-pink-50', border: 'border-pink-500', text: 'text-pink-600' },
+  Projects: { accent: '#0891b2', bg: 'bg-cyan-50', border: 'border-cyan-500', text: 'text-cyan-600' },
+  Settings: { accent: '#6b7280', bg: 'bg-gray-50', border: 'border-gray-400', text: 'text-gray-600' },
+};
+
+export function getSectionColor(groupName) {
+  return SECTION_COLORS[groupName] || SECTION_COLORS.Home;
+}

--- a/tools/app-shell/src/pages/AccountingPage.jsx
+++ b/tools/app-shell/src/pages/AccountingPage.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { KPIHeader, DataTable } from '@/components/contract-ui';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Calculator, FileText, Receipt, Landmark, Scale } from 'lucide-react';
+import { FileText, Receipt, Landmark, Scale } from 'lucide-react';
 
-import { kpisConfig, sections, actions } from '@generated/accounting/generated/config';
+import { kpisConfig, sections } from '@generated/accounting/generated/config';
 import * as mockData from '@generated/accounting/generated/mockData';
 
 // -- Derived data from contract files -----------------------------------------
@@ -30,18 +28,6 @@ const TAX_SUMMARY_DATA = mockData.taxSummary;
 export default function AccountingPage() {
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight">Accounting</h1>
-        <div className="flex items-center gap-2">
-          {actions.map(action => (
-            <Button key={action.route} variant={action.variant} asChild>
-              <Link to={action.route}>{action.label}</Link>
-            </Button>
-          ))}
-        </div>
-      </div>
-
       {/* KPIs */}
       <KPIHeader kpis={KPIS} />
 

--- a/tools/app-shell/src/pages/ContactsPage.jsx
+++ b/tools/app-shell/src/pages/ContactsPage.jsx
@@ -1,16 +1,14 @@
 import React, { useState, useMemo } from 'react';
-import { Link } from 'react-router-dom';
 import { KPIHeader } from '@/components/contract-ui/KPIHeader';
 import { KanbanBoard } from '@/components/contract-ui/KanbanBoard';
 import { Chatter } from '@/components/contract-ui/Chatter';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Input } from '@/components/ui/input';
 import { Separator } from '@/components/ui/separator';
-import { Users, Search, Mail, Phone, MapPin, X, Plus } from 'lucide-react';
+import { Users, Mail, Phone, MapPin, X } from 'lucide-react';
 
-import { kpisConfig, sections, actions } from '@generated/contacts/generated/config';
+import { kpisConfig, sections } from '@generated/contacts/generated/config';
 import * as mockData from '@generated/contacts/generated/mockData';
 
 // -- Icon map (string name -> component) --------------------------------------
@@ -209,28 +207,6 @@ export default function ContactsPage() {
   return (
     <div className="flex h-full">
       <div className="flex-1 min-w-0 p-6 overflow-y-auto">
-        {/* Header */}
-        <div className="flex items-center justify-between gap-4 mb-6">
-          <h1 className="text-2xl font-bold tracking-tight">Contacts</h1>
-          <div className="flex items-center gap-3">
-            <div className="relative">
-              <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-              <Input
-                placeholder="Search contacts..."
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                className="pl-9 w-[240px]"
-              />
-            </div>
-            <Button asChild>
-              <Link to={actions[0].route}>
-                <Plus className="h-4 w-4 mr-1.5" />
-                {actions[0].label}
-              </Link>
-            </Button>
-          </div>
-        </div>
-
         {/* KPIs */}
         <KPIHeader kpis={KPIS} />
 

--- a/tools/app-shell/src/pages/CrmPage.jsx
+++ b/tools/app-shell/src/pages/CrmPage.jsx
@@ -1,13 +1,11 @@
 import React, { useState, useCallback } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { KPIHeader, KanbanBoard, DataTable } from '@/components/contract-ui';
-import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { Target, DollarSign, Trophy, TrendingUp, Users, Activity, ArrowUp, ArrowDown } from 'lucide-react';
 
-import { sections, actions } from '@generated/crm/generated/config';
+import { sections } from '@generated/crm/generated/config';
 import * as mockData from '@generated/crm/generated/mockData';
 
 // -- Icon resolution (config stores string names) -----------------------------
@@ -61,18 +59,6 @@ export default function CrmPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header bar */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight">CRM</h1>
-        <div className="flex items-center gap-2">
-          {actions.map((action) => (
-            <Button key={action.route} variant={action.variant} asChild>
-              <Link to={action.route}>{action.label}</Link>
-            </Button>
-          ))}
-        </div>
-      </div>
-
       {/* KPIs */}
       <KPIHeader kpis={KPIS} />
 

--- a/tools/app-shell/src/pages/HrPage.jsx
+++ b/tools/app-shell/src/pages/HrPage.jsx
@@ -1,12 +1,11 @@
 import React, { useState, useCallback } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { KPIHeader, KanbanBoard, DataTable } from '@/components/contract-ui';
-import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { Users, Calendar, UserPlus, Clock, Bell, ArrowUp, ArrowDown } from 'lucide-react';
 
-import { sections, actions } from '@generated/hr/generated/config';
+import { sections } from '@generated/hr/generated/config';
 import * as mockData from '@generated/hr/generated/mockData';
 
 // -- Icon resolution (config stores string names) -----------------------------
@@ -52,18 +51,6 @@ export default function HrPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header bar */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight">HR</h1>
-        <div className="flex items-center gap-2">
-          {actions.map((action) => (
-            <Button key={action.route} variant={action.variant} asChild>
-              <Link to={action.route}>{action.label}</Link>
-            </Button>
-          ))}
-        </div>
-      </div>
-
       {/* KPIs */}
       <KPIHeader kpis={KPIS} />
 

--- a/tools/app-shell/src/pages/InventoryPage.jsx
+++ b/tools/app-shell/src/pages/InventoryPage.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { KPIHeader, DataTable } from '@/components/contract-ui';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Package, AlertTriangle, ArrowUp, ArrowDown, Search } from 'lucide-react';
 
-import { kpisConfig, sections, actions } from '@generated/inventory/generated/config';
+import { kpisConfig, sections } from '@generated/inventory/generated/config';
 import * as mockData from '@generated/inventory/generated/mockData';
 
 // -- Icon map for resolving string names from config to React components ------
@@ -34,18 +32,6 @@ const RECENT_MOVEMENTS = mockData.recentMovements;
 export default function InventoryPage() {
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight">Inventory</h1>
-        <div className="flex items-center gap-2">
-          {actions.map(action => (
-            <Button key={action.route} variant={action.variant} asChild>
-              <Link to={action.route}>{action.label}</Link>
-            </Button>
-          ))}
-        </div>
-      </div>
-
       {/* KPIs */}
       <KPIHeader kpis={KPIS} />
 

--- a/tools/app-shell/src/pages/ProjectsPage.jsx
+++ b/tools/app-shell/src/pages/ProjectsPage.jsx
@@ -1,11 +1,10 @@
 import React, { useState, useCallback } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { KPIHeader, KanbanBoard, DataTable } from '@/components/contract-ui';
-import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { FolderKanban, Clock, PieChart, FileText } from 'lucide-react';
 
-import { sections, actions } from '@generated/projects/generated/config';
+import { sections } from '@generated/projects/generated/config';
 import * as mockData from '@generated/projects/generated/mockData';
 
 // -- Icon resolution (config stores string names) -----------------------------
@@ -53,18 +52,6 @@ export default function ProjectsPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header bar */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight">Projects</h1>
-        <div className="flex items-center gap-2">
-          {actions.map((action) => (
-            <Button key={action.route} variant={action.variant} asChild>
-              <Link to={action.route}>{action.label}</Link>
-            </Button>
-          ))}
-        </div>
-      </div>
-
       {/* KPIs */}
       <KPIHeader kpis={KPIS} />
 

--- a/tools/app-shell/src/pages/PurchasesPage.jsx
+++ b/tools/app-shell/src/pages/PurchasesPage.jsx
@@ -1,12 +1,12 @@
 import React, { useState, useCallback } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { KPIHeader, KanbanBoard } from '@/components/contract-ui';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
-import { Truck, FileText, Plus } from 'lucide-react';
+import { Truck, FileText } from 'lucide-react';
 
-import { kpisConfig, sections, actions } from '@generated/purchases/generated/config';
+import { kpisConfig, sections } from '@generated/purchases/generated/config';
 import * as mockData from '@generated/purchases/generated/mockData';
 
 // -- Icon map (string name -> component) --------------------------------------
@@ -64,17 +64,6 @@ export default function PurchasesPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header bar */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight">Purchases</h1>
-        <Button asChild>
-          <Link to={actions[0].route}>
-            <Plus className="mr-2 h-4 w-4" />
-            {actions[0].label}
-          </Link>
-        </Button>
-      </div>
-
       {/* KPIs */}
       <KPIHeader kpis={KPIS} />
 

--- a/tools/app-shell/src/pages/ReportsPage.jsx
+++ b/tools/app-shell/src/pages/ReportsPage.jsx
@@ -1,11 +1,9 @@
 import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
 import { DataTable } from '@/components/contract-ui';
 import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
-import { BarChart3 } from 'lucide-react';
 
-import { sections, actions } from '@generated/reports/generated/config';
+import { sections } from '@generated/reports/generated/config';
 import * as mockData from '@generated/reports/generated/mockData';
 
 // -- Tab definitions ----------------------------------------------------------
@@ -28,21 +26,6 @@ export default function ReportsPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2">
-          <BarChart3 className="h-6 w-6" />
-          Financial Reports
-        </h1>
-        <div className="flex items-center gap-2">
-          {actions.map((action) => (
-            <Button key={action.route} variant={action.variant || 'default'} asChild>
-              <Link to={action.route}>{action.label}</Link>
-            </Button>
-          ))}
-        </div>
-      </div>
-
       {/* Tab switcher */}
       <div className="flex items-center gap-2">
         {TABS.map((tab) => (

--- a/tools/app-shell/src/pages/SalesPage.jsx
+++ b/tools/app-shell/src/pages/SalesPage.jsx
@@ -1,12 +1,12 @@
 import React, { useState, useCallback } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { KPIHeader, KanbanBoard } from '@/components/contract-ui';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { ShoppingCart, FileText, TrendingUp } from 'lucide-react';
 
-import { sections, actions } from '@generated/sales/generated/config';
+import { sections } from '@generated/sales/generated/config';
 import * as mockData from '@generated/sales/generated/mockData';
 
 // -- Icon resolution (config stores string names) -----------------------------
@@ -67,16 +67,6 @@ export default function SalesPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header bar */}
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold tracking-tight">Sales</h1>
-        {actions.map((action) => (
-          <Button key={action.route} asChild>
-            <Link to={action.route}>{action.label}</Link>
-          </Button>
-        ))}
-      </div>
-
       {/* KPIs */}
       <KPIHeader kpis={KPIS} />
 


### PR DESCRIPTION
## Summary
- Remove duplicate h1 titles and action buttons from 9 overview pages (TopBar already shows section name + tabs)
- Add section color system (`sectionColors.js`) with distinct accent colors per menu group
- Add 3px colored accent line on TopBar matching active section
- Add active indicator on Sidebar icons (left border + tinted background using section color)
- Add page transition animation (fade + slide-up, 200ms) on route change

## Test plan
- [ ] Navigate between sections and verify TopBar accent line changes color per section
- [ ] Verify Sidebar active icon shows left border + tinted background
- [ ] Verify no duplicate titles or "New" buttons appear on overview pages
- [ ] Verify page transition animation plays on navigation
- [ ] Run `npm run build` in `tools/app-shell/` — passes clean

Generated with [Claude Code](https://claude.com/claude-code)