### PR TITLE
Feature ETP-3529: Standalone process pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,22 +206,24 @@ schema-forge/                             # THIS REPO — design + tooling
 ├── cli/                                  # Node.js CLI tools
 │   └── src/
 │       ├── extract-from-db.js            # Extract fields + rules from Etendo DB
+│       ├── extract-from-process.js      # Extract process metadata + parameters
 │       ├── extract-fields.js             # Field extraction with FK resolution
 │       ├── extract-rules.js              # Rule + callout extraction
 │       ├── pre-classify.js               # Auto-classify rules (deterministic + AI)
 │       ├── validate-schema.js            # 4-level validation
 │       ├── generate-contract.js          # Frontend/backend contracts
-│       ├── push-to-neo.js                # Webhook calls → NEO Headless config
+│       ├── push-to-neo.js                # Direct DB writes → NEO Headless config (windows + processes)
+│       ├── neo-writer.js                # Low-level DB writer for ETGO_SF_* tables
 │       ├── generate-frontend.js          # React SPA generation
 │       ├── generate-mock-data.js         # Mock catalogs for UI preview
 │       ├── run-contract-tests.js         # Contract test runner
-│       └── pipeline.js                   # Full extraction-to-generation pipeline
+│       └── pipeline.js                   # Full pipeline (windows + processes)
 ├── tools/                                # React decision UIs
 │   ├── app-shell/                        # Main UI shell (Vite + React + Tailwind)
 │   ├── decision-panel/                   # Field visibility + rule curation
 │   └── ui-preview/                       # Live preview with mock data
 ├── templates/etendo-module/              # Legacy templates (replaced by NEO Headless config via webhooks)
-├── artifacts/{window-name}/              # Per-window: schemas, rules, decisions, generated code
+├── artifacts/{window-or-process-name}/   # Per-window/process: schemas, rules, decisions, generated code
 ├── core-maps/                            # system-columns.json, impact-messages.json, ad-reference-map.json
 ├── pending/                              # Future proposals (callouts, OpenAPI registration)
 └── docs/                                 # All documentation
@@ -238,10 +240,11 @@ schema-forge/                             # THIS REPO — design + tooling
 Etendo AD Metadata
     │
     ▼
-Schema Forge CLI (extract-from-db.js)
-    │ Extracts fields, rules, callouts, FK references
+Schema Forge CLI (extract-from-db.js / extract-from-process.js)
+    │ Extracts fields, rules, callouts, FK references (windows)
+    │ Extracts process metadata + parameters (standalone processes)
     ▼
-Per-Window Artifacts (artifacts/{window}/)
+Per-Window/Process Artifacts (artifacts/{name}/)
     │ schema-curated.json, rules-curated.json
     ▼
 Decision UIs (tools/decision-panel/)
@@ -366,7 +369,15 @@ Config at `/Users/futit/Workspace/etendo_develop/gradle.properties`:
 See `docs/brainstorming-2026-03-10.md` for detailed notes on:
 - NeoHandler CDI hook mechanism (custom endpoint logic via `@Named` + `JAVA_QUALIFIER`)
 - Callouts NOT in NEO Headless (deferred to v2, only classic UI)
-- Pipeline → NEO gap: webhooks ready but no `push-to-neo.js` CLI module yet
+- Pipeline → NEO: fully integrated via `push-to-neo.js` + `neo-writer.js` (direct DB writes, supports windows + processes)
+
+### Discovery Webhooks (read-only, for tooling)
+
+| Webhook | Purpose |
+|---------|---------|
+| `SFListProcesses` | List available processes (GET, `?q=` search, up to 100 results) |
+| `SFListWindows` | List available windows |
+| `SFListMenu` | Full menu tree with type resolution |
 
 ## Etendo AD Database Conventions
 

--- a/cli/src/extract-from-process.js
+++ b/cli/src/extract-from-process.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { createDbPool, closePool } from './db.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = join(__dirname, '..', '..');
+
+export const QUERIES = {
+  'process-metadata': `
+SELECT p.AD_Process_ID, p.Name, p.Description, p.Help,
+       p.UIPattern, p.JavaClassName, p.ProcedureName,
+       p.IsReport, p.IsBackground
+FROM AD_Process p
+WHERE p.AD_Process_ID = $1 AND p.IsActive = 'Y'`,
+
+  'process-parameters': `
+SELECT pp.AD_Process_Para_ID, pp.Name, pp.ColumnName, pp.Description,
+       pp.AD_Reference_ID, pp.AD_Reference_Value_ID,
+       pp.IsMandatory, pp.IsRange, pp.DefaultValue, pp.SeqNo,
+       pp.FieldLength, pp.AD_Val_Rule_ID,
+       r.Name AS reference_name
+FROM AD_Process_Para pp
+JOIN AD_Reference r ON r.AD_Reference_ID = pp.AD_Reference_ID
+WHERE pp.AD_Process_ID = $1 AND pp.IsActive = 'Y'
+ORDER BY pp.SeqNo`,
+};
+
+export function rowsToCsv(rows) {
+  if (rows.length === 0) return '';
+  const headers = Object.keys(rows[0]);
+  const lines = [headers.join(',')];
+  for (const row of rows) {
+    const values = headers.map((h) => {
+      const val = row[h];
+      if (val == null) return '';
+      const str = String(val);
+      if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+        return '"' + str.replace(/"/g, '""') + '"';
+      }
+      return str;
+    });
+    lines.push(values.join(','));
+  }
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Transform raw query results into the process-raw.json structure.
+ */
+export function buildProcessRaw(metadataRows, parameterRows) {
+  if (metadataRows.length === 0) {
+    throw new Error('Process not found or inactive');
+  }
+  const p = metadataRows[0];
+  return {
+    process: {
+      id: p.ad_process_id,
+      name: p.name,
+      description: p.description || null,
+      help: p.help || null,
+      uiPattern: p.uipattern,
+      javaClassName: p.javaclassname || null,
+      procedureName: p.procedurename || null,
+      isReport: p.isreport === 'Y',
+      isBackground: p.isbackground === 'Y',
+    },
+    parameters: parameterRows.map((pp) => ({
+      id: pp.ad_process_para_id,
+      name: pp.name,
+      column: pp.columnname,
+      description: pp.description || null,
+      referenceId: pp.ad_reference_id,
+      referenceName: pp.reference_name,
+      referenceValueId: pp.ad_reference_value_id || null,
+      mandatory: pp.ismandatory === 'Y',
+      isRange: pp.isrange === 'Y',
+      defaultValue: pp.defaultvalue || null,
+      seqNo: parseInt(pp.seqno, 10),
+      fieldLength: parseInt(pp.fieldlength, 10) || 0,
+      valRuleId: pp.ad_val_rule_id || null,
+    })),
+  };
+}
+
+export async function main(processId, processSlug) {
+  const pool = createDbPool();
+  const outDir = join(ROOT, 'artifacts', processSlug, 'raw-query-results');
+  await mkdir(outDir, { recursive: true });
+
+  try {
+    const [metadataResult, paramsResult] = await Promise.all([
+      pool.query(QUERIES['process-metadata'], [processId]),
+      pool.query(QUERIES['process-parameters'], [processId]),
+    ]);
+
+    // Write CSVs
+    const metaCsv = rowsToCsv(metadataResult.rows);
+    await writeFile(join(outDir, 'process-metadata.csv'), metaCsv, 'utf-8');
+    console.log(`  process-metadata.csv: ${metadataResult.rows.length} rows`);
+
+    const paramsCsv = rowsToCsv(paramsResult.rows);
+    await writeFile(join(outDir, 'process-parameters.csv'), paramsCsv, 'utf-8');
+    console.log(`  process-parameters.csv: ${paramsResult.rows.length} rows`);
+
+    // Build and write process-raw.json
+    const processRaw = buildProcessRaw(metadataResult.rows, paramsResult.rows);
+    const jsonPath = join(ROOT, 'artifacts', processSlug, 'process-raw.json');
+    await writeFile(jsonPath, JSON.stringify(processRaw, null, 2), 'utf-8');
+    console.log(`  process-raw.json written`);
+
+    console.log(`\nArtifacts written to artifacts/${processSlug}/`);
+    return processRaw;
+  } finally {
+    await closePool(pool);
+  }
+}
+
+// CLI entry point
+const isCLI =
+  process.argv[1] &&
+  import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/'));
+
+if (isCLI) {
+  const processId = process.argv[2];
+  const processSlug = process.argv[3];
+
+  if (!processId || !processSlug) {
+    console.error('Usage: node extract-from-process.js <processId> <processSlug>');
+    console.error('Example: node extract-from-process.js 2AC62B61C988442882DFC742E16A5EB4 enroll-student');
+    process.exit(1);
+  }
+
+  main(processId, processSlug).catch((err) => {
+    console.error('Extraction failed:', err.message);
+    process.exit(1);
+  });
+}

--- a/cli/src/generate-contract.js
+++ b/cli/src/generate-contract.js
@@ -597,3 +597,146 @@ export function generateContract(schema, rules = [], processes = []) {
     ...contractData,
   };
 }
