### PR TITLE
Feature ETP-3546: Add post-pipeline next steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,28 @@ schema-forge/
 └── .env                          # Local config (not committed)
 ```
 
+## Building and Deploying
+
+After the pipeline generates frontend components and pushes NEO config, you need to build and deploy the UI into the Etendo module so it is served by Tomcat.
+
+```bash
+# Build and deploy in one step
+make deploy
+
+# Override Etendo root if needed
+make deploy MODULE_WEB=<etendo_root>/modules/com.etendoerp.go/web/com.etendoerp.go
+```
+
+After deploying, if this is the first time or if NEO configuration changed, rebuild and restart:
+
+```bash
+cd <etendo_root> && ./gradlew smartbuild export.database --info
+```
+
+If not using Docker, restart Tomcat manually. Docker environments auto-restart after a few seconds.
+
+The pipeline prints contextual "Next steps" after completion to remind you which commands are needed based on what ran.
+
 ## Documentation
 
 Full documentation lives in `docs/`. Start with [docs/index.md](docs/index.md).

--- a/cli/src/pipeline.js
+++ b/cli/src/pipeline.js
@@ -62,6 +62,31 @@ function parseArgs(argv) {
   return result;
 }
 
+/**
+ * Print contextual next steps based on which pipeline phases ran.
+ * @param {{ pushToNeoRan: boolean, frontendGenerated: boolean }} flags
+ */
+function printNextSteps({ pushToNeoRan, frontendGenerated }) {
+  if (!pushToNeoRan && !frontendGenerated) return;
+
+  console.log('Next steps:');
+
+  if (pushToNeoRan && frontendGenerated) {
+    console.log('  → Deploy UI, rebuild, and export config in one step:');
+    console.log('    make deploy');
+    console.log('    cd <etendo_root> && ./gradlew smartbuild export.database --info');
+    console.log('  → Restart Tomcat (if not using Docker — Docker auto-restarts after a few seconds)');
+  } else if (pushToNeoRan) {
+    console.log('  → Run export.database to persist NEO config to XML sourcedata:');
+    console.log('    cd <etendo_root> && ./gradlew export.database --info');
+  } else if (frontendGenerated) {
+    console.log('  → Deploy the UI and rebuild:');
+    console.log('    make deploy');
+    console.log('    cd <etendo_root> && ./gradlew smartbuild --info');
+    console.log('  → Restart Tomcat (if not using Docker — Docker auto-restarts after a few seconds)');
+  }
+}
+
 // CLI entry point
 async function main() {
   const parsed = parseArgs(process.argv);
@@ -89,6 +114,8 @@ async function main() {
 
 async function runProcessPipeline({ processId, processName, dryRun }) {
   const steps = buildProcessPipelineSteps();
+  let pushToNeoRan = false;
+  let frontendGenerated = false;
   console.log(`\n=== Schema Forge Process Pipeline: ${processName} ===\n`);
 
   for (const step of steps) {
@@ -117,6 +144,7 @@ async function runProcessPipeline({ processId, processName, dryRun }) {
             console.log(`  ✓ Dry run: push plan logged`);
           } else {
             console.log(`  ✓ NEO Headless configured (spec: ${result.specId})`);
+            pushToNeoRan = true;
           }
           break;
         }
@@ -131,6 +159,7 @@ async function runProcessPipeline({ processId, processName, dryRun }) {
             await writeFile(`${outDir}/${filename}`, code, 'utf8');
           }
           console.log(`  ✓ ${Object.keys(files).length} frontend components generated`);
+          frontendGenerated = true;
           break;
         }
         case 'run-tests': {
@@ -153,10 +182,13 @@ async function runProcessPipeline({ processId, processName, dryRun }) {
   }
 
   console.log('\n=== Process Pipeline complete ===\n');
+  printNextSteps({ pushToNeoRan, frontendGenerated });
 }
 
 async function runWindowPipeline({ windowId, windowName }) {
   const steps = buildPipelineSteps();
+  let pushToNeoRan = false;
+  let frontendGenerated = false;
   console.log(`\n=== Schema Forge Pipeline: ${windowName} ===\n`);
 
   for (const step of steps) {
@@ -249,6 +281,7 @@ async function runWindowPipeline({ windowId, windowName }) {
             console.log(`  ✓ Dry run: ${result.summary.totalFields} fields planned`);
           } else {
             console.log(`  ✓ NEO Headless configured (${result.fieldsUpdated} fields)`);
+            pushToNeoRan = true;
           }
           break;
         }
@@ -291,6 +324,7 @@ async function runWindowPipeline({ windowId, windowName }) {
             summary += ')';
           }
           console.log(summary);
+          frontendGenerated = true;
           break;
         }
         case 'run-tests': {
@@ -313,6 +347,7 @@ async function runWindowPipeline({ windowId, windowName }) {
   }
 
   console.log('\n=== Pipeline complete ===\n');
+  printNextSteps({ pushToNeoRan, frontendGenerated });
 }
 
 // Only run main if executed directly


### PR DESCRIPTION
## Summary
- Add contextual "Next steps" guidance after pipeline completion in `cli/src/pipeline.js`
- Track which phases ran (push-to-neo, generate-frontend) and print appropriate commands
- Dry-run mode correctly skips the push-to-neo flag
- Add "Building and Deploying" section to README.md

## Test plan
- [ ] Run window pipeline with push-to-neo and frontend steps -- verify both next steps appear
- [ ] Run with `--dry-run` -- verify push-to-neo next step is NOT shown
- [ ] Run process pipeline -- verify next steps appear after completion
- [ ] Verify README deploy section renders correctly