### PR TITLE
Feature ETP-3546: OBUISEL custom HQL selector support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,6 +382,10 @@ When `generate-frontend.js` regenerates React components, custom code (callout t
 - `cli/src/generate-frontend.js` -- emits `GENERATED_START/END` blocks and `CUSTOM_SLOT` placeholders
 - `cli/src/pipeline.js` -- integrates preservation into the regeneration step
 
+## Generated Files Policy
+
+**NEVER manually edit generated output files** (e.g., files in `artifacts/*/generated/`). All fixes must be made at the **pipeline level** — generators (`cli/src/generate-*.js`), extractors (`cli/src/extract-*.js`), or shared components (`tools/app-shell/src/`) — so they apply to ALL windows, not just the current one. Generated files are outputs, not sources.
+
 ## Testing
 
 - **Contract tests (Node.js):** Run against JSON contract in Schema Forge. No backend needed. Cover field presence, types, visibility, searchable filters.

--- a/docs/plans/completed/2026-03-14/fix-write-operations.md
+++ b/docs/plans/completed/2026-03-14/fix-write-operations.md
@@ -1,0 +1,224 @@
+# Plan: Fix Broken Write Operations (POST, PUT, PATCH) in NEO Headless
+
+**Status:** Pending
+**Ticket:** ETP-3546
+**Severity:** Critical — all write operations are broken
+**Created:** 2026-03-13
+
+## Problem Summary
+
+All write operations (POST, PUT, PATCH) in `NeoServlet.handleDefault()` fail with `JSONObject["data"] not found`.
+
+### Root Cause
+
+1. Client sends flat JSON: `{"deliveryNotes": "test"}`
+2. `NeoFieldFilter.filterWriteRequest()` processes top-level keys (keeps only writable fields)
+3. Filtered flat body is passed as string to `DefaultJsonDataService.update()` / `.add()`
+4. Internally, `DefaultJsonDataService.getContentAsJSON(content)` does `jsonObject.get("data")` → **crash** — no `"data"` wrapper exists
+5. Even if client sends `{"data": {...}}`, the filter strips `data` key (not a configured field)
+
+### What Works vs What's Broken
+
+| Operation | Status | Notes |
+|-----------|--------|-------|
+| GET (list + byId) | OK | |
+| DELETE | OK | No body needed |
+| 405 on disabled methods | OK | |
+| **POST** | **BROKEN** | `JSONObject["data"] not found` |
+| **PUT** | **BROKEN** | Same error |
+| **PATCH** | **BROKEN** | Same error |
+
+### Additional Issue: PUT vs PATCH Are Identical
+
+Both share the exact same code path (lines 625-634) — both call `jsonService.update()`. No semantic difference. Both would do partial updates. Decision: keep both as partial updates (documented below in Step 6).
+
+## Key Files
+
+| File | Role | Lines |
+|------|------|-------|
+| `modules/com.etendoerp.go/.../NeoServlet.java` | Core fix location | 628-665 |
+| `modules/com.etendoerp.go/.../NeoFieldFilter.java` | Filter strips `data` key | 177-189 |
+| `modules_core/.../DefaultJsonDataService.java` | Expects `{"data": {...}}` format | 1172-1182 |
+| `modules_core/.../JsonConstants.java` | Constants: `DATA`, `ENTITYNAME`, `ID` | Reference |
+
+## Implementation Steps
+
+### Step 1: Add `wrapForSmartclient()` helper in NeoServlet
+
+Add a private method near `handleDefault()` (~line 677):
+
+```java
+private String wrapForSmartclient(JSONObject body, String dalEntityName, String recordId)
+    throws JSONException {
+  if (body == null) {
+    body = new JSONObject();
+  }
+  body.put(JsonConstants.ENTITYNAME, dalEntityName);  // "_entityName"
+  if (recordId != null) {
+    body.put(JsonConstants.ID, recordId);              // "id"
+  }
+  JSONObject wrapper = new JSONObject();
+  wrapper.put(JsonConstants.DATA, body);               // "data"
+  return wrapper.toString();
+}
+```
+
+### Step 2: Fix POST case (lines 644-648)
+
+```java
+// Before (broken):
+case "POST": {
+  JSONObject filteredBody = fieldFilter.filterWriteRequest(context.getRequestBody());
+  result = jsonService.add(params, filteredBody != null ? filteredBody.toString() : "{}");
+  break;
+}
+
+// After (fixed):
+case "POST": {
+  JSONObject filteredBody = fieldFilter.filterWriteRequest(context.getRequestBody());
+  String wrappedBody = wrapForSmartclient(filteredBody, dalEntityName, null);
+  result = jsonService.add(params, wrappedBody);
+  break;
+}
+```
+
+Note: `recordId` is `null` for POST — no `id` injected, system auto-generates.
+
+### Step 3: Fix PUT/PATCH case (lines 650-655)
+
+```java
+// Before (broken):
+case "PUT":
+case "PATCH": {
+  JSONObject filteredBody = fieldFilter.filterWriteRequest(context.getRequestBody());
+  result = jsonService.update(params, filteredBody != null ? filteredBody.toString() : "{}");
+  break;
+}
+
+// After (fixed):
+case "PUT":
+case "PATCH": {
+  JSONObject filteredBody = fieldFilter.filterWriteRequest(context.getRequestBody());
+  String wrappedBody = wrapForSmartclient(filteredBody, dalEntityName, context.getRecordId());
+  result = jsonService.update(params, wrappedBody);
+  break;
+}
+```
+
+### Step 4: Add recordId validation for PUT/PATCH
+
+Before the switch statement (~line 639):
+
+```java
+if (("PUT".equals(context.getHttpMethod()) || "PATCH".equals(context.getHttpMethod()))
+    && context.getRecordId() == null) {
+  return NeoResponse.error(HttpServletResponse.SC_BAD_REQUEST,
+      "Record ID required in URL for " + context.getHttpMethod() + " requests");
+}
+```
+
+### Step 5: Add validation — POST should not have recordId in URL
+
+```java
+if ("POST".equals(context.getHttpMethod()) && context.getRecordId() != null) {
+  return NeoResponse.error(HttpServletResponse.SC_BAD_REQUEST,
+      "POST (create) should not include a record ID in the URL. Use PUT or PATCH to update.");
+}
+```
+
+### Step 6: PUT vs PATCH semantics — decision
+
+**Decision: Keep both as partial updates.** Rationale:
+
+- OBDal does not easily support "set all non-provided fields to null" without breaking mandatory fields, defaults, and audit columns
+- Most modern APIs (including Etendo's own Smartclient) treat both as partial updates
+- The only future enhancement worth considering: PUT could validate that all writable fields are present (validation-only, same underlying update)
+
+Document this decision with a code comment in the PUT/PATCH case block.
+
+### Step 7: Improve error handling for write responses
+
+After `jsonService.add()`/`.update()` (~line 665), parse and check for errors:
+
+```java
+JSONObject responseJson = new JSONObject(result);
+JSONObject resp = responseJson.optJSONObject("response");
+if (resp != null) {
+  int status = resp.optInt("status", 0);
+  if (status == -1) {  // RPCREQUEST_STATUS_FAILURE
+    String errorMsg = resp.optString("error", "Unknown error");
+    return NeoResponse.error(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, errorMsg);
+  }
+  if (status == -4) {  // RPCREQUEST_STATUS_VALIDATION_ERROR
+    return NeoResponse.error(HttpServletResponse.SC_BAD_REQUEST, responseJson);
+  }
+}
+```
+
+### Step 8: Filter write response bodies
+
+POST/PUT/PATCH responses contain the full saved record. Apply the same field filter used for GET:
+
+```java
+if ("POST".equals(context.getHttpMethod()) || "PUT".equals(context.getHttpMethod())
+    || "PATCH".equals(context.getHttpMethod())) {
+  fieldFilter.filterGetResponse(responseJson);
+}
+```
+
+### Step 9: Defensive handling in NeoFieldFilter
+
+If a client sends already-wrapped `{"data": {...}}`, handle it gracefully in `filterWriteRequest()`:
+
+```java
+public JSONObject filterWriteRequest(JSONObject requestBody) {
+  if (!active || requestBody == null) {
+    return requestBody;
+  }
+  try {
+    // If client sent already-wrapped Smartclient format, unwrap first
+    if (requestBody.has("data") && !writableFields.contains("data")) {
+      JSONObject inner = requestBody.optJSONObject("data");
+      if (inner != null) {
+        filterRecord(inner, writableFields);
+        return inner;  // Return unwrapped, NeoServlet will re-wrap
+      }
+    }
+    filterRecord(requestBody, writableFields);
+  } catch (Exception e) {
+    log.error("Error filtering write request: {}", e.getMessage(), e);
+  }
+  return requestBody;
+}
+```
+
+### Step 10: Write integration tests
+
+New file: `NeoServletWriteTest.java` (pattern: follow `NeoServletTabFilterTest.java`).
+
+| Test | What it verifies |
+|------|-----------------|
+| POST creates a new record | Flat JSON → 200, record exists in DB |
+| PUT/PATCH updates existing record | Create → update → verify changed fields |
+| POST with missing required fields | Appropriate validation error |
+| PUT/PATCH without recordId in URL | 400 error |
+| POST with recordId in URL | 400 error |
+| Write with field filter active | Read-only fields in body are stripped |
+| Write response filtering | Response only contains included fields |
+| PATCH single field | Only that field changes, others unchanged |
+
+## File Changes Summary
+
+| File | Change |
+|------|--------|
+| `NeoServlet.java` | Add `wrapForSmartclient()`, fix POST/PUT/PATCH cases, add validation guards, error handling, response filtering |
+| `NeoFieldFilter.java` | Handle pre-wrapped `data` input defensively |
+| `NeoServletWriteTest.java` | New integration test file |
+
+## Risks and Considerations
+
+1. **`_entityName` format:** Must be DAL entity name (e.g., `"OrderHeader"` not `"C_Order"`). Already what line 589 puts in params.
+2. **FK fields:** Clients may send FK as IDs or objects — `DefaultJsonDataService` handles both via `JsonToDataConverter`.
+3. **Mandatory fields:** `DefaultJsonDataService` validates via `fromJsonConverter.hasErrors()`. Step 7 surfaces these.
+4. **Audit columns:** OBDal auto-sets `creationDate`, `updated`, etc. Should be system/read-only, stripped by filter.
+5. **Core bug note:** `DefaultJsonDataService` line 1048 has `jsonObject.put(ID, parameters.containsKey(ID))` — puts boolean instead of value. NOT our bug, but means we MUST inject `id` ourselves (can't rely on fallback).

--- a/docs/plans/defaults-endpoint.md
+++ b/docs/plans/defaults-endpoint.md
@@ -47,41 +47,37 @@ User interacts → POST /callout (existing endpoint)
 - `NeoOpenAPIEndpoint.java` — OpenAPI documentation
 - `useEntity.js` — handleNew fetches defaults async (best-effort)
 
-### Phase 2: Real Sequence Preview — PENDING
+### Phase 2: Reuse Etendo Utilities (Sequence + SQL + Preferences) — IN PROGRESS
 
-**Current state:** Returns `<auto>` placeholder for DocumentNo fields.
+**Approach:** Instead of reimplementing, delegate to Etendo's existing static utility methods.
+
+**Key insight:** `FormInitializationComponent` is too coupled to HTTP, but the utilities it calls internally are all `public static` and callable from NEO:
+
+| Method | What it does | Dependency |
+|--------|-------------|------------|
+| `Utility.getDefault()` | Resolves literals, preferences, context vars, comma fallbacks | `VariablesSecureApp` |
+| `Utility.parseContext()` | Replaces `@...@` placeholders (inline or parameterized) | `VariablesSecureApp` |
+| `Utility.getDocumentNo()` | Next document number (preview with `updateNext=false`) | Window/table/doctype context |
+| `Utility.getPreference()` | User preferences per field | `VariablesSecureApp` |
+| `UIDefinition.getDefaultValueFromSQLExpression()` | Executes `@SQL=SELECT...` with parameter binding | `Field` object, `VariablesSecureApp` |
+| `SequenceUtils.isSequence()` | Detects sequence columns | `Column` object |
 
 **What needs to be done:**
-- Integrate `Utility.getDocumentNo()` with `updateNext=false` to get the real next number without consuming it
-- Requires: document type context (C_DocType_ID / C_DocTypeTarget_ID) which may not be known at init time
-- For columns with `isUseAutomaticSequence()`, use `NextSequenceValue.getInstance().generateNextSequenceValue()` in preview mode
+1. Build a `VariablesSecureApp` from `OBContext` (NEO already has JWT-authenticated context)
+2. Replace `resolveFieldDefault()` manual logic with `Utility.getDefault()` delegation
+3. Replace `resolveSequencePreview()` with `Utility.getDocumentNo(..., updateNext=false)`
+4. Add SQL expression support via `Utility.parseContext()` + direct SQL execution
+5. Add preference support (comes free with `Utility.getDefault()`)
 
 **Key files to modify:**
-- `NeoDefaultsService.java` — `resolveSequencePreview()` method (currently returns `<auto>`)
+- `NeoDefaultsService.java` — refactor to delegate to Etendo utilities
 
-**Reference implementation:**
-- `UIDefinition.java` lines 178-213 — sequence detection and DocumentNo generation
-- `Utility.java` line 834 — `getDocumentNo()` signature
+**Reference classes (Etendo core, read-only):**
+- `Utility.java` — `getDefault()` (line 647), `parseContext()` (line 769), `getDocumentNo()` (line 834)
+- `UIDefinition.java` — `getDefaultValueFromSQLExpression()` (line 290)
+- `SequenceUtils.java` — `isSequence()` (line 81)
 
-### Phase 3: SQL Expression Defaults — PENDING
-
-**Current state:** `@SQL=SELECT...` expressions are skipped and added to `metadata.unresolvedFields`.
-
-**What needs to be done:**
-- Parse SQL after `@SQL=` prefix
-- Extract `@parameter@` placeholders, resolve from context vars or already-resolved defaults
-- Execute via `PreparedStatement` on `OBDal.getInstance().getConnection(false)`
-- Two-pass resolution: first resolve non-SQL defaults, then SQL defaults (which may reference other defaults)
-
-**Key reference:**
-- `UIDefinition.java` lines 290-333 — `getDefaultValueFromSQLExpression()`
-
-**Example:**
-```
-@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM C_OrderLine WHERE C_Order_ID=@C_Order_ID@
-```
-
-### Phase 4: Callout Cascade — PENDING
+### Phase 3: Callout Cascade — PENDING
 
 **Current state:** Defaults are resolved but callouts triggered by those defaults are not executed.
 

--- a/docs/plans/obuisel-selectors.md
+++ b/docs/plans/obuisel-selectors.md
@@ -1,0 +1,30 @@
+# Plan: OBUISEL Selector Support in NEO Headless
+
+**Created:** 2026-03-13
+**Status:** Pending
+**ETP:** TBD
+
+## Problem
+
+NEO Headless selector endpoint (`/sws/neo/{spec}/{entity}/selectors/{column}`) currently only supports **simple selectors** (TableDir, Table). OBUISEL selectors return `{"error":{"message":"Custom HQL selectors not supported yet","status":400}}`.
+
+## Impact
+
+Many FK fields use OBUISEL (Warehouse, Business Partner, Project, Asset, Cost Center, User Dimensions). These dropdowns can't be populated from the API yet.
+
+## Root Cause
+
+OBUISEL selectors use custom HQL/SQL defined in `OBUISEL_Selector` table with complex filtering, paging, and column definitions. The current `NeoSelectorService` only handles TableDir and Table reference types.
+
+## Implementation Plan
+
+1. In `NeoSelectorService.java`, add a handler for OBUISEL reference type
+2. Read `OBUISEL_Selector` config (HQL, table, display column, value column)
+3. Execute the HQL with proper OBContext (org, client filtering)
+4. Support `?q=` search param for typeahead filtering
+5. Support `?_startRow=&_endRow=` for pagination
+6. Return same `{ items: [{ id, label }], totalCount }` format as simple selectors
+
+## Workaround
+
+Until implemented, use mock/fallback data for OBUISEL selectors in the frontend.

--- a/docs/plans/obuisel-selectors.md
+++ b/docs/plans/obuisel-selectors.md
@@ -1,8 +1,8 @@
 # Plan: OBUISEL Selector Support in NEO Headless
 
 **Created:** 2026-03-13
-**Status:** Pending
-**ETP:** TBD
+**Completed:** 2026-03-14
+**Status:** Completed
 
 ## Problem
 
@@ -24,6 +24,19 @@ OBUISEL selectors use custom HQL/SQL defined in `OBUISEL_Selector` table with co
 4. Support `?q=` search param for typeahead filtering
 5. Support `?_startRow=&_endRow=` for pagination
 6. Return same `{ items: [{ id, label }], totalCount }` format as simple selectors
+
+## Implementation Notes
+
+### Changes made
+
+**NeoSelectorService.java:**
+- Added `customHql` and `entityAlias` fields to `SelectorMeta` inner class
+- In `resolveObuiselSelector()`: when `isCustomQuery` is true, captures the full HQL via `Selector.getHQL()` and the alias via `Selector.getEntityAlias()` (defaults to "e")
+- In `executeRichQuery()`: replaced the 400 error block with a delegation to `executeCustomHqlQuery()` when custom HQL is present. If `isCustomQuery` is true but no HQL is defined, falls through to the standard entity-based query (graceful degradation)
+- New method `executeCustomHqlQuery()`: uses `Session.createQuery()` with the full custom HQL as the FROM clause base. Appends WHERE clause filters, validation filters, readable org restrictions, and search filters using the selector's entity alias. Executes count and data queries with pagination. Maps results using the same grid field resolution as standard rich selectors.
+
+**NeoOpenAPIEndpoint.java:**
+- Replaced vague `createObjectSchema("Selector query results")` with `createSelectorQueryResponseSchema()` that documents the actual response format: `items` (array with id, label, plus grid fields), `columns` (array with name, label, sortNo), `totalCount`, `limit`, `offset`, `hasMore`
 
 ## Workaround
 


### PR DESCRIPTION
## Summary

- Implement custom HQL selector execution in `NeoSelectorService.java` — replaces the 400 error with actual query execution using `Session.createQuery()` for selectors with custom HQL definitions
- Add proper OpenAPI response schema for selector query endpoint in `NeoOpenAPIEndpoint.java` — documents items, columns, pagination fields
- Update OBUISEL selectors plan doc to completed status

## Changes

**NeoSelectorService.java** (Etendo Go module — committed separately):
- Added `customHql` and `entityAlias` fields to `SelectorMeta`
- Captures `Selector.getHQL()` and `Selector.getEntityAlias()` when `isCustomQuery` is true
- New `executeCustomHqlQuery()` method: uses full HQL as FROM clause, appends WHERE/validation/org/search filters, handles count + pagination via Hibernate Session
- Graceful degradation: if custom query flag is set but no HQL defined, falls through to standard entity-based query

**NeoOpenAPIEndpoint.java** (Etendo Go module):
- New `createSelectorQueryResponseSchema()` method with proper schema: items (id, label + grid fields), columns (name, label, sortNo), totalCount, limit, offset, hasMore

## Test plan

- [ ] Query a custom HQL selector (e.g., Warehouse selector) — should return items instead of 400 error
- [ ] Verify search filtering works across searchable properties
- [ ] Verify pagination (limit/offset) works correctly
- [ ] Verify selectors without custom HQL still work (standard rich query path)
- [ ] Verify simple selectors (TableDir, Table) are unaffected
- [ ] Check OpenAPI spec at `/etendo/ws/com.etendoerp.openapi.openAPIController?tag=EtendoGo` shows proper selector response schema