### PR TITLE
Feature ETP-3529: DataTable visual redesign

### DIFF
--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -359,7 +359,9 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
           Enter to add &middot; Esc to cancel
         </p>
       )}
-      <p className="text-xs text-muted-foreground">{filteredData.length} of {data.length} records</p>
+      <div className="flex items-center justify-between text-xs text-muted-foreground pt-1">
+        <span>{filteredData.length} of {data.length} records</span>
+      </div>
     </div>
   );
 }

--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -294,7 +294,7 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
               {columns.map(col => {
                 const colLabel = t(col.column) ?? col.label ?? col.key;
                 return (
-                  <TableHead key={col.key} className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  <TableHead key={col.key} className={`text-xs font-medium text-muted-foreground/70 tracking-wide ${col.type === 'amount' ? 'text-right' : ''}`}>
                     <FieldHighlight entityName={entity} fieldName={col.key}>
                       {colLabel}
                     </FieldHighlight>
@@ -316,13 +316,15 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
                   key={row.id ?? idx}
                   onClick={() => onNavigate ? onNavigate(row) : onRowSelect?.(row)}
                   className={[
-                    'cursor-pointer transition-colors',
+                    'cursor-pointer transition-colors h-12',
                     row.id === selectedId ? 'bg-primary/10 border-l-2 border-l-primary' : '',
                     'hover:bg-muted/50',
                   ].filter(Boolean).join(' ')}
                 >
                   {columns.map(col => (
-                    <TableCell key={col.key}>{renderCellValue(row, col)}</TableCell>
+                    <TableCell key={col.key} className={col.type === 'amount' ? 'text-right' : ''}>
+                      {renderCellValue(row, col)}
+                    </TableCell>
                   ))}
                 </TableRow>
               ))

--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -28,6 +28,20 @@ function getStatusBadgeProps(status) {
 }
 
 /**
+ * Return a colored dot class based on whether a date is past, future, or today.
+ * Green = future (not yet due), Red = past (overdue), null = today or empty.
+ */
+function getDateDotColor(dateValue) {
+  if (!dateValue) return null;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const d = new Date(dateValue);
+  d.setHours(0, 0, 0, 0);
+  if (d.getTime() === today.getTime()) return null;
+  return d > today ? 'bg-emerald-500' : 'bg-red-500';
+}
+
+/**
  * Loading skeleton that mimics a table layout.
  */
 function TableSkeleton({ columns }) {
@@ -217,6 +231,18 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
       if (val === true || val === 'Y') return <span className="text-emerald-600">Yes</span>;
       if (val === false || val === 'N') return <span className="text-slate-400">No</span>;
       return <span className="text-slate-300">&mdash;</span>;
+    }
+    if (col.type === 'date') {
+      const dotColor = getDateDotColor(row[col.key]);
+      const formatted = row[col.key]
+        ? new Date(row[col.key]).toLocaleDateString()
+        : '\u2014';
+      return (
+        <span className="inline-flex items-center gap-1.5">
+          {formatted}
+          {dotColor && <span className={`inline-block h-2 w-2 rounded-full ${dotColor}`} />}
+        </span>
+      );
     }
     if (col.type === 'amount') {
       return <span className="tabular-nums">{row[col.key]?.toLocaleString()}</span>;

--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, TableFooter } from '@/components/ui/table';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -217,6 +217,20 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
     );
   }, [data, filters, searchQuery]);
 
+  const amountColumns = useMemo(
+    () => columns.filter(col => col.type === 'amount'),
+    [columns]
+  );
+
+  const totals = useMemo(() => {
+    if (amountColumns.length === 0) return null;
+    const sums = {};
+    for (const col of amountColumns) {
+      sums[col.key] = filteredData.reduce((sum, row) => sum + (Number(row[col.key]) || 0), 0);
+    }
+    return sums;
+  }, [filteredData, amountColumns]);
+
   const renderCellValue = (row, col) => {
     // Link styling on first string column
     if (col === columns[0] && col.type === 'string') {
@@ -323,6 +337,19 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
               />
             )}
           </TableBody>
+          {totals && (
+            <TableFooter>
+              <TableRow className="bg-muted/30 font-medium">
+                {columns.map((col, idx) => (
+                  <TableCell key={col.key} className={col.type === 'amount' ? 'tabular-nums text-right' : ''}>
+                    {col.type === 'amount'
+                      ? totals[col.key]?.toLocaleString()
+                      : idx === 0 ? '' : ''}
+                  </TableCell>
+                ))}
+              </TableRow>
+            </TableFooter>
+          )}
         </Table>
       </div>
       {addRow?.active && (

--- a/tools/app-shell/src/components/contract-ui/ListView.jsx
+++ b/tools/app-shell/src/components/contract-ui/ListView.jsx
@@ -32,16 +32,17 @@ export function ListView({
     <div className="h-[calc(100vh-7.5rem)] flex flex-col">
       {/* Toolbar */}
       <div className="flex items-center justify-between px-1 pb-4">
-        <div className="flex items-center gap-2">
-          <h2 className="text-lg font-semibold text-foreground">{label}</h2>
+        <div className="flex items-center gap-3">
+          <h2 className="text-xl font-semibold text-foreground">{label}</h2>
           {!hook.loading && (
-            <span className="text-xs text-muted-foreground bg-muted px-2 py-0.5 rounded-full">
+            <span className="inline-flex items-center justify-center h-6 min-w-[1.5rem] px-1.5 text-xs font-medium text-primary bg-primary/10 rounded-full">
               {hook.items.length}
             </span>
           )}
         </div>
         <Button
           size="sm"
+          className="gap-1"
           onClick={() => navigate(`/${windowName}/new`)}
         >
           + New


### PR DESCRIPTION
## Summary
- Add green/red status dots on date columns (future = green, past = red)
- Add footer totals row that sums all amount columns
- Improve typography: remove uppercase headers, soften colors, add row height, right-align amounts
- Update ListView header with colored record count badge
- Update record count display styling

## Files modified
- `tools/app-shell/src/components/contract-ui/DataTable.jsx`
- `tools/app-shell/src/components/contract-ui/ListView.jsx`

## Test plan
- [ ] Open any list view with date columns — verify green/red dots appear correctly
- [ ] Open a list view with amount columns — verify footer row shows summed totals
- [ ] Verify headers are sentence case (not uppercase), amounts right-aligned
- [ ] Verify ListView title is larger with colored badge