### PR TITLE
feat: crossfade transition between grid and form views

### DIFF
--- a/tools/app-shell/src/index.css
+++ b/tools/app-shell/src/index.css
@@ -5,16 +5,16 @@
 @keyframes page-enter {
   from {
     opacity: 0;
-    transform: translateY(8px);
+    transform: scale(0.98) translateY(4px);
   }
   to {
     opacity: 1;
-    transform: translateY(0);
+    transform: scale(1) translateY(0);
   }
 }
 
 .page-transition {
-  animation: page-enter 0.2s ease-out;
+  animation: page-enter 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .content-bg {


### PR DESCRIPTION
## Summary
- Replace the existing slide-up page transition with a crossfade + subtle scale animation
- Enter animation: fade in + scale from 98% + 4px upward motion over 250ms with ease-out cubic bezier
- CSS-only change in `index.css`, no library dependencies

## Test plan
- [ ] Navigate from ListView to DetailView — verify smooth crossfade with subtle scale-up
- [ ] Navigate back from DetailView to ListView — verify same transition
- [ ] Rapid navigation between views — verify no animation glitches
- [ ] Build passes with no errors

Generated with [Claude Code](https://claude.com/claude-code)