+
+// ---------------------------------------------------------------------------
+// Process contract generation
+// ---------------------------------------------------------------------------
+
+const PROCESS_REFERENCE_MAP = {
+  '15': { type: 'date', tsType: 'string', inputMode: 'date-picker' },
+  '16': { type: 'datetime', tsType: 'string', inputMode: 'datetime-picker' },
+  '10': { type: 'string', tsType: 'string', inputMode: 'text' },
+  '14': { type: 'string', tsType: 'string', inputMode: 'text' },
+  '11': { type: 'integer', tsType: 'number', inputMode: 'number' },
+  '22': { type: 'number', tsType: 'number', inputMode: 'number' },
+  '12': { type: 'amount', tsType: 'number', inputMode: 'number' },
+  '800019': { type: 'number', tsType: 'number', inputMode: 'number' },
+  '20': { type: 'boolean', tsType: 'boolean', inputMode: 'checkbox' },
+  '17': { type: 'list', tsType: 'string', inputMode: 'select' },
+  '19': { type: 'foreignKey', tsType: 'string', inputMode: 'search' },
+  '18': { type: 'foreignKey', tsType: 'string', inputMode: 'search' },
+  '30': { type: 'foreignKey', tsType: 'string', inputMode: 'search' },
+  '800011': { type: 'foreignKey', tsType: 'string', inputMode: 'search' },
+};
+
+const DEFAULT_REFERENCE = { type: 'string', tsType: 'string', inputMode: 'text' };
+
+/**
+ * Map an AD_Reference_ID to type info for process parameters.
+ */
+export function mapProcessReference(referenceId) {
+  return PROCESS_REFERENCE_MAP[String(referenceId)] ?? DEFAULT_REFERENCE;
+}
+
+/**
+ * Generate a contract for a standalone process (not window-attached).
+ *
+ * @param {object} processRaw - The process-raw.json structure
+ * @returns {object} Process contract
+ */
+export function generateProcessContract(processRaw) {
+  const { process: proc, parameters: rawParams } = processRaw;
+  const specName = toSpecName(proc.name);
+
+  const parameters = rawParams.map(p => {
+    const ref = mapProcessReference(p.referenceId);
+    const param = {
+      name: p.name,
+      column: p.column,
+      type: ref.type,
+      tsType: ref.tsType,
+      inputMode: ref.inputMode,
+      required: p.mandatory === true,
+      isRange: p.isRange === true,
+    };
+    if (p.defaultValue) param.defaultValue = p.defaultValue;
+    if (p.referenceValueId) param.referenceValueId = p.referenceValueId;
+    return param;
+  });
+
+  const apiPrediction = {
+    specName,
+    baseUrl: `/sws/neo/${specName}`,
+    describe: `GET /sws/neo/${specName}`,
+    execute: `POST /sws/neo/${specName}`,
+  };
+
+  // Build test manifest
+  const tests = [];
+  let idCounter = 0;
+  const nextId = () => `t-${++idCounter}`;
+
+  for (const param of parameters) {
+    tests.push({
+      id: nextId(),
+      category: 'param-presence',
+      param: param.name,
+      runner: 'node',
+      description: `Parameter '${param.name}' should be present`,
+    });
+  }
+
+  for (const param of parameters) {
+    tests.push({
+      id: nextId(),
+      category: 'param-type',
+      param: param.name,
+      expectedType: param.tsType,
+      runner: 'node',
+      description: `Parameter '${param.name}' should have type '${param.tsType}'`,
+    });
+  }
+
+  tests.push({
+    id: nextId(),
+    category: 'execution-happy',
+    runner: 'junit',
+    description: `Process '${proc.name}' should execute successfully with valid parameters`,
+  });
+
+  tests.push({
+    id: nextId(),
+    category: 'execution-failure',
+    runner: 'junit',
+    description: `Process '${proc.name}' should fail with invalid parameters`,
+  });
+
+  const byCategory = {};
+  const byRunner = { node: 0, junit: 0 };
+  for (const t of tests) {
+    byCategory[t.category] = (byCategory[t.category] ?? 0) + 1;
+    byRunner[t.runner] = (byRunner[t.runner] ?? 0) + 1;
+  }
+
+  const testManifest = {
+    tests,
+    summary: { total: tests.length, byCategory, byRunner },
+  };
+
+  const contractData = {
+    type: 'process',
+    process: {
+      id: proc.id,
+      name: proc.name,
+      specName,
+      uiPattern: proc.uiPattern,
+      javaClassName: proc.javaClassName || null,
+      isReport: proc.isReport === true,
+    },
+    parameters,
+    apiPrediction,
+    testManifest,
+  };
+
+  const checksum = createHash('sha256')
+    .update(JSON.stringify(contractData))
+    .digest('hex')
+    .slice(0, 16);
+
+  return {
+    version: '0.1.0',
+    generatedAt: new Date().toISOString(),
+    checksum,
+    ...contractData,
+  };
+}

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -503,6 +503,84 @@ export function captureCurrentState(windowName, baseDir) {
   return files;
 }
 
