### PR TITLE
Replace webhooks with direct DB writer (Phase 1+2)

### DIFF
--- a/cli/src/neo-writer.js
+++ b/cli/src/neo-writer.js
@@ -415,7 +415,7 @@ async function populateProcessSpec(client, { specId, processId, moduleId, audit 
   // Create single POST-only entity
   const { entityId } = await upsertEntity(client, {
     specId,
-    tabId: processId, // Process specs use processId as tabId placeholder
+    tabId: null, // Process specs have no tab — ad_tab_id must be NULL
     moduleId,
     name: processName,
     isPost: 'Y',
@@ -449,6 +449,6 @@ async function populateProcessSpec(client, { specId, processId, moduleId, audit 
   return {
     entityCount: 1,
     fieldCount,
-    entities: [{ entityId, name: processName, tabId: processId }],
+    entities: [{ entityId, name: processName, tabId: null }],
   };
 }

--- a/cli/src/neo-writer.js
+++ b/cli/src/neo-writer.js
@@ -1,0 +1,454 @@
+/**
+ * neo-writer.js — Direct PostgreSQL writer for NEO Headless configuration tables.
+ *
+ * Replaces the HTTP webhook approach with direct DB inserts/updates to:
+ *   - etgo_sf_spec
+ *   - etgo_sf_entity
+ *   - etgo_sf_field
+ *
+ * All functions receive a `pg` client for transaction control.
+ */
+
+import { randomUUID } from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SYSTEM_COLUMNS = [
+  'ad_client_id',
+  'ad_org_id',
+  'isactive',
+  'created',
+  'createdby',
+  'updated',
+  'updatedby',
+];
+
+/**
+ * Generate an Etendo-compatible UUID (32-char uppercase hex, no dashes).
+ */
+export function generateId() {
+  return randomUUID().replace(/-/g, '').toUpperCase();
+}
+
+/**
+ * Return default audit column values for INSERT statements.
+ */
+export function auditDefaults(opts = {}) {
+  const now = new Date();
+  return {
+    ad_client_id: opts.clientId || '0',
+    ad_org_id: opts.orgId || '0',
+    isactive: 'Y',
+    created: now,
+    updated: now,
+    createdby: opts.userId || '0',
+    updatedby: opts.userId || '0',
+  };
+}
+
+// ---------------------------------------------------------------------------
+// upsertSpec
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert or update a spec row in etgo_sf_spec.
+ *
+ * @param {import('pg').PoolClient} client
+ * @param {object} params
+ * @param {string} params.name - Spec name (kebab-case)
+ * @param {string} params.moduleId - AD_Module_ID
+ * @param {string} [params.windowId] - AD_Window_ID (required for type W)
+ * @param {string} [params.processId] - AD_Process_ID (required for type P)
+ * @param {string} [params.specType='W'] - 'W' (window) or 'P' (process)
+ * @param {string} [params.description]
+ * @param {string} [params.specId] - If provided, UPDATE instead of INSERT
+ * @param {object} [params.audit] - Override audit defaults
+ * @returns {{ specId: string, created: boolean }}
+ */
+export async function upsertSpec(client, params) {
+  const {
+    name,
+    moduleId,
+    windowId = null,
+    processId = null,
+    specType = 'W',
+    description = null,
+    specId: existingId = null,
+    audit = {},
+  } = params;
+
+  // Check for duplicate name
+  const dupCheck = await client.query(
+    'SELECT etgo_sf_spec_id FROM etgo_sf_spec WHERE name = $1',
+    [name],
+  );
+  if (dupCheck.rows.length > 0) {
+    const foundId = dupCheck.rows[0].etgo_sf_spec_id;
+    if (!existingId || foundId !== existingId) {
+      throw new Error(`Spec with name '${name}' already exists (id: ${foundId})`);
+    }
+  }
+
+  const auditVals = auditDefaults(audit);
+
+  if (existingId) {
+    // UPDATE
+    await client.query(
+      `UPDATE etgo_sf_spec
+       SET name = $1, spec_type = $2, ad_window_id = $3, ad_process_id = $4,
+           ad_module_id = $5, description = $6, updated = $7, updatedby = $8
+       WHERE etgo_sf_spec_id = $9`,
+      [name, specType, windowId, processId, moduleId, description,
+       auditVals.updated, auditVals.updatedby, existingId],
+    );
+    return { specId: existingId, created: false };
+  }
+
+  // INSERT
+  const specId = generateId();
+  await client.query(
+    `INSERT INTO etgo_sf_spec
+     (etgo_sf_spec_id, name, spec_type, ad_window_id, ad_process_id, ad_module_id,
+      description, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+    [specId, name, specType, windowId, processId, moduleId, description,
+     auditVals.ad_client_id, auditVals.ad_org_id, auditVals.isactive,
+     auditVals.created, auditVals.createdby, auditVals.updated, auditVals.updatedby],
+  );
+  return { specId, created: true };
+}
+
+// ---------------------------------------------------------------------------
+// upsertEntity
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert or update an entity row in etgo_sf_entity.
+ *
+ * @param {import('pg').PoolClient} client
+ * @param {object} params
+ * @param {string} params.specId - Parent etgo_sf_spec_id
+ * @param {string} params.tabId - AD_Tab_ID
+ * @param {string} params.moduleId - AD_Module_ID
+ * @param {string} [params.name] - Entity name (falls back to AD_Tab.name)
+ * @param {string} [params.entityId] - If provided, UPDATE instead of INSERT
+ * @param {string} [params.isIncluded='Y']
+ * @param {string} [params.isGet='N']
+ * @param {string} [params.isGetbyid='N']
+ * @param {string} [params.isPost='N']
+ * @param {string} [params.isPut='N']
+ * @param {string} [params.isPatch='N']
+ * @param {string} [params.isDelete='N']
+ * @param {string} [params.javaQualifier]
+ * @param {number} [params.seqNo]
+ * @param {object} [params.audit] - Override audit defaults
+ * @returns {{ entityId: string, created: boolean }}
+ */
+export async function upsertEntity(client, params) {
+  const {
+    specId,
+    tabId,
+    moduleId,
+    entityId: existingId = null,
+    isIncluded = 'Y',
+    isGet = 'N',
+    isGetbyid = 'N',
+    isPost = 'N',
+    isPut = 'N',
+    isPatch = 'N',
+    isDelete = 'N',
+    javaQualifier = null,
+    seqNo = null,
+    audit = {},
+  } = params;
+
+  // Resolve name: use provided or fall back to AD_Tab.name
+  let { name } = params;
+  if (!name) {
+    const tabResult = await client.query(
+      'SELECT name FROM ad_tab WHERE ad_tab_id = $1',
+      [tabId],
+    );
+    name = tabResult.rows[0]?.name || 'unnamed';
+  }
+
+  const auditVals = auditDefaults(audit);
+
+  if (existingId) {
+    await client.query(
+      `UPDATE etgo_sf_entity
+       SET etgo_sf_spec_id = $1, ad_tab_id = $2, ad_module_id = $3, name = $4,
+           isincluded = $5, isget = $6, isgetbyid = $7, ispost = $8,
+           isput = $9, ispatch = $10, isdelete = $11, java_qualifier = $12,
+           seqno = $13, updated = $14, updatedby = $15
+       WHERE etgo_sf_entity_id = $16`,
+      [specId, tabId, moduleId, name,
+       isIncluded, isGet, isGetbyid, isPost,
+       isPut, isPatch, isDelete, javaQualifier,
+       seqNo, auditVals.updated, auditVals.updatedby, existingId],
+    );
+    return { entityId: existingId, created: false };
+  }
+
+  const entityId = generateId();
+  await client.query(
+    `INSERT INTO etgo_sf_entity
+     (etgo_sf_entity_id, etgo_sf_spec_id, ad_tab_id, ad_module_id, name,
+      isincluded, isget, isgetbyid, ispost, isput, ispatch, isdelete,
+      java_qualifier, seqno,
+      ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14,
+             $15, $16, $17, $18, $19, $20, $21)`,
+    [entityId, specId, tabId, moduleId, name,
+     isIncluded, isGet, isGetbyid, isPost, isPut, isPatch, isDelete,
+     javaQualifier, seqNo,
+     auditVals.ad_client_id, auditVals.ad_org_id, auditVals.isactive,
+     auditVals.created, auditVals.createdby, auditVals.updated, auditVals.updatedby],
+  );
+  return { entityId, created: true };
+}
+
+// ---------------------------------------------------------------------------
+// upsertField
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert or update a field row in etgo_sf_field.
+ *
+ * @param {import('pg').PoolClient} client
+ * @param {object} params
+ * @param {string} params.entityId - Parent etgo_sf_entity_id
+ * @param {string} [params.columnId] - AD_Column_ID (null for process params)
+ * @param {string} params.moduleId - AD_Module_ID
+ * @param {string} [params.fieldId] - If provided, UPDATE instead of INSERT
+ * @param {string} [params.isIncluded='Y']
+ * @param {string} [params.isReadOnly='N']
+ * @param {string} [params.defaultValue]
+ * @param {string} [params.javaQualifier]
+ * @param {number} [params.seqNo]
+ * @param {object} [params.audit] - Override audit defaults
+ * @returns {{ fieldId: string, created: boolean }}
+ */
+export async function upsertField(client, params) {
+  const {
+    entityId,
+    columnId = null,
+    moduleId,
+    fieldId: existingId = null,
+    isIncluded = 'Y',
+    isReadOnly = 'N',
+    defaultValue = null,
+    javaQualifier = null,
+    seqNo = null,
+    audit = {},
+  } = params;
+
+  const auditVals = auditDefaults(audit);
+
+  if (existingId) {
+    await client.query(
+      `UPDATE etgo_sf_field
+       SET etgo_sf_entity_id = $1, ad_column_id = $2, ad_module_id = $3,
+           isincluded = $4, isreadonly = $5, defaultvalue = $6,
+           java_qualifier = $7, seqno = $8, updated = $9, updatedby = $10
+       WHERE etgo_sf_field_id = $11`,
+      [entityId, columnId, moduleId,
+       isIncluded, isReadOnly, defaultValue,
+       javaQualifier, seqNo, auditVals.updated, auditVals.updatedby, existingId],
+    );
+    return { fieldId: existingId, created: false };
+  }
+
+  const fieldId = generateId();
+  await client.query(
+    `INSERT INTO etgo_sf_field
+     (etgo_sf_field_id, etgo_sf_entity_id, ad_column_id, ad_module_id,
+      isincluded, isreadonly, defaultvalue, java_qualifier, seqno,
+      ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
+    [fieldId, entityId, columnId, moduleId,
+     isIncluded, isReadOnly, defaultValue, javaQualifier, seqNo,
+     auditVals.ad_client_id, auditVals.ad_org_id, auditVals.isactive,
+     auditVals.created, auditVals.createdby, auditVals.updated, auditVals.updatedby],
+  );
+  return { fieldId, created: true };
+}
+
+// ---------------------------------------------------------------------------
+// populateSpec
+// ---------------------------------------------------------------------------
+
+/**
+ * Populate a spec by reading AD metadata and creating entities + fields.
+ * Deletes existing entities/fields first, then recreates from AD.
+ *
+ * @param {import('pg').PoolClient} client
+ * @param {object} params
+ * @param {string} params.specId - The spec to populate
+ * @param {string} params.moduleId - AD_Module_ID for new rows
+ * @param {boolean} [params.excludeSystemColumns=true]
+ * @param {boolean} [params.includeAllMethods=false]
+ * @param {object} [params.audit] - Override audit defaults
+ * @returns {{ entityCount: number, fieldCount: number, entities: Array }}
+ */
+export async function populateSpec(client, params) {
+  const {
+    specId,
+    moduleId,
+    excludeSystemColumns = true,
+    includeAllMethods = false,
+    audit = {},
+  } = params;
+
+  // Fetch spec to determine type
+  const specResult = await client.query(
+    'SELECT spec_type, ad_window_id, ad_process_id FROM etgo_sf_spec WHERE etgo_sf_spec_id = $1',
+    [specId],
+  );
+  if (specResult.rows.length === 0) {
+    throw new Error(`Spec not found: ${specId}`);
+  }
+  const spec = specResult.rows[0];
+
+  // Delete existing fields for this spec's entities, then delete entities
+  await client.query(
+    `DELETE FROM etgo_sf_field
+     WHERE etgo_sf_entity_id IN (
+       SELECT etgo_sf_entity_id FROM etgo_sf_entity WHERE etgo_sf_spec_id = $1
+     )`,
+    [specId],
+  );
+  await client.query(
+    'DELETE FROM etgo_sf_entity WHERE etgo_sf_spec_id = $1',
+    [specId],
+  );
+
+  if (spec.spec_type === 'W') {
+    return populateWindowSpec(client, { specId, windowId: spec.ad_window_id, moduleId, excludeSystemColumns, includeAllMethods, audit });
+  } else if (spec.spec_type === 'P') {
+    return populateProcessSpec(client, { specId, processId: spec.ad_process_id, moduleId, audit });
+  }
+
+  throw new Error(`Unknown spec type: ${spec.spec_type}`);
+}
+
+/**
+ * Populate entities + fields for a Window-type spec from AD_Tab/AD_Column.
+ */
+async function populateWindowSpec(client, { specId, windowId, moduleId, excludeSystemColumns, includeAllMethods, audit }) {
+  // Get active tabs ordered by seqno
+  const tabsResult = await client.query(
+    `SELECT ad_tab_id, name, ad_table_id, seqno
+     FROM ad_tab
+     WHERE ad_window_id = $1 AND isactive = 'Y'
+     ORDER BY seqno`,
+    [windowId],
+  );
+
+  const methodFlags = includeAllMethods
+    ? { isGet: 'Y', isGetbyid: 'Y', isPost: 'Y', isPut: 'Y', isPatch: 'Y', isDelete: 'Y' }
+    : {};
+
+  let entityCount = 0;
+  let fieldCount = 0;
+  const entities = [];
+
+  for (const tab of tabsResult.rows) {
+    const entitySeqNo = (entityCount + 1) * 10;
+    const { entityId } = await upsertEntity(client, {
+      specId,
+      tabId: tab.ad_tab_id,
+      moduleId,
+      name: tab.name,
+      seqNo: entitySeqNo,
+      ...methodFlags,
+      audit,
+    });
+    entityCount++;
+
+    // Get active columns for this tab's table
+    const colsResult = await client.query(
+      `SELECT ad_column_id, columnname, position
+       FROM ad_column
+       WHERE ad_table_id = $1 AND isactive = 'Y'
+       ORDER BY position`,
+      [tab.ad_table_id],
+    );
+
+    let fieldSeqCounter = 0;
+    for (const col of colsResult.rows) {
+      // Skip system columns if flag is set
+      if (excludeSystemColumns && SYSTEM_COLUMNS.includes(col.columnname.toLowerCase())) {
+        continue;
+      }
+
+      fieldSeqCounter++;
+      await upsertField(client, {
+        entityId,
+        columnId: col.ad_column_id,
+        moduleId,
+        seqNo: fieldSeqCounter * 10,
+        audit,
+      });
+      fieldCount++;
+    }
+
+    entities.push({ entityId, name: tab.name, tabId: tab.ad_tab_id });
+  }
+
+  return { entityCount, fieldCount, entities };
+}
+
+/**
+ * Populate entity + fields for a Process-type spec from AD_Process_Para.
+ */
+async function populateProcessSpec(client, { specId, processId, moduleId, audit }) {
+  // Get process name
+  const procResult = await client.query(
+    'SELECT name FROM ad_process WHERE ad_process_id = $1',
+    [processId],
+  );
+  const processName = procResult.rows[0]?.name || 'unnamed-process';
+
+  // Create single POST-only entity
+  const { entityId } = await upsertEntity(client, {
+    specId,
+    tabId: processId, // Process specs use processId as tabId placeholder
+    moduleId,
+    name: processName,
+    isPost: 'Y',
+    seqNo: 10,
+    audit,
+  });
+
+  // Get active process parameters
+  const parasResult = await client.query(
+    `SELECT ad_process_para_id, name, defaultvalue, seqno
+     FROM ad_process_para
+     WHERE ad_process_id = $1 AND isactive = 'Y'
+     ORDER BY seqno`,
+    [processId],
+  );
+
+  let fieldCount = 0;
+  for (const para of parasResult.rows) {
+    fieldCount++;
+    await upsertField(client, {
+      entityId,
+      columnId: null, // Process params have no AD_Column
+      moduleId,
+      javaQualifier: para.name,
+      defaultValue: para.defaultvalue || null,
+      seqNo: fieldCount * 10,
+      audit,
+    });
+  }
+
+  return {
+    entityCount: 1,
+    fieldCount,
+    entities: [{ entityId, name: processName, tabId: processId }],
+  };
+}

--- a/cli/src/push-to-neo.js
+++ b/cli/src/push-to-neo.js
@@ -1,11 +1,10 @@
 #!/usr/bin/env node
 
 /**
- * push-to-neo.js — Configure NEO Headless via webhooks from contract + schema artifacts.
+ * push-to-neo.js — Configure NEO Headless via direct DB writes from contract + schema artifacts.
  *
- * Reads contract.json and schema-curated.json for a given window, then calls
- * Etendo webhooks (SFUpsertSpec, SFPopulateSpec, SFUpsertField) to configure
- * the NEO Headless runtime.
+ * Reads contract.json and schema-curated.json for a given window, then writes
+ * configuration directly to the ETGO_SF_* tables via PostgreSQL.
  *
  * Usage:
  *   node cli/src/push-to-neo.js <windowName>
@@ -16,6 +15,12 @@
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { createDbPool, closePool } from './db.js';
+import {
+  upsertSpec as writerUpsertSpec,
+  populateSpec as writerPopulateSpec,
+  upsertField as writerUpsertField,
+} from './neo-writer.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -39,7 +44,7 @@ export function toSpecName(windowName) {
 }
 
 /**
- * Map a field visibility value to NEO webhook params.
+ * Map a field visibility value to NEO params.
  * Returns { isIncluded: "Y"|"N", isReadOnly: "Y"|"N" }.
  */
 export function mapVisibility(visibility) {
@@ -58,6 +63,7 @@ export function mapVisibility(visibility) {
 
 /**
  * Build the full webhook URL from a base Etendo URL and webhook name.
+ * @deprecated Use direct DB writes via neo-writer.js instead.
  */
 export function buildWebhookUrl(etendoUrl, webhookName) {
   const base = etendoUrl.replace(/\/+$/, '');
@@ -105,6 +111,8 @@ function parseProperties(content) {
 /**
  * Load Etendo connection config from env vars or schema_forge.properties.
  * Env vars take precedence.
+ * @deprecated HTTP config is no longer needed for live mode. DB config comes from db.js.
+ *             Kept for backwards compatibility with dry-run display and existing tests.
  */
 export async function loadConfig(projectRoot) {
   const env = process.env;
@@ -129,58 +137,22 @@ export async function loadConfig(projectRoot) {
 }
 
 // ---------------------------------------------------------------------------
-// Webhook callers
-// ---------------------------------------------------------------------------
-
-/**
- * Build Basic auth header value.
- */
-function basicAuth(user, password) {
-  return 'Basic ' + Buffer.from(`${user}:${password}`).toString('base64');
-}
-
-/**
- * Call a webhook. Returns the parsed JSON response.
- * Throws on non-2xx status.
- */
-async function callWebhook(url, params, authHeader) {
-  const searchParams = new URLSearchParams(params);
-  const fullUrl = `${url}?${searchParams.toString()}`;
-
-  const response = await fetch(fullUrl, {
-    method: 'POST',
-    headers: {
-      'Authorization': authHeader,
-    },
-  });
-
-  if (!response.ok) {
-    const body = await response.text().catch(() => '');
-    throw new Error(`Webhook ${url} failed with status ${response.status}: ${body}`);
-  }
-
-  const text = await response.text();
-  try {
-    return JSON.parse(text);
-  } catch {
-    return { raw: text };
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Main push function
 // ---------------------------------------------------------------------------
 
 /**
- * Push a window's contract configuration to NEO Headless via webhooks.
+ * Push a window's contract configuration to NEO Headless via direct DB writes.
  *
  * @param {string} windowName - The window artifact folder name (e.g., "sales-order")
  * @param {object} [options] - Override options
- * @param {string} [options.etendoUrl] - Override Etendo base URL
- * @param {string} [options.user] - Override auth user
- * @param {string} [options.password] - Override auth password
- * @param {boolean} [options.dryRun] - If true, log planned actions without calling webhooks
+ * @param {boolean} [options.dryRun] - If true, log planned actions without writing to DB
  * @param {string} [options.projectRoot] - Override project root path
+ * @param {string} [options.moduleId='0'] - AD_Module_ID for new rows
+ * @param {object} [options.dbConfig] - Override DB pool config (passed to createDbPool)
+ * @param {object} [options.audit] - Override audit defaults
+ * @param {string} [options.etendoUrl] - Kept for backwards compat (dry-run plan display)
+ * @param {string} [options.user] - Kept for backwards compat
+ * @param {string} [options.password] - Kept for backwards compat
  * @returns {object} Result summary with spec, entities, and field updates
  */
 export async function pushToNeo(windowName, options = {}) {
@@ -207,63 +179,44 @@ export async function pushToNeo(windowName, options = {}) {
   const windowDisplayName = schema.window.name;
   const specName = toSpecName(windowDisplayName);
 
-  // Load connection config (options override file/env)
-  let config;
-  if (options.etendoUrl && options.user && options.password) {
-    config = { url: options.etendoUrl, user: options.user, password: options.password };
-  } else {
-    config = await loadConfig(projectRoot);
-    if (options.etendoUrl) config.url = options.etendoUrl;
-    if (options.user) config.user = options.user;
-    if (options.password) config.password = options.password;
-  }
-
-  const authHeader = basicAuth(config.user, config.password);
-  const dryRun = options.dryRun === true;
-
-  // Extract all fields from backend contract (has all visibility levels)
+  // Extract all fields from backend contract
   const allFields = extractFieldsFromContract(contract.backendContract);
 
-  // Build planned actions
-  const plan = {
-    spec: {
-      webhook: 'SFUpsertSpec',
-      url: buildWebhookUrl(config.url, 'SFUpsertSpec'),
-      params: { windowId, name: specName, type: 'W' },
-    },
-    populate: {
-      webhook: 'SFPopulateSpec',
-      url: buildWebhookUrl(config.url, 'SFPopulateSpec'),
-      params: { specId: '(from step 1)' },
-    },
-    fields: allFields.map(f => {
-      const vis = mapVisibility(f.visibility);
-      return {
-        webhook: 'SFUpsertField',
-        url: buildWebhookUrl(config.url, 'SFUpsertField'),
-        entityName: f.entityName,
-        params: {
-          entityId: '(from populate)',
-          column: f.column,
-          isIncluded: vis.isIncluded,
-          isReadOnly: vis.isReadOnly,
-        },
-      };
-    }),
-  };
+  // Dry run mode — plan generation without DB writes
+  if (options.dryRun === true) {
+    const plan = {
+      spec: {
+        action: 'upsertSpec',
+        params: { windowId, name: specName, specType: 'W' },
+      },
+      populate: {
+        action: 'populateSpec',
+        params: { specId: '(from step 1)' },
+      },
+      fields: allFields.map(f => {
+        const vis = mapVisibility(f.visibility);
+        return {
+          action: 'upsertField',
+          entityName: f.entityName,
+          params: {
+            entityId: '(from populate)',
+            column: f.column,
+            isIncluded: vis.isIncluded,
+            isReadOnly: vis.isReadOnly,
+          },
+        };
+      }),
+    };
 
-  if (dryRun) {
     console.log(`[DRY RUN] Push to NEO for window: ${windowDisplayName} (${windowName})`);
     console.log(`  Spec name: ${specName}`);
     console.log(`  Window ID: ${windowId}`);
-    console.log(`  Etendo URL: ${config.url}`);
-    console.log(`\n  Step 1: ${plan.spec.webhook}`);
-    console.log(`    URL: ${plan.spec.url}`);
+    console.log(`  Method: direct DB write`);
+    console.log(`\n  Step 1: upsertSpec`);
     console.log(`    Params:`, plan.spec.params);
-    console.log(`\n  Step 2: ${plan.populate.webhook}`);
-    console.log(`    URL: ${plan.populate.url}`);
+    console.log(`\n  Step 2: populateSpec`);
     console.log(`    Params: { specId: <returned from step 1> }`);
-    console.log(`\n  Step 3: ${plan.fields.length} field updates via ${plan.fields[0]?.webhook || 'SFUpsertField'}`);
+    console.log(`\n  Step 3: ${plan.fields.length} field updates via upsertField`);
 
     const included = plan.fields.filter(f => f.params.isIncluded === 'Y');
     const excluded = plan.fields.filter(f => f.params.isIncluded === 'N');
@@ -285,72 +238,109 @@ export async function pushToNeo(windowName, options = {}) {
     };
   }
 
-  // Step 1: Upsert spec
-  console.log(`[1/3] Upserting spec '${specName}' for window ${windowId}...`);
-  const specResult = await callWebhook(plan.spec.url, plan.spec.params, authHeader);
-  const specId = specResult.specId || specResult.id || specResult.data?.id;
-  if (!specId) {
-    throw new Error(`SFUpsertSpec did not return a specId. Response: ${JSON.stringify(specResult)}`);
-  }
-  console.log(`       Spec ID: ${specId}`);
+  // Live mode — write to DB via transaction
+  const moduleId = options.moduleId || '0';
+  const auditOpts = options.audit || {};
+  const pool = createDbPool(options.dbConfig);
+  const client = await pool.connect();
 
-  // Step 2: Populate spec (auto-creates entities + fields from AD metadata)
-  console.log(`[2/3] Populating spec from AD metadata...`);
-  const populateResult = await callWebhook(
-    plan.populate.url,
-    { specId },
-    authHeader,
-  );
-  // Extract entity IDs from populate result
-  const entityMap = {};
-  if (populateResult.entities) {
-    for (const ent of populateResult.entities) {
-      entityMap[ent.name] = ent.id || ent.entityId;
+  try {
+    await client.query('BEGIN');
+
+    // Step 1: Upsert spec
+    console.log(`[1/3] Upserting spec '${specName}' for window ${windowId}...`);
+    const specResult = await writerUpsertSpec(client, {
+      name: specName,
+      moduleId,
+      windowId,
+      specType: 'W',
+      audit: auditOpts,
+    });
+    const specId = specResult.specId;
+    console.log(`       Spec ID: ${specId} (${specResult.created ? 'created' : 'updated'})`);
+
+    // Step 2: Populate spec from AD metadata
+    console.log(`[2/3] Populating spec from AD metadata...`);
+    const popResult = await writerPopulateSpec(client, {
+      specId,
+      moduleId,
+      audit: auditOpts,
+    });
+
+    // Build entity name -> entityId map from populate result
+    const entityMap = {};
+    for (const ent of popResult.entities) {
+      entityMap[ent.name] = ent.entityId;
     }
-  }
-  console.log(`       Entities populated: ${Object.keys(entityMap).length}`);
+    console.log(`       Entities populated: ${popResult.entityCount}, Fields: ${popResult.fieldCount}`);
 
-  // Step 3: Update fields based on contract visibility
-  console.log(`[3/3] Updating ${allFields.length} fields...`);
-  const fieldResults = [];
-  let successCount = 0;
-  let errorCount = 0;
+    // Step 3: Update field visibility from contract
+    console.log(`[3/3] Updating ${allFields.length} fields from contract visibility...`);
+    let successCount = 0;
+    let errorCount = 0;
+    const fieldResults = [];
 
-  for (const fieldPlan of plan.fields) {
-    const entityId = entityMap[fieldPlan.entityName];
-    if (!entityId) {
-      console.warn(`  Warning: No entity ID found for '${fieldPlan.entityName}', skipping field '${fieldPlan.params.column}'`);
-      errorCount++;
-      continue;
-    }
+    for (const f of allFields) {
+      const entityId = entityMap[f.entityName];
+      if (!entityId) {
+        console.warn(`  Warning: No entity ID found for '${f.entityName}', skipping field '${f.column}'`);
+        errorCount++;
+        fieldResults.push({ column: f.column, entityName: f.entityName, success: false, error: 'no entity' });
+        continue;
+      }
 
-    try {
-      const result = await callWebhook(
-        fieldPlan.url,
-        { ...fieldPlan.params, entityId },
-        authHeader,
+      const vis = mapVisibility(f.visibility);
+
+      // Find the field by entity + column name (look up column ID first)
+      const colLookup = await client.query(
+        `SELECT sf.etgo_sf_field_id
+         FROM etgo_sf_field sf
+         JOIN ad_column c ON c.ad_column_id = sf.ad_column_id
+         WHERE sf.etgo_sf_entity_id = $1 AND c.columnname = $2`,
+        [entityId, f.column],
       );
-      fieldResults.push({ ...fieldPlan.params, entityId, success: true });
+
+      if (colLookup.rows.length === 0) {
+        // Field might have been excluded as a system column — skip silently
+        fieldResults.push({ column: f.column, entityName: f.entityName, success: true, skipped: true });
+        successCount++;
+        continue;
+      }
+
+      const fieldId = colLookup.rows[0].etgo_sf_field_id;
+      await writerUpsertField(client, {
+        entityId,
+        fieldId,
+        moduleId,
+        isIncluded: vis.isIncluded,
+        isReadOnly: vis.isReadOnly,
+        audit: auditOpts,
+      });
+      fieldResults.push({ column: f.column, entityName: f.entityName, success: true });
       successCount++;
-    } catch (err) {
-      console.warn(`  Warning: Failed to update field '${fieldPlan.params.column}': ${err.message}`);
-      fieldResults.push({ ...fieldPlan.params, entityId, success: false, error: err.message });
-      errorCount++;
     }
+
+    await client.query('COMMIT');
+
+    console.log(`\nDone. ${successCount} fields updated, ${errorCount} errors.`);
+
+    return {
+      dryRun: false,
+      specName,
+      specId,
+      windowId,
+      entitiesPopulated: popResult.entityCount,
+      fieldsUpdated: successCount,
+      fieldsErrored: errorCount,
+      fieldResults,
+    };
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+    await closePool(pool);
   }
-
-  console.log(`\nDone. ${successCount} fields updated, ${errorCount} errors.`);
-
-  return {
-    dryRun: false,
-    specName,
-    specId,
-    windowId,
-    entitiesPopulated: Object.keys(entityMap).length,
-    fieldsUpdated: successCount,
-    fieldsErrored: errorCount,
-    fieldResults,
-  };
 }
 
 // ---------------------------------------------------------------------------

--- a/cli/test/push-to-neo.test.js
+++ b/cli/test/push-to-neo.test.js
@@ -8,6 +8,10 @@ import {
   pushToNeo,
   loadConfig,
 } from '../src/push-to-neo.js';
+import {
+  generateId,
+  auditDefaults,
+} from '../src/neo-writer.js';
 import { writeFile, mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -39,7 +43,7 @@ describe('mapVisibility', () => {
 });
 
 // ---------------------------------------------------------------------------
-// 2. Webhook URL construction
+// 2. Webhook URL construction (deprecated but still exported)
 // ---------------------------------------------------------------------------
 
 describe('buildWebhookUrl', () => {
@@ -177,15 +181,9 @@ describe('pushToNeo dry run', () => {
 
     await writeFile(join(artifactsDir, 'schema-curated.json'), JSON.stringify(schema));
     await writeFile(join(artifactsDir, 'contract.json'), JSON.stringify(contract));
-
-    // Write a minimal properties file
-    await writeFile(
-      join(tmpDir, 'schema_forge.properties'),
-      'etendo.url=http://localhost:8080/etendo\netendo.user=admin\netendo.password=admin\n',
-    );
   });
 
-  it('returns plan without making HTTP calls', async () => {
+  it('returns plan without writing to DB', async () => {
     const result = await pushToNeo('sales-order', {
       dryRun: true,
       projectRoot: tmpDir,
@@ -215,15 +213,15 @@ describe('pushToNeo dry run', () => {
     assert.equal(result.summary.totalFields, 4);
   });
 
-  it('builds correct webhook URLs in plan', async () => {
+  it('uses direct DB action names in plan', async () => {
     const result = await pushToNeo('sales-order', {
       dryRun: true,
       projectRoot: tmpDir,
     });
 
-    assert.equal(result.plan.spec.url, 'http://localhost:8080/etendo/sws/webhooks/SFUpsertSpec');
-    assert.equal(result.plan.populate.url, 'http://localhost:8080/etendo/sws/webhooks/SFPopulateSpec');
-    assert.equal(result.plan.fields[0].url, 'http://localhost:8080/etendo/sws/webhooks/SFUpsertField');
+    assert.equal(result.plan.spec.action, 'upsertSpec');
+    assert.equal(result.plan.populate.action, 'populateSpec');
+    assert.equal(result.plan.fields[0].action, 'upsertField');
   });
 
   it('derives spec name from schema window name', async () => {
@@ -233,7 +231,7 @@ describe('pushToNeo dry run', () => {
     });
 
     assert.equal(result.plan.spec.params.name, 'sales-order');
-    assert.equal(result.plan.spec.params.type, 'W');
+    assert.equal(result.plan.spec.params.specType, 'W');
     assert.equal(result.plan.spec.params.windowId, '143');
   });
 });
@@ -252,9 +250,6 @@ describe('pushToNeo error handling', () => {
       () => pushToNeo('nonexistent', {
         dryRun: true,
         projectRoot: tmpDir,
-        etendoUrl: 'http://localhost:8080/etendo',
-        user: 'admin',
-        password: 'admin',
       }),
       /Cannot read contract\.json/,
     );
@@ -272,48 +267,14 @@ describe('pushToNeo error handling', () => {
       () => pushToNeo('partial', {
         dryRun: true,
         projectRoot: tmpDir,
-        etendoUrl: 'http://localhost:8080/etendo',
-        user: 'admin',
-        password: 'admin',
       }),
       /Cannot read schema-curated\.json/,
     );
   });
-
-  it('throws on missing config when no options provided', async () => {
-    const tmpDir = join(tmpdir(), `push-to-neo-err3-${Date.now()}`);
-    const artifactsDir = join(tmpDir, 'artifacts', 'test-win');
-    await mkdir(artifactsDir, { recursive: true });
-
-    const schema = { window: { id: '1', name: 'Test' }, entities: [] };
-    const contract = { backendContract: { entities: {} } };
-    await writeFile(join(artifactsDir, 'schema-curated.json'), JSON.stringify(schema));
-    await writeFile(join(artifactsDir, 'contract.json'), JSON.stringify(contract));
-
-    // Clear env vars for this test
-    const origUrl = process.env.ETENDO_URL;
-    const origUser = process.env.ETENDO_USER;
-    const origPass = process.env.ETENDO_PASSWORD;
-    delete process.env.ETENDO_URL;
-    delete process.env.ETENDO_USER;
-    delete process.env.ETENDO_PASSWORD;
-
-    try {
-      await assert.rejects(
-        () => pushToNeo('test-win', { projectRoot: tmpDir }),
-        /Missing Etendo URL/,
-      );
-    } finally {
-      // Restore env vars
-      if (origUrl !== undefined) process.env.ETENDO_URL = origUrl;
-      if (origUser !== undefined) process.env.ETENDO_USER = origUser;
-      if (origPass !== undefined) process.env.ETENDO_PASSWORD = origPass;
-    }
-  });
 });
 
 // ---------------------------------------------------------------------------
-// 7. loadConfig
+// 7. loadConfig (deprecated but still tested for backwards compat)
 // ---------------------------------------------------------------------------
 
 describe('loadConfig', () => {
@@ -367,8 +328,46 @@ describe('loadConfig', () => {
       assert.equal(cfg.password, 'env-pass');
     } finally {
       if (origUrl !== undefined) process.env.ETENDO_URL = origUrl; else delete process.env.ETENDO_URL;
-      if (origUser !== undefined) process.env.ETENDO_USER = origUser; else delete process.env.ETENDO_USER;
+      if (origUser !== undefined) process.env.ETENDO_USER = origUser; else delete process.env.ETENDO_URL;
       if (origPass !== undefined) process.env.ETENDO_PASSWORD = origPass; else delete process.env.ETENDO_PASSWORD;
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. neo-writer.js pure function tests
+// ---------------------------------------------------------------------------
+
+describe('generateId', () => {
+  it('returns a 32-character uppercase hex string', () => {
+    const id = generateId();
+    assert.equal(id.length, 32);
+    assert.match(id, /^[0-9A-F]{32}$/);
+  });
+
+  it('generates unique IDs', () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateId()));
+    assert.equal(ids.size, 100);
+  });
+});
+
+describe('auditDefaults', () => {
+  it('returns all required audit columns', () => {
+    const audit = auditDefaults();
+    assert.equal(audit.ad_client_id, '0');
+    assert.equal(audit.ad_org_id, '0');
+    assert.equal(audit.isactive, 'Y');
+    assert.equal(audit.createdby, '0');
+    assert.equal(audit.updatedby, '0');
+    assert.ok(audit.created instanceof Date);
+    assert.ok(audit.updated instanceof Date);
+  });
+
+  it('accepts custom clientId, orgId, userId', () => {
+    const audit = auditDefaults({ clientId: 'ABC', orgId: 'DEF', userId: 'GHI' });
+    assert.equal(audit.ad_client_id, 'ABC');
+    assert.equal(audit.ad_org_id, 'DEF');
+    assert.equal(audit.createdby, 'GHI');
+    assert.equal(audit.updatedby, 'GHI');
   });
 });

--- a/cli/test/push-to-neo.test.js
+++ b/cli/test/push-to-neo.test.js
@@ -328,7 +328,7 @@ describe('loadConfig', () => {
       assert.equal(cfg.password, 'env-pass');
     } finally {
       if (origUrl !== undefined) process.env.ETENDO_URL = origUrl; else delete process.env.ETENDO_URL;
-      if (origUser !== undefined) process.env.ETENDO_USER = origUser; else delete process.env.ETENDO_URL;
+      if (origUser !== undefined) process.env.ETENDO_USER = origUser; else delete process.env.ETENDO_USER;
       if (origPass !== undefined) process.env.ETENDO_PASSWORD = origPass; else delete process.env.ETENDO_PASSWORD;
     }
   });


### PR DESCRIPTION
## Summary
- New `cli/src/neo-writer.js` module with pure functions for direct PostgreSQL writes to ETGO_SF_* tables (generateId, auditDefaults, upsertSpec, upsertEntity, upsertField, populateSpec)
- Refactored `cli/src/push-to-neo.js` to use neo-writer instead of HTTP webhook calls, with full transaction support (BEGIN/COMMIT/ROLLBACK)
- All existing pure functions (toSpecName, mapVisibility, extractFieldsFromContract, buildWebhookUrl, loadConfig) preserved for backwards compatibility
- Dry-run mode still works without DB connection
- Updated tests to match new plan structure; added neo-writer unit tests (generateId format, auditDefaults)

## Test plan
- [x] All 3083 existing tests pass (0 failures)
- [ ] Integration test against real Etendo DB (Phase 3, separate PR)
- [ ] Verify dry-run output matches expected plan format

Generated with [Claude Code](https://claude.com/claude-code)