### PR TITLE
Feature ETP-3546: Document epic branch model and restrict agent merge scope

### DIFF
--- a/docs/branch-workflow.md
+++ b/docs/branch-workflow.md
@@ -30,11 +30,31 @@ On rejection: DEV fixes in the SAME worktree, cycle restarts from the rejecting 
 - Independent tasks → parallel worktrees
 - Within a task → sequential pipeline
 
-## PR Rules (feature → develop)
+## Epic Branch Model (MANDATORY)
 
-**The only GitHub PR is feature → develop**, created when the feature is complete. The user controls when to push and create this PR.
+All feature work branches from and merges back to the **current epic branch**. The epic branch is the integration point for related features.
 
-- **NEVER target `main` directly.** The highest allowed target is `develop`.
+```
+develop  (protected — manual merge only)
+  └── epic/ETP-3504  (current epic)
+        ├── feature/ETP-XXXX  →  PR targets epic/ETP-3504
+        ├── feature/ETP-YYYY  →  PR targets epic/ETP-3504
+        └── ...
+```
+
+### Hierarchy and merge rules
+
+| Merge | Who | How |
+|-------|-----|-----|
+| `feature → epic` | Agents (via PR) | Automated — agents create PRs targeting the epic branch |
+| `epic → develop` | **Human only** | Manual, under supervision — agents **NEVER** do this |
+| `develop → main` | **Human only** | Manual — agents **NEVER** do this |
+
+### Key rules
+
+- **Features branch FROM the current epic** and PRs **target the epic**, not `develop`.
+- **Agents NEVER merge to `develop` or `main`.** This is always a manual, supervised operation.
+- **NEVER target `main` directly.** The highest allowed PR target for agents is the current epic branch.
 - **NEVER use squash merge.** Always use regular merge (`--merge`) to preserve full commit history. Squash discards individual commits and breaks traceability.
 - **Always assign the PR to the current user.**
 - **GitHub usernames must be stored in auto-memory** (not committed). On first interaction, look up the current user's GitHub username and any known reviewers, and save them to auto-memory for future use. **CRITICAL:** Before ANY GitHub operation, read the `github-usernames.md` file from the auto-memory directory (`~/.claude/projects/.../memory/github-usernames.md` — use the absolute path, NEVER a path relative to the project root). NEVER assume, hardcode, or guess a username — if no username is stored, ask the user and save it immediately.
@@ -46,7 +66,7 @@ When the user requests a new task while on a feature branch, the coordinator MUS
 2. **Does it depend on changes in the current feature branch?**
 
 Based on the answer:
-- **Independent task →** Create new branch from `develop` (with `git pull` first to update)
+- **Independent task →** Create new branch from the current epic (with `git pull` first to update)
 - **Dependent task →** Create new branch from the current feature branch
 
 ## Branch Safety (MANDATORY)


### PR DESCRIPTION
## Summary
- Document epic branch model in `docs/branch-workflow.md`
- Features branch from and PR back to the current epic branch
- Agents NEVER merge to `develop` or `main` — manual only under human supervision

## Test plan
- [ ] Verify branch-workflow.md renders correctly
- [ ] Confirm agents follow the new merge hierarchy