+// ---------------------------------------------------------------------------
+// Process form generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert a kebab-case string to PascalCase.
+ * "generate-invoices" -> "GenerateInvoices"
+ */
+function toPascalCase(kebab) {
+  return kebab
+    .split('-')
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+/**
+ * Generate a process form component from a process contract.
+ */
+export function generateProcessFormComponent(contract) {
+  const proc = contract.process;
+  const compName = toPascalCase(proc.specName) + 'Process';
+
+  const paramsArray = contract.parameters.map(p => {
+    const requiredPart = p.required ? ', required: true' : '';
+    const defaultPart = p.defaultValue ? `, defaultValue: '${p.defaultValue.replace(/'/g, "\\'")}'` : '';
+    const referencePart = p.referenceValueId ? `, reference: '${p.referenceValueId}'` : '';
+    return `  { key: '${p.name}', column: '${p.column}', type: '${p.inputMode}'${requiredPart}${defaultPart}${referencePart} },`;
+  }).join('\n');
+
+  const executeUrl = contract.apiPrediction?.baseUrl || `/sws/neo/${proc.specName}`;
+
+  return `import { ProcessForm } from '@/components/contract-ui';
+
+const parameters = [
+${paramsArray}
+];
+
+const processConfig = {
+  name: '${proc.name.replace(/'/g, "\\'")}',
+  specName: '${proc.specName}',
+  executeUrl: '${executeUrl}',
+};
+
+export default function ${compName}(props) {
+  return <ProcessForm parameters={parameters} process={processConfig} {...props} />;
+}
+`;
+}
+
+/**
+ * Generate the index/entry point for a process form.
+ */
+export function generateProcessIndex(contract) {
+  const proc = contract.process;
+  const compName = toPascalCase(proc.specName) + 'Process';
+
+  return `import ${compName} from './${compName}';
+
+const processMeta = { name: '${proc.name.replace(/'/g, "\\'")}', specName: '${proc.specName}' };
+
+export default function App({ token, apiBaseUrl }) {
+  return <${compName} token={token} apiBaseUrl={apiBaseUrl} process={processMeta} />;
+}
+`;
+}
+
+/**
+ * Generate all frontend files for a process contract.
+ * Returns { filename: code } map.
+ */
+export function generateAllProcess(contract) {
+  const compName = toPascalCase(contract.process.specName) + 'Process';
+  const files = {};
+  files[`${compName}.jsx`] = generateProcessFormComponent(contract);
+  files['index.jsx'] = generateProcessIndex(contract);
+  return files;
+}
+
 // CLI entry point -- only runs when executed directly
 const isDirectRun = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/.*\//, ''));
 if (isDirectRun) {

--- a/cli/src/pipeline.js
+++ b/cli/src/pipeline.js
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
 
 export function validatePipelineInput(input) {
+  if (input.processId) {
+    if (!input.processName) return { valid: false, error: 'processName is required for process mode' };
+    return { valid: true, mode: 'process' };
+  }
   if (!input.windowId) return { valid: false, error: 'windowId is required' };
   if (!input.windowName) return { valid: false, error: 'windowName is required' };
-  return { valid: true };
+  return { valid: true, mode: 'window' };
 }
 
 export function buildPipelineSteps() {
@@ -21,18 +25,136 @@ export function buildPipelineSteps() {
   ];
 }
 
+export function buildProcessPipelineSteps() {
+  return [
+    { name: 'extract-process', description: 'Extract process metadata + parameters from Etendo DB', phase: 'P1' },
+    { name: 'generate-process-contract', description: 'Generate process contract', phase: 'P2' },
+    { name: 'push-process-to-neo', description: 'Configure NEO Headless for process via DB writes', phase: 'P3' },
+    { name: 'generate-process-frontend', description: 'Generate process form component', phase: 'P4' },
+    { name: 'run-tests', description: 'Run contract tests', phase: 'P5' },
+  ];
+}
+
+/**
+ * Parse CLI arguments for both window and process modes.
+ */
+function parseArgs(argv) {
+  const args = argv.slice(2);
+  const result = {};
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--process-id' && args[i + 1]) {
+      result.processId = args[++i];
+    } else if (args[i] === '--process-name' && args[i + 1]) {
+      result.processName = args[++i];
+    } else if (args[i] === '--dry-run') {
+      result.dryRun = true;
+    } else if (args[i] === '--skip-to' && args[i + 1]) {
+      result.skipTo = args[++i];
+    } else if (!args[i].startsWith('--') && !result.windowId) {
+      result.windowId = args[i];
+    } else if (!args[i].startsWith('--') && result.windowId && !result.windowName) {
+      result.windowName = args[i];
+    }
+  }
+
+  return result;
+}
+
 // CLI entry point
 async function main() {
-  const windowId = process.argv[2];
-  const windowName = process.argv[3] || 'sales-order';
+  const parsed = parseArgs(process.argv);
 
-  const validation = validatePipelineInput({ windowId, windowName });
+  // Backwards compat: positional args for window mode
+  if (!parsed.processId && !parsed.windowName && parsed.windowId) {
+    parsed.windowName = 'sales-order';
+  }
+
+  const validation = validatePipelineInput(parsed);
   if (!validation.valid) {
     console.error(`Error: ${validation.error}`);
-    console.error('Usage: sf-pipeline <windowId> [windowName]');
+    console.error('Usage:');
+    console.error('  sf-pipeline <windowId> [windowName]                    # Window mode');
+    console.error('  sf-pipeline --process-id <id> --process-name <name>    # Process mode');
     process.exit(1);
   }
 
+  if (validation.mode === 'process') {
+    await runProcessPipeline(parsed);
+  } else {
+    await runWindowPipeline(parsed);
+  }
+}
+
+async function runProcessPipeline({ processId, processName, dryRun }) {
+  const steps = buildProcessPipelineSteps();
+  console.log(`\n=== Schema Forge Process Pipeline: ${processName} ===\n`);
+
+  for (const step of steps) {
+    console.log(`[${step.phase}] ${step.description}...`);
+
+    try {
+      switch (step.name) {
+        case 'extract-process': {
+          const { main: extractProcess } = await import('./extract-from-process.js');
+          await extractProcess(processId, processName);
+          break;
+        }
+        case 'generate-process-contract': {
+          const { generateProcessContract } = await import('./generate-contract.js');
+          const { readFile, writeFile } = await import('node:fs/promises');
+          const processRaw = JSON.parse(await readFile(`artifacts/${processName}/process-raw.json`, 'utf8'));
+          const contract = generateProcessContract(processRaw);
+          await writeFile(`artifacts/${processName}/contract.json`, JSON.stringify(contract, null, 2));
+          console.log(`  ✓ Process contract generated (${contract.testManifest.summary.total} tests)`);
+          break;
+        }
+        case 'push-process-to-neo': {
+          const { pushProcessToNeo } = await import('./push-to-neo.js');
+          const result = await pushProcessToNeo(processName, { dryRun });
+          if (dryRun) {
+            console.log(`  ✓ Dry run: push plan logged`);
+          } else {
+            console.log(`  ✓ NEO Headless configured (spec: ${result.specId})`);
+          }
+          break;
+        }
+        case 'generate-process-frontend': {
+          const { generateAllProcess } = await import('./generate-frontend.js');
+          const { readFile, writeFile, mkdir } = await import('node:fs/promises');
+          const contract = JSON.parse(await readFile(`artifacts/${processName}/contract.json`, 'utf8'));
+          const files = generateAllProcess(contract);
+          const outDir = `artifacts/${processName}/generated/web/${processName}`;
+          await mkdir(outDir, { recursive: true });
+          for (const [filename, code] of Object.entries(files)) {
+            await writeFile(`${outDir}/${filename}`, code, 'utf8');
+          }
+          console.log(`  ✓ ${Object.keys(files).length} frontend components generated`);
+          break;
+        }
+        case 'run-tests': {
+          const { runContractTests } = await import('./run-contract-tests.js');
+          const { readFile } = await import('node:fs/promises');
+          const contract = JSON.parse(await readFile(`artifacts/${processName}/contract.json`, 'utf8'));
+          const result = runContractTests(contract);
+          console.log(`  ✓ ${result.passed}/${result.total} passed, ${result.skipped} skipped`);
+          if (result.failed > 0) {
+            console.error(`  ✗ ${result.failed} tests failed`);
+            result.results.filter(r => !r.passed).forEach(r => console.error(`    - ${r.description}: ${r.reason}`));
+          }
+          break;
+        }
+      }
+    } catch (err) {
+      console.error(`  ✗ ${step.name} failed: ${err.message}`);
+      process.exit(1);
+    }
+  }
+
+  console.log('\n=== Process Pipeline complete ===\n');
+}
+
+async function runWindowPipeline({ windowId, windowName }) {
   const steps = buildPipelineSteps();
   console.log(`\n=== Schema Forge Pipeline: ${windowName} ===\n`);
 
@@ -48,13 +170,12 @@ async function main() {
         console.log('  → Save curated artifacts, then re-run pipeline with --skip-to=generate-contract');
         console.log('  → For AI classification, run: /sf:classify-rules');
       }
-      break; // Stop at interactive step
+      break;
     }
 
     console.log(`[${step.phase}] ${step.description}...`);
 
     try {
-      // Dynamic import and execution of each phase
       switch (step.name) {
         case 'extract-fields': {
           const { main: extractFields } = await import('./extract-fields.js');
@@ -103,9 +224,9 @@ async function main() {
           const dryRun = process.argv.includes('--dry-run');
           const result = await pushToNeo(windowName, { dryRun });
           if (dryRun) {
-            console.log(`  ✓ Dry run: ${result.actions.length} webhook calls planned`);
+            console.log(`  ✓ Dry run: ${result.summary.totalFields} fields planned`);
           } else {
-            console.log(`  ✓ NEO Headless configured (${result.fieldsConfigured} fields)`);
+            console.log(`  ✓ NEO Headless configured (${result.fieldsUpdated} fields)`);
           }
           break;
         }

--- a/cli/src/push-to-neo.js
+++ b/cli/src/push-to-neo.js
@@ -344,6 +344,117 @@ export async function pushToNeo(windowName, options = {}) {
 }
 
 // ---------------------------------------------------------------------------
+// Process push function
+// ---------------------------------------------------------------------------
+
+/**
+ * Push a process contract configuration to NEO Headless via direct DB writes.
+ *
+ * @param {string} processName - The process artifact folder name (e.g., "generate-invoices")
+ * @param {object} [options] - Override options
+ * @param {boolean} [options.dryRun] - If true, log planned actions without writing to DB
+ * @param {string} [options.projectRoot] - Override project root path
+ * @param {string} [options.moduleId='0'] - AD_Module_ID for new rows
+ * @param {object} [options.dbConfig] - Override DB pool config
+ * @param {object} [options.audit] - Override audit defaults
+ * @returns {object} Result summary
+ */
+export async function pushProcessToNeo(processName, options = {}) {
+  const projectRoot = options.projectRoot || ROOT;
+  const artifactsDir = join(projectRoot, 'artifacts', processName);
+
+  // Load process contract
+  let contractRaw;
+  try {
+    contractRaw = await readFile(join(artifactsDir, 'contract.json'), 'utf-8');
+  } catch (err) {
+    throw new Error(`Cannot read contract.json for process '${processName}': ${err.message}`);
+  }
+
+  const contract = JSON.parse(contractRaw);
+
+  if (contract.type !== 'process') {
+    throw new Error(`Contract type is '${contract.type}', expected 'process'`);
+  }
+
+  const processId = contract.process.id;
+  const specName = contract.process.specName;
+  const processDisplayName = contract.process.name;
+
+  // Dry run mode
+  if (options.dryRun === true) {
+    console.log(`[DRY RUN] Push to NEO for process: ${processDisplayName} (${processName})`);
+    console.log(`  Spec name: ${specName}`);
+    console.log(`  Process ID: ${processId}`);
+    console.log(`  Method: direct DB write`);
+    console.log(`\n  Step 1: upsertSpec (specType=P)`);
+    console.log(`    Params: { name: '${specName}', specType: 'P', processId: '${processId}' }`);
+    console.log(`\n  Step 2: populateSpec (auto-creates entity + fields from AD_Process_Para)`);
+    console.log(`    Params: { specId: <from step 1> }`);
+
+    return {
+      dryRun: true,
+      specName,
+      processId,
+      plan: {
+        spec: { action: 'upsertSpec', params: { name: specName, specType: 'P', processId } },
+        populate: { action: 'populateSpec', params: { specId: '(from step 1)' } },
+      },
+    };
+  }
+
+  // Live mode — write to DB via transaction
+  const moduleId = options.moduleId || '0';
+  const auditOpts = options.audit || {};
+  const pool = createDbPool(options.dbConfig);
+  const client = await pool.connect();
+
+  try {
+    await client.query('BEGIN');
+
+    // Step 1: Upsert spec
+    console.log(`[1/2] Upserting spec '${specName}' for process ${processId}...`);
+    const specResult = await writerUpsertSpec(client, {
+      name: specName,
+      moduleId,
+      processId,
+      specType: 'P',
+      audit: auditOpts,
+    });
+    const specId = specResult.specId;
+    console.log(`       Spec ID: ${specId} (${specResult.created ? 'created' : 'updated'})`);
+
+    // Step 2: Populate spec from AD metadata (creates entity + fields automatically)
+    console.log(`[2/2] Populating spec from AD_Process_Para...`);
+    const popResult = await writerPopulateSpec(client, {
+      specId,
+      moduleId,
+      audit: auditOpts,
+    });
+    console.log(`       Entity: ${popResult.entities[0]?.name || 'unnamed'}, Fields: ${popResult.fieldCount}`);
+
+    await client.query('COMMIT');
+
+    console.log(`\nDone. Process spec '${specName}' configured.`);
+
+    return {
+      dryRun: false,
+      specName,
+      specId,
+      processId,
+      entityCount: popResult.entityCount,
+      fieldCount: popResult.fieldCount,
+    };
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+    await closePool(pool);
+  }
+}
+
+// ---------------------------------------------------------------------------
 // CLI entry point
 // ---------------------------------------------------------------------------
 

--- a/cli/test/extract-from-process.test.js
+++ b/cli/test/extract-from-process.test.js
@@ -1,0 +1,198 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { QUERIES, rowsToCsv, buildProcessRaw } from '../src/extract-from-process.js';
+import {
+  validatePipelineInput,
+  buildProcessPipelineSteps,
+} from '../src/pipeline.js';
+
+describe('extract-from-process QUERIES', () => {
+  it('has process-metadata query', () => {
+    assert.ok(QUERIES['process-metadata']);
+    assert.ok(QUERIES['process-metadata'].includes('AD_Process'));
+    assert.ok(QUERIES['process-metadata'].includes('AD_Process_ID'));
+  });
+
+  it('has process-parameters query', () => {
+    assert.ok(QUERIES['process-parameters']);
+    assert.ok(QUERIES['process-parameters'].includes('AD_Process_Para'));
+    assert.ok(QUERIES['process-parameters'].includes('AD_Reference'));
+    assert.ok(QUERIES['process-parameters'].includes('ORDER BY'));
+  });
+
+  it('both queries use parameterized $1 placeholder', () => {
+    assert.ok(QUERIES['process-metadata'].includes('$1'));
+    assert.ok(QUERIES['process-parameters'].includes('$1'));
+  });
+
+  it('both queries filter by IsActive', () => {
+    assert.ok(QUERIES['process-metadata'].includes("IsActive = 'Y'"));
+    assert.ok(QUERIES['process-parameters'].includes("IsActive = 'Y'"));
+  });
+});
+
+describe('rowsToCsv', () => {
+  it('returns empty string for empty array', () => {
+    assert.equal(rowsToCsv([]), '');
+  });
+
+  it('converts rows to CSV with headers', () => {
+    const rows = [{ name: 'foo', value: '1' }, { name: 'bar', value: '2' }];
+    const csv = rowsToCsv(rows);
+    const lines = csv.trim().split('\n');
+    assert.equal(lines[0], 'name,value');
+    assert.equal(lines[1], 'foo,1');
+    assert.equal(lines[2], 'bar,2');
+  });
+
+  it('quotes values with commas', () => {
+    const rows = [{ name: 'foo,bar', value: '1' }];
+    const csv = rowsToCsv(rows);
+    assert.ok(csv.includes('"foo,bar"'));
+  });
+});
+
+describe('buildProcessRaw', () => {
+  const mockMetadata = [{
+    ad_process_id: 'TEST123',
+    name: 'Test Process',
+    description: 'A test',
+    help: null,
+    uipattern: 'S',
+    javaclassname: 'com.test.Proc',
+    procedurename: null,
+    isreport: 'N',
+    isbackground: 'N',
+  }];
+
+  const mockParams = [
+    {
+      ad_process_para_id: 'P1',
+      name: 'dateFrom',
+      columnname: 'DateFrom',
+      description: 'Start date',
+      ad_reference_id: '15',
+      ad_reference_value_id: null,
+      ismandatory: 'Y',
+      isrange: 'N',
+      defaultvalue: '@#Date@',
+      seqno: '10',
+      fieldlength: '0',
+      ad_val_rule_id: null,
+      reference_name: 'Date',
+    },
+    {
+      ad_process_para_id: 'P2',
+      name: 'partner',
+      columnname: 'C_BPartner_ID',
+      description: null,
+      ad_reference_id: '19',
+      ad_reference_value_id: null,
+      ismandatory: 'N',
+      isrange: 'N',
+      defaultvalue: null,
+      seqno: '20',
+      fieldlength: '32',
+      ad_val_rule_id: null,
+      reference_name: 'TableDir',
+    },
+  ];
+
+  it('builds correct process structure', () => {
+    const result = buildProcessRaw(mockMetadata, mockParams);
+    assert.equal(result.process.id, 'TEST123');
+    assert.equal(result.process.name, 'Test Process');
+    assert.equal(result.process.uiPattern, 'S');
+    assert.equal(result.process.isReport, false);
+    assert.equal(result.process.isBackground, false);
+  });
+
+  it('builds correct parameter structure', () => {
+    const result = buildProcessRaw(mockMetadata, mockParams);
+    assert.equal(result.parameters.length, 2);
+    assert.equal(result.parameters[0].name, 'dateFrom');
+    assert.equal(result.parameters[0].column, 'DateFrom');
+    assert.equal(result.parameters[0].referenceId, '15');
+    assert.equal(result.parameters[0].mandatory, true);
+    assert.equal(result.parameters[0].defaultValue, '@#Date@');
+    assert.equal(result.parameters[0].seqNo, 10);
+  });
+
+  it('handles non-mandatory parameters', () => {
+    const result = buildProcessRaw(mockMetadata, mockParams);
+    assert.equal(result.parameters[1].mandatory, false);
+    assert.equal(result.parameters[1].defaultValue, null);
+  });
+
+  it('throws for empty metadata', () => {
+    assert.throws(() => buildProcessRaw([], mockParams), /not found/);
+  });
+});
+
+describe('validatePipelineInput — process mode', () => {
+  it('accepts valid process input', () => {
+    const result = validatePipelineInput({ processId: '123', processName: 'test' });
+    assert.equal(result.valid, true);
+    assert.equal(result.mode, 'process');
+  });
+
+  it('rejects process input without processName', () => {
+    const result = validatePipelineInput({ processId: '123' });
+    assert.equal(result.valid, false);
+    assert.ok(result.error.includes('processName'));
+  });
+
+  it('still accepts window input (backwards compat)', () => {
+    const result = validatePipelineInput({ windowId: '143', windowName: 'sales-order' });
+    assert.equal(result.valid, true);
+    assert.equal(result.mode, 'window');
+  });
+
+  it('process mode takes priority over window mode', () => {
+    const result = validatePipelineInput({ processId: '123', processName: 'test', windowId: '143', windowName: 'so' });
+    assert.equal(result.mode, 'process');
+  });
+});
+
+describe('buildProcessPipelineSteps', () => {
+  it('returns 5 steps', () => {
+    const steps = buildProcessPipelineSteps();
+    assert.equal(steps.length, 5);
+  });
+
+  it('starts with extract-process', () => {
+    const steps = buildProcessPipelineSteps();
+    assert.equal(steps[0].name, 'extract-process');
+    assert.equal(steps[0].phase, 'P1');
+  });
+
+  it('ends with run-tests', () => {
+    const steps = buildProcessPipelineSteps();
+    assert.equal(steps[steps.length - 1].name, 'run-tests');
+  });
+
+  it('has correct step names in order', () => {
+    const steps = buildProcessPipelineSteps();
+    const names = steps.map(s => s.name);
+    assert.deepEqual(names, [
+      'extract-process',
+      'generate-process-contract',
+      'push-process-to-neo',
+      'generate-process-frontend',
+      'run-tests',
+    ]);
+  });
+
+  it('all steps have name, description, and phase', () => {
+    for (const step of buildProcessPipelineSteps()) {
+      assert.ok(step.name);
+      assert.ok(step.description);
+      assert.ok(step.phase);
+    }
+  });
+
+  it('no steps are interactive', () => {
+    const steps = buildProcessPipelineSteps();
+    assert.ok(steps.every(s => !s.interactive));
+  });
+});

--- a/cli/test/generate-process-contract.test.js
+++ b/cli/test/generate-process-contract.test.js
@@ -1,0 +1,175 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mapProcessReference, generateProcessContract } from '../src/generate-contract.js';
+
+const mockProcessRaw = {
+  process: {
+    id: 'TEST123',
+    name: 'Generate Invoices',
+    description: 'Test process',
+    uiPattern: 'S',
+    javaClassName: 'com.test.GenInv',
+    isReport: false,
+    isBackground: false,
+  },
+  parameters: [
+    {
+      id: 'P1', name: 'dateFrom', column: 'DateFrom',
+      referenceId: '15', referenceName: 'Date', referenceValueId: null,
+      mandatory: true, isRange: false, defaultValue: '@#Date@', seqNo: 10,
+    },
+    {
+      id: 'P2', name: 'businessPartner', column: 'C_BPartner_ID',
+      referenceId: '19', referenceName: 'TableDir', referenceValueId: null,
+      mandatory: false, isRange: false, defaultValue: null, seqNo: 20,
+    },
+    {
+      id: 'P3', name: 'includeVoided', column: 'IncludeVoided',
+      referenceId: '20', referenceName: 'YesNo', referenceValueId: null,
+      mandatory: false, isRange: false, defaultValue: 'N', seqNo: 30,
+    },
+  ],
+};
+
+describe('mapProcessReference', () => {
+  it('maps Date (15) correctly', () => {
+    const ref = mapProcessReference('15');
+    assert.equal(ref.type, 'date');
+    assert.equal(ref.tsType, 'string');
+    assert.equal(ref.inputMode, 'date-picker');
+  });
+
+  it('maps DateTime (16) correctly', () => {
+    const ref = mapProcessReference('16');
+    assert.equal(ref.type, 'datetime');
+    assert.equal(ref.inputMode, 'datetime-picker');
+  });
+
+  it('maps YesNo (20) to boolean', () => {
+    const ref = mapProcessReference('20');
+    assert.equal(ref.type, 'boolean');
+    assert.equal(ref.tsType, 'boolean');
+    assert.equal(ref.inputMode, 'checkbox');
+  });
+
+  it('maps TableDir (19) to foreignKey', () => {
+    const ref = mapProcessReference('19');
+    assert.equal(ref.type, 'foreignKey');
+    assert.equal(ref.tsType, 'string');
+    assert.equal(ref.inputMode, 'search');
+  });
+
+  it('maps Table (18) to foreignKey', () => {
+    assert.equal(mapProcessReference('18').type, 'foreignKey');
+  });
+
+  it('maps Search (30) to foreignKey', () => {
+    assert.equal(mapProcessReference('30').type, 'foreignKey');
+  });
+
+  it('maps OBUISEL (800011) to foreignKey', () => {
+    assert.equal(mapProcessReference('800011').type, 'foreignKey');
+  });
+
+  it('maps List (17) to select', () => {
+    const ref = mapProcessReference('17');
+    assert.equal(ref.type, 'list');
+    assert.equal(ref.inputMode, 'select');
+  });
+
+  it('maps String (10) to text', () => {
+    assert.equal(mapProcessReference('10').inputMode, 'text');
+  });
+
+  it('maps Integer (11) to number', () => {
+    const ref = mapProcessReference('11');
+    assert.equal(ref.type, 'integer');
+    assert.equal(ref.tsType, 'number');
+  });
+
+  it('maps Amount (12) to number', () => {
+    assert.equal(mapProcessReference('12').tsType, 'number');
+  });
+
+  it('returns string default for unknown reference', () => {
+    const ref = mapProcessReference('9999');
+    assert.equal(ref.type, 'string');
+    assert.equal(ref.tsType, 'string');
+    assert.equal(ref.inputMode, 'text');
+  });
+});
+
+describe('generateProcessContract', () => {
+  const contract = generateProcessContract(mockProcessRaw);
+
+  it('has type "process"', () => {
+    assert.equal(contract.type, 'process');
+  });
+
+  it('has version 0.1.0', () => {
+    assert.equal(contract.version, '0.1.0');
+  });
+
+  it('has generatedAt ISO string', () => {
+    assert.ok(contract.generatedAt);
+    assert.ok(!isNaN(Date.parse(contract.generatedAt)));
+  });
+
+  it('has 16-char hex checksum', () => {
+    assert.equal(contract.checksum.length, 16);
+    assert.ok(/^[0-9a-f]{16}$/.test(contract.checksum));
+  });
+
+  it('has correct process info', () => {
+    assert.equal(contract.process.id, 'TEST123');
+    assert.equal(contract.process.name, 'Generate Invoices');
+    assert.equal(contract.process.specName, 'generate-invoices');
+    assert.equal(contract.process.uiPattern, 'S');
+  });
+
+  it('maps all parameters', () => {
+    assert.equal(contract.parameters.length, 3);
+  });
+
+  it('maps parameter types correctly', () => {
+    const dateParam = contract.parameters.find(p => p.name === 'dateFrom');
+    assert.equal(dateParam.type, 'date');
+    assert.equal(dateParam.inputMode, 'date-picker');
+    assert.equal(dateParam.required, true);
+    assert.equal(dateParam.defaultValue, '@#Date@');
+
+    const bpParam = contract.parameters.find(p => p.name === 'businessPartner');
+    assert.equal(bpParam.type, 'foreignKey');
+    assert.equal(bpParam.required, false);
+
+    const boolParam = contract.parameters.find(p => p.name === 'includeVoided');
+    assert.equal(boolParam.type, 'boolean');
+    assert.equal(boolParam.inputMode, 'checkbox');
+  });
+
+  it('has correct apiPrediction', () => {
+    assert.equal(contract.apiPrediction.specName, 'generate-invoices');
+    assert.equal(contract.apiPrediction.baseUrl, '/sws/neo/generate-invoices');
+    assert.ok(contract.apiPrediction.describe.includes('GET'));
+    assert.ok(contract.apiPrediction.execute.includes('POST'));
+  });
+
+  it('has correct test count (2*params + 2)', () => {
+    const expected = 2 * mockProcessRaw.parameters.length + 2;
+    assert.equal(contract.testManifest.summary.total, expected);
+  });
+
+  it('has correct test categories', () => {
+    const cats = contract.testManifest.summary.byCategory;
+    assert.equal(cats['param-presence'], 3);
+    assert.equal(cats['param-type'], 3);
+    assert.equal(cats['execution-happy'], 1);
+    assert.equal(cats['execution-failure'], 1);
+  });
+
+  it('has correct runner distribution', () => {
+    const runners = contract.testManifest.summary.byRunner;
+    assert.equal(runners.node, 6);
+    assert.equal(runners.junit, 2);
+  });
+});

--- a/cli/test/generate-process-frontend.test.js
+++ b/cli/test/generate-process-frontend.test.js
@@ -1,0 +1,107 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import {
+  generateProcessFormComponent,
+  generateProcessIndex,
+  generateAllProcess,
+} from '../src/generate-frontend.js';
+
+const mockContract = {
+  type: 'process',
+  process: { name: 'Generate Invoices', specName: 'generate-invoices', uiPattern: 'S' },
+  parameters: [
+    { name: 'dateFrom', column: 'DateFrom', type: 'date', tsType: 'string', inputMode: 'date-picker', required: true, defaultValue: '@#Date@' },
+    { name: 'businessPartner', column: 'C_BPartner_ID', type: 'foreignKey', tsType: 'string', inputMode: 'search', required: false, referenceValueId: 'BPartnerRef' },
+    { name: 'includeVoided', column: 'IncludeVoided', type: 'boolean', tsType: 'boolean', inputMode: 'checkbox', required: false },
+  ],
+  apiPrediction: { specName: 'generate-invoices', baseUrl: '/sws/neo/generate-invoices', execute: 'POST /sws/neo/generate-invoices' },
+};
+
+describe('generateProcessFormComponent', () => {
+  const code = generateProcessFormComponent(mockContract);
+
+  it('imports ProcessForm from contract-ui', () => {
+    assert.ok(code.includes("import { ProcessForm } from '@/components/contract-ui'"));
+  });
+
+  it('uses correct component name (PascalCase + Process)', () => {
+    assert.ok(code.includes('GenerateInvoicesProcess'));
+    assert.ok(code.includes('export default function GenerateInvoicesProcess'));
+  });
+
+  it('includes all parameter keys', () => {
+    assert.ok(code.includes("key: 'dateFrom'"));
+    assert.ok(code.includes("key: 'businessPartner'"));
+    assert.ok(code.includes("key: 'includeVoided'"));
+  });
+
+  it('includes required flag for required params', () => {
+    assert.ok(code.includes("required: true"));
+  });
+
+  it('includes defaultValue when present', () => {
+    assert.ok(code.includes("defaultValue: '@#Date@'"));
+  });
+
+  it('includes inputMode as type', () => {
+    assert.ok(code.includes("type: 'date-picker'"));
+    assert.ok(code.includes("type: 'search'"));
+    assert.ok(code.includes("type: 'checkbox'"));
+  });
+
+  it('includes reference for FK params with referenceValueId', () => {
+    assert.ok(code.includes("reference: 'BPartnerRef'"));
+  });
+
+  it('includes processConfig with executeUrl', () => {
+    assert.ok(code.includes("executeUrl: '/sws/neo/generate-invoices'"));
+  });
+
+  it('includes processConfig with specName', () => {
+    assert.ok(code.includes("specName: 'generate-invoices'"));
+  });
+});
+
+describe('generateProcessIndex', () => {
+  const code = generateProcessIndex(mockContract);
+
+  it('imports the process component', () => {
+    assert.ok(code.includes("import GenerateInvoicesProcess from './GenerateInvoicesProcess'"));
+  });
+
+  it('exports App as default', () => {
+    assert.ok(code.includes('export default function App'));
+  });
+
+  it('passes token and apiBaseUrl props', () => {
+    assert.ok(code.includes('token={token}'));
+    assert.ok(code.includes('apiBaseUrl={apiBaseUrl}'));
+  });
+
+  it('includes processMeta', () => {
+    assert.ok(code.includes("name: 'Generate Invoices'"));
+    assert.ok(code.includes("specName: 'generate-invoices'"));
+  });
+});
+
+describe('generateAllProcess', () => {
+  const files = generateAllProcess(mockContract);
+
+  it('returns correct filenames', () => {
+    const keys = Object.keys(files);
+    assert.ok(keys.includes('GenerateInvoicesProcess.jsx'));
+    assert.ok(keys.includes('index.jsx'));
+  });
+
+  it('returns exactly 2 files', () => {
+    assert.equal(Object.keys(files).length, 2);
+  });
+
+  it('form component file contains ProcessForm import', () => {
+    assert.ok(files['GenerateInvoicesProcess.jsx'].includes('ProcessForm'));
+  });
+
+  it('index file imports the form component', () => {
+    assert.ok(files['index.jsx'].includes('GenerateInvoicesProcess'));
+  });
+});

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -45,16 +45,17 @@ Schema Forge decides **what** to expose. Etendo Go decides **how** to serve it.
 │                                                                      │
 │  CLI Tools (Node.js)          Decision UIs (React)                   │
 │  ├── extract-from-db.js       ├── app-shell (port 5173)             │
-│  ├── extract-fields.js        ├── decision-panel (port 5174)        │
-│  ├── extract-rules.js         └── ui-preview (port 5175)            │
-│  ├── pre-classify.js                                                 │
-│  ├── validate-schema.js       Webhooks (NEO Headless config)        │
-│  ├── generate-contract.js     ├── SFUpsertSpec                      │
-│  ├── push-to-neo.js (planned) ├── SFUpsertEntity                    │
-│  ├── generate-frontend.js     ├── SFUpsertField                     │
-│  ├── generate-mock-data.js    └── SFPopulateSpec                    │
-│  ├── run-contract-tests.js                                          │
-│  └── pipeline.js                                                     │
+│  ├── extract-from-process.js  ├── decision-panel (port 5174)        │
+│  ├── extract-fields.js        └── ui-preview (port 5175)            │
+│  ├── extract-rules.js                                                │
+│  ├── pre-classify.js          DB Writers (direct PostgreSQL)         │
+│  ├── validate-schema.js       ├── neo-writer.js (ETGO_SF_* tables)  │
+│  ├── generate-contract.js     └── push-to-neo.js (orchestrator)     │
+│  ├── generate-frontend.js                                            │
+│  ├── generate-mock-data.js    Webhooks (legacy, still available)    │
+│  ├── run-contract-tests.js    ├── SFUpsertSpec / SFUpsertEntity     │
+│  └── pipeline.js              ├── SFUpsertField / SFPopulateSpec    │
+│                                └── SFListProcesses / SFListWindows  │
 │                                                                      │
 │  Artifacts (per-window)        Documentation                         │
 │  ├── sales-order/              ├── PRD.md, TDD.md                   │
@@ -75,6 +76,9 @@ Etendo DB ──SQL──▶ extract-from-db.js ──▶ artifacts/{window}/
                                               ├── schema-raw.json      (all fields, FK refs, callouts)
                                               ├── rules-raw.json       (all business rules)
                                               └── schema-curated.json  (after human decisions)
+
+Etendo DB ──SQL──▶ extract-from-process.js ──▶ artifacts/{process}/
+                                                    └── process-raw.json   (metadata + parameters)
 ```
 
 The extraction connects to the Etendo PostgreSQL database and queries AD_Window, AD_Tab, AD_Column, AD_Field, AD_Reference, and related tables. It resolves FK types (TableDir, Table, Search, OBUISEL) and captures callout references, display logic, and validation rules.
@@ -91,12 +95,12 @@ Humans classify each field's visibility (editable, readOnly, system, discarded) 
 ### 3. Configuration (Schema Forge writes to Etendo Go)
 
 ```
-schema-curated.json ──▶ Webhooks ──▶ ETGO_SF_SPEC
-                                     ETGO_SF_ENTITY
-                                     ETGO_SF_FIELD
+contract.json ──▶ push-to-neo.js ──▶ neo-writer.js ──▶ ETGO_SF_SPEC
+                                                       ETGO_SF_ENTITY
+                                                       ETGO_SF_FIELD
 ```
 
-Schema Forge calls 4 webhooks on the running Etendo instance:
+Schema Forge writes configuration directly to the Etendo PostgreSQL database via `neo-writer.js` (transactional, all-or-nothing). The legacy webhook approach is still available but deprecated. The 4 webhooks on the Etendo instance are:
 
 | Webhook | Purpose |
 |---------|---------|
@@ -132,15 +136,17 @@ All tools are Node.js, zero-dependency. Located in `cli/src/`.
 | Tool | Input | Output |
 |------|-------|--------|
 | `extract-from-db.js` | Etendo DB (windowId) | `schema-raw.json`, `rules-raw.json` |
+| `extract-from-process.js` | Etendo DB (processId) | `process-raw.json` (metadata + parameters) |
 | `pre-classify.js` | `rules-raw.json` | `rules-classified.json` (AI pre-classification) |
 | `validate-schema.js` | `schema-curated.json` | Validation report (4 levels: structural, semantic, visibility, cross-reference) |
-| `generate-contract.js` | Curated schema + rules | `contract.json` (frontend + backend contract) |
-| `push-to-neo.js` (planned) | Curated schema | Webhook calls → ETGO_SF_* tables (NEO Headless config) |
-| `generate-frontend.js` | Contract + decisions | React SPA components |
+| `generate-contract.js` | Curated schema + rules (windows) or `process-raw.json` (processes) | `contract.json` (frontend + backend contract, or process contract) |
+| `neo-writer.js` | DB client + params | Direct INSERT/UPDATE to ETGO_SF_* tables (transactional) |
+| `push-to-neo.js` | Contract + schema artifacts | Orchestrates neo-writer: spec → populate → field updates |
+| `generate-frontend.js` | Contract | React SPA components (window entities or process forms) |
 | `translate-todos.js` | Generated React components | Components with translated callout/onchange logic (AI-assisted, interactive) |
 | `generate-mock-data.js` | Contract | `mockData.js`, `mockCatalogs.js` for UI preview |
 | `run-contract-tests.js` | Contract | Test results (Node.js assertions) |
-| `pipeline.js` | Window name | Runs full pipeline: extract → validate → classify → generate |
+| `pipeline.js` | Window or process ID | Runs full pipeline: window mode or process mode |
 
 ### Decision UIs
 
@@ -190,6 +196,25 @@ artifacts/sales-order/
 ```
 
 36 windows are currently in the artifacts directory.
+
+### Per-Process Artifacts
+
+Standalone processes (AD_Menu.action = 'P') produce a simpler artifact structure:
+
+```
+artifacts/generate-invoices/
+├── raw-query-results/
+│   ├── process-metadata.csv    # Process info from AD_Process
+│   └── process-parameters.csv  # Parameters from AD_Process_Para
+├── process-raw.json            # Structured extraction
+├── contract.json               # Process contract (type: "process")
+└── generated/
+    └── web/generate-invoices/
+        ├── GenerateInvoicesProcess.jsx  # Process form component
+        └── index.jsx                   # Entry point
+```
+
+Key differences from window artifacts: no tabs, no curation step, no rules, single POST-only entity.
 
 ---
 

--- a/docs/diagrams/complete-pipeline.mmd
+++ b/docs/diagrams/complete-pipeline.mmd
@@ -5,8 +5,10 @@ flowchart TD
 
     subgraph Extraction["1. EXTRACTION (CLI — Node.js)"]
         EXT["extract-from-db.js<br/>extract-fields.js<br/>extract-rules.js"]
+        PEXT["extract-from-process.js"]
         RAW_S["schema-raw.json<br/>(all fields, FK refs, callouts)"]
         RAW_R["rules-raw.json<br/>(all business rules)"]
+        RAW_P["process-raw.json<br/>(metadata + parameters)"]
     end
 
     subgraph PreClassify["2. PRE-CLASSIFICATION (CLI + AI)"]
@@ -30,8 +32,7 @@ flowchart TD
     end
 
     subgraph BackendConfig["6. BACKEND CONFIGURATION"]
-        PTN["push-to-neo.js"]
-        WH["4 Webhooks<br/>(SFUpsertSpec, SFUpsertEntity,<br/>SFUpsertField, SFPopulateSpec)"]
+        PTN["push-to-neo.js<br/>+ neo-writer.js"]
         TABLES["ETGO_SF_SPEC<br/>ETGO_SF_ENTITY<br/>ETGO_SF_FIELD"]
     end
 
@@ -67,10 +68,18 @@ flowchart TD
         APP["React SPA / Mobile App / External Client"]
     end
 
-    %% Extraction
+    %% Extraction (Windows)
     AD -->|SQL queries| EXT
     EXT --> RAW_S
     EXT --> RAW_R
+
+    %% Extraction (Processes)
+    AD -->|SQL queries| PEXT
+    PEXT --> RAW_P
+
+    %% Process pipeline (simplified: extract → contract → push → frontend)
+    RAW_P -->|process mode| GC
+    GC -->|process contract| CONTRACT
 
     %% Pre-classification
     RAW_R --> PC
@@ -91,10 +100,9 @@ flowchart TD
     CUR_R --> GC
     GC --> CONTRACT
 
-    %% Backend: contract → push-to-neo → webhooks → NEO Headless
+    %% Backend: contract → push-to-neo → direct DB → NEO Headless
     CONTRACT -->|"visibility, apiPrediction"| PTN
-    PTN --> WH
-    WH -->|idempotent HTTP| TABLES
+    PTN -->|direct SQL INSERT/UPDATE| TABLES
 
     %% Frontend: contract → React SPA + mock data
     CONTRACT -->|"types, inputMode, callouts,<br/>displayLogic, apiPrediction"| GF
@@ -134,11 +142,11 @@ flowchart TD
     classDef client fill:#bd10e0,stroke:#8a0ca5,color:white
 
     class AD db
-    class EXT,PC,VAL cli
+    class EXT,PEXT,PC,VAL cli
     class DP human
     class WH webhook
     class NEO,AUTH,RESOLVE,FILTER,HANDLER,DS,SEL,PROC runtime
-    class RAW_S,RAW_R,CLASS_R,CUR_S,CUR_R,TABLES,CONTRACT,REACT,MOCK artifact
+    class RAW_S,RAW_R,RAW_P,CLASS_R,CUR_S,CUR_R,TABLES,CONTRACT,REACT,MOCK artifact
     class CT,IT test
     class APP client
     class GC,PTN,GF,GM,TT cli

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,8 +30,11 @@ General findings about how the Etendo Application Dictionary works. Not window-s
 
 ## Plans & Evaluations
 
+Plans follow a lifecycle: active in `plans/`, completed in `plans/completed/YYYY-MM-DD/`, discarded in `plans/discarded/`.
+
 | File | Description |
 |------|-------------|
+| [plans/process-and-report-pipeline.md](plans/process-and-report-pipeline.md) | Process & Report Pipeline — **Phase 1 Complete** (standalone processes), Phase 2-4 deferred |
 | [plans/2026-03-05-vertical-slice-design.md](plans/2026-03-05-vertical-slice-design.md) | Vertical slice design |
 | [plans/2026-03-05-vertical-slice-plan.md](plans/2026-03-05-vertical-slice-plan.md) | Vertical slice execution plan |
 | [plans/evaluations/architecture-review.md](plans/evaluations/architecture-review.md) | Architecture review |

--- a/docs/plans/process-and-report-pipeline.md
+++ b/docs/plans/process-and-report-pipeline.md
@@ -1,11 +1,21 @@
 # Plan: Process & Report Pipeline Support
 
-**Status:** PLAN ONLY — not yet implemented
+**Status:** Phase 1 COMPLETE — Standalone Process Pipeline Implemented
 **Date:** 2026-03-10
+**Phase 1 completed:** 2026-03-11
+
+### Implementation Status
+
+| Phase | Scope | Status | Date |
+|-------|-------|--------|------|
+| **Phase 1** | Standalone Processes | **Complete** | 2026-03-11 |
+| **Phase 2** | Reports | Deferred — requires NEO Headless changes | — |
+| **Phase 3** | Forms | Not planned — inherently custom | — |
+| **Phase 4** | Unified entry point | Deferred — after Phase 1 proven | — |
 
 ## Context
 
-The Schema Forge pipeline currently supports **only AD_Window entries**. The Etendo AD_Menu links to 4 types of actionable entries:
+The Schema Forge pipeline originally supported **only AD_Window entries**. Phase 1 added standalone process support. The Etendo AD_Menu links to 4 types of actionable entries:
 
 | AD_Menu.action | Type | Count (approx) | Pipeline Support | NEO Runtime Support |
 |----------------|------|-----------------|------------------|---------------------|


### PR DESCRIPTION
## Summary
- New `extract-from-process.js` for extracting standalone AD_Process metadata + parameters
- `pipeline.js` now supports process mode via `--process-id` / `--process-name` flags
- `generate-contract.js` adds `generateProcessContract()` with full reference type mapping
- `push-to-neo.js` adds `pushProcessToNeo()` using direct DB writes via neo-writer
- `generate-frontend.js` adds `generateProcessFormComponent()` / `generateAllProcess()`
- 61 new tests covering all 3 tasks, 248 existing tests unaffected

## Test plan
- [x] 61 new tests pass (extraction, contract, frontend)
- [x] 248 existing tests pass (zero regressions)
- [ ] Review: code style, completeness, edge cases
- [ ] QA: run full test suite, verify pipeline integration