### PR TITLE
Feature ETP-3585: Fix stray closing bracket in secondary tabs JSX

### DIFF
--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -1101,7 +1101,6 @@ export function DetailView({
                         </button>
                       )}
                     </div>
-                    )}
                     {st.Form && !st.Panel && (selectedSecondaryLine?._tabKey === st.key || isClosingSecondaryLine) && (
                       <div className={`w-[48rem] shrink-0 border-l border-border pl-4 self-stretch overflow-hidden ${isClosingSecondaryLine ? 'sidebar-slide-out' : 'sidebar-slide-in'}`}>
                         <div className="flex items-center justify-between mb-3">


### PR DESCRIPTION
Fix closing bracket that sent a warning in VITE:

11:51:29 [vite] (client) warning: The character "}" is not valid inside a JSX element
1121|                          }
1122|                      </div>
1123|                      )}
   |                       ^
1124|                      {st.Form && !st.Panel && (selectedSecondaryLine?._tabKey === st.key || isClosingSecondaryLine) &&
1125|                        <div className={`w-[48rem] shrink-0 border-l border-border pl-4 self-stretch overflow-hidden ${isClosingSecondaryLine ? 'sidebar-slide-out' : 'sidebar-slide-in'}`}>

  Plugin: vite:esbuild
  File: /Users/gremiger/workspaces/etendogo/etendo/etendo_schema_forge/tools/app-shell/src/components/contract-ui/DetailView.jsx