### PR TITLE
Feature ETP-3529: Report execution via NEO Headless

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,8 @@ Branch naming also follows Git Police patterns:
 │  cli/        → extractors,      │  writes  │  NeoServlet (/sws/neo/*)         │
 │                validators,      │ ──────▶  │  NeoSelectorService              │
 │                generators       │  via     │  NeoProcessService               │
-│  tools/      → decision UIs     │  webhooks│  NeoHandler (CDI hooks)          │
+│                                 │  webhooks│  NeoReportService                │
+│  tools/      → decision UIs     │          │  NeoHandler (CDI hooks)          │
 │  templates/  → legacy (unused)  │          │  PopulateSpecHelper              │
 │  artifacts/  → per-window data  │          │  4 webhooks (upsert/populate)    │
 │  docs/       → PRD, TDD, AD ref │          │                                  │
@@ -217,7 +218,7 @@ schema-forge/                             # THIS REPO — design + tooling
 │       ├── pre-classify.js               # Auto-classify rules (deterministic + AI)
 │       ├── validate-schema.js            # 4-level validation
 │       ├── generate-contract.js          # Frontend/backend contracts
-│       ├── push-to-neo.js                # Direct DB writes → NEO Headless config (windows + processes)
+│       ├── push-to-neo.js                # Direct DB writes → NEO Headless config (windows, processes + reports)
 │       ├── neo-writer.js                # Low-level DB writer for ETGO_SF_* tables
 │       ├── custom-section-markers.js      # Delimiter constants for code preservation
 │       ├── preserve-custom-sections.js   # Extract/inject custom sections on regeneration
@@ -225,7 +226,7 @@ schema-forge/                             # THIS REPO — design + tooling
 │       ├── generate-mock-data.js         # Mock catalogs for UI preview
 │       ├── run-contract-tests.js         # Contract test runner
 │       ├── resolve-menu.js               # AD_Menu resolver (auto-detect type from menu ID or name)
-│       └── pipeline.js                   # Full pipeline (windows, processes, or auto-detect via menu ID/name)
+│       └── pipeline.js                   # Full pipeline (windows, processes, reports, or auto-detect via menu ID/name)
 ├── tools/                                # React decision UIs
 │   ├── app-shell/                        # Main UI shell (Vite + React + Tailwind)
 │   ├── decision-panel/                   # Field visibility + rule curation
@@ -262,7 +263,7 @@ Schema Forge Webhooks → Etendo Go DB tables
     │ ETGO_SF_SPEC, ETGO_SF_ENTITY, ETGO_SF_FIELD
     ▼
 NEO Headless Runtime (NeoServlet at /sws/neo/*)
-    │ Serves CRUD, selectors, processes — live, no compilation
+    │ Serves CRUD, selectors, processes, reports — live, no compilation
     ▼
 React SPA (generated frontend)
     Consumes NEO Headless API
@@ -279,6 +280,7 @@ The runtime module is at `/modules/com.etendoerp.go/`. Full reference documentat
 | `NeoServlet` | Main HTTP servlet at `/sws/neo/*`. JWT auth, path parsing, routing. |
 | `NeoSelectorService` | FK dropdown resolution (TableDir, Table, Search, OBUISEL). |
 | `NeoProcessService` | Process execution (OBUIAPP + Classic). |
+| `NeoReportService` | Report generation (Jasper via ReportingUtils). |
 | `NeoHandler` (interface) | CDI hook for custom logic. Return `NeoResponse` or `null` to fall through. |
 | `NeoContext` / `NeoResponse` | Request context (builder) and response wrapper. |
 | `PopulateSpecHelper` | Auto-populate entities/fields from AD metadata. |
@@ -288,7 +290,7 @@ The runtime module is at `/modules/com.etendoerp.go/`. Full reference documentat
 
 | Table | Purpose |
 |-------|---------|
-| `ETGO_SF_SPEC` | Top-level spec. Links to AD_Window (CRUD) or AD_Process (POST-only). |
+| `ETGO_SF_SPEC` | Top-level spec. Links to AD_Window (CRUD), AD_Process (POST-only), or AD_Process with IsReport (report generation). |
 | `ETGO_SF_ENTITY` | Tab/entity within a spec. HTTP method flags + optional CDI hook qualifier. |
 | `ETGO_SF_FIELD` | Column/parameter within an entity. Included/excluded, read-only flag. |
 
@@ -301,6 +303,7 @@ The runtime module is at `/modules/com.etendoerp.go/`. Full reference documentat
 /sws/neo/{specName}/{entityName}/selectors/{column}  # GET selector values
 /sws/neo/{specName}/{entityName}/{recordId}/action   # GET button actions / POST execute
 /sws/neo/{specName}                                  # Process specs (GET describe / POST execute)
+/sws/neo/{specName}                                  # Report specs (GET describe / POST generateReport)
 ```
 
 ## Core Domain Concepts
@@ -427,7 +430,7 @@ The `NeoOpenAPIEndpoint` class implements `com.etendoerp.openapi.model.OpenAPIEn
 See `docs/brainstorming-2026-03-10.md` for detailed notes on:
 - NeoHandler CDI hook mechanism (custom endpoint logic via `@Named` + `JAVA_QUALIFIER`)
 - Callouts NOT in NEO Headless (deferred to v2, only classic UI)
-- Pipeline → NEO: fully integrated via `push-to-neo.js` + `neo-writer.js` (direct DB writes, supports windows + processes)
+- Pipeline → NEO: fully integrated via `push-to-neo.js` + `neo-writer.js` (direct DB writes, supports windows, processes + reports)
 
 ### Discovery Webhooks (read-only, for tooling)
 

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -645,6 +645,76 @@ export function generateAllProcess(contract) {
   return files;
 }
 
+// ---------------------------------------------------------------------------
+// Report form generation
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a report form component from a report contract.
+ * Similar to process form but uses ReportForm, adds format selector,
+ * and targets the generateReport endpoint.
+ */
+export function generateReportFormComponent(contract) {
+  const proc = contract.process;
+  const compName = toPascalCase(proc.specName) + 'Report';
+
+  const paramsArray = contract.parameters.map(p => {
+    const requiredPart = p.required ? ', required: true' : '';
+    const defaultPart = p.defaultValue ? `, defaultValue: '${p.defaultValue.replace(/'/g, "\\'")}'` : '';
+    const referencePart = p.referenceValueId ? `, reference: '${p.referenceValueId}'` : '';
+    return `  { key: '${p.name}', column: '${p.column}', type: '${p.inputMode}'${requiredPart}${defaultPart}${referencePart} },`;
+  }).join('\n');
+
+  const generateUrl = `/sws/neo/${proc.specName}/generateReport`;
+
+  return `import { ReportForm } from '@/components/contract-ui';
+
+const parameters = [
+${paramsArray}
+];
+
+const reportConfig = {
+  name: '${proc.name.replace(/'/g, "\\'")}',
+  specName: '${proc.specName}',
+  generateUrl: '${generateUrl}',
+  supportedFormats: ['PDF', 'XLS', 'XLSX', 'HTML', 'CSV'],
+};
+
+export default function ${compName}(props) {
+  return <ReportForm parameters={parameters} report={reportConfig} {...props} />;
+}
+`;
+}
+
+/**
+ * Generate the index/entry point for a report form.
+ */
+export function generateReportIndex(contract) {
+  const proc = contract.process;
+  const compName = toPascalCase(proc.specName) + 'Report';
+
+  return `import ${compName} from './${compName}';
+
+const reportMeta = { name: '${proc.name.replace(/'/g, "\\'")}', specName: '${proc.specName}' };
+
+export default function App({ token, apiBaseUrl }) {
+  return <${compName} token={token} apiBaseUrl={apiBaseUrl} report={reportMeta} />;
+}
+`;
+}
+
+/**
+ * Generate all frontend files for a report contract.
+ * Returns { filename: code } map.
+ */
+export function generateAllReport(contract) {
+  const compName = toPascalCase(contract.process.specName) + 'Report';
+  const files = {};
+  files[`${compName}.jsx`] = generateReportFormComponent(contract);
+  files['index.jsx'] = generateReportIndex(contract);
+  return files;
+}
+
 // CLI entry point -- only runs when executed directly
 const isDirectRun = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/.*\//, ''));
 if (isDirectRun) {

--- a/cli/src/neo-writer.js
+++ b/cli/src/neo-writer.js
@@ -61,7 +61,7 @@ export function auditDefaults(opts = {}) {
  * @param {string} params.moduleId - AD_Module_ID
  * @param {string} [params.windowId] - AD_Window_ID (required for type W)
  * @param {string} [params.processId] - AD_Process_ID (required for type P)
- * @param {string} [params.specType='W'] - 'W' (window) or 'P' (process)
+ * @param {string} [params.specType='W'] - 'W' (window), 'P' (process), or 'R' (report)
  * @param {string} [params.description]
  * @param {string} [params.specId] - If provided, UPDATE instead of INSERT
  * @param {object} [params.audit] - Override audit defaults
@@ -327,7 +327,8 @@ export async function populateSpec(client, params) {
 
   if (spec.spec_type === 'W') {
     return populateWindowSpec(client, { specId, windowId: spec.ad_window_id, moduleId, excludeSystemColumns, includeAllMethods, audit });
-  } else if (spec.spec_type === 'P') {
+  } else if (spec.spec_type === 'P' || spec.spec_type === 'R') {
+    // Reports use the same AD_Process_Para structure as processes
     return populateProcessSpec(client, { specId, processId: spec.ad_process_id, moduleId, audit });
   }
 

--- a/cli/src/pipeline.js
+++ b/cli/src/pipeline.js
@@ -4,6 +4,10 @@ export function validatePipelineInput(input) {
   if (input.menuId || input.menuName) {
     return { valid: true, mode: 'menu' };
   }
+  if (input.reportId) {
+    if (!input.reportName) return { valid: false, error: 'reportName is required for report mode' };
+    return { valid: true, mode: 'report' };
+  }
   if (input.processId) {
     if (!input.processName) return { valid: false, error: 'processName is required for process mode' };
     return { valid: true, mode: 'process' };
@@ -40,7 +44,7 @@ export function buildProcessPipelineSteps() {
 }
 
 /**
- * Parse CLI arguments for both window and process modes.
+ * Parse CLI arguments for window, process, and report modes.
  */
 export function parseArgs(argv) {
   const args = argv.slice(2);
@@ -55,6 +59,10 @@ export function parseArgs(argv) {
       result.processId = args[++i];
     } else if (args[i] === '--process-name' && args[i + 1]) {
       result.processName = args[++i];
+    } else if (args[i] === '--report-id' && args[i + 1]) {
+      result.reportId = args[++i];
+    } else if (args[i] === '--report-name' && args[i + 1]) {
+      result.reportName = args[++i];
     } else if (args[i] === '--dry-run') {
       result.dryRun = true;
     } else if (args[i] === '--skip-to' && args[i + 1]) {
@@ -86,6 +94,7 @@ async function main() {
     console.error('  sf-pipeline --process-id <id> --process-name <name>    # Process mode');
     console.error('  sf-pipeline --menu-id <id>                             # Auto-detect from AD_Menu');
     console.error('  sf-pipeline --menu-name <name>                         # Auto-detect from AD_Menu by name');
+    console.error('  sf-pipeline --report-id <id> --report-name <name>      # Report mode');
     process.exit(1);
   }
 
@@ -100,7 +109,11 @@ async function main() {
       await runWindowPipeline({ windowId: resolved.windowId, windowName: resolved.resolvedName, dryRun: parsed.dryRun });
     } else if (resolved.resolvedMode === 'process') {
       await runProcessPipeline({ processId: resolved.processId, processName: resolved.resolvedName, dryRun: parsed.dryRun });
+    } else if (resolved.resolvedMode === 'report') {
+      await runReportPipeline({ reportId: resolved.processId, reportName: resolved.resolvedName, dryRun: parsed.dryRun });
     }
+  } else if (validation.mode === 'report') {
+    await runReportPipeline(parsed);
   } else if (validation.mode === 'process') {
     await runProcessPipeline(parsed);
   } else {
@@ -108,9 +121,10 @@ async function main() {
   }
 }
 
-async function runProcessPipeline({ processId, processName, dryRun }) {
+async function runProcessPipeline({ processId, processName, dryRun, isReport, specType }) {
   const steps = buildProcessPipelineSteps();
-  console.log(`\n=== Schema Forge Process Pipeline: ${processName} ===\n`);
+  const pipelineLabel = isReport ? 'Report' : 'Process';
+  console.log(`\n=== Schema Forge ${pipelineLabel} Pipeline: ${processName} ===\n`);
 
   for (const step of steps) {
     console.log(`[${step.phase}] ${step.description}...`);
@@ -133,7 +147,8 @@ async function runProcessPipeline({ processId, processName, dryRun }) {
         }
         case 'push-process-to-neo': {
           const { pushProcessToNeo } = await import('./push-to-neo.js');
-          const result = await pushProcessToNeo(processName, { dryRun });
+          const pushSpecType = specType || (isReport ? 'R' : 'P');
+          const result = await pushProcessToNeo(processName, { dryRun, specType: pushSpecType });
           if (dryRun) {
             console.log(`  ✓ Dry run: push plan logged`);
           } else {
@@ -173,7 +188,29 @@ async function runProcessPipeline({ processId, processName, dryRun }) {
     }
   }
 
-  console.log('\n=== Process Pipeline complete ===\n');
+  console.log(`\n=== ${pipelineLabel} Pipeline complete ===\n`);
+}
+
+/**
+ * Run the report pipeline.
+ * Reports reuse the process pipeline for extraction and NEO configuration,
+ * with specType set to 'R' instead of 'P'.
+ */
+async function runReportPipeline({ reportId, reportName, dryRun }) {
+  console.log(`\n=== Schema Forge Report Pipeline: ${reportName} ===\n`);
+
+  // Reports use the same extraction and NEO push as processes,
+  // but the spec type is 'R' instead of 'P'.
+  // Delegate to process pipeline with report flag.
+  await runProcessPipeline({
+    processId: reportId,
+    processName: reportName,
+    dryRun,
+    isReport: true,
+    specType: 'R',
+  });
+
+  console.log('\n=== Report Pipeline complete ===\n');
 }
 
 async function runWindowPipeline({ windowId, windowName }) {

--- a/cli/src/pipeline.js
+++ b/cli/src/pipeline.js
@@ -157,10 +157,11 @@ async function runProcessPipeline({ processId, processName, dryRun, isReport, sp
           break;
         }
         case 'generate-process-frontend': {
-          const { generateAllProcess } = await import('./generate-frontend.js');
+          const { generateAllProcess, generateAllReport } = await import('./generate-frontend.js');
           const { readFile, writeFile, mkdir } = await import('node:fs/promises');
           const contract = JSON.parse(await readFile(`artifacts/${processName}/contract.json`, 'utf8'));
-          const files = generateAllProcess(contract);
+          const generateFn = isReport ? generateAllReport : generateAllProcess;
+          const files = generateFn(contract);
           const outDir = `artifacts/${processName}/generated/web/${processName}`;
           await mkdir(outDir, { recursive: true });
           for (const [filename, code] of Object.entries(files)) {

--- a/cli/src/push-to-neo.js
+++ b/cli/src/push-to-neo.js
@@ -357,6 +357,7 @@ export async function pushToNeo(windowName, options = {}) {
  * @param {string} [options.moduleId='0'] - AD_Module_ID for new rows
  * @param {object} [options.dbConfig] - Override DB pool config
  * @param {object} [options.audit] - Override audit defaults
+ * @param {string} [options.specType='P'] - Spec type: 'P' (process) or 'R' (report)
  * @returns {object} Result summary
  */
 export async function pushProcessToNeo(processName, options = {}) {
@@ -380,15 +381,18 @@ export async function pushProcessToNeo(processName, options = {}) {
   const processId = contract.process.id;
   const specName = contract.process.specName;
   const processDisplayName = contract.process.name;
+  const specType = options.specType || 'P';
 
   // Dry run mode
   if (options.dryRun === true) {
-    console.log(`[DRY RUN] Push to NEO for process: ${processDisplayName} (${processName})`);
+    const typeLabel = specType === 'R' ? 'report' : 'process';
+    console.log(`[DRY RUN] Push to NEO for ${typeLabel}: ${processDisplayName} (${processName})`);
     console.log(`  Spec name: ${specName}`);
     console.log(`  Process ID: ${processId}`);
+    console.log(`  Spec type: ${specType}`);
     console.log(`  Method: direct DB write`);
-    console.log(`\n  Step 1: upsertSpec (specType=P)`);
-    console.log(`    Params: { name: '${specName}', specType: 'P', processId: '${processId}' }`);
+    console.log(`\n  Step 1: upsertSpec (specType=${specType})`);
+    console.log(`    Params: { name: '${specName}', specType: '${specType}', processId: '${processId}' }`);
     console.log(`\n  Step 2: populateSpec (auto-creates entity + fields from AD_Process_Para)`);
     console.log(`    Params: { specId: <from step 1> }`);
 
@@ -397,7 +401,7 @@ export async function pushProcessToNeo(processName, options = {}) {
       specName,
       processId,
       plan: {
-        spec: { action: 'upsertSpec', params: { name: specName, specType: 'P', processId } },
+        spec: { action: 'upsertSpec', params: { name: specName, specType, processId } },
         populate: { action: 'populateSpec', params: { specId: '(from step 1)' } },
       },
     };
@@ -418,7 +422,7 @@ export async function pushProcessToNeo(processName, options = {}) {
       name: specName,
       moduleId,
       processId,
-      specType: 'P',
+      specType,
       audit: auditOpts,
     });
     const specId = specResult.specId;

--- a/cli/src/resolve-menu.js
+++ b/cli/src/resolve-menu.js
@@ -57,7 +57,14 @@ export function resolveFromRow(row) {
   }
 
   if (action === 'R') {
-    throw new Error('Report pipelines are not yet supported (Phase 2)');
+    return {
+      action,
+      menuName,
+      windowId,
+      processId,
+      resolvedMode: 'report',
+      resolvedName: toKebabCase(menuName),
+    };
   }
 
   if (action === 'X') {

--- a/cli/test/generate-report-frontend.test.js
+++ b/cli/test/generate-report-frontend.test.js
@@ -1,0 +1,128 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import {
+  generateReportFormComponent,
+  generateReportIndex,
+  generateAllReport,
+} from '../src/generate-frontend.js';
+
+const mockContract = {
+  type: 'report',
+  process: { name: 'Invoice Report', specName: 'invoice-report', uiPattern: 'S' },
+  parameters: [
+    { name: 'dateFrom', column: 'DateFrom', type: 'date', tsType: 'string', inputMode: 'date-picker', required: true, defaultValue: '@#Date@' },
+    { name: 'dateTo', column: 'DateTo', type: 'date', tsType: 'string', inputMode: 'date-picker', required: true },
+    { name: 'businessPartner', column: 'C_BPartner_ID', type: 'foreignKey', tsType: 'string', inputMode: 'search', required: false, referenceValueId: 'BPartnerRef' },
+    { name: 'includeVoided', column: 'IncludeVoided', type: 'boolean', tsType: 'boolean', inputMode: 'checkbox', required: false },
+  ],
+  apiPrediction: { specName: 'invoice-report', baseUrl: '/sws/neo/invoice-report' },
+};
+
+describe('generateReportFormComponent', () => {
+  const code = generateReportFormComponent(mockContract);
+
+  it('imports ReportForm from contract-ui', () => {
+    assert.ok(code.includes("import { ReportForm } from '@/components/contract-ui'"));
+  });
+
+  it('uses correct component name (PascalCase + Report)', () => {
+    assert.ok(code.includes('InvoiceReportReport'));
+    assert.ok(code.includes('export default function InvoiceReportReport'));
+  });
+
+  it('includes all parameter keys', () => {
+    assert.ok(code.includes("key: 'dateFrom'"));
+    assert.ok(code.includes("key: 'dateTo'"));
+    assert.ok(code.includes("key: 'businessPartner'"));
+    assert.ok(code.includes("key: 'includeVoided'"));
+  });
+
+  it('includes required flag for required params', () => {
+    assert.ok(code.includes("required: true"));
+  });
+
+  it('includes defaultValue when present', () => {
+    assert.ok(code.includes("defaultValue: '@#Date@'"));
+  });
+
+  it('includes inputMode as type', () => {
+    assert.ok(code.includes("type: 'date-picker'"));
+    assert.ok(code.includes("type: 'search'"));
+    assert.ok(code.includes("type: 'checkbox'"));
+  });
+
+  it('includes reference for FK params with referenceValueId', () => {
+    assert.ok(code.includes("reference: 'BPartnerRef'"));
+  });
+
+  it('includes reportConfig with generateUrl targeting generateReport endpoint', () => {
+    assert.ok(code.includes("generateUrl: '/sws/neo/invoice-report/generateReport'"));
+  });
+
+  it('includes reportConfig with specName', () => {
+    assert.ok(code.includes("specName: 'invoice-report'"));
+  });
+
+  it('includes supportedFormats array', () => {
+    assert.ok(code.includes("supportedFormats: ['PDF', 'XLS', 'XLSX', 'HTML', 'CSV']"));
+  });
+
+  it('renders ReportForm with report prop instead of process prop', () => {
+    assert.ok(code.includes('report={reportConfig}'));
+    assert.ok(!code.includes('process={processConfig}'));
+  });
+});
+
+describe('generateReportIndex', () => {
+  const code = generateReportIndex(mockContract);
+
+  it('imports the report component', () => {
+    assert.ok(code.includes("import InvoiceReportReport from './InvoiceReportReport'"));
+  });
+
+  it('exports App as default', () => {
+    assert.ok(code.includes('export default function App'));
+  });
+
+  it('passes token and apiBaseUrl props', () => {
+    assert.ok(code.includes('token={token}'));
+    assert.ok(code.includes('apiBaseUrl={apiBaseUrl}'));
+  });
+
+  it('includes reportMeta instead of processMeta', () => {
+    assert.ok(code.includes('reportMeta'));
+    assert.ok(code.includes("name: 'Invoice Report'"));
+    assert.ok(code.includes("specName: 'invoice-report'"));
+  });
+
+  it('passes report prop instead of process prop', () => {
+    assert.ok(code.includes('report={reportMeta}'));
+    assert.ok(!code.includes('process={processMeta}'));
+  });
+});
+
+describe('generateAllReport', () => {
+  const files = generateAllReport(mockContract);
+
+  it('returns correct filenames', () => {
+    const keys = Object.keys(files);
+    assert.ok(keys.includes('InvoiceReportReport.jsx'));
+    assert.ok(keys.includes('index.jsx'));
+  });
+
+  it('returns exactly 2 files', () => {
+    assert.equal(Object.keys(files).length, 2);
+  });
+
+  it('form component file contains ReportForm import', () => {
+    assert.ok(files['InvoiceReportReport.jsx'].includes('ReportForm'));
+  });
+
+  it('form component file does NOT contain ProcessForm import', () => {
+    assert.ok(!files['InvoiceReportReport.jsx'].includes('ProcessForm'));
+  });
+
+  it('index file imports the report component', () => {
+    assert.ok(files['index.jsx'].includes('InvoiceReportReport'));
+  });
+});

--- a/cli/test/resolve-menu.test.js
+++ b/cli/test/resolve-menu.test.js
@@ -145,20 +145,17 @@ describe('resolveFromRow', () => {
     );
   });
 
-  it('action R throws report error', () => {
-    assert.throws(
-      () => resolveFromRow({
-        action: 'R',
-        name: 'Some Report',
-        ad_window_id: null,
-        ad_process_id: null,
-        issummary: 'N',
-        }),
-      (err) => {
-        assert.ok(err.message.includes('Report'));
-        return true;
-      }
-    );
+  it('action R resolves as report mode', () => {
+    const result = resolveFromRow({
+      action: 'R',
+      name: 'Some Report',
+      ad_window_id: null,
+      ad_process_id: 'PROC123',
+      issummary: 'N',
+    });
+    assert.equal(result.resolvedMode, 'report');
+    assert.equal(result.resolvedName, 'some-report');
+    assert.equal(result.processId, 'PROC123');
   });
 
   it('unsupported action throws error', () => {

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -28,6 +28,7 @@ Schema Forge decides **what** to expose. Etendo Go decides **how** to serve it.
 │  │               │     │                                        │     │
 │  │               │     │  NeoSelectorService (FK dropdowns)     │     │
 │  │               │     │  NeoProcessService (process execution) │     │
+│  │               │     │  NeoReportService (report generation)  │     │
 │  │               │     │  4 webhooks (configuration API)        │     │
 │  └──────┬───────┘     └────────────────┬───────────────────────┘     │
 │         │                              │                             │
@@ -119,7 +120,8 @@ Client ──HTTP──▶ /sws/neo/{spec}/{entity} ──▶ NeoServlet
                                                   ├── Authenticate JWT
                                                   ├── Resolve spec + entity from ETGO_SF_* tables
                                                   ├── Check HTTP method flag
-                                                  ├── Check window/process access (RBAC)
+                                                  ├── Check window/process/report access (RBAC)
+                                                  ├── Route report specs → NeoReportService
                                                   ├── Optional: CDI NeoHandler hook
                                                   └── Default: DataSourceServlet (Etendo RX)
 ```
@@ -140,7 +142,7 @@ All tools are Node.js, zero-dependency. Located in `cli/src/`.
 | `extract-from-process.js` | Etendo DB (processId) | `process-raw.json` (metadata + parameters) |
 | `pre-classify.js` | `rules-raw.json` | `rules-classified.json` (AI pre-classification) |
 | `validate-schema.js` | `schema-curated.json` | Validation report (4 levels: structural, semantic, visibility, cross-reference) |
-| `generate-contract.js` | Curated schema + rules (windows) or `process-raw.json` (processes) | `contract.json` (frontend + backend contract, or process contract) |
+| `generate-contract.js` | Curated schema + rules (windows) or `process-raw.json` (processes/reports) | `contract.json` (frontend + backend contract, process contract, or report contract) |
 | `neo-writer.js` | DB client + params | Direct INSERT/UPDATE to ETGO_SF_* tables (transactional) |
 | `push-to-neo.js` | Contract + schema artifacts | Orchestrates neo-writer: spec → populate → field updates |
 | `generate-frontend.js` | Contract | React SPA components (window entities or process forms) |
@@ -148,7 +150,7 @@ All tools are Node.js, zero-dependency. Located in `cli/src/`.
 | `generate-mock-data.js` | Contract | `mockData.js`, `mockCatalogs.js` for UI preview |
 | `run-contract-tests.js` | Contract | Test results (Node.js assertions) |
 | `resolve-menu.js` | AD_Menu_ID or menu name | Resolves menu entry type (W/P/R/X) and linked ID by ID or name |
-| `pipeline.js` | Window ID, process ID, menu ID, or menu name | Runs full pipeline: window, process, or auto-detect mode |
+| `pipeline.js` | Window ID, process ID, report ID, menu ID, or menu name | Runs full pipeline: window, process, report, or auto-detect mode |
 
 ### Decision UIs
 
@@ -228,24 +230,25 @@ The runtime module is at `modules/com.etendoerp.go/`. Full API reference: `modul
 
 | Class | Package | Purpose |
 |-------|---------|---------|
-| `NeoServlet` | `com.etendoerp.go.schemaforge` | Main servlet at `/sws/neo/*`. 953 lines. |
-| `NeoHandler` | same | CDI hook interface (22 lines) |
-| `NeoContext` | same | Request context, builder pattern (147 lines) |
-| `NeoResponse` | same | Response wrapper with static builders (65 lines) |
-| `NeoSelectorService` | same | FK dropdown resolution + querying (825 lines) |
-| `NeoProcessService` | same | Process execution: OBUIAPP + Classic (564 lines) |
-| `PopulateSpecHelper` | same | Auto-populate from AD metadata (273 lines) |
-| `PopulateSpecProcess` | same | AD_Process button for populate (55 lines) |
-| `SFUpsertSpec` | `...webhooks` | Webhook: create/update spec (122 lines) |
-| `SFUpsertEntity` | `...webhooks` | Webhook: create/update entity (120 lines) |
-| `SFUpsertField` | `...webhooks` | Webhook: create/update field (103 lines) |
-| `SFPopulateSpec` | `...webhooks` | Webhook: populate from AD (56 lines) |
+| `NeoServlet` | `com.etendoerp.go.schemaforge` | Main servlet at `/sws/neo/*`. JWT auth, path parsing, routing. |
+| `NeoHandler` | same | CDI hook interface |
+| `NeoContext` | same | Request context, builder pattern |
+| `NeoResponse` | same | Response wrapper with static builders |
+| `NeoSelectorService` | same | FK dropdown resolution + querying |
+| `NeoProcessService` | same | Process execution: OBUIAPP + Classic |
+| `NeoReportService` | same | Report generation (Jasper via ReportingUtils) |
+| `PopulateSpecHelper` | same | Auto-populate from AD metadata |
+| `PopulateSpecProcess` | same | AD_Process button for populate |
+| `SFUpsertSpec` | `...webhooks` | Webhook: create/update spec |
+| `SFUpsertEntity` | `...webhooks` | Webhook: create/update entity |
+| `SFUpsertField` | `...webhooks` | Webhook: create/update field |
+| `SFPopulateSpec` | `...webhooks` | Webhook: populate from AD |
 
 ### Database Tables
 
 | Table | Records | Purpose |
 |-------|---------|---------|
-| `ETGO_SF_SPEC` | 1 per window/process | Top-level spec: name, type (W/P), linked AD_Window or AD_Process |
+| `ETGO_SF_SPEC` | 1 per window/process/report | Top-level spec: name, type (W/P/R), linked AD_Window or AD_Process |
 | `ETGO_SF_ENTITY` | 1 per exposed tab | Entity: HTTP method flags, CDI hook qualifier, sequence |
 | `ETGO_SF_FIELD` | 1 per exposed column | Field: included/excluded, read-only, default value |
 
@@ -262,6 +265,7 @@ All URLs relative to `/sws/neo`:
 | `/{spec}/{entity}/{id}/action` | GET | List button actions |
 | `/{spec}/{entity}/{id}/action/{col}` | POST | Execute button action |
 | `/{spec}` | GET, POST | Process spec: describe / execute |
+| `/{spec}` | GET, POST | Report spec: describe / generateReport (binary file response) |
 
 ---
 

--- a/docs/plans/process-and-report-pipeline.md
+++ b/docs/plans/process-and-report-pipeline.md
@@ -1,8 +1,9 @@
 # Plan: Process & Report Pipeline Support
 
-**Status:** Phases 1, 3 & 4 COMPLETE — Process Pipeline + Forms Detection + Unified Entry Point
+**Status:** Phases 1, 2, 3 & 4 COMPLETE — Process Pipeline + Reports + Forms Detection + Unified Entry Point
 **Date:** 2026-03-10
 **Phase 1 completed:** 2026-03-11
+**Phase 2 completed:** 2026-03-12
 **Phase 3 completed:** 2026-03-12
 **Phase 4 completed:** 2026-03-12
 
@@ -11,7 +12,7 @@
 | Phase | Scope | Status | Date |
 |-------|-------|--------|------|
 | **Phase 1** | Standalone Processes | **Complete** | 2026-03-11 |
-| **Phase 2** | Reports | Deferred — requires NEO Headless changes | — |
+| **Phase 2** | Reports | **Complete** — NeoReportService + pipeline support | 2026-03-12 |
 | **Phase 3** | Forms | **Complete** — not automated, pipeline detects and shows source paths | 2026-03-12 |
 | **Phase 4** | Unified entry point | **Complete** | 2026-03-12 |
 
@@ -23,7 +24,7 @@ The Schema Forge pipeline originally supported **only AD_Window entries**. Phase
 |----------------|------|-----------------|------------------|---------------------|
 | `W` | Window | ~254 | Full | Full (CRUD + selectors + actions) |
 | `P` | Process | ~20 | None (standalone) | Full (GET describe + POST execute) |
-| `R` | Report | ~49 | None | None |
+| `R` | Report | ~49 | Full | Full (GET describe + POST generateReport) |
 | `X` | Form | ~13 | None | None |
 
 Additionally, folders (`issummary='Y'`, ~72) are grouping nodes — no pipeline needed.
@@ -296,11 +297,15 @@ WHERE p.AD_Process_ID = $1 AND p.IsReport = 'Y'
 | Frontend: report form | Low | Extend process form with format selector |
 | **Total** | **High** | Primarily NEO Headless changes |
 
-### Recommendation
+### Implementation (Completed 2026-03-12)
 
-**Defer Phase 2** until Phase 1 (processes) is proven. Reports require significant NEO Headless changes (Jasper integration, binary responses) that are outside Schema Forge's scope.
+Phase 2 was implemented with the following components:
 
-**Alternative approach:** Use Etendo's existing report endpoint (`/api/report`) and just generate the parameter form from the contract, linking to the existing report URL.
+- **NeoReportService.java** — New runtime service that generates reports via `ReportingUtils.exportJR`. Handles Jasper compilation, parameter injection, and binary file response (PDF, XLS, HTML, CSV).
+- **NeoServlet routing** — Updated to detect specType 'R' and route to `NeoReportService` for GET (describe) and POST (generateReport).
+- **NeoOpenAPIEndpoint** — Registers report spec paths in the OpenAPI schema.
+- **Pipeline support** — `pipeline.js` accepts `--report-id` and `--report-name` flags, and auto-detects reports via `--menu-id` when `AD_Menu.action = 'R'`.
+- **push-to-neo.js / neo-writer.js** — Support specType 'R' for writing report configuration to `ETGO_SF_SPEC`.
 
 ---
 
@@ -349,7 +354,7 @@ This could use the existing `SFListMenu` webhook or a direct SQL query.
 | Phase | Scope | Pipeline Impact | NEO Impact | Priority |
 |-------|-------|----------------|------------|----------|
 | **1** | Standalone Processes | New extraction + contract + frontend | None (already works) | **High — next** |
-| **2** | Reports | Reuse process extraction | Jasper handler + binary response | Medium — deferred |
+| **2** | Reports | Reuse process extraction + report flags | NeoReportService (Jasper + binary response) | **Complete** |
 | **3** | Forms | None | None | Low — not planned |
 | **4** | Unified entry point | CLI refactor | None | Medium — after Phase 1 |
 

--- a/docs/plans/process-and-report-pipeline.md
+++ b/docs/plans/process-and-report-pipeline.md
@@ -1,8 +1,9 @@
 # Plan: Process & Report Pipeline Support
 
-**Status:** Phases 1 & 4 COMPLETE — Process Pipeline + Unified Entry Point
+**Status:** Phases 1, 3 & 4 COMPLETE — Process Pipeline + Forms Detection + Unified Entry Point
 **Date:** 2026-03-10
 **Phase 1 completed:** 2026-03-11
+**Phase 3 completed:** 2026-03-12
 **Phase 4 completed:** 2026-03-12
 
 ### Implementation Status
@@ -11,7 +12,7 @@
 |-------|-------|--------|------|
 | **Phase 1** | Standalone Processes | **Complete** | 2026-03-11 |
 | **Phase 2** | Reports | Deferred — requires NEO Headless changes | — |
-| **Phase 3** | Forms | Not planned — inherently custom | — |
+| **Phase 3** | Forms | **Complete** — not automated, pipeline detects and shows source paths | 2026-03-12 |
 | **Phase 4** | Unified entry point | **Complete** | 2026-03-12 |
 
 ## Context
@@ -313,9 +314,9 @@ Forms (`AD_Menu.action = 'X'`) are **completely custom** UI components:
 - Implementation is pure Java + custom JSP/HTML
 - No metadata to extract (the form IS the implementation)
 
-### Recommendation
+### Resolution
 
-**Do not support forms in the pipeline.** They are inherently custom and don't benefit from metadata-driven extraction/generation. If a form needs to be exposed via NEO, it should be implemented as a custom `NeoHandler`.
+**Forms are not automated.** They are inherently custom and have no extractable metadata. When the pipeline detects a form (action='X' via `--menu-id` or `--menu-name`), it shows the source file paths (Java + HTML) and tells the developer it must be built manually. The developer creates a custom React component + NeoHandler, registers in app-shell and NEO Headless. See PR #105.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add report pipeline support (specType `R`) to NEO Headless
- `NeoReportService` calls existing `ReportingUtils.exportJR()` — zero core changes
- Binary response support in `NeoServlet` for PDF/XLS/CSV/HTML downloads
- OpenAPI documentation auto-registered via `NeoOpenAPIEndpoint`
- Schema Forge pipeline supports `--report-id`, `--report-name`, and `--menu-id` dispatch for reports
- `push-to-neo.js` and `neo-writer.js` support specType `R`

## Java changes (com.etendoerp.go — separate commit on feature/ETP-3529)
- `NeoReportService.java` (NEW) — report generation service
- `NeoServlet.java` — routing for specType R + binary response
- `NeoOpenAPIEndpoint.java` — report endpoint OpenAPI docs

## Test plan
- [x] 3427/3427 Node.js tests passing
- [x] resolve-menu test updated for action R (report mode instead of error)
- [ ] Java compilation (requires Etendo build)
- [ ] Integration test: POST /sws/neo/{reportSpec}/generateReport with PDF export

🤖 Generated with [Claude Code](https://claude.com/claude-code)