### PR TITLE
Feature: Hybrid display logic CLI support

### DIFF
--- a/cli/src/extract-rules.js
+++ b/cli/src/extract-rules.js
@@ -191,6 +191,15 @@ export function translateExpression(expr) {
 
   let result = expr;
 
+  // Fix Category 1: convert !' to !=' and !@ to !=@ (Etendo shorthand for "not equal")
+  result = result.replace(/!'/g, "!='");
+  result = result.replace(/!@/g, '!=@');
+
+  // Fix Category 2: handle @#VAR@ (system preferences) and @$VAR@ (accounting dimensions)
+  result = result.replace(/@[#$](\w+)@/g, (_match, name) => {
+    return name.charAt(0).toLowerCase() + name.slice(1);
+  });
+
   // Replace @VAR@ with camelCase variable name
   result = result.replace(/@([A-Za-z_][A-Za-z0-9_]*)@/g, (_match, varName) => {
     // camelCase: lowercase first char

--- a/cli/src/generate-contract.js
+++ b/cli/src/generate-contract.js
@@ -36,6 +36,44 @@ function findMatchingRule(rules, identifier, type) {
 }
 
 /**
+ * Classify whether a raw display/readOnly logic expression can be evaluated client-side.
+ * Returns { evaluable: true } or { evaluable: false, reason: string }.
+ */
+function classifyEvaluability(rawExpr) {
+  if (!rawExpr) return { evaluable: true };
+
+  // Server-expanded macro
+  if (rawExpr.includes('@ACCT_DIMENSION_DISPLAY@')) {
+    return { evaluable: false, reason: 'server-macro' };
+  }
+  // System preferences (@#VAR@)
+  if (/@#\w+@/.test(rawExpr)) {
+    return { evaluable: false, reason: 'session-preference' };
+  }
+  // Accounting dimensions (@$VAR@)
+  if (/@\$\w+@/.test(rawExpr)) {
+    return { evaluable: false, reason: 'accounting-dimension' };
+  }
+  // Known session context variables (module flags, not field values)
+  const sessionVarPatterns = [
+    'FinancialManagement', 'StockReservations', 'IsSOTrx', 'ShowAcct', 'ShowTrl',
+    'ACCS_Account_Ope', 'APRM_', 'showAddPayment', 'IsStocked',
+  ];
+  for (const pattern of sessionVarPatterns) {
+    if (rawExpr.includes(`@${pattern}`)) {
+      return { evaluable: false, reason: 'session-variable' };
+    }
+  }
+  // Auxiliary inputs (SQL-computed values — lowercase start or known patterns)
+  if (/@SQL@/i.test(rawExpr)) {
+    return { evaluable: false, reason: 'auxiliary-input' };
+  }
+  // If @ symbols remain after the known patterns, might be untranslatable
+  // But simple @FieldName@ patterns are fine — those are field references
+  return { evaluable: true };
+}
+
+/**
  * Generate frontend contract: visible fields, searchable fields, computed fields.
  * Includes behavioral metadata (callout, displayLogic, readOnlyLogic) when present.
  */
@@ -96,6 +134,12 @@ export function generateFrontendContract(schema, rules = []) {
         if (matchingRule && matchingRule.translated) {
           mapped.displayLogic.js = matchingRule.translated;
         }
+        const evalInfo = classifyEvaluability(f.displayLogic);
+        mapped.displayLogic.evaluable = evalInfo.evaluable;
+        if (!evalInfo.evaluable) {
+          mapped.displayLogic.reason = evalInfo.reason;
+          mapped.displayLogic.js = null;
+        }
       }
 
       // Behavioral metadata: readOnlyLogic
@@ -104,6 +148,12 @@ export function generateFrontendContract(schema, rules = []) {
         const matchingRule = findMatchingRule(rules, f.readOnlyLogic, 'readOnlyLogic');
         if (matchingRule && matchingRule.translated) {
           mapped.readOnlyLogic.js = matchingRule.translated;
+        }
+        const evalInfo = classifyEvaluability(f.readOnlyLogic);
+        mapped.readOnlyLogic.evaluable = evalInfo.evaluable;
+        if (!evalInfo.evaluable) {
+          mapped.readOnlyLogic.reason = evalInfo.reason;
+          mapped.readOnlyLogic.js = null;
         }
       }
 
@@ -250,6 +300,34 @@ export function generateTestManifest(frontendContract, backendContract, rules = 
           field: field.name,
           runner: 'node',
           description: `Read-only logic for '${field.name}' in ${entityName} should be valid JS`,
+        });
+      }
+    }
+
+    // displayLogic evaluable: one per field with displayLogic
+    for (const field of visibleFields) {
+      if (field.displayLogic) {
+        tests.push({
+          id: nextId(),
+          category: 'displaylogic-evaluable',
+          entity: entityName,
+          field: field.name,
+          runner: 'node',
+          description: `Display logic for '${field.name}' in ${entityName} should have evaluable flag`,
+        });
+      }
+    }
+
+    // readOnlyLogic evaluable: one per field with readOnlyLogic
+    for (const field of visibleFields) {
+      if (field.readOnlyLogic) {
+        tests.push({
+          id: nextId(),
+          category: 'readonlylogic-evaluable',
+          entity: entityName,
+          field: field.name,
+          runner: 'node',
+          description: `Read-only logic for '${field.name}' in ${entityName} should have evaluable flag`,
         });
       }
     }

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -121,12 +121,22 @@ export function generateFormComponent(entityName, contract) {
     const fieldGroupPart = f.fieldGroup ? `, fieldGroup: '${f.fieldGroup.replace(/'/g, "\\'")}'` : '';
     const precisionPart = f.precision ? `, precision: ${f.precision}` : '';
     // Behavioral metadata: displayLogic and readOnlyLogic
-    const displayLogicPart = f.displayLogic?.js
-      ? `, displayLogic: (record) => ${f.displayLogic.js}`
-      : '';
-    const readOnlyLogicPart = f.readOnlyLogic?.js
-      ? `, readOnlyLogic: (record) => ${f.readOnlyLogic.js}`
-      : '';
+    let displayLogicPart = '';
+    if (f.displayLogic) {
+      if (f.displayLogic.evaluable === false) {
+        displayLogicPart = `, visible: null, visibilitySource: 'server', displayLogicReason: '${f.displayLogic.reason || 'unknown'}'`;
+      } else if (f.displayLogic.js) {
+        displayLogicPart = `, displayLogic: (record) => ${f.displayLogic.js}`;
+      }
+    }
+    let readOnlyLogicPart = '';
+    if (f.readOnlyLogic) {
+      if (f.readOnlyLogic.evaluable === false) {
+        readOnlyLogicPart = `, readOnlySource: 'server', readOnlyLogicReason: '${f.readOnlyLogic.reason || 'unknown'}'`;
+      } else if (f.readOnlyLogic.js) {
+        readOnlyLogicPart = `, readOnlyLogic: (record) => ${f.readOnlyLogic.js}`;
+      }
+    }
     // TODO comments for callout and onChangeFunction behavioral hints
     const todoLines = [];
     if (f.callout) {

--- a/cli/src/run-contract-tests.js
+++ b/cli/src/run-contract-tests.js
@@ -156,6 +156,48 @@ function checkReadOnlyLogicValid(contract, test) {
 }
 
 /**
+ * Check displaylogic-evaluable: displayLogic has evaluable flag and reason when false
+ */
+function checkDisplayLogicEvaluable(contract, test) {
+  const entity = contract.frontendContract?.entities?.[test.entity];
+  if (!entity) return { passed: false, reason: `Entity '${test.entity}' not found` };
+  const field = entity.fields.find(f => f.name === test.field);
+  if (!field) return { passed: false, reason: `Field '${test.field}' not found` };
+  if (!field.displayLogic) return { passed: true };
+  if (typeof field.displayLogic.evaluable !== 'boolean') {
+    return { passed: false, reason: `displayLogic.evaluable is missing or not boolean` };
+  }
+  if (field.displayLogic.evaluable === false && !field.displayLogic.reason) {
+    return { passed: false, reason: `displayLogic.evaluable is false but no reason provided` };
+  }
+  if (field.displayLogic.evaluable === false && field.displayLogic.js !== null) {
+    return { passed: false, reason: `displayLogic.evaluable is false but js is not null` };
+  }
+  return { passed: true };
+}
+
+/**
+ * Check readonlylogic-evaluable: readOnlyLogic has evaluable flag and reason when false
+ */
+function checkReadOnlyLogicEvaluable(contract, test) {
+  const entity = contract.frontendContract?.entities?.[test.entity];
+  if (!entity) return { passed: false, reason: `Entity '${test.entity}' not found` };
+  const field = entity.fields.find(f => f.name === test.field);
+  if (!field) return { passed: false, reason: `Field '${test.field}' not found` };
+  if (!field.readOnlyLogic) return { passed: true };
+  if (typeof field.readOnlyLogic.evaluable !== 'boolean') {
+    return { passed: false, reason: `readOnlyLogic.evaluable is missing or not boolean` };
+  }
+  if (field.readOnlyLogic.evaluable === false && !field.readOnlyLogic.reason) {
+    return { passed: false, reason: `readOnlyLogic.evaluable is false but no reason provided` };
+  }
+  if (field.readOnlyLogic.evaluable === false && field.readOnlyLogic.js !== null) {
+    return { passed: false, reason: `readOnlyLogic.evaluable is false but js is not null` };
+  }
+  return { passed: true };
+}
+
+/**
  * Check selector-endpoint: FK field has matching selector in apiPrediction
  */
 function checkSelectorEndpoint(contract, test) {
@@ -215,6 +257,8 @@ const categoryHandlers = {
   'rule-declared': checkRuleDeclared,
   'displaylogic-valid': checkDisplayLogicValid,
   'readonlylogic-valid': checkReadOnlyLogicValid,
+  'displaylogic-evaluable': checkDisplayLogicEvaluable,
+  'readonlylogic-evaluable': checkReadOnlyLogicEvaluable,
   'selector-endpoint': checkSelectorEndpoint,
   'action-endpoint': checkActionEndpoint,
   'crud-flags': checkCrudFlags,


### PR DESCRIPTION
## Summary
- Fix `translateExpression()` bugs: `!'` to `!='` and `!@` to `!=@` (Category 1 from display logic analysis)
- Handle `@#VAR@` and `@$VAR@` prefix patterns in expression translation (Category 2)
- Add `classifyEvaluability()` function to detect server-only expressions (session vars, preferences, macros)
- Add `evaluable`/`reason` flags to displayLogic and readOnlyLogic in contract output
- Update frontend generator: emit `visibilitySource: 'server'` for non-evaluable fields
- Add `displaylogic-evaluable` and `readonlylogic-evaluable` contract test handlers

## Test plan
- [x] All 3076 existing tests pass (0 failures)
- [ ] Verify evaluable flag appears in generated contracts for windows with display logic
- [ ] Verify non-evaluable fields get `js: null` and a `reason` string
- [ ] Verify frontend generator emits `visibilitySource: 'server'` instead of arrow functions for non-evaluable fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)