### PR TITLE
Feature ETP-3529: Unified --menu-id entry point (Phase 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,7 +221,8 @@ schema-forge/                             # THIS REPO — design + tooling
 │       ├── generate-frontend.js          # React SPA generation (emits section markers)
 │       ├── generate-mock-data.js         # Mock catalogs for UI preview
 │       ├── run-contract-tests.js         # Contract test runner
-│       └── pipeline.js                   # Full pipeline (windows + processes)
+│       ├── resolve-menu.js               # AD_Menu resolver (auto-detect type from menu ID)
+│       └── pipeline.js                   # Full pipeline (windows, processes, or auto-detect via menu ID)
 ├── tools/                                # React decision UIs
 │   ├── app-shell/                        # Main UI shell (Vite + React + Tailwind)
 │   ├── decision-panel/                   # Field visibility + rule curation

--- a/cli/src/pipeline.js
+++ b/cli/src/pipeline.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 
 export function validatePipelineInput(input) {
+  if (input.menuId) {
+    return { valid: true, mode: 'menu' };
+  }
   if (input.processId) {
     if (!input.processName) return { valid: false, error: 'processName is required for process mode' };
     return { valid: true, mode: 'process' };
@@ -39,12 +42,14 @@ export function buildProcessPipelineSteps() {
 /**
  * Parse CLI arguments for both window and process modes.
  */
-function parseArgs(argv) {
+export function parseArgs(argv) {
   const args = argv.slice(2);
   const result = {};
 
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--process-id' && args[i + 1]) {
+    if (args[i] === '--menu-id' && args[i + 1]) {
+      result.menuId = args[++i];
+    } else if (args[i] === '--process-id' && args[i + 1]) {
       result.processId = args[++i];
     } else if (args[i] === '--process-name' && args[i + 1]) {
       result.processName = args[++i];
@@ -77,10 +82,21 @@ async function main() {
     console.error('Usage:');
     console.error('  sf-pipeline <windowId> [windowName]                    # Window mode');
     console.error('  sf-pipeline --process-id <id> --process-name <name>    # Process mode');
+    console.error('  sf-pipeline --menu-id <id>                             # Auto-detect from AD_Menu');
     process.exit(1);
   }
 
-  if (validation.mode === 'process') {
+  if (validation.mode === 'menu') {
+    const { resolveMenuEntry } = await import('./resolve-menu.js');
+    const resolved = await resolveMenuEntry(parsed.menuId);
+    console.log(`Menu entry '${resolved.menuName}' resolved as ${resolved.resolvedMode} (${resolved.resolvedName})`);
+
+    if (resolved.resolvedMode === 'window') {
+      await runWindowPipeline({ windowId: resolved.windowId, windowName: resolved.resolvedName, dryRun: parsed.dryRun });
+    } else if (resolved.resolvedMode === 'process') {
+      await runProcessPipeline({ processId: resolved.processId, processName: resolved.resolvedName, dryRun: parsed.dryRun });
+    }
+  } else if (validation.mode === 'process') {
     await runProcessPipeline(parsed);
   } else {
     await runWindowPipeline(parsed);

--- a/cli/src/resolve-menu.js
+++ b/cli/src/resolve-menu.js
@@ -1,0 +1,80 @@
+import { createDbPool } from './db.js';
+
+/**
+ * SQL query to resolve a menu entry from AD_Menu.
+ */
+export const MENU_QUERY = `
+  SELECT m.AD_Menu_ID, m.Name, m.Action, m.AD_Window_ID, m.AD_Process_ID, m.IsSummary
+  FROM AD_Menu m
+  WHERE m.AD_Menu_ID = $1 AND m.IsActive = 'Y'
+`;
+
+/**
+ * Convert a name to kebab-case.
+ * Lowercases, replaces spaces/underscores with hyphens,
+ * removes non-alphanumeric chars except hyphens, collapses multiple hyphens, trims hyphens.
+ */
+export function toKebabCase(name) {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[\s_]+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/**
+ * Resolve a menu entry from AD_Menu by ID.
+ * Returns the action type, linked IDs, resolved mode, and kebab-cased name.
+ *
+ * @param {string} menuId - AD_Menu_ID to look up
+ * @returns {Promise<{action: string, menuName: string, windowId: string|null, processId: string|null, resolvedMode: string|null, resolvedName: string}>}
+ */
+export async function resolveMenuEntry(menuId) {
+  const pool = createDbPool();
+  try {
+    const { rows } = await pool.query(MENU_QUERY, [menuId]);
+
+    if (rows.length === 0) {
+      throw new Error(`Menu entry not found: ${menuId}`);
+    }
+
+    const row = rows[0];
+    const action = row.action;
+    const menuName = row.name;
+    const windowId = row.ad_window_id || null;
+    const processId = row.ad_process_id || null;
+    const isSummary = row.issummary;
+
+    if (isSummary === 'Y') {
+      throw new Error('Menu entry is a folder, not an actionable item');
+    }
+
+    if (action === 'R') {
+      throw new Error('Report pipelines are not yet supported (Phase 2)');
+    }
+
+    if (action === 'X') {
+      throw new Error('Form pipelines are not supported');
+    }
+
+    let resolvedMode = null;
+    if (action === 'W') {
+      resolvedMode = 'window';
+    } else if (action === 'P') {
+      resolvedMode = 'process';
+    }
+
+    return {
+      action,
+      menuName,
+      windowId,
+      processId,
+      resolvedMode,
+      resolvedName: toKebabCase(menuName),
+    };
+  } finally {
+    await pool.end();
+  }
+}

--- a/cli/src/resolve-menu.js
+++ b/cli/src/resolve-menu.js
@@ -1,4 +1,4 @@
-import { createDbPool } from './db.js';
+import { createDbPool, closePool } from './db.js';
 
 /**
  * SQL query to resolve a menu entry from AD_Menu.
@@ -59,11 +59,13 @@ export async function resolveMenuEntry(menuId) {
       throw new Error('Form pipelines are not supported');
     }
 
-    let resolvedMode = null;
+    let resolvedMode;
     if (action === 'W') {
       resolvedMode = 'window';
     } else if (action === 'P') {
       resolvedMode = 'process';
+    } else {
+      throw new Error(`Unsupported menu action '${action}' for menu '${menuName}'`);
     }
 
     return {
@@ -75,6 +77,6 @@ export async function resolveMenuEntry(menuId) {
       resolvedName: toKebabCase(menuName),
     };
   } finally {
-    await pool.end();
+    await closePool(pool);
   }
 }

--- a/cli/test/extract-from-process.test.js
+++ b/cli/test/extract-from-process.test.js
@@ -152,6 +152,11 @@ describe('validatePipelineInput — process mode', () => {
     const result = validatePipelineInput({ processId: '123', processName: 'test', windowId: '143', windowName: 'so' });
     assert.equal(result.mode, 'process');
   });
+
+  it('menu mode takes priority over process mode', () => {
+    const result = validatePipelineInput({ menuId: '123', processId: '456', processName: 'test' });
+    assert.equal(result.mode, 'menu');
+  });
 });
 
 describe('buildProcessPipelineSteps', () => {

--- a/cli/test/resolve-menu.test.js
+++ b/cli/test/resolve-menu.test.js
@@ -1,0 +1,79 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { toKebabCase, MENU_QUERY } from '../src/resolve-menu.js';
+import { validatePipelineInput, parseArgs } from '../src/pipeline.js';
+
+describe('toKebabCase', () => {
+  it('converts spaced name to kebab', () => {
+    assert.equal(toKebabCase('Generate Invoices'), 'generate-invoices');
+  });
+
+  it('converts two-word name', () => {
+    assert.equal(toKebabCase('Sales Order'), 'sales-order');
+  });
+
+  it('converts underscored name', () => {
+    assert.equal(toKebabCase('My_Process_Name'), 'my-process-name');
+  });
+
+  it('preserves already-kebab name', () => {
+    assert.equal(toKebabCase('already-kebab'), 'already-kebab');
+  });
+
+  it('trims and collapses extra spaces', () => {
+    assert.equal(toKebabCase('  Extra  Spaces  '), 'extra-spaces');
+  });
+
+  it('lowercases mixed case', () => {
+    assert.equal(toKebabCase('MixedCASE Test'), 'mixedcase-test');
+  });
+
+  it('removes parentheses and special chars', () => {
+    assert.equal(toKebabCase('Name with (parens)'), 'name-with-parens');
+  });
+});
+
+describe('MENU_QUERY', () => {
+  it('references AD_Menu table', () => {
+    assert.ok(MENU_QUERY.includes('AD_Menu'));
+  });
+
+  it('uses $1 parameterized placeholder', () => {
+    assert.ok(MENU_QUERY.includes('$1'));
+  });
+
+  it('filters by IsActive', () => {
+    assert.ok(MENU_QUERY.includes("IsActive = 'Y'"));
+  });
+});
+
+describe('validatePipelineInput — menu mode', () => {
+  it('accepts menuId input', () => {
+    const result = validatePipelineInput({ menuId: '123' });
+    assert.equal(result.valid, true);
+    assert.equal(result.mode, 'menu');
+  });
+
+  it('menu mode takes priority over process mode', () => {
+    const result = validatePipelineInput({ menuId: '123', processId: '456', processName: 'test' });
+    assert.equal(result.mode, 'menu');
+  });
+
+  it('menu mode takes priority over window mode', () => {
+    const result = validatePipelineInput({ menuId: '123', windowId: '143', windowName: 'sales-order' });
+    assert.equal(result.mode, 'menu');
+  });
+});
+
+describe('parseArgs — --menu-id', () => {
+  it('parses --menu-id flag', () => {
+    const result = parseArgs(['node', 'pipeline.js', '--menu-id', 'ABC123']);
+    assert.equal(result.menuId, 'ABC123');
+  });
+
+  it('combines --menu-id with --dry-run', () => {
+    const result = parseArgs(['node', 'pipeline.js', '--menu-id', 'ABC123', '--dry-run']);
+    assert.equal(result.menuId, 'ABC123');
+    assert.equal(result.dryRun, true);
+  });
+});

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -46,6 +46,7 @@ Schema Forge decides **what** to expose. Etendo Go decides **how** to serve it.
 │  CLI Tools (Node.js)          Decision UIs (React)                   │
 │  ├── extract-from-db.js       ├── app-shell (port 5173)             │
 │  ├── extract-from-process.js  ├── decision-panel (port 5174)        │
+│  ├── resolve-menu.js                                                │
 │  ├── extract-fields.js        └── ui-preview (port 5175)            │
 │  ├── extract-rules.js                                                │
 │  ├── pre-classify.js          DB Writers (direct PostgreSQL)         │
@@ -146,7 +147,8 @@ All tools are Node.js, zero-dependency. Located in `cli/src/`.
 | `translate-todos.js` | Generated React components | Components with translated callout/onchange logic (AI-assisted, interactive) |
 | `generate-mock-data.js` | Contract | `mockData.js`, `mockCatalogs.js` for UI preview |
 | `run-contract-tests.js` | Contract | Test results (Node.js assertions) |
-| `pipeline.js` | Window or process ID | Runs full pipeline: window mode or process mode |
+| `resolve-menu.js` | AD_Menu_ID | Resolves menu entry type (W/P/R/X) and linked ID |
+| `pipeline.js` | Window ID, process ID, or menu ID | Runs full pipeline: window, process, or auto-detect mode |
 
 ### Decision UIs
 

--- a/docs/plans/process-and-report-pipeline.md
+++ b/docs/plans/process-and-report-pipeline.md
@@ -1,8 +1,9 @@
 # Plan: Process & Report Pipeline Support
 
-**Status:** Phase 1 COMPLETE — Standalone Process Pipeline Implemented
+**Status:** Phases 1 & 4 COMPLETE — Process Pipeline + Unified Entry Point
 **Date:** 2026-03-10
 **Phase 1 completed:** 2026-03-11
+**Phase 4 completed:** 2026-03-12
 
 ### Implementation Status
 
@@ -11,7 +12,7 @@
 | **Phase 1** | Standalone Processes | **Complete** | 2026-03-11 |
 | **Phase 2** | Reports | Deferred — requires NEO Headless changes | — |
 | **Phase 3** | Forms | Not planned — inherently custom | — |
-| **Phase 4** | Unified entry point | Deferred — after Phase 1 proven | — |
+| **Phase 4** | Unified entry point | **Complete** | 2026-03-12 |
 
 ## Context
 


### PR DESCRIPTION
## Summary
- Add `--menu-id <id>` flag to pipeline that auto-detects menu entry type from AD_Menu
- New `resolve-menu.js` module: queries AD_Menu, resolves action type (W/P/R/X), dispatches to correct pipeline
- Includes `toKebabCase()` helper for menu name → artifact slug conversion
- Clear error messages for unsupported types (reports → Phase 2, forms → not supported, folders → not actionable)

## Files Changed
- **NEW** `cli/src/resolve-menu.js` — Menu resolution logic + SQL query
- **MOD** `cli/src/pipeline.js` — `--menu-id` parsing, menu mode validation, dispatch in main()
- **NEW** `cli/test/resolve-menu.test.js` — 12 tests (toKebabCase, MENU_QUERY, validation, parseArgs)
- **MOD** `cli/test/extract-from-process.test.js` — Added menu priority test

## Test plan
- [ ] All 55 existing + new tests pass (`node --test cli/test/resolve-menu.test.js cli/test/extract-from-process.test.js`)
- [ ] Full test suite passes (`node --test cli/test/`)
- [ ] `--menu-id` correctly resolves window entries (action=W)
- [ ] `--menu-id` correctly resolves process entries (action=P)
- [ ] Reports (action=R) throw clear "Phase 2" message
- [ ] Forms (action=X) throw clear "not supported" message
- [ ] Folders (isSummary=Y) throw clear "not actionable" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)