### PR TITLE
Feature ETP-3616: OAuth2 Admin UI for MCP client management

### DIFF
--- a/cli/test/wiring-completeness.test.js
+++ b/cli/test/wiring-completeness.test.js
@@ -27,7 +27,7 @@ const allMenuItems = menu.menu.flatMap(g => g.items.map(i => i.name));
 const SPECIAL_PAGES = new Set([
   'dashboard', 'sales', 'purchases', 'accounting', 'inventory', 'contacts',
   'crm', 'hr', 'projects', 'reports', 'onboarding', 'smart-scan', 'preview',
-  'report-viewer-purchases', 'report-viewer-finance',
+  'report-viewer-purchases', 'report-viewer-finance', 'oauth2-clients',
 ]);
 
 const entityWindows = allMenuItems.filter(name => !SPECIAL_PAGES.has(name));

--- a/tools/app-shell/src/App.jsx
+++ b/tools/app-shell/src/App.jsx
@@ -27,6 +27,7 @@ import ArtifactViewerPage from './pages/ArtifactViewerPage.jsx';
 
 const OnboardingPage = lazy(() => import('./pages/OnboardingPage.jsx'));
 const SmartScanPage = lazy(() => import('./pages/SmartScanPage.jsx'));
+const OAuth2ClientsPage = lazy(() => import('./pages/OAuth2ClientsPage.jsx'));
 
 function detectBasePath() {
   const path = window.location.pathname;
@@ -149,6 +150,7 @@ function AppRoutes({ menuGroups, windowMap }) {
         <Route path="hr" element={<HrPage />} />
         <Route path="projects" element={<ProjectsPage />} />
         <Route path="smart-scan" element={<Suspense fallback={<div className="p-8 text-muted-foreground">Loading...</div>}><SmartScanPage /></Suspense>} />
+        <Route path="oauth2-clients" element={<Suspense fallback={<div className="p-8 text-muted-foreground">Loading...</div>}><OAuth2ClientsPage /></Suspense>} />
         <Route path="artifacts" element={<ArtifactViewerPage />} />
         <Route path="artifacts/:windowName" element={<ArtifactViewerPage />} />
         <Route

--- a/tools/app-shell/src/components/OAuth2ClientDialog.jsx
+++ b/tools/app-shell/src/components/OAuth2ClientDialog.jsx
@@ -1,0 +1,372 @@
+import { useState, useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { createClient, updateClient } from '@/lib/oauth2Api.js';
+import { toast } from 'sonner';
+import { Copy, AlertTriangle, Loader2 } from 'lucide-react';
+
+const ALL_SCOPES = ['neo:read', 'neo:write', 'neo:process', 'neo:report', 'neo:*'];
+const GRANULAR_SCOPES = ALL_SCOPES.filter((s) => s !== 'neo:*');
+
+/**
+ * Dialog for creating or editing an OAuth2 client.
+ *
+ * Create mode: client prop is null. On success, shows SecretRevealDialog.
+ * Edit mode: client prop is an existing client object.
+ */
+export default function OAuth2ClientDialog({ open, onOpenChange, client, apiFetch, onSuccess }) {
+  const isEdit = !!client;
+
+  const [name, setName] = useState('');
+  const [adUserId, setAdUserId] = useState('');
+  const [adRoleId, setAdRoleId] = useState('');
+  const [scopes, setScopes] = useState([]);
+  const [isActive, setIsActive] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+
+  // Secret reveal state (only used after create)
+  const [revealData, setRevealData] = useState(null);
+
+  // Reset form when dialog opens or client changes
+  useEffect(() => {
+    if (open) {
+      if (client) {
+        setName(client.name || '');
+        setAdUserId(client.adUserId || '');
+        setAdRoleId(client.adRoleId || '');
+        setScopes(client.scopes || []);
+        setIsActive(client.isActive !== false);
+      } else {
+        setName('');
+        setAdUserId('');
+        setAdRoleId('');
+        setScopes([]);
+        setIsActive(true);
+      }
+      setRevealData(null);
+    }
+  }, [open, client]);
+
+  const hasWildcard = scopes.includes('neo:*');
+
+  const toggleScope = (scope) => {
+    if (scope === 'neo:*') {
+      // Toggle wildcard: if already set, clear all; otherwise set wildcard + all granular
+      if (hasWildcard) {
+        setScopes([]);
+      } else {
+        setScopes([...ALL_SCOPES]);
+      }
+    } else {
+      if (hasWildcard) return; // granular scopes locked when wildcard is on
+      setScopes((prev) =>
+        prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope]
+      );
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!name.trim()) {
+      toast.error('Name is required');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const payload = {
+        name: name.trim(),
+        adUserId: adUserId.trim() || undefined,
+        adRoleId: adRoleId.trim() || undefined,
+        scopes,
+        isActive,
+      };
+
+      if (isEdit) {
+        await updateClient(apiFetch, client.id, payload);
+        toast.success('Client updated');
+        onOpenChange(false);
+        onSuccess?.();
+      } else {
+        const result = await createClient(apiFetch, payload);
+        if (result.clientSecret) {
+          setRevealData({
+            clientId: result.clientId,
+            clientSecret: result.clientSecret,
+          });
+        } else {
+          toast.success('Client created');
+          onOpenChange(false);
+          onSuccess?.();
+        }
+      }
+    } catch (err) {
+      toast.error(isEdit ? 'Failed to update client' : 'Failed to create client', {
+        description: err.message,
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCloseReveal = () => {
+    setRevealData(null);
+    onOpenChange(false);
+    onSuccess?.();
+  };
+
+  // If we have reveal data, show the secret reveal dialog instead
+  if (revealData) {
+    return (
+      <SecretRevealDialog
+        open={open}
+        onClose={handleCloseReveal}
+        clientId={revealData.clientId}
+        clientSecret={revealData.clientSecret}
+      />
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>{isEdit ? 'Edit Client' : 'Create OAuth2 Client'}</DialogTitle>
+            <DialogDescription>
+              {isEdit
+                ? 'Update the client configuration. Secret is not changed here.'
+                : 'Create a new OAuth2 client for MCP agent authentication.'}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-4 py-4">
+            {/* Name */}
+            <div className="grid gap-2">
+              <Label htmlFor="client-name">Name *</Label>
+              <Input
+                id="client-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="My MCP Agent"
+                required
+              />
+            </div>
+
+            {/* Etendo User ID */}
+            <div className="grid gap-2">
+              <Label htmlFor="client-user-id">Etendo User ID</Label>
+              <Input
+                id="client-user-id"
+                value={adUserId}
+                onChange={(e) => setAdUserId(e.target.value)}
+                placeholder="e.g. 100"
+                className="font-mono text-sm"
+              />
+            </div>
+
+            {/* Etendo Role ID */}
+            <div className="grid gap-2">
+              <Label htmlFor="client-role-id">Etendo Role ID</Label>
+              <Input
+                id="client-role-id"
+                value={adRoleId}
+                onChange={(e) => setAdRoleId(e.target.value)}
+                placeholder="e.g. 0"
+                className="font-mono text-sm"
+              />
+            </div>
+
+            {/* Scopes */}
+            <div className="grid gap-2">
+              <Label>Scopes</Label>
+              <div className="grid grid-cols-2 gap-2">
+                {ALL_SCOPES.map((scope) => {
+                  const isGranular = scope !== 'neo:*';
+                  const checked = scopes.includes(scope) || (isGranular && hasWildcard);
+                  const disabled = isGranular && hasWildcard;
+
+                  return (
+                    <label
+                      key={scope}
+                      className={`flex items-center gap-2 rounded-md border px-3 py-2 text-sm cursor-pointer transition-colors ${
+                        checked
+                          ? 'border-primary bg-primary/5'
+                          : 'border-input hover:border-primary/50'
+                      } ${disabled ? 'opacity-60 cursor-not-allowed' : ''}`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        disabled={disabled}
+                        onChange={() => toggleScope(scope)}
+                        className="rounded border-input"
+                      />
+                      <span className={`font-mono ${scope === 'neo:*' ? 'font-semibold' : ''}`}>
+                        {scope}
+                      </span>
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+
+            {/* Active toggle */}
+            <div className="flex items-center justify-between">
+              <Label htmlFor="client-active">Active</Label>
+              <Switch
+                id="client-active"
+                checked={isActive}
+                onCheckedChange={setIsActive}
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={submitting}>
+              {submitting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              {isEdit ? 'Save Changes' : 'Create Client'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Dialog shown once after client creation, displaying the generated secret.
+ * The secret cannot be retrieved again after closing.
+ */
+export function SecretRevealDialog({ open, onClose, clientId, clientSecret }) {
+  const [copied, setCopied] = useState(null);
+
+  const copyToClipboard = async (text, label) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(label);
+      toast.success(`${label} copied to clipboard`);
+      setTimeout(() => setCopied(null), 2000);
+    } catch {
+      toast.error('Failed to copy to clipboard');
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Client Created Successfully</DialogTitle>
+          <DialogDescription>
+            Save these credentials now. The secret will not be shown again.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          <div className="flex items-center gap-2 rounded-md bg-amber-500/10 border border-amber-500/30 px-3 py-2 text-sm text-amber-600 dark:text-amber-400">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            <span>This secret will not be shown again. Copy it now.</span>
+          </div>
+
+          {/* Client ID */}
+          <div className="grid gap-1.5">
+            <Label className="text-xs text-muted-foreground">Client ID</Label>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 rounded-md bg-muted px-3 py-2 text-sm font-mono break-all">
+                {clientId}
+              </code>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="shrink-0"
+                onClick={() => copyToClipboard(clientId, 'Client ID')}
+              >
+                <Copy className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          {/* Client Secret */}
+          <div className="grid gap-1.5">
+            <Label className="text-xs text-muted-foreground">Client Secret</Label>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 rounded-md bg-muted px-3 py-2 text-sm font-mono break-all">
+                {clientSecret}
+              </code>
+              <Button
+                type="button"
+                variant="outline"
+                size="icon"
+                className="shrink-0"
+                onClick={() => copyToClipboard(clientSecret, 'Secret')}
+              >
+                <Copy className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button onClick={onClose}>
+            I have saved the secret
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Confirmation dialog built on top of shadcn Dialog.
+ * Used for destructive actions (delete, regenerate, revoke).
+ */
+export function ConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'default',
+  loading = false,
+  onConfirm,
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)} disabled={loading}>
+            {cancelLabel}
+          </Button>
+          <Button
+            type="button"
+            variant={variant === 'destructive' ? 'destructive' : 'default'}
+            onClick={onConfirm}
+            disabled={loading}
+          >
+            {loading && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            {confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/tools/app-shell/src/lib/oauth2Api.js
+++ b/tools/app-shell/src/lib/oauth2Api.js
@@ -1,0 +1,113 @@
+/**
+ * OAuth2 Client Management API
+ *
+ * Provides functions to interact with the OAuth2 backend endpoints at /sws/oauth2/*.
+ * All functions receive an `apiFetch` instance (from createApiFetch in auth/api.js)
+ * which handles Bearer token injection and 401 redirects.
+ */
+
+/**
+ * List all OAuth2 clients.
+ * @param {Function} apiFetch - Fetch wrapper from createApiFetch
+ * @returns {Promise<Array>} Array of client objects
+ */
+export async function listClients(apiFetch) {
+  const res = await apiFetch('/sws/oauth2/clients');
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(text || `Failed to list clients: ${res.status}`);
+  }
+  return res.json();
+}
+
+/**
+ * Create a new OAuth2 client.
+ * @param {Function} apiFetch - Fetch wrapper from createApiFetch
+ * @param {Object} params - Client creation parameters
+ * @param {string} params.name - Display name
+ * @param {string} params.adUserId - Etendo AD_User ID
+ * @param {string} params.adRoleId - Etendo AD_Role ID
+ * @param {string[]} params.scopes - Granted scopes
+ * @param {boolean} params.isActive - Whether the client is active
+ * @returns {Promise<Object>} Created client with clientSecret (plaintext, shown once)
+ */
+export async function createClient(apiFetch, { name, adUserId, adRoleId, scopes, isActive }) {
+  const res = await apiFetch('/sws/oauth2/clients', {
+    method: 'POST',
+    body: JSON.stringify({ name, adUserId, adRoleId, scopes, isActive }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(text || `Failed to create client: ${res.status}`);
+  }
+  return res.json();
+}
+
+/**
+ * Update an existing OAuth2 client.
+ * @param {Function} apiFetch - Fetch wrapper from createApiFetch
+ * @param {string} id - Client ID
+ * @param {Object} params - Fields to update
+ * @returns {Promise<Object>} Updated client
+ */
+export async function updateClient(apiFetch, id, { name, adUserId, adRoleId, scopes, isActive }) {
+  const res = await apiFetch(`/sws/oauth2/clients/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify({ name, adUserId, adRoleId, scopes, isActive }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(text || `Failed to update client: ${res.status}`);
+  }
+  return res.json();
+}
+
+/**
+ * Delete an OAuth2 client.
+ * @param {Function} apiFetch - Fetch wrapper from createApiFetch
+ * @param {string} id - Client ID
+ * @returns {Promise<void>}
+ */
+export async function deleteClient(apiFetch, id) {
+  const res = await apiFetch(`/sws/oauth2/clients/${id}`, {
+    method: 'DELETE',
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(text || `Failed to delete client: ${res.status}`);
+  }
+}
+
+/**
+ * Regenerate the client secret. Returns the new plaintext secret (shown once).
+ * @param {Function} apiFetch - Fetch wrapper from createApiFetch
+ * @param {string} id - Client ID
+ * @returns {Promise<Object>} Object with clientSecret field
+ */
+export async function regenerateSecret(apiFetch, id) {
+  const res = await apiFetch(`/sws/oauth2/clients/${id}/regenerate-secret`, {
+    method: 'PUT',
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(text || `Failed to regenerate secret: ${res.status}`);
+  }
+  return res.json();
+}
+
+/**
+ * Revoke all active tokens for a client.
+ * @param {Function} apiFetch - Fetch wrapper from createApiFetch
+ * @param {string} id - Client ID (sent as clientId in body)
+ * @returns {Promise<void>}
+ */
+export async function revokeTokens(apiFetch, id) {
+  const res = await apiFetch('/sws/oauth2/revoke', {
+    method: 'POST',
+    body: JSON.stringify({ clientId: id }),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(text || `Failed to revoke tokens: ${res.status}`);
+  }
+}

--- a/tools/app-shell/src/menu.json
+++ b/tools/app-shell/src/menu.json
@@ -93,7 +93,8 @@
         { "name": "tax", "label": "Taxes" },
         { "name": "uom", "label": "Units of Measure" },
         { "name": "user", "label": "Users" },
-        { "name": "smart-scan", "label": "Smart Scan" }
+        { "name": "smart-scan", "label": "Smart Scan" },
+        { "name": "oauth2-clients", "label": "OAuth2 Clients", "icon": "Shield" }
       ]
     }
   ]

--- a/tools/app-shell/src/pages/OAuth2ClientsPage.jsx
+++ b/tools/app-shell/src/pages/OAuth2ClientsPage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useAuth } from '@/auth/AuthContext.jsx';
 import { createApiFetch } from '@/auth/api.js';
 import { listClients, deleteClient, regenerateSecret, revokeTokens } from '@/lib/oauth2Api.js';
+import OAuth2ClientDialog, { SecretRevealDialog, ConfirmDialog } from '@/components/OAuth2ClientDialog.jsx';
 import { Card, CardContent } from '@/components/ui/card';
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
 import { Badge } from '@/components/ui/badge';
@@ -13,7 +14,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Shield, Plus, RefreshCw, Trash2, Key, MoreHorizontal, Copy, Ban } from 'lucide-react';
+import { Shield, Plus, RefreshCw, Trash2, Key, MoreHorizontal, Copy, Ban, Pencil } from 'lucide-react';
 import { toast } from 'sonner';
 
 function detectBaseUrl() {
@@ -51,42 +52,111 @@ export default function OAuth2ClientsPage() {
     fetchClients();
   }, [fetchClients]);
 
-  const handleDelete = async (client) => {
-    if (!window.confirm(`Delete client "${client.name}"? This cannot be undone.`)) return;
-    try {
-      await deleteClient(apiFetch, client.id);
-      toast.success('Client deleted');
-      fetchClients();
-    } catch (err) {
-      toast.error('Failed to delete client', { description: err.message });
-    }
+  // Create/Edit dialog state
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingClient, setEditingClient] = useState(null);
+
+  // Confirmation dialog state
+  const [confirmState, setConfirmState] = useState({
+    open: false,
+    title: '',
+    description: '',
+    confirmLabel: 'Confirm',
+    variant: 'default',
+    onConfirm: null,
+  });
+  const [confirmLoading, setConfirmLoading] = useState(false);
+
+  // Secret reveal after regenerate
+  const [revealSecret, setRevealSecret] = useState(null);
+
+  const handleCreate = () => {
+    setEditingClient(null);
+    setDialogOpen(true);
   };
 
-  const handleRegenerateSecret = async (client) => {
-    if (!window.confirm(`Regenerate secret for "${client.name}"? The current secret will stop working immediately.`)) return;
-    try {
-      const result = await regenerateSecret(apiFetch, client.id);
-      if (result.clientSecret) {
-        await navigator.clipboard.writeText(result.clientSecret).catch(() => {});
-        toast.success('Secret regenerated and copied to clipboard', {
-          description: 'Store it securely — it will not be shown again.',
-          duration: 10000,
-        });
-      } else {
-        toast.success('Secret regenerated');
-      }
-    } catch (err) {
-      toast.error('Failed to regenerate secret', { description: err.message });
-    }
+  const handleEdit = (client) => {
+    setEditingClient(client);
+    setDialogOpen(true);
   };
 
-  const handleRevokeTokens = async (client) => {
-    try {
-      await revokeTokens(apiFetch, client.id);
-      toast.success('All tokens revoked', { description: `Tokens for "${client.name}" have been invalidated.` });
-    } catch (err) {
-      toast.error('Failed to revoke tokens', { description: err.message });
-    }
+  const handleDelete = (client) => {
+    setConfirmState({
+      open: true,
+      title: `Delete "${client.name}"?`,
+      description:
+        'This will permanently delete the client and revoke all its tokens. This action cannot be undone.',
+      confirmLabel: 'Delete',
+      variant: 'destructive',
+      onConfirm: async () => {
+        setConfirmLoading(true);
+        try {
+          await deleteClient(apiFetch, client.id);
+          toast.success('Client deleted');
+          setConfirmState((s) => ({ ...s, open: false }));
+          fetchClients();
+        } catch (err) {
+          toast.error('Failed to delete client', { description: err.message });
+        } finally {
+          setConfirmLoading(false);
+        }
+      },
+    });
+  };
+
+  const handleRegenerateSecret = (client) => {
+    setConfirmState({
+      open: true,
+      title: `Regenerate secret for "${client.name}"?`,
+      description:
+        'Are you sure? The current secret will be invalidated immediately. Any agents using the old secret will stop working.',
+      confirmLabel: 'Regenerate',
+      variant: 'destructive',
+      onConfirm: async () => {
+        setConfirmLoading(true);
+        try {
+          const result = await regenerateSecret(apiFetch, client.id);
+          setConfirmState((s) => ({ ...s, open: false }));
+          if (result.clientSecret) {
+            setRevealSecret({
+              clientId: result.clientId || client.clientId,
+              clientSecret: result.clientSecret,
+            });
+          } else {
+            toast.success('Secret regenerated');
+          }
+        } catch (err) {
+          toast.error('Failed to regenerate secret', { description: err.message });
+        } finally {
+          setConfirmLoading(false);
+        }
+      },
+    });
+  };
+
+  const handleRevokeTokens = (client) => {
+    setConfirmState({
+      open: true,
+      title: `Revoke tokens for "${client.name}"?`,
+      description:
+        'This will invalidate all active tokens for this client. Agents will need to re-authenticate.',
+      confirmLabel: 'Revoke All',
+      variant: 'destructive',
+      onConfirm: async () => {
+        setConfirmLoading(true);
+        try {
+          await revokeTokens(apiFetch, client.id);
+          toast.success('All tokens revoked', {
+            description: `Tokens for "${client.name}" have been invalidated.`,
+          });
+          setConfirmState((s) => ({ ...s, open: false }));
+        } catch (err) {
+          toast.error('Failed to revoke tokens', { description: err.message });
+        } finally {
+          setConfirmLoading(false);
+        }
+      },
+    });
   };
 
   const copyClientId = async (clientId) => {
@@ -96,11 +166,6 @@ export default function OAuth2ClientsPage() {
     } catch {
       toast.error('Failed to copy');
     }
-  };
-
-  const handleCreate = () => {
-    // D3 will add the create/edit dialog — for now show a placeholder toast
-    toast.info('Create client dialog coming soon');
   };
 
   return (
@@ -181,7 +246,7 @@ export default function OAuth2ClientsPage() {
                           </Badge>
                         ))}
                         {(!client.scopes || client.scopes.length === 0) && (
-                          <span className="text-xs text-muted-foreground">\u2014</span>
+                          <span className="text-xs text-muted-foreground">{'\u2014'}</span>
                         )}
                       </div>
                     </TableCell>
@@ -198,6 +263,10 @@ export default function OAuth2ClientsPage() {
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
+                          <DropdownMenuItem onClick={() => handleEdit(client)}>
+                            <Pencil className="h-4 w-4 mr-2" />
+                            Edit
+                          </DropdownMenuItem>
                           <DropdownMenuItem onClick={() => handleRegenerateSecret(client)}>
                             <Key className="h-4 w-4 mr-2" />
                             Regenerate Secret
@@ -224,6 +293,39 @@ export default function OAuth2ClientsPage() {
           )}
         </CardContent>
       </Card>
+
+      {/* Create/Edit dialog */}
+      <OAuth2ClientDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        client={editingClient}
+        apiFetch={apiFetch}
+        onSuccess={fetchClients}
+      />
+
+      {/* Confirmation dialog (delete, regenerate, revoke) */}
+      <ConfirmDialog
+        open={confirmState.open}
+        onOpenChange={(v) => {
+          if (!v) setConfirmState((s) => ({ ...s, open: false }));
+        }}
+        title={confirmState.title}
+        description={confirmState.description}
+        confirmLabel={confirmState.confirmLabel}
+        variant={confirmState.variant}
+        loading={confirmLoading}
+        onConfirm={confirmState.onConfirm}
+      />
+
+      {/* Secret reveal after regenerate */}
+      {revealSecret && (
+        <SecretRevealDialog
+          open={!!revealSecret}
+          onClose={() => setRevealSecret(null)}
+          clientId={revealSecret.clientId}
+          clientSecret={revealSecret.clientSecret}
+        />
+      )}
     </div>
   );
 }

--- a/tools/app-shell/src/pages/OAuth2ClientsPage.jsx
+++ b/tools/app-shell/src/pages/OAuth2ClientsPage.jsx
@@ -1,0 +1,229 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useAuth } from '@/auth/AuthContext.jsx';
+import { createApiFetch } from '@/auth/api.js';
+import { listClients, deleteClient, regenerateSecret, revokeTokens } from '@/lib/oauth2Api.js';
+import { Card, CardContent } from '@/components/ui/card';
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Shield, Plus, RefreshCw, Trash2, Key, MoreHorizontal, Copy, Ban } from 'lucide-react';
+import { toast } from 'sonner';
+
+function detectBaseUrl() {
+  const path = window.location.pathname;
+  const webIdx = path.indexOf('/web/');
+  if (webIdx !== -1) return path.substring(0, webIdx);
+  return import.meta.env.VITE_API_BASE || '';
+}
+
+export default function OAuth2ClientsPage() {
+  const { token, logout } = useAuth();
+  const [clients, setClients] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const apiFetch = useMemo(
+    () => createApiFetch(detectBaseUrl(), () => token, logout),
+    [token, logout]
+  );
+
+  const fetchClients = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await listClients(apiFetch);
+      setClients(Array.isArray(data) ? data : []);
+    } catch (err) {
+      console.error('Failed to fetch OAuth2 clients:', err);
+      toast.error('Failed to load clients', { description: err.message });
+      setClients([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [apiFetch]);
+
+  useEffect(() => {
+    fetchClients();
+  }, [fetchClients]);
+
+  const handleDelete = async (client) => {
+    if (!window.confirm(`Delete client "${client.name}"? This cannot be undone.`)) return;
+    try {
+      await deleteClient(apiFetch, client.id);
+      toast.success('Client deleted');
+      fetchClients();
+    } catch (err) {
+      toast.error('Failed to delete client', { description: err.message });
+    }
+  };
+
+  const handleRegenerateSecret = async (client) => {
+    if (!window.confirm(`Regenerate secret for "${client.name}"? The current secret will stop working immediately.`)) return;
+    try {
+      const result = await regenerateSecret(apiFetch, client.id);
+      if (result.clientSecret) {
+        await navigator.clipboard.writeText(result.clientSecret).catch(() => {});
+        toast.success('Secret regenerated and copied to clipboard', {
+          description: 'Store it securely — it will not be shown again.',
+          duration: 10000,
+        });
+      } else {
+        toast.success('Secret regenerated');
+      }
+    } catch (err) {
+      toast.error('Failed to regenerate secret', { description: err.message });
+    }
+  };
+
+  const handleRevokeTokens = async (client) => {
+    try {
+      await revokeTokens(apiFetch, client.id);
+      toast.success('All tokens revoked', { description: `Tokens for "${client.name}" have been invalidated.` });
+    } catch (err) {
+      toast.error('Failed to revoke tokens', { description: err.message });
+    }
+  };
+
+  const copyClientId = async (clientId) => {
+    try {
+      await navigator.clipboard.writeText(clientId);
+      toast.success('Client ID copied');
+    } catch {
+      toast.error('Failed to copy');
+    }
+  };
+
+  const handleCreate = () => {
+    // D3 will add the create/edit dialog — for now show a placeholder toast
+    toast.info('Create client dialog coming soon');
+  };
+
+  return (
+    <div className="space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">OAuth2 Clients</h2>
+          <p className="text-muted-foreground">Manage MCP agent credentials</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="icon" onClick={fetchClients} disabled={loading}>
+            <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
+          </Button>
+          <Button onClick={handleCreate}>
+            <Plus className="h-4 w-4 mr-2" />
+            New Client
+          </Button>
+        </div>
+      </div>
+
+      <Card>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="flex items-center justify-center py-12 text-muted-foreground">
+              <RefreshCw className="h-5 w-5 animate-spin mr-2" />
+              Loading clients...
+            </div>
+          ) : clients.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <Shield className="h-12 w-12 text-muted-foreground/40 mb-4" />
+              <h3 className="text-lg font-medium text-foreground mb-1">No OAuth2 clients</h3>
+              <p className="text-sm text-muted-foreground mb-4">
+                Create a client to allow MCP agents to authenticate with Etendo.
+              </p>
+              <Button onClick={handleCreate}>
+                <Plus className="h-4 w-4 mr-2" />
+                Create First Client
+              </Button>
+            </div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Client ID</TableHead>
+                  <TableHead>User</TableHead>
+                  <TableHead>Role</TableHead>
+                  <TableHead>Scopes</TableHead>
+                  <TableHead>Active</TableHead>
+                  <TableHead className="w-[60px]" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {clients.map((client) => (
+                  <TableRow key={client.id}>
+                    <TableCell className="font-medium">{client.name}</TableCell>
+                    <TableCell>
+                      <button
+                        onClick={() => copyClientId(client.clientId)}
+                        className="inline-flex items-center gap-1.5 font-mono text-xs text-muted-foreground hover:text-foreground transition-colors"
+                        title="Click to copy"
+                      >
+                        {client.clientId?.slice(0, 12)}...
+                        <Copy className="h-3 w-3" />
+                      </button>
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {client.adUserIdentifier || client.adUserId || '\u2014'}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {client.adRoleIdentifier || client.adRoleId || '\u2014'}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex flex-wrap gap-1">
+                        {(client.scopes || []).map((scope) => (
+                          <Badge key={scope} variant="secondary" className="text-xs">
+                            {scope}
+                          </Badge>
+                        ))}
+                        {(!client.scopes || client.scopes.length === 0) && (
+                          <span className="text-xs text-muted-foreground">\u2014</span>
+                        )}
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={client.isActive ? 'default' : 'outline'}>
+                        {client.isActive ? 'Active' : 'Inactive'}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" size="icon" className="h-8 w-8">
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem onClick={() => handleRegenerateSecret(client)}>
+                            <Key className="h-4 w-4 mr-2" />
+                            Regenerate Secret
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => handleRevokeTokens(client)}>
+                            <Ban className="h-4 w-4 mr-2" />
+                            Revoke Tokens
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            onClick={() => handleDelete(client)}
+                            className="text-destructive focus:text-destructive"
+                          >
+                            <Trash2 className="h-4 w-4 mr-2" />
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/tools/app-shell/src/pages/OnboardingPage.jsx
+++ b/tools/app-shell/src/pages/OnboardingPage.jsx
@@ -1,71 +1,130 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible';
-import {
-  Loader2, CheckCircle2, XCircle, Circle, ChevronDown,
+  Loader2, Check, ChevronRight, ChevronDown,
   Plus, LogIn, Building2, RefreshCw,
+  Briefcase, Users, Database, FileText, Rocket, Settings,
 } from 'lucide-react';
 
-const STEPS = [
-  { name: 'createClient', label: 'Create Client' },
-  { name: 'createOrganization', label: 'Create Organization' },
-  { name: 'createRole', label: 'Configure Roles' },
-  { name: 'seedReferenceData', label: 'Seed Reference Data' },
-  { name: 'createDocTypes', label: 'Document Types' },
-  { name: 'markOrgReady', label: 'Finalize Setup' },
+const SETUP_STEPS = [
+  { name: 'createClient', label: 'Crear empresa', icon: Briefcase, estimate: '2 min' },
+  { name: 'createOrganization', label: 'Crear organizacion', icon: Building2, estimate: '1 min' },
+  { name: 'createRole', label: 'Configurar roles', icon: Users, estimate: '1 min' },
+  { name: 'seedReferenceData', label: 'Datos de referencia', icon: Database, estimate: '3 min' },
+  { name: 'createDocTypes', label: 'Tipos de documento', icon: FileText, estimate: '1 min' },
+  { name: 'markOrgReady', label: 'Finalizar configuracion', icon: Rocket, estimate: '1 min' },
 ];
 
 const CURRENCIES = ['EUR', 'USD', 'ARS', 'GBP', 'BRL', 'MXN', 'CLP', 'COP'];
 const LANGUAGES = [
-  { value: 'es_ES', label: 'Español' },
+  { value: 'es_ES', label: 'Espanol' },
   { value: 'en_US', label: 'English' },
 ];
 const COUNTRIES = [
   { value: 'AR', label: 'Argentina' },
-  { value: 'ES', label: 'España' },
+  { value: 'ES', label: 'Espana' },
   { value: 'US', label: 'United States' },
-  { value: 'MX', label: 'México' },
+  { value: 'MX', label: 'Mexico' },
   { value: 'BR', label: 'Brasil' },
   { value: 'CL', label: 'Chile' },
   { value: 'CO', label: 'Colombia' },
   { value: 'GB', label: 'United Kingdom' },
 ];
 
+function formatMs(ms) {
+  if (ms == null) return null;
+  if (ms < 1000) return `${ms}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
+}
+
+function StepIcon({ status, Icon }) {
+  if (status === 'done') {
+    return (
+      <div className="flex items-center justify-center w-8 h-8 rounded-full bg-green-500 flex-shrink-0">
+        <Check className="h-5 w-5 text-white" strokeWidth={3} />
+      </div>
+    );
+  }
+  if (status === 'active') {
+    return (
+      <div className="flex items-center justify-center w-8 h-8 rounded-full border-2 border-gray-900 bg-white flex-shrink-0">
+        <Icon className="h-4 w-4 text-gray-900" />
+      </div>
+    );
+  }
+  if (status === 'running') {
+    return (
+      <div className="flex items-center justify-center w-8 h-8 rounded-full bg-amber-400 flex-shrink-0">
+        <Loader2 className="h-4 w-4 text-white animate-spin" />
+      </div>
+    );
+  }
+  if (status === 'failed') {
+    return (
+      <div className="flex items-center justify-center w-8 h-8 rounded-full bg-red-500 flex-shrink-0">
+        <span className="text-white text-sm font-bold">!</span>
+      </div>
+    );
+  }
+  // pending
+  return (
+    <div className="flex items-center justify-center w-8 h-8 rounded-full border border-gray-200 bg-gray-50 flex-shrink-0">
+      <Icon className="h-4 w-4 text-gray-400" />
+    </div>
+  );
+}
+
+function SelectField({ id, value, onChange, disabled, children, label }) {
+  return (
+    <div>
+      <Label htmlFor={id} className="text-sm text-gray-600">{label}</Label>
+      <select
+        id={id}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        className="mt-1 flex h-11 w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-transparent transition-shadow"
+      >
+        {children}
+      </select>
+    </div>
+  );
+}
+
 export default function OnboardingPage() {
   const navigate = useNavigate();
-  const [view, setView] = useState('list'); // 'list' | 'create'
+  const [view, setView] = useState('list');
   const [environments, setEnvironments] = useState([]);
   const [loadingEnvs, setLoadingEnvs] = useState(true);
-  const [loggingIn, setLoggingIn] = useState(null); // clientId being logged into
+  const [loggingIn, setLoggingIn] = useState(null);
 
-  // Create form state
+  // Create form
   const [form, setForm] = useState({
     clientName: '', orgName: '', adminUser: '', adminPassword: '',
     currency: 'EUR', language: 'es_ES', countryCode: 'AR',
   });
   const [steps, setSteps] = useState(
-    STEPS.map(s => ({ ...s, status: 'pending', ms: null, error: null }))
+    SETUP_STEPS.map(s => ({ ...s, status: 'pending', ms: null, error: null }))
   );
   const [result, setResult] = useState(null);
   const [running, setRunning] = useState(false);
+  const [formSubmitted, setFormSubmitted] = useState(false);
 
-  // For onboarding, prefer system token over user token (user token may lack permissions)
   const systemToken = import.meta.env.VITE_SYSTEM_TOKEN;
   const token = systemToken || localStorage.getItem('token');
+
+  // API base: use VITE_ETENDO_URL directly (bypass proxy), fallback to relative path in production
+  const etendoUrl = import.meta.env.VITE_ETENDO_URL || '';
+  const apiBase = etendoUrl ? `${etendoUrl}/sws/go/onboarding` : '/sws/go/onboarding';
 
   // Load environments
   const loadEnvironments = useCallback(async () => {
     setLoadingEnvs(true);
     try {
-      const res = await fetch('/sws/go/onboarding?action=environments', {
+      const res = await fetch(`${apiBase}?action=environments`, {
         headers: token ? { Authorization: `Bearer ${token}` } : {},
       });
       if (res.ok) {
@@ -79,15 +138,12 @@ export default function OnboardingPage() {
     }
   }, [token]);
 
-  useEffect(() => {
-    loadEnvironments();
-  }, [loadEnvironments]);
+  useEffect(() => { loadEnvironments(); }, [loadEnvironments]);
 
-  // Login to environment via token generation (no password needed)
   const loginToEnvironment = async (env) => {
     setLoggingIn(env.clientId);
     try {
-      const res = await fetch(`/sws/go/onboarding?action=login&userId=${env.adminUserId}`, {
+      const res = await fetch(`${apiBase}?action=login&userId=${env.adminUserId}`, {
         headers: token ? { Authorization: `Bearer ${token}` } : {},
       });
       if (res.ok) {
@@ -106,15 +162,15 @@ export default function OnboardingPage() {
     }
   };
 
-  // Run onboarding
   const runOnboarding = useCallback(async () => {
     setRunning(true);
     setResult(null);
-    setSteps(STEPS.map(s => ({ ...s, status: 'pending', ms: null, error: null })));
+    setFormSubmitted(true);
+    setSteps(SETUP_STEPS.map(s => ({ ...s, status: 'pending', ms: null, error: null })));
 
     let succeededToken = null;
     try {
-      const res = await fetch('/sws/go/onboarding', {
+      const res = await fetch(apiBase, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
@@ -129,12 +185,8 @@ export default function OnboardingPage() {
 
       while (true) {
         const { done, value } = await reader.read();
-        if (value) {
-          buffer += decoder.decode(value, { stream: !done });
-        }
-        if (done) {
-          buffer += decoder.decode();
-        }
+        if (value) buffer += decoder.decode(value, { stream: !done });
+        if (done) buffer += decoder.decode();
 
         const lines = buffer.split('\n');
         buffer = done ? '' : lines.pop();
@@ -144,9 +196,7 @@ export default function OnboardingPage() {
           const msg = JSON.parse(line);
           if (msg.result || msg.status === 'success') {
             setResult(msg);
-            if (msg.status === 'success' && msg.token) {
-              succeededToken = msg.token;
-            }
+            if (msg.status === 'success' && msg.token) succeededToken = msg.token;
           } else if (msg.step) {
             setSteps(prev => prev.map((s, i) =>
               i === msg.step - 1
@@ -162,210 +212,396 @@ export default function OnboardingPage() {
     } finally {
       setRunning(false);
       if (succeededToken) {
-        // Token comes directly from the onboarding response — no separate login needed
         localStorage.setItem('token', succeededToken);
         setTimeout(() => { window.location.href = '/dashboard'; }, 100);
       }
     }
-  }, [form, token, loadEnvironments]);
-
+  }, [form, token]);
 
   const updateField = (field, value) => setForm(f => ({ ...f, [field]: value }));
   const isFormValid = form.clientName && form.orgName && form.adminUser && form.adminPassword;
 
-  const StatusIcon = ({ status }) => {
-    if (status === 'running') return <Loader2 className="h-4 w-4 animate-spin text-blue-500" />;
-    if (status === 'done') return <CheckCircle2 className="h-4 w-4 text-green-500" />;
-    if (status === 'failed') return <XCircle className="h-4 w-4 text-red-500" />;
-    return <Circle className="h-4 w-4 text-gray-300" />;
-  };
+  // Calculate progress
+  const completedCount = steps.filter(s => s.status === 'done').length;
+  const totalSteps = steps.length + 1; // +1 for the form step
+  const progressPercent = formSubmitted
+    ? Math.round(((completedCount + 1) / totalSteps) * 100)
+    : 0;
 
   // ── LIST VIEW ──
   if (view === 'list') {
     return (
-      <div className="max-w-3xl mx-auto p-6 space-y-6">
-        <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-bold">Environments</h1>
-          <div className="flex gap-2">
-            <Button variant="outline" size="sm" onClick={loadEnvironments} disabled={loadingEnvs}>
-              <RefreshCw className={`h-4 w-4 mr-1 ${loadingEnvs ? 'animate-spin' : ''}`} />
-              Refresh
-            </Button>
-            <Button onClick={() => setView('create')}>
-              <Plus className="h-4 w-4 mr-1" /> New Environment
-            </Button>
-          </div>
-        </div>
-
-        {loadingEnvs ? (
-          <div className="flex justify-center p-8">
-            <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
-          </div>
-        ) : environments.length === 0 ? (
-          <Card>
-            <CardContent className="p-8 text-center text-gray-500">
-              <Building2 className="h-12 w-12 mx-auto mb-4 text-gray-300" />
-              <p className="text-lg font-medium mb-2">No environments yet</p>
-              <p className="mb-4">Create your first environment to get started.</p>
-              <Button onClick={() => setView('create')}>
-                <Plus className="h-4 w-4 mr-1" /> Create Environment
+      <div className="min-h-screen bg-gray-50">
+        {/* Header */}
+        <header className="bg-white border-b border-gray-100 px-6 py-4">
+          <div className="max-w-2xl mx-auto flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <div className="w-8 h-8 bg-amber-400 rounded-lg flex items-center justify-center">
+                <span className="text-white font-bold text-sm">E</span>
+              </div>
+              <span className="font-semibold text-gray-900">Etendo</span>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={loadEnvironments}
+                disabled={loadingEnvs}
+                className="text-gray-500"
+              >
+                <RefreshCw className={`h-4 w-4 ${loadingEnvs ? 'animate-spin' : ''}`} />
               </Button>
-            </CardContent>
-          </Card>
-        ) : (
-          <div className="space-y-3">
-            {environments.map(env => (
-              <Card key={env.clientId} className="hover:border-gray-400 transition-colors">
-                <CardContent className="p-4 flex items-center justify-between">
-                  <div>
-                    <p className="font-semibold text-lg">{env.clientName}</p>
-                    <p className="text-sm text-gray-500">
-                      Org: {env.orgName || '—'} &middot; User: {env.adminUser || '—'}
-                    </p>
-                    <p className="text-xs text-gray-400">
-                      Created: {env.created ? new Date(env.created).toLocaleDateString() : '—'}
-                    </p>
+              <Button
+                onClick={() => setView('create')}
+                className="bg-amber-400 hover:bg-amber-500 text-white"
+              >
+                <Plus className="h-4 w-4 mr-1" /> Nuevo entorno
+              </Button>
+            </div>
+          </div>
+        </header>
+
+        <div className="max-w-2xl mx-auto p-6">
+          <h1 className="text-2xl font-bold text-gray-900 mb-1">Tus entornos</h1>
+          <p className="text-gray-500 text-sm mb-6">
+            Selecciona un entorno para comenzar a trabajar.
+          </p>
+
+          {loadingEnvs ? (
+            <div className="flex justify-center py-16">
+              <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
+            </div>
+          ) : environments.length === 0 ? (
+            <div className="bg-white rounded-xl border border-gray-100 p-12 text-center">
+              <div className="w-16 h-16 bg-gray-50 rounded-2xl flex items-center justify-center mx-auto mb-4">
+                <Building2 className="h-8 w-8 text-gray-300" />
+              </div>
+              <p className="text-lg font-medium text-gray-900 mb-1">Sin entornos</p>
+              <p className="text-gray-500 text-sm mb-6">Crea tu primer entorno para comenzar.</p>
+              <Button
+                onClick={() => setView('create')}
+                className="bg-amber-400 hover:bg-amber-500 text-white"
+              >
+                <Plus className="h-4 w-4 mr-1" /> Crear entorno
+              </Button>
+            </div>
+          ) : (
+            <div className="bg-white rounded-xl border border-gray-100 divide-y divide-gray-50">
+              {environments.map(env => (
+                <div
+                  key={env.clientId}
+                  className="flex items-center justify-between px-5 py-4 hover:bg-gray-50/50 transition-colors"
+                >
+                  <div className="flex items-center gap-4">
+                    <div className="w-10 h-10 bg-amber-50 rounded-lg flex items-center justify-center">
+                      <Building2 className="h-5 w-5 text-amber-600" />
+                    </div>
+                    <div>
+                      <p className="font-medium text-gray-900">{env.clientName}</p>
+                      <p className="text-sm text-gray-500">
+                        {env.orgName || '\u2014'} &middot; {env.adminUser || '\u2014'}
+                      </p>
+                    </div>
                   </div>
                   <Button
-                    variant="outline"
+                    variant="ghost"
+                    size="sm"
                     onClick={() => loginToEnvironment(env)}
                     disabled={loggingIn === env.clientId}
+                    className="text-amber-600 hover:text-amber-700 hover:bg-amber-50"
                   >
                     {loggingIn === env.clientId ? (
-                      <Loader2 className="h-4 w-4 animate-spin mr-1" />
+                      <Loader2 className="h-4 w-4 animate-spin" />
                     ) : (
-                      <LogIn className="h-4 w-4 mr-1" />
+                      <>Entrar <ChevronRight className="h-4 w-4 ml-1" /></>
                     )}
-                    Enter
                   </Button>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     );
   }
 
-  // ── CREATE VIEW ──
+  // ── CREATE VIEW (matches "Primeros pasos" design) ──
   return (
-    <div className="max-w-2xl mx-auto p-6 space-y-6">
-      <div className="flex items-center justify-between">
-        <h1 className="text-2xl font-bold">New Environment</h1>
-        <Button variant="ghost" onClick={() => { setView('list'); setResult(null); }}>
-          Back to list
-        </Button>
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <header className="bg-white border-b border-gray-100 px-6 py-4">
+        <div className="max-w-2xl mx-auto flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <div className="w-8 h-8 bg-amber-400 rounded-lg flex items-center justify-center">
+              <span className="text-white font-bold text-sm">E</span>
+            </div>
+            <span className="font-semibold text-gray-900">Etendo</span>
+          </div>
+          {!running && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => { setView('list'); setResult(null); setFormSubmitted(false); }}
+              className="text-gray-500"
+            >
+              Mis entornos
+            </Button>
+          )}
+        </div>
+      </header>
+
+      {/* Progress bar — always visible */}
+      <div className="bg-white border-b border-gray-100">
+        <div className="max-w-2xl mx-auto px-6 py-3 flex items-center gap-3">
+          <div className="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-gray-900 rounded-full transition-all duration-700 ease-out"
+              style={{ width: `${progressPercent}%` }}
+            />
+          </div>
+          <span className="text-xs text-gray-400 whitespace-nowrap">
+            {result?.status === 'success'
+              ? 'Listo'
+              : completedCount === 0 && !formSubmitted
+                ? 'Primeros pasos'
+                : `Paso ${completedCount + (formSubmitted ? 1 : 0)} de ${totalSteps}`
+            }
+          </span>
+        </div>
       </div>
 
-      <Card>
-        <CardHeader><CardTitle>Configuration</CardTitle></CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <Label htmlFor="clientName">Company Name</Label>
-              <Input id="clientName" value={form.clientName}
-                onChange={e => updateField('clientName', e.target.value)} disabled={running} />
-            </div>
-            <div>
-              <Label htmlFor="orgName">Organization Name</Label>
-              <Input id="orgName" value={form.orgName}
-                onChange={e => updateField('orgName', e.target.value)} disabled={running} />
-            </div>
-            <div>
-              <Label htmlFor="adminUser">Admin Email</Label>
-              <Input id="adminUser" type="email" value={form.adminUser}
-                onChange={e => updateField('adminUser', e.target.value)} disabled={running} />
-            </div>
-            <div>
-              <Label htmlFor="adminPassword">Admin Password</Label>
-              <Input id="adminPassword" type="password" value={form.adminPassword}
-                onChange={e => updateField('adminPassword', e.target.value)} disabled={running} />
-            </div>
-            <div>
-              <Label htmlFor="currency">Currency</Label>
-              <select id="currency" value={form.currency}
-                onChange={e => updateField('currency', e.target.value)} disabled={running}
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm">
-                {CURRENCIES.map(c => <option key={c} value={c}>{c}</option>)}
-              </select>
-            </div>
-            <div>
-              <Label htmlFor="language">Language</Label>
-              <select id="language" value={form.language}
-                onChange={e => updateField('language', e.target.value)} disabled={running}
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm">
-                {LANGUAGES.map(l => <option key={l.value} value={l.value}>{l.label}</option>)}
-              </select>
-            </div>
-            <div>
-              <Label htmlFor="countryCode">Country</Label>
-              <select id="countryCode" value={form.countryCode}
-                onChange={e => updateField('countryCode', e.target.value)} disabled={running}
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm">
-                {COUNTRIES.map(c => <option key={c.value} value={c.value}>{c.label}</option>)}
-              </select>
-            </div>
-          </div>
-          <Button onClick={runOnboarding} disabled={running || !isFormValid}>
-            {running ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Creating...</> : 'Create Environment'}
-          </Button>
-        </CardContent>
-      </Card>
+      <div className="max-w-2xl mx-auto p-6">
+        {/* Title */}
+        <h1 className="text-2xl font-bold text-gray-900 mb-1">
+          Vamos a preparar tu cuenta
+        </h1>
+        <p className="text-gray-500 text-sm mb-6">
+          Completa los datos y en menos de 10 minutos tendras todo listo para empezar.
+        </p>
 
-      {/* Progress Accordion */}
-      {(running || result) && (
-        <Card>
-          <CardHeader><CardTitle>Progress</CardTitle></CardHeader>
-          <CardContent className="space-y-2">
-            {steps.map((step, i) => (
-              <Collapsible key={step.name}
-                open={step.status === 'running' || step.status === 'failed'}>
-                <CollapsibleTrigger className="flex items-center justify-between w-full p-3 rounded-lg bg-gray-50 hover:bg-gray-100">
-                  <div className="flex items-center gap-3">
-                    <StatusIcon status={step.status} />
-                    <span className="font-medium">Step {i + 1}: {step.label}</span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    {step.ms != null && <span className="text-sm text-gray-500">{step.ms}ms</span>}
-                    <ChevronDown className="h-4 w-4" />
-                  </div>
-                </CollapsibleTrigger>
-                <CollapsibleContent className="p-3 pl-10 text-sm">
-                  {step.status === 'running' && <span className="text-blue-600">Executing...</span>}
-                  {step.status === 'failed' && <span className="text-red-600 break-all">{step.error}</span>}
-                  {step.status === 'done' && <span className="text-green-600">Completed in {step.ms}ms</span>}
-                </CollapsibleContent>
-              </Collapsible>
-            ))}
-          </CardContent>
-        </Card>
-      )}
+        {/* Steps list */}
+        <div className="bg-white rounded-xl border border-gray-100">
 
-      {/* Result */}
-      {result && (
-        <Card className={result.status === 'success' || result.result === 'success' ? 'border-green-500' : 'border-red-500'}>
-          <CardContent className="p-4">
-            {result.status === 'success' ? (
-              <div className="text-green-700 space-y-2">
-                <p className="font-bold">Environment created ({result.totalMs}ms)</p>
-                <Button onClick={() => { setView('list'); setResult(null); }}>
-                  <LogIn className="h-4 w-4 mr-1" /> Go to Environments
-                </Button>
+          {/* Step 0: Configuration form */}
+          <div className="border-b border-gray-50">
+            <button
+              type="button"
+              className="w-full flex items-center gap-4 px-5 py-4 text-left"
+              onClick={() => !running && setFormSubmitted(false)}
+              disabled={running}
+            >
+              <StepIcon
+                status={formSubmitted ? 'done' : 'active'}
+                Icon={Settings}
+              />
+              <div className="flex-1 min-w-0">
+                <p className={`text-lg font-semibold ${formSubmitted ? 'text-gray-500' : 'text-gray-900'}`}>
+                  Datos de tu empresa
+                </p>
+                {formSubmitted && !running && (
+                  <p className="text-xs text-gray-400 mt-0.5">{form.clientName} &middot; {form.orgName}</p>
+                )}
               </div>
-            ) : (
-              <div className="text-red-700 space-y-2">
-                <p className="font-bold">Creation failed</p>
-                <p className="text-sm">{result.error}</p>
-                {result.rolledBack && <p className="text-sm mt-1">All changes have been rolled back.</p>}
-                <Button variant="outline" size="sm" onClick={() => {
-                  setResult(null);
-                  setSteps(STEPS.map(s => ({ ...s, status: 'pending', ms: null, error: null })));
-                }}>Try Again</Button>
+              {!formSubmitted && (
+                <ChevronDown className="h-4 w-4 text-gray-400" />
+              )}
+            </button>
+
+            {/* Inline form (shown when not submitted) */}
+            {!formSubmitted && (
+              <div className="px-5 pb-5 pt-1 space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="clientName" className="text-sm text-gray-600">
+                      Nombre de la empresa <span className="text-red-400">*</span>
+                    </Label>
+                    <Input
+                      id="clientName"
+                      value={form.clientName}
+                      onChange={e => updateField('clientName', e.target.value)}
+                      disabled={running}
+                      placeholder="Mi Empresa S.A."
+                      className="mt-1 h-11 rounded-lg border-gray-200 focus:ring-amber-400 focus:border-amber-400"
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="orgName" className="text-sm text-gray-600">
+                      Nombre de la organizacion <span className="text-red-400">*</span>
+                    </Label>
+                    <Input
+                      id="orgName"
+                      value={form.orgName}
+                      onChange={e => updateField('orgName', e.target.value)}
+                      disabled={running}
+                      placeholder="Sucursal Principal"
+                      className="mt-1 h-11 rounded-lg border-gray-200 focus:ring-amber-400 focus:border-amber-400"
+                    />
+                  </div>
+                </div>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="adminUser" className="text-sm text-gray-600">
+                      Email del administrador <span className="text-red-400">*</span>
+                    </Label>
+                    <Input
+                      id="adminUser"
+                      type="email"
+                      value={form.adminUser}
+                      onChange={e => updateField('adminUser', e.target.value)}
+                      disabled={running}
+                      placeholder="admin@miempresa.com"
+                      className="mt-1 h-11 rounded-lg border-gray-200 focus:ring-amber-400 focus:border-amber-400"
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="adminPassword" className="text-sm text-gray-600">
+                      Contrasena <span className="text-red-400">*</span>
+                    </Label>
+                    <Input
+                      id="adminPassword"
+                      type="password"
+                      value={form.adminPassword}
+                      onChange={e => updateField('adminPassword', e.target.value)}
+                      disabled={running}
+                      placeholder="********"
+                      className="mt-1 h-11 rounded-lg border-gray-200 focus:ring-amber-400 focus:border-amber-400"
+                    />
+                  </div>
+                </div>
+                <div className="grid grid-cols-3 gap-4">
+                  <SelectField
+                    id="currency"
+                    value={form.currency}
+                    onChange={e => updateField('currency', e.target.value)}
+                    disabled={running}
+                    label="Moneda"
+                  >
+                    {CURRENCIES.map(c => <option key={c} value={c}>{c}</option>)}
+                  </SelectField>
+                  <SelectField
+                    id="language"
+                    value={form.language}
+                    onChange={e => updateField('language', e.target.value)}
+                    disabled={running}
+                    label="Idioma"
+                  >
+                    {LANGUAGES.map(l => <option key={l.value} value={l.value}>{l.label}</option>)}
+                  </SelectField>
+                  <SelectField
+                    id="countryCode"
+                    value={form.countryCode}
+                    onChange={e => updateField('countryCode', e.target.value)}
+                    disabled={running}
+                    label="Pais"
+                  >
+                    {COUNTRIES.map(c => <option key={c.value} value={c.value}>{c.label}</option>)}
+                  </SelectField>
+                </div>
+                <div className="pt-2">
+                  <Button
+                    onClick={runOnboarding}
+                    disabled={running || !isFormValid}
+                    className="w-full h-11 bg-gray-900 hover:bg-gray-800 text-white rounded-lg text-sm font-medium"
+                  >
+                    {running
+                      ? <><Loader2 className="mr-2 h-4 w-4 animate-spin" />Creando...</>
+                      : <><ChevronRight className="mr-1 h-4 w-4" />Crear entorno</>
+                    }
+                  </Button>
+                </div>
               </div>
             )}
-          </CardContent>
-        </Card>
-      )}
+          </div>
+
+          {/* Automated steps */}
+          {steps.map((step, i) => {
+            const isExpanded = step.status === 'running' || step.status === 'failed';
+            const isPending = step.status === 'pending';
+            const isDone = step.status === 'done';
+
+            return (
+              <div
+                key={step.name}
+                className={`${i < steps.length - 1 ? 'border-b border-gray-50' : ''}`}
+              >
+                <div className="flex items-center gap-4 px-5 py-4">
+                  <StepIcon status={step.status} Icon={step.icon} />
+                  <div className="flex-1 min-w-0">
+                    <p className={`text-lg font-semibold ${
+                      isDone ? 'text-gray-500' :
+                      step.status === 'running' ? 'text-gray-900' :
+                      step.status === 'failed' ? 'text-red-600' :
+                      'text-gray-400'
+                    }`}>
+                      {step.label}
+                    </p>
+                    {step.status === 'running' && (
+                      <p className="text-xs text-amber-600 mt-0.5">Procesando...</p>
+                    )}
+                    {step.status === 'failed' && (
+                      <p className="text-xs text-red-500 mt-0.5 break-all">{step.error}</p>
+                    )}
+                  </div>
+                  <div className="text-right">
+                    {isDone && step.ms != null && (
+                      <span className="text-xs text-gray-400">{formatMs(step.ms)}</span>
+                    )}
+                    {isPending && (
+                      <span className="text-xs text-gray-300">{step.estimate}</span>
+                    )}
+                    {step.status === 'running' && (
+                      <Loader2 className="h-3 w-3 animate-spin text-amber-400" />
+                    )}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Result message */}
+        {result && (
+          <div className={`mt-4 rounded-xl border p-5 ${
+            result.status === 'success'
+              ? 'bg-green-50 border-green-200'
+              : 'bg-red-50 border-red-200'
+          }`}>
+            {result.status === 'success' ? (
+              <div className="flex items-center gap-3">
+                <div className="w-10 h-10 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0">
+                  <Check className="h-5 w-5 text-white" strokeWidth={3} />
+                </div>
+                <div>
+                  <p className="font-medium text-green-900">Entorno creado</p>
+                  <p className="text-sm text-green-700">
+                    Listo en {formatMs(result.totalMs)}. Redirigiendo...
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div>
+                <p className="font-medium text-red-900 mb-1">No se pudo crear el entorno</p>
+                <p className="text-sm text-red-700 mb-3">{result.error}</p>
+                {result.rolledBack && (
+                  <p className="text-xs text-red-500 mb-3">Todos los cambios fueron revertidos.</p>
+                )}
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => {
+                    setResult(null);
+                    setFormSubmitted(false);
+                    setSteps(SETUP_STEPS.map(s => ({ ...s, status: 'pending', ms: null, error: null })));
+                  }}
+                  className="border-red-200 text-red-700 hover:bg-red-100"
+                >
+                  Intentar de nuevo
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add OAuth2 client management API service (`lib/oauth2Api.js`) with 6 functions
- Add OAuth2 Clients list page with shadcn Table, empty state, loading state
- Add Create/Edit client dialog with scope checkboxes and SecretRevealDialog (one-time secret display)
- Add row actions: Edit, Regenerate Secret, Revoke Tokens, Delete with confirmation dialogs
- Wire route in App.jsx and menu entry in Settings section
- Add oauth2-clients to SPECIAL_PAGES in wiring test

## Test plan
- [ ] `npm run build` passes in tools/app-shell
- [ ] OAuth2 Clients page renders at /oauth2-clients
- [ ] Create client shows secret once in dialog
- [ ] Edit client pre-fills form
- [ ] Regenerate secret shows confirmation then new secret
- [ ] Revoke tokens shows confirmation
- [ ] Delete client shows confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)