### PR TITLE
Feature ETP-3570: Invoice creation flow and Send/Download

### DIFF
--- a/artifacts/goods-shipment/contract.json
+++ b/artifacts/goods-shipment/contract.json
@@ -2274,11 +2274,11 @@
       },
       {
         "id": "t-95",
-        "category": "system-field",
+        "category": "field-presence",
         "entity": "goodsShipment",
         "field": "completelyInvoiced",
         "runner": "node",
-        "description": "System field 'completelyInvoiced' should exist in backend but not frontend for goodsShipment"
+        "description": "Field 'completelyInvoiced' should be present in goodsShipment"
       },
       {
         "id": "t-96",

--- a/artifacts/goods-shipment/contract.json
+++ b/artifacts/goods-shipment/contract.json
@@ -12,7 +12,8 @@
       "relatedDocuments": true,
       "hideDeleteWhenComplete": true,
       "customComponents": {
-        "topbarRight": "GoodsShipmentActions"
+        "topbarRight": "GoodsShipmentActions",
+        "bulkActions": "BulkInvoiceFromShipment"
       },
       "menuActions": [
         {

--- a/artifacts/goods-shipment/contract.json
+++ b/artifacts/goods-shipment/contract.json
@@ -8,9 +8,6 @@
       "name": "Goods Shipment",
       "primaryEntity": "goodsShipment",
       "category": "sales",
-      "documentPreview": {
-        "titlePrefix": "Shipment"
-      },
       "notesField": "description",
       "relatedDocuments": true,
       "hideDeleteWhenComplete": true,
@@ -109,12 +106,12 @@
             "name": "partnerAddress",
             "apiKey": "partnerAddress",
             "column": "C_BPartner_Location_ID",
-            "label": "Partner Address",
+            "label": "Shipping Address",
             "type": "foreignKey",
             "tsType": "string",
             "visibility": "editable",
             "required": true,
-            "grid": false,
+            "grid": true,
             "form": true,
             "reference": "BusinessPartnerLocation",
             "inputMode": "dependent",
@@ -217,7 +214,8 @@
                 "name": "Voided"
               }
             ],
-            "defaultValue": "DR"
+            "defaultValue": "DR",
+            "display": "dot"
           },
           {
             "name": "processed",
@@ -230,6 +228,23 @@
             "required": true,
             "grid": false,
             "form": false
+          },
+          {
+            "name": "completelyInvoiced",
+            "apiKey": "completelyInvoiced",
+            "column": "Iscompletelyinvoiced",
+            "label": "Invoiced",
+            "type": "boolean",
+            "tsType": "boolean",
+            "visibility": "readOnly",
+            "required": false,
+            "grid": true,
+            "form": false,
+            "badge": true,
+            "badgeLabels": {
+              "true": "Invoiced",
+              "false": "Pending"
+            }
           }
         ],
         "searchableFields": [
@@ -794,11 +809,13 @@
             "required": false
           },
           {
-            "name": "completelyInvoiced",
+            "name": "invoiced",
             "apiKey": "completelyInvoiced",
             "column": "Iscompletelyinvoiced",
             "type": "boolean",
-            "visibility": "discarded",
+            "visibility": "readOnly",
+            "grid": true,
+            "form": false,
             "required": true
           },
           {

--- a/artifacts/goods-shipment/custom/BulkInvoiceFromShipment.jsx
+++ b/artifacts/goods-shipment/custom/BulkInvoiceFromShipment.jsx
@@ -1,0 +1,394 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { toast } from 'sonner';
+
+export default function BulkInvoiceFromShipment({ selectedRows, clearSelection, token, apiBaseUrl }) {
+  const [showModal, setShowModal] = useState(false);
+
+  const invoiceableRows = useMemo(
+    () => selectedRows.filter(r => r.documentStatus === 'CO' && r.completelyInvoiced !== true),
+    [selectedRows],
+  );
+
+  const bpCheck = useMemo(() => {
+    if (invoiceableRows.length === 0) return { same: false, name: '' };
+    const firstBp = invoiceableRows[0].businessPartner;
+    const allSame = invoiceableRows.every(r => r.businessPartner === firstBp);
+    const name = invoiceableRows[0]['businessPartner$_identifier'] || '';
+    return { same: allSame, name };
+  }, [invoiceableRows]);
+
+  const invoiceableCount = invoiceableRows.length;
+  const allInvoiced = invoiceableCount === 0;
+  const canCreate = invoiceableCount > 0 && bpCheck.same;
+
+  if (selectedRows.length < 1) return null;
+
+  const tooltip = allInvoiced
+    ? 'All selected shipments are already invoiced'
+    : !bpCheck.same
+      ? 'Select shipments from the same customer'
+      : undefined;
+
+  return (
+    <>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, borderLeft: '1px solid #e5e7eb', paddingLeft: 8, marginLeft: 4 }}>
+        <button
+          type="button"
+          disabled={!canCreate}
+          onClick={() => setShowModal(true)}
+          title={tooltip}
+          className="inline-flex items-center gap-1.5 text-[13px] font-medium transition-colors"
+          style={{
+            padding: '4px 12px', borderRadius: 6,
+            border: canCreate ? '1px solid #93c5fd' : '1px solid #e5e7eb',
+            background: canCreate ? '#eff6ff' : 'transparent',
+            color: canCreate ? '#2563eb' : '#9ca3af',
+            cursor: canCreate ? 'pointer' : 'not-allowed',
+            opacity: canCreate ? 1 : 0.5,
+          }}
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+          Create Invoice ({invoiceableCount})
+        </button>
+      </div>
+
+      {showModal && createPortal(
+        <BulkInvoiceModal
+          shipments={invoiceableRows}
+          bpName={bpCheck.name}
+          token={token}
+          apiBaseUrl={apiBaseUrl}
+          onClose={() => setShowModal(false)}
+          onSuccess={() => { setShowModal(false); clearSelection(); }}
+        />,
+        document.body,
+      )}
+    </>
+  );
+}
+
+function BulkInvoiceModal({ shipments, bpName, token, apiBaseUrl, onClose, onSuccess }) {
+  const [linesByShipment, setLinesByShipment] = useState({});
+  const [orderLinePrices, setOrderLinePrices] = useState({});
+  const [loadingLines, setLoadingLines] = useState(true);
+  const [creating, setCreating] = useState(false);
+  const [collapsed, setCollapsed] = useState(() => {
+    const init = {};
+    shipments.forEach(s => { init[s.id] = true; });
+    return init;
+  });
+  const [selectedLines, setSelectedLines] = useState(new Set());
+  const [lineQuantities, setLineQuantities] = useState({});
+  const [existingDraft, setExistingDraft] = useState(null);
+  const [dismissedWarning, setDismissedWarning] = useState(false);
+
+  const base = useMemo(() => (apiBaseUrl || '').replace(/\/[^/]+$/, ''), [apiBaseUrl]);
+  const hdrs = useMemo(() => ({
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  }), [token]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const lineResults = await Promise.all(
+          shipments.map(async (s) => {
+            const res = await fetch(`${base}/goods-shipment/goodsShipmentLine?parentId=${s.id}&_startRow=0&_endRow=200`, { headers: hdrs });
+            if (!res.ok) return { id: s.id, lines: [] };
+            return { id: s.id, lines: (await res.json())?.response?.data || [] };
+          }),
+        );
+        if (cancelled) return;
+        const linesMap = {};
+        const allLineIds = new Set();
+        const qtyDefaults = {};
+        lineResults.forEach(r => {
+          linesMap[r.id] = r.lines;
+          r.lines.forEach(l => { allLineIds.add(l.id); qtyDefaults[l.id] = Number(l.movementQuantity) || 0; });
+        });
+        setLinesByShipment(linesMap);
+        setSelectedLines(allLineIds);
+        setLineQuantities(qtyDefaults);
+
+        const orderIds = [...new Set(shipments.map(s => s.salesOrder).filter(Boolean))];
+        const priceMap = {};
+        await Promise.all(orderIds.map(async (orderId) => {
+          try {
+            const res = await fetch(`${base}/sales-order/lines?parentId=${orderId}&_startRow=0&_endRow=200`, { headers: hdrs });
+            if (res.ok) {
+              ((await res.json())?.response?.data || []).forEach(ol => { priceMap[ol.id] = ol; });
+            }
+          } catch { /* silent */ }
+        }));
+        if (!cancelled) setOrderLinePrices(priceMap);
+
+        try {
+          const draftRes = await fetch(
+            `${base}/goods-shipment/goodsShipment/${shipments[0].id}/action/checkDraftInvoice`,
+            { method: 'POST', headers: hdrs, body: JSON.stringify({ shipmentIds: shipments.map(s => s.id) }) },
+          );
+          if (draftRes.ok && !cancelled) {
+            const draftData = (await draftRes.json())?.response?.data;
+            if (draftData?.exists) setExistingDraft(draftData);
+          }
+        } catch { /* silent */ }
+      } catch { /* silent */ }
+      finally { if (!cancelled) setLoadingLines(false); }
+    })();
+    return () => { cancelled = true; };
+  }, [shipments, base, hdrs]);
+
+  const shipmentSummaries = useMemo(() =>
+    shipments.map(s => {
+      const lines = (linesByShipment[s.id] || []).map(l => {
+        const ol = orderLinePrices[l.salesOrderLine] || {};
+        const unitPrice = Number(ol.unitPrice) || 0;
+        const maxQty = Number(l.movementQuantity) || 0;
+        const currentQty = lineQuantities[l.id] ?? maxQty;
+        const isSel = selectedLines.has(l.id);
+        return { ...l, unitPrice, maxQty, currentQty, lineTotal: isSel ? unitPrice * currentQty : 0, productName: l['product$_identifier'] || l.id, isSelected: isSel };
+      });
+      const total = lines.reduce((sum, l) => sum + l.lineTotal, 0);
+      const selectedCount = lines.filter(l => l.isSelected).length;
+      return { ...s, enrichedLines: lines, total, selectedCount };
+    }),
+    [shipments, linesByShipment, orderLinePrices, selectedLines, lineQuantities],
+  );
+
+  const totalSelectedLines = shipmentSummaries.reduce((sum, s) => sum + s.selectedCount, 0);
+  const grandTotal = shipmentSummaries.reduce((sum, s) => sum + s.total, 0);
+
+  const toggleCollapse = useCallback((id) => setCollapsed(prev => ({ ...prev, [id]: !prev[id] })), []);
+  const toggleLine = (lineId) => setSelectedLines(prev => { const n = new Set(prev); n.has(lineId) ? n.delete(lineId) : n.add(lineId); return n; });
+  const toggleShipmentLines = (shipmentId) => {
+    const lines = linesByShipment[shipmentId] || [];
+    const lineIds = lines.map(l => l.id);
+    const allSel = lineIds.every(id => selectedLines.has(id));
+    setSelectedLines(prev => {
+      const n = new Set(prev);
+      if (allSel) { lineIds.forEach(id => n.delete(id)); } else { lineIds.forEach(id => n.add(id)); }
+      return n;
+    });
+  };
+
+  const fmtDate = (d) => d ? new Date(d).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) : '';
+  const fmtNum = (v) => Number(v || 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+  const handleCreate = async () => {
+    if (creating || totalSelectedLines === 0) return;
+    setCreating(true);
+    try {
+      const linesPayload = [];
+      shipmentSummaries.forEach(s => {
+        s.enrichedLines.forEach(l => {
+          if (l.isSelected) linesPayload.push({ shipmentLineId: l.id, quantity: String(l.currentQty) });
+        });
+      });
+      const res = await fetch(
+        `${base}/goods-shipment/goodsShipment/${shipments[0].id}/action/createDraftInvoice`,
+        { method: 'POST', headers: hdrs, body: JSON.stringify({ shipmentIds: shipments.map(s => s.id), lines: linesPayload }) },
+      );
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        throw new Error(err?.response?.message || err?.message || `Failed (${res.status})`);
+      }
+      const json = await res.json();
+      const invoiceId = json?.response?.data?.id;
+      const docNo = json?.response?.data?.documentNo || '';
+      if (invoiceId) {
+        const bp = window.location.pathname.replace(/\/goods-shipment\/.*$/, '').replace(/\/goods-shipment\/?$/, '');
+        const invoiceUrl = `${bp}/sales-invoice/${invoiceId}`;
+        toast.custom((t) => (
+          <div style={{ background: '#16a34a', color: '#fff', borderRadius: 10, padding: '14px 18px', display: 'flex', alignItems: 'center', gap: 14, boxShadow: '0 8px 30px rgba(0,0,0,0.18)', minWidth: 380 }}>
+            <div style={{ width: 32, height: 32, borderRadius: '50%', background: 'rgba(255,255,255,0.2)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 14, fontWeight: 600, whiteSpace: 'nowrap' }}>Invoice #{docNo} created as Draft</div>
+              <div style={{ fontSize: 12, opacity: 0.8, marginTop: 2 }}>Review before confirming</div>
+            </div>
+            <button
+              onClick={() => { toast.dismiss(t); window.location.href = invoiceUrl; }}
+              style={{ border: '1px solid rgba(255,255,255,0.4)', borderRadius: 6, padding: '6px 14px', fontSize: 13, fontWeight: 500, color: '#fff', background: 'rgba(255,255,255,0.15)', cursor: 'pointer', whiteSpace: 'nowrap' }}
+            >View Invoice →</button>
+          </div>
+        ), { duration: 10000 });
+      } else {
+        toast.success('Invoice created as Draft');
+      }
+      onSuccess();
+    } catch (err) {
+      toast.error(err.message || 'Failed to create invoice');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const navToInvoice = (id) => {
+    onClose();
+    const bp = window.location.pathname.replace(/\/goods-shipment\/.*$/, '').replace(/\/goods-shipment\/?$/, '');
+    window.location.href = `${bp}/sales-invoice/${id}`;
+  };
+
+  return (
+    <div onClick={onClose} style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, zIndex: 9999, display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: 'rgba(0,0,0,0.3)' }}>
+      <div onClick={e => e.stopPropagation()} style={{ width: 600, minWidth: 560, maxHeight: '80vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', borderRadius: 12, backgroundColor: '#fff', boxShadow: '0 8px 30px rgba(0,0,0,0.12)', border: '0.5px solid #E5E7EB' }}>
+
+        {/* Header — fixed */}
+        <div style={{ padding: '14px 16px', background: '#F4F5F7', borderBottom: '1px solid #E5E7EB', flexShrink: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
+            <div>
+              <div style={{ fontSize: 15, fontWeight: 600, color: '#111827' }}>Create Invoice</div>
+              <div style={{ fontSize: 13, color: '#6B7280', marginTop: 3 }}>
+                {shipments.length} shipment{shipments.length !== 1 ? 's' : ''} · {bpName}
+              </div>
+            </div>
+            <button type="button" onClick={onClose} style={{ fontSize: 18, lineHeight: 1, padding: '2px 6px', borderRadius: 4, background: 'none', border: 'none', cursor: 'pointer', color: '#9ca3af' }}>&times;</button>
+          </div>
+        </div>
+
+        {existingDraft && !dismissedWarning && (
+          <div style={{ padding: '12px 20px', background: '#FAEEDA', borderBottom: '0.5px solid #EF9F27', display: 'flex', gap: 10, flexShrink: 0 }}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#854F0B" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, marginTop: 1 }}><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+            <div>
+              <div style={{ fontSize: 13, fontWeight: 500, color: '#633806' }}>Draft invoice already exists for these shipments</div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 4 }}>
+                <button type="button" onClick={() => navToInvoice(existingDraft.id)} style={{ fontSize: 12, color: '#185FA5', background: 'none', border: 'none', padding: 0, cursor: 'pointer', textDecoration: 'underline' }}>View existing invoice →</button>
+                <span style={{ color: '#854F0B', fontSize: 12 }}>·</span>
+                <button type="button" onClick={() => setDismissedWarning(true)} style={{ fontSize: 12, color: '#854F0B', background: 'none', border: 'none', padding: 0, cursor: 'pointer', textDecoration: 'underline' }}>Create another anyway</button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Body — scrollable */}
+        <div style={{ flex: 1, overflowY: 'auto', maxHeight: 380, padding: 0 }}>
+          {loadingLines ? (
+            <p style={{ fontSize: 13, color: '#9ca3af', padding: '24px 0', textAlign: 'center' }}>Loading shipment lines...</p>
+          ) : shipmentSummaries.every(s => s.enrichedLines.length === 0) ? (
+            <p style={{ fontSize: 13, color: '#9ca3af', padding: '24px 0', textAlign: 'center' }}>No lines found in selected shipments.</p>
+          ) : (
+            shipmentSummaries.map((shipment) => {
+              const isExpanded = !collapsed[shipment.id];
+              const allLinesSel = shipment.enrichedLines.every(l => l.isSelected);
+              const someLinesSel = shipment.enrichedLines.some(l => l.isSelected) && !allLinesSel;
+              return (
+                <div key={shipment.id}>
+                  {/* Shipment header */}
+                  <div
+                    onClick={() => toggleCollapse(shipment.id)}
+                    style={{
+                      display: 'flex', alignItems: 'center', gap: 6,
+                      padding: '9px 16px', background: '#F4F5F7', borderBottom: '0.5px solid #E5E7EB',
+                      borderLeft: isExpanded ? '3px solid #378ADD' : '3px solid transparent',
+                      cursor: 'pointer', userSelect: 'none',
+                    }}
+                  >
+                    <span style={{ fontSize: 11, color: '#9ca3af', width: 14, textAlign: 'center', transition: 'transform 0.2s ease', transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)', flexShrink: 0 }}>▶</span>
+                    <input
+                      type="checkbox"
+                      checked={allLinesSel}
+                      ref={el => { if (el) el.indeterminate = someLinesSel; }}
+                      onChange={(e) => { e.stopPropagation(); toggleShipmentLines(shipment.id); }}
+                      onClick={(e) => e.stopPropagation()}
+                      style={{ accentColor: '#3b82f6', cursor: 'pointer', flexShrink: 0 }}
+                    />
+                    <span style={{ fontSize: 13, fontWeight: 600, color: '#374151' }}>Shipment #{shipment.documentNo}</span>
+                    <span style={{ fontSize: 12, color: '#9ca3af' }}>· {fmtDate(shipment.movementDate)} · {shipment.enrichedLines.length} line{shipment.enrichedLines.length !== 1 ? 's' : ''}</span>
+                    <span style={{ marginLeft: 'auto', fontSize: 13, color: '#374151', fontVariantNumeric: 'tabular-nums', fontWeight: 500, flexShrink: 0 }}>
+                      {fmtNum(shipment.total)}
+                    </span>
+                  </div>
+
+                  {/* Lines */}
+                  {isExpanded && (
+                    <>
+                      <div style={{ display: 'flex', padding: '4px 16px 4px 54px', fontSize: 11, fontWeight: 600, color: '#9ca3af', textTransform: 'uppercase', letterSpacing: '0.5px', borderBottom: '0.5px solid #E5E7EB' }}>
+                        <span style={{ flex: 1 }}>Product</span>
+                        <span style={{ width: 70, textAlign: 'right' }}>Qty</span>
+                        <span style={{ width: 70, textAlign: 'right' }}>Price</span>
+                        <span style={{ width: 80, textAlign: 'right' }}>Amount</span>
+                      </div>
+                      {shipment.enrichedLines.map(line => {
+                        const qtyEdited = line.currentQty !== line.maxQty;
+                        return (
+                          <div
+                            key={line.id}
+                            onClick={() => toggleLine(line.id)}
+                            style={{
+                              display: 'flex', alignItems: 'center', padding: '5px 16px 5px 38px', borderBottom: '0.5px solid #F3F4F6', cursor: 'pointer',
+                              background: line.isSelected ? '#eff6ff' : 'transparent',
+                              opacity: line.isSelected ? 1 : 0.5,
+                            }}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={line.isSelected}
+                              onChange={() => toggleLine(line.id)}
+                              onClick={e => e.stopPropagation()}
+                              style={{ accentColor: '#3b82f6', cursor: 'pointer', marginRight: 8, flexShrink: 0 }}
+                            />
+                            <span style={{ flex: 1, fontSize: 13, color: line.isSelected ? '#2563eb' : '#111827', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: line.isSelected ? 500 : 400 }}>
+                              {line.productName}
+                            </span>
+                            <span style={{ width: 70, textAlign: 'right' }} onClick={e => e.stopPropagation()}>
+                              <input
+                                type="number"
+                                min={1}
+                                max={line.maxQty}
+                                value={line.currentQty}
+                                onChange={e => {
+                                  const v = Math.max(1, Math.min(line.maxQty, Number(e.target.value) || 1));
+                                  setLineQuantities(prev => ({ ...prev, [line.id]: v }));
+                                }}
+                                style={{
+                                  width: 56, fontSize: 12, padding: '2px 4px', borderRadius: 4, textAlign: 'center',
+                                  fontVariantNumeric: 'tabular-nums', outline: 'none',
+                                  border: qtyEdited ? '1px solid #f59e0b' : '0.5px solid #d1d5db',
+                                  background: qtyEdited ? '#fffbeb' : '#fff',
+                                }}
+                              />
+                            </span>
+                            <span style={{ width: 70, fontSize: 12, color: '#6B7280', fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>
+                              {fmtNum(line.unitPrice)}
+                            </span>
+                            <span style={{ width: 80, fontSize: 13, color: '#111827', fontVariantNumeric: 'tabular-nums', textAlign: 'right', fontWeight: 500 }}>
+                              {line.isSelected ? fmtNum(line.lineTotal) : '-'}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        {/* Footer — fixed */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: '#F4F5F7', borderTop: '1px solid #E5E7EB', padding: '10px 16px', flexShrink: 0 }}>
+          <span style={{ fontSize: 13, color: '#6B7280', fontVariantNumeric: 'tabular-nums' }}>
+            {totalSelectedLines > 0 ? (
+              <>
+                {totalSelectedLines} line{totalSelectedLines !== 1 ? 's' : ''} from {shipments.length} shipment{shipments.length !== 1 ? 's' : ''}
+                {' · '}<span style={{ fontWeight: 500, color: '#2563eb' }}>Total: {fmtNum(grandTotal)}</span>
+              </>
+            ) : 'Select lines to invoice'}
+          </span>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button type="button" onClick={onClose} style={{ fontSize: 13, padding: '6px 14px', borderRadius: 6, border: '1px solid #E5E7EB', background: 'transparent', color: '#6B7280', cursor: 'pointer' }}>Cancel</button>
+            <button
+              type="button"
+              onClick={handleCreate}
+              disabled={totalSelectedLines === 0 || creating}
+              style={{ fontSize: 13, fontWeight: 500, padding: '6px 14px', borderRadius: 6, border: 'none', background: '#18181b', color: '#fff', cursor: (totalSelectedLines === 0 || creating) ? 'not-allowed' : 'pointer', opacity: (totalSelectedLines === 0 || creating) ? 0.4 : 1 }}
+            >{creating ? 'Creating...' : 'Create Invoice'}</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/artifacts/goods-shipment/custom/GoodsShipmentActions.jsx
+++ b/artifacts/goods-shipment/custom/GoodsShipmentActions.jsx
@@ -1,19 +1,19 @@
 import { useState, useEffect, useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { toast } from 'sonner';
 import ReturnWizard from './ReturnWizard';
+import SendDocumentModal, { SendDocumentButton } from '@/components/contract-ui/SendDocumentModal';
 
-/**
- * GoodsShipmentActions — topbarRight component for Goods Shipment detail view.
- *
- * Shows a "Create Return" button when the shipment is completed (CO).
- * Opens the ReturnWizard dialog to create a return receipt + credit note.
- *
- * Props received from DetailView: { data, recordId, token, apiBaseUrl, api }
- */
 export default function GoodsShipmentActions({ data, recordId, token, apiBaseUrl, api }) {
   const [wizardOpen, setWizardOpen] = useState(false);
-  const [lines, setLines] = useState([]);
+  const [showInvoicePreview, setShowInvoicePreview] = useState(false);
+  const [creatingInvoice, setCreatingInvoice] = useState(false);
+  const [returnLines, setReturnLines] = useState([]);
+  const [showSend, setShowSend] = useState(false);
 
   const isCompleted = data?.documentStatus === 'CO';
+  const ci = data?.completelyInvoiced;
+  const isFullyInvoiced = ci === true || ci === 'true' || ci === 'Y';
 
   const base = useMemo(() => (apiBaseUrl || '').replace(/\/[^/]+$/, ''), [apiBaseUrl]);
   const headers = useMemo(() => ({
@@ -21,64 +21,333 @@ export default function GoodsShipmentActions({ data, recordId, token, apiBaseUrl
     'Content-Type': 'application/json',
   }), [token]);
 
-  // Fetch shipment lines when wizard opens
   useEffect(() => {
     if (!wizardOpen || !recordId || !base) return;
     let cancelled = false;
-
     (async () => {
       try {
-        const res = await fetch(
-          `${base}/goods-shipment/goodsShipmentLine?parentId=${recordId}&_startRow=0&_endRow=200`,
-          { headers },
-        );
+        const res = await fetch(`${base}/goods-shipment/goodsShipmentLine?parentId=${recordId}&_startRow=0&_endRow=200`, { headers });
         if (!res.ok || cancelled) return;
         const json = await res.json();
-        const fetchedLines = json?.response?.data || [];
-        if (!cancelled) setLines(fetchedLines);
-      } catch {
-        // silent — wizard will show empty lines
-      }
+        if (!cancelled) setReturnLines(json?.response?.data || []);
+      } catch { /* silent */ }
     })();
-
     return () => { cancelled = true; };
   }, [wizardOpen, recordId, base, headers]);
 
-  if (!isCompleted) return null;
+  const handleCreateInvoice = async (linesPayload) => {
+    if (creatingInvoice) return;
+    setCreatingInvoice(true);
+    try {
+      const body = linesPayload && linesPayload.length > 0 ? { lines: linesPayload } : {};
+      const res = await fetch(
+        `${base}/goods-shipment/goodsShipment/${recordId}/action/createDraftInvoice`,
+        { method: 'POST', headers, body: JSON.stringify(body) },
+      );
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        throw new Error(err?.response?.message || err?.message || `Failed (${res.status})`);
+      }
+      const json = await res.json();
+      const invoiceId = json?.response?.data?.id;
+      const docNo = json?.response?.data?.documentNo || '';
+
+      if (invoiceId) {
+        const currentPath = window.location.pathname;
+        const basePath = currentPath.replace(/\/goods-shipment\/.*$/, '');
+        const invoiceUrl = `${basePath}/sales-invoice/${invoiceId}`;
+        toast.custom((t) => (
+          <div style={{ background: '#16a34a', color: '#fff', borderRadius: 10, padding: '14px 18px', display: 'flex', alignItems: 'center', gap: 14, boxShadow: '0 8px 30px rgba(0,0,0,0.18)', minWidth: 380 }}>
+            <div style={{ width: 32, height: 32, borderRadius: '50%', background: 'rgba(255,255,255,0.2)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 14, fontWeight: 600, whiteSpace: 'nowrap' }}>Invoice #{docNo} created as Draft</div>
+              <div style={{ fontSize: 12, opacity: 0.8, marginTop: 2 }}>Review before confirming</div>
+            </div>
+            <button
+              onClick={() => { toast.dismiss(t); window.location.href = invoiceUrl; }}
+              style={{ border: '1px solid rgba(255,255,255,0.4)', borderRadius: 6, padding: '6px 14px', fontSize: 13, fontWeight: 500, color: '#fff', background: 'rgba(255,255,255,0.15)', cursor: 'pointer', whiteSpace: 'nowrap' }}
+            >
+              View Invoice →
+            </button>
+          </div>
+        ), { duration: 10000 });
+      } else {
+        toast.success('Invoice created as Draft');
+      }
+    } catch (err) {
+      toast.error(err.message || 'Failed to create invoice');
+    } finally {
+      setCreatingInvoice(false);
+      setShowInvoicePreview(false);
+    }
+  };
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() => setWizardOpen(true)}
-        className="inline-flex items-center gap-1.5 text-[13px] font-medium border border-border text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-colors"
-        style={{ padding: '4px 12px', borderRadius: '6px', borderWidth: '1px' }}
-      >
-        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-          <path d="M9 17H4a2 2 0 01-2-2V5a2 2 0 012-2h16a2 2 0 012 2v10a2 2 0 01-2 2h-5" />
-          <path d="M12 15l-3 3 3 3" />
-          <path d="M9 18h8" />
-        </svg>
-        Create Return
-      </button>
+      {isCompleted && !isFullyInvoiced && (
+        <button
+          type="button"
+          onClick={() => setShowInvoicePreview(true)}
+          disabled={creatingInvoice}
+          className="inline-flex items-center gap-1.5 text-[13px] font-medium transition-colors"
+          style={{ padding: '4px 12px', borderRadius: 6, border: '1px solid var(--color-border-info, #93c5fd)', background: 'var(--color-background-info, #eff6ff)', color: 'var(--color-text-info, #2563eb)', opacity: creatingInvoice ? 0.6 : 1, cursor: creatingInvoice ? 'not-allowed' : 'pointer' }}
+          onMouseEnter={e => { e.currentTarget.style.background = 'var(--color-background-info-hover, #dbeafe)'; }}
+          onMouseLeave={e => { e.currentTarget.style.background = 'var(--color-background-info, #eff6ff)'; }}
+        >
+          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+            <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+            <polyline points="14 2 14 8 20 8" />
+            <line x1="16" y1="13" x2="8" y2="13" />
+            <line x1="16" y1="17" x2="8" y2="17" />
+          </svg>
+          Create Invoice
+        </button>
+      )}
+
+      {isCompleted && (
+        <button
+          type="button"
+          onClick={() => setWizardOpen(true)}
+          className="inline-flex items-center gap-1.5 text-[13px] font-medium border border-border text-muted-foreground hover:text-foreground hover:bg-muted/30 transition-colors"
+          style={{ padding: '4px 12px', borderRadius: '6px', borderWidth: '1px' }}
+        >
+          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+            <path d="M9 17H4a2 2 0 01-2-2V5a2 2 0 012-2h16a2 2 0 012 2v10a2 2 0 01-2 2h-5" />
+            <path d="M12 15l-3 3 3 3" />
+            <path d="M9 18h8" />
+          </svg>
+          Create Return
+        </button>
+      )}
+
+      {showInvoicePreview && createPortal(
+        <ShipmentInvoicePreview
+          shipmentId={recordId}
+          shipmentData={data}
+          base={base}
+          headers={headers}
+          loading={creatingInvoice}
+          onConfirm={handleCreateInvoice}
+          onClose={() => setShowInvoicePreview(false)}
+        />,
+        document.body,
+      )}
+
+      <SendDocumentButton onClick={() => setShowSend(true)} />
 
       <ReturnWizard
         open={wizardOpen}
         onClose={() => setWizardOpen(false)}
         shipmentData={data}
-        lines={lines}
+        lines={returnLines}
         token={token}
         apiBaseUrl={apiBaseUrl}
-        onSuccess={() => {
-          setWizardOpen(false);
-          // Reload page to reflect changes
-          window.location.reload();
-        }}
-        onError={(msg) => {
-          // Error is handled inside ReturnWizard; keep dialog open
-          console.error('Return creation failed:', msg);
-        }}
+        onSuccess={() => { setWizardOpen(false); window.location.reload(); }}
+        onError={(msg) => console.error('Return creation failed:', msg)}
       />
+
+      {showSend && createPortal(
+        <SendDocumentModal
+          documentType="Shipment"
+          documentNo={data?.documentNo}
+          bpName={data?.['businessPartner$_identifier']}
+          bpEmail={data?.['userContact$_identifier']}
+          documentId={recordId}
+          windowName="goods-shipment"
+          token={token}
+          onClose={() => setShowSend(false)}
+        />,
+        document.body,
+      )}
     </>
+  );
+}
+
+function ShipmentInvoicePreview({ shipmentId, shipmentData, base, headers, loading, onConfirm, onClose }) {
+  const [lines, setLines] = useState([]);
+  const [loadingLines, setLoadingLines] = useState(true);
+  const [orderLinePrices, setOrderLinePrices] = useState({});
+  const [existingDraft, setExistingDraft] = useState(null);
+  const [dismissedWarning, setDismissedWarning] = useState(false);
+  const [lineQuantities, setLineQuantities] = useState({});
+
+  const bpName = shipmentData?.['businessPartner$_identifier'] || '';
+  const shipmentNo = shipmentData?.documentNo || '';
+  const orderId = shipmentData?.salesOrder;
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [linesRes, draftRes] = await Promise.all([
+          fetch(`${base}/goods-shipment/goodsShipmentLine?parentId=${shipmentId}&_startRow=0&_endRow=200`, { headers }),
+          fetch(`${base}/goods-shipment/goodsShipment/${shipmentId}/action/checkDraftInvoice`, { headers }),
+        ]);
+        if (!cancelled && linesRes.ok) {
+          setLines((await linesRes.json())?.response?.data || []);
+        }
+        if (!cancelled && draftRes.ok) {
+          const draftData = (await draftRes.json())?.response?.data;
+          if (draftData?.exists) setExistingDraft(draftData);
+        }
+      } catch { /* silent */ }
+      finally { if (!cancelled) setLoadingLines(false); }
+    })();
+    return () => { cancelled = true; };
+  }, [shipmentId, base, headers]);
+
+  useEffect(() => {
+    if (!orderId || !base) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`${base}/sales-order/lines?parentId=${orderId}&_startRow=0&_endRow=200`, { headers });
+        if (res.ok && !cancelled) {
+          const json = await res.json();
+          const olMap = {};
+          (json?.response?.data || []).forEach(ol => { olMap[ol.id] = ol; });
+          setOrderLinePrices(olMap);
+        }
+      } catch { /* silent */ }
+    })();
+    return () => { cancelled = true; };
+  }, [orderId, base, headers]);
+
+  const enrichedLines = useMemo(() =>
+    lines.map(l => {
+      const ol = orderLinePrices[l.salesOrderLine] || {};
+      const unitPrice = Number(ol.unitPrice) || 0;
+      const maxQty = Number(l.movementQuantity) || 0;
+      const currentQty = lineQuantities[l.id] ?? maxQty;
+      return { ...l, unitPrice, maxQty, currentQty, lineTotal: unitPrice * currentQty };
+    }),
+    [lines, orderLinePrices, lineQuantities],
+  );
+
+  useEffect(() => {
+    if (lines.length > 0 && Object.keys(lineQuantities).length === 0) {
+      const defaults = {};
+      lines.forEach(l => { defaults[l.id] = Number(l.movementQuantity) || 0; });
+      setLineQuantities(defaults);
+    }
+  }, [lines]);
+
+  const total = useMemo(() => enrichedLines.reduce((sum, l) => sum + l.lineTotal, 0), [enrichedLines]);
+
+  const fmtNum = (v) => v != null ? Number(v).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : '-';
+
+  return (
+    <div onClick={onClose} style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, zIndex: 9999, display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: 'rgba(0,0,0,0.3)' }}>
+      <div onClick={e => e.stopPropagation()} style={{ width: 560, maxHeight: '80vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', borderRadius: 12, backgroundColor: '#fff', boxShadow: '0 8px 30px rgba(0,0,0,0.12)', border: '0.5px solid #E5E7EB' }}>
+
+        <div style={{ padding: '14px 16px', background: '#F4F5F7', borderBottom: '1px solid #E5E7EB', flexShrink: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
+            <div>
+              <div style={{ fontSize: 15, fontWeight: 600, color: '#111827' }}>Create Invoice</div>
+              <div style={{ fontSize: 13, color: '#6B7280', marginTop: 3 }}>
+                Shipment {shipmentNo}{bpName ? ` · ${bpName}` : ''}
+              </div>
+            </div>
+            <button type="button" onClick={onClose} style={{ fontSize: 18, lineHeight: 1, padding: '2px 6px', borderRadius: 4, background: 'none', border: 'none', cursor: 'pointer', color: '#9ca3af' }}>&times;</button>
+          </div>
+        </div>
+
+        {existingDraft && !dismissedWarning && (
+          <div style={{ padding: '12px 20px', background: '#FAEEDA', borderBottom: '0.5px solid #EF9F27', display: 'flex', gap: 10, flexShrink: 0 }}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#854F0B" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, marginTop: 1 }}><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+            <div>
+              <div style={{ fontSize: 13, fontWeight: 500, color: '#633806' }}>This shipment already has a Draft invoice</div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 4 }}>
+                <button type="button" onClick={() => { onClose(); const bp = window.location.pathname.replace(/\/goods-shipment\/.*$/, ''); window.location.href = `${bp}/sales-invoice/${existingDraft.id}`; }} style={{ fontSize: 12, color: '#185FA5', background: 'none', border: 'none', padding: 0, cursor: 'pointer', textDecoration: 'underline' }}>View existing invoice →</button>
+                <span style={{ color: '#854F0B', fontSize: 12 }}>·</span>
+                <button type="button" onClick={() => setDismissedWarning(true)} style={{ fontSize: 12, color: '#854F0B', background: 'none', border: 'none', padding: 0, cursor: 'pointer', textDecoration: 'underline' }}>Create another anyway</button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div style={{ flex: 1, overflowY: 'auto', padding: 0 }}>
+          {loadingLines ? (
+            <p style={{ fontSize: 13, color: '#9ca3af', padding: '24px 0', textAlign: 'center' }}>Loading shipment lines...</p>
+          ) : enrichedLines.length === 0 ? (
+            <p style={{ fontSize: 13, color: '#9ca3af', padding: '24px 0', textAlign: 'center' }}>No lines found in this shipment.</p>
+          ) : (
+            <>
+              <div style={{ display: 'flex', padding: '8px 16px', fontSize: 11, fontWeight: 600, color: '#9ca3af', textTransform: 'uppercase', letterSpacing: '0.5px', borderBottom: '0.5px solid #E5E7EB', background: '#F9FAFB' }}>
+                <span style={{ flex: 1 }}>Product</span>
+                <span style={{ width: 70, textAlign: 'right' }}>Qty</span>
+                <span style={{ width: 80, textAlign: 'right' }}>Price</span>
+                <span style={{ width: 90, textAlign: 'right' }}>Amount</span>
+              </div>
+              {enrichedLines.map(line => {
+                const productName = line['product$_identifier'] || line.id;
+                const qtyEdited = line.currentQty !== line.maxQty;
+                return (
+                  <div key={line.id} style={{ display: 'flex', alignItems: 'center', padding: '8px 16px', borderBottom: '0.5px solid #F3F4F6' }}>
+                    <span style={{ flex: 1, fontSize: 13, color: '#111827', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{productName}</span>
+                    <span style={{ width: 70, textAlign: 'right' }}>
+                      <input
+                        type="number"
+                        min={1}
+                        max={line.maxQty}
+                        value={line.currentQty}
+                        onChange={e => {
+                          const v = Math.max(1, Math.min(line.maxQty, Number(e.target.value) || 1));
+                          setLineQuantities(prev => ({ ...prev, [line.id]: v }));
+                        }}
+                        style={{
+                          width: 56, fontSize: 12, padding: '2px 4px', borderRadius: 4, textAlign: 'center',
+                          fontVariantNumeric: 'tabular-nums', outline: 'none',
+                          border: qtyEdited ? '1px solid #f59e0b' : '0.5px solid #d1d5db',
+                          background: qtyEdited ? '#fffbeb' : '#fff',
+                        }}
+                      />
+                    </span>
+                    <span style={{ width: 80, fontSize: 12, color: '#6B7280', fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>
+                      {fmtNum(line.unitPrice)}
+                    </span>
+                    <span style={{ width: 90, fontSize: 13, color: '#111827', fontVariantNumeric: 'tabular-nums', textAlign: 'right', fontWeight: 500 }}>
+                      {fmtNum(line.lineTotal)}
+                    </span>
+                  </div>
+                );
+              })}
+            </>
+          )}
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: '#F5F5F5', borderTop: '1px solid #E5E5E5', padding: '10px 16px', flexShrink: 0 }}>
+          <span style={{ fontSize: 13, color: '#6B7280', fontVariantNumeric: 'tabular-nums' }}>
+            {enrichedLines.length > 0 && (
+              <>
+                {enrichedLines.length} line{enrichedLines.length !== 1 ? 's' : ''}
+                {' · '}<span style={{ fontWeight: 500, color: '#378ADD' }}>Total: {fmtNum(total)}</span>
+              </>
+            )}
+          </span>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button type="button" onClick={onClose} style={{ fontSize: 13, padding: '6px 14px', borderRadius: 6, border: '1px solid #E5E7EB', background: 'transparent', color: '#6B7280', cursor: 'pointer' }}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                const payload = enrichedLines.map(l => ({
+                  shipmentLineId: l.id,
+                  quantity: String(l.currentQty),
+                }));
+                onConfirm(payload);
+              }}
+              disabled={enrichedLines.length === 0 || loading}
+              style={{ fontSize: 13, fontWeight: 500, padding: '6px 14px', borderRadius: 6, border: 'none', background: '#18181b', color: '#fff', cursor: (enrichedLines.length === 0 || loading) ? 'not-allowed' : 'pointer', opacity: (enrichedLines.length === 0 || loading) ? 0.4 : 1 }}
+            >
+              {loading ? 'Creating...' : 'Create Invoice'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/artifacts/goods-shipment/custom/__tests__/BulkInvoiceFromShipment.test.js
+++ b/artifacts/goods-shipment/custom/__tests__/BulkInvoiceFromShipment.test.js
@@ -1,0 +1,66 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dirname, '..', 'BulkInvoiceFromShipment.jsx'), 'utf8');
+
+describe('BulkInvoiceFromShipment', () => {
+  it('exports a default function component', () => {
+    assert.match(src, /export default function BulkInvoiceFromShipment/);
+  });
+
+  it('accepts selectedRows, clearSelection, token, and apiBaseUrl props', () => {
+    assert.match(src, /\{\s*selectedRows.*clearSelection.*token.*apiBaseUrl\s*\}/);
+  });
+
+  it('filters invoiceable rows by documentStatus CO and not completely invoiced', () => {
+    assert.match(src, /documentStatus\s*===\s*'CO'/);
+    assert.match(src, /completelyInvoiced\s*!==\s*true/);
+  });
+
+  it('checks all selected shipments belong to the same business partner', () => {
+    assert.match(src, /invoiceableRows\.every\(r\s*=>\s*r\.businessPartner\s*===\s*firstBp\)/);
+  });
+
+  it('returns null when no rows are selected', () => {
+    assert.match(src, /selectedRows\.length\s*<\s*1.*return null/s);
+  });
+
+  it('renders a BulkInvoiceModal via createPortal', () => {
+    assert.match(src, /createPortal/);
+    assert.match(src, /BulkInvoiceModal/);
+  });
+
+  it('fetches shipment lines from goods-shipment API', () => {
+    assert.match(src, /goods-shipment\/goodsShipmentLine\?parentId=/);
+  });
+
+  it('fetches order line prices for unit price enrichment', () => {
+    assert.match(src, /sales-order\/lines\?parentId=/);
+  });
+
+  it('checks for existing draft invoices before creation', () => {
+    assert.match(src, /action\/checkDraftInvoice/);
+  });
+
+  it('creates draft invoice via action endpoint', () => {
+    assert.match(src, /action\/createDraftInvoice/);
+  });
+
+  it('supports line selection toggle and quantity editing', () => {
+    assert.match(src, /toggleLine/);
+    assert.match(src, /setLineQuantities/);
+  });
+
+  it('uses toast notifications for success and error feedback', () => {
+    assert.match(src, /toast\.success|toast\.custom|toast\.error/);
+  });
+
+  it('supports collapse/expand per shipment', () => {
+    assert.match(src, /toggleCollapse/);
+    assert.match(src, /collapsed/);
+  });
+});

--- a/artifacts/goods-shipment/decisions.json
+++ b/artifacts/goods-shipment/decisions.json
@@ -9,7 +9,8 @@
     "hideDeleteWhenComplete": true,
     "hidePrint": true,
     "customComponents": {
-      "topbarRight": "GoodsShipmentActions"
+      "topbarRight": "GoodsShipmentActions",
+      "bulkActions": "BulkInvoiceFromShipment"
     },
     "menuActions": [
       { "key": "cancel", "label": "Cancel", "destructive": true, "visibleWhenStatus": "CO" }

--- a/artifacts/goods-shipment/decisions.json
+++ b/artifacts/goods-shipment/decisions.json
@@ -4,12 +4,10 @@
     "category": "sales",
     "name": "Goods Shipment",
     "salesTheme": true,
-    "documentPreview": {
-      "titlePrefix": "Shipment"
-    },
     "notesField": "description",
     "relatedDocuments": true,
     "hideDeleteWhenComplete": true,
+    "hidePrint": true,
     "customComponents": {
       "topbarRight": "GoodsShipmentActions"
     },
@@ -55,7 +53,8 @@
           "visibility": "readOnly",
           "grid": true,
           "searchable": true,
-          "form": false
+          "form": false,
+          "display": "dot"
         },
         "partnerAddress": {
           "reference": "BusinessPartnerLocation",
@@ -64,6 +63,7 @@
             "field": "businessPartner",
             "filterKey": "C_BPartner_ID"
           },
+          "grid": true,
           "section": "principal"
         },
         "accountingDate": {
@@ -175,7 +175,9 @@
           "visibility": "discarded"
         },
         "completelyInvoiced": {
-          "visibility": "discarded"
+          "visibility": "readOnly",
+          "grid": true,
+          "name": "invoiced"
         },
         "invoicefromshipment": {
           "visibility": "discarded"

--- a/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentForm.jsx
+++ b/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentForm.jsx
@@ -7,7 +7,7 @@ const fields = [
   { key: 'warehouse', column: 'M_Warehouse_ID', type: 'search', label: 'Warehouse', required: true, section: 'principal', reference: 'Warehouse', inputMode: 'search', readOnlyLogic: (record) => record['processed'] === true },
   // @sf-custom-slot callout:SL_InOut_BPartner
   { key: 'businessPartner', column: 'C_BPartner_ID', type: 'search', label: 'Business Partner', required: true, section: 'principal', reference: 'BusinessPartner', inputMode: 'search', readOnlyLogic: (record) => record['processed'] === true },
-  { key: 'partnerAddress', column: 'C_BPartner_Location_ID', type: 'dependent', label: 'Partner Address', required: true, section: 'principal', reference: 'BusinessPartnerLocation', inputMode: 'dependent', dependsOn: { field: 'businessPartner', filterKey: 'C_BPartner_ID' }, readOnlyLogic: (record) => record['processed'] === true },
+  { key: 'partnerAddress', column: 'C_BPartner_Location_ID', type: 'dependent', label: 'Shipping Address', required: true, section: 'principal', reference: 'BusinessPartnerLocation', inputMode: 'dependent', dependsOn: { field: 'businessPartner', filterKey: 'C_BPartner_ID' }, readOnlyLogic: (record) => record['processed'] === true },
   { key: 'description', column: 'Description', type: 'textarea', label: 'Description', section: 'collapsed' },
   // @sf-custom-slot callout:SL_InOut_AccountingDate
   { key: 'movementDate', column: 'MovementDate', type: 'date', label: 'Movement Date', required: true, section: 'principal', defaultValue: '@#Date@', readOnlyLogic: (record) => record['processed'] === true },

--- a/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentPage.jsx
+++ b/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentPage.jsx
@@ -6,6 +6,7 @@ import GoodsShipmentLineTable from './GoodsShipmentLineTable';
 import GoodsShipmentLineForm from './GoodsShipmentLineForm';
 import RelatedDocuments from '../../../custom/RelatedDocuments';
 import GoodsShipmentActions from '../../../custom/GoodsShipmentActions';
+import BulkInvoiceFromShipment from '../../../custom/BulkInvoiceFromShipment';
 import catalogs from './mockCatalogs';
 
 
@@ -233,6 +234,9 @@ const api = {
 // @sf-generated-start component:GoodsShipmentPage
 export default function GoodsShipmentPage({ windowName, recordId, ...props }) {
   // @sf-custom-slot hooks:GoodsShipmentPage
+  const bulkActions = (ctx) => <BulkInvoiceFromShipment {...ctx} />;
+  props = { ...props, bulkActions };
+  // @sf-custom-slot-end hooks:GoodsShipmentPage
   if (recordId) {
     return (
       <DetailView
@@ -253,8 +257,8 @@ export default function GoodsShipmentPage({ windowName, recordId, ...props }) {
         recordId={recordId}
         breadcrumb={breadcrumb}
       api={api}
-        documentPreview={{ titlePrefix: 'Shipment', pdfUrl: null }}
         hideDeleteWhenComplete
+        hidePrint
         notesField="description"
         customTabs={[{ key: 'related', label: 'Related Documents', Component: RelatedDocuments }]}
         topbarRight={GoodsShipmentActions}

--- a/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentPage.jsx
+++ b/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentPage.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { ListView, DetailView } from '@/components/contract-ui';
 import { toast } from 'sonner';
 import GoodsShipmentTable from './GoodsShipmentTable';
@@ -233,10 +234,10 @@ const api = {
 
 // @sf-generated-start component:GoodsShipmentPage
 export default function GoodsShipmentPage({ windowName, recordId, ...props }) {
-  // @sf-custom-slot hooks:GoodsShipmentPage
+  // @sf-custom-start hooks:GoodsShipmentPage
   const bulkActions = (ctx) => <BulkInvoiceFromShipment {...ctx} />;
   props = { ...props, bulkActions };
-  // @sf-custom-slot-end hooks:GoodsShipmentPage
+  // @sf-custom-end hooks:GoodsShipmentPage
   if (recordId) {
     return (
       <DetailView
@@ -258,7 +259,6 @@ export default function GoodsShipmentPage({ windowName, recordId, ...props }) {
         breadcrumb={breadcrumb}
       api={api}
         hideDeleteWhenComplete
-        hidePrint
         notesField="description"
         customTabs={[{ key: 'related', label: 'Related Documents', Component: RelatedDocuments }]}
         topbarRight={GoodsShipmentActions}

--- a/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentTable.jsx
+++ b/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentTable.jsx
@@ -5,8 +5,10 @@ const columns = [
   { key: 'documentNo', column: 'DocumentNo', type: 'string', label: 'Document No.' },
   { key: 'warehouse', column: 'M_Warehouse_ID', type: 'string', label: 'Warehouse' },
   { key: 'businessPartner', column: 'C_BPartner_ID', type: 'string', label: 'Business Partner' },
+  { key: 'partnerAddress', column: 'C_BPartner_Location_ID', type: 'string', label: 'Shipping Address' },
   { key: 'movementDate', column: 'MovementDate', type: 'date', label: 'Movement Date' },
-  { key: 'documentStatus', column: 'DocStatus', type: 'status', label: 'Document Status' },
+  { key: 'documentStatus', column: 'DocStatus', type: 'status', label: 'Document Status', display: 'dot' },
+  { key: 'completelyInvoiced', column: 'Iscompletelyinvoiced', type: 'boolean', label: 'Invoiced', badge: true, badgeLabels: {"true":"Invoiced","false":"Pending"} },
 ];
 // @sf-generated-end columns:goodsShipment
 

--- a/artifacts/payment-in/contract.json
+++ b/artifacts/payment-in/contract.json
@@ -88,8 +88,7 @@
             "visibility": "readOnly",
             "required": false,
             "grid": false,
-            "form": true,
-            "section": "details"
+            "form": false
           },
           {
             "name": "paymentDate",
@@ -101,9 +100,8 @@
             "visibility": "readOnly",
             "required": false,
             "grid": true,
-            "form": true,
+            "form": false,
             "defaultValue": "@#Date@",
-            "section": "principal",
             "callout": {
               "className": "org.openbravo.erpCommon.ad_callouts.SE_Payment_MultiCurrency"
             },
@@ -123,10 +121,9 @@
             "visibility": "readOnly",
             "required": false,
             "grid": true,
-            "form": true,
+            "form": false,
             "reference": "BPartner",
             "inputMode": "search",
-            "section": "principal",
             "callout": {
               "className": "org.openbravo.erpCommon.ad_callouts.SE_Payment_BPartner"
             },
@@ -152,8 +149,7 @@
             "visibility": "editable",
             "required": false,
             "grid": false,
-            "form": true,
-            "section": "collapsed"
+            "form": false
           },
           {
             "name": "paymentMethod",
@@ -165,10 +161,9 @@
             "visibility": "readOnly",
             "required": true,
             "grid": false,
-            "form": true,
+            "form": false,
             "reference": "Paymentmethod",
             "inputMode": "search",
-            "section": "principal",
             "callout": {
               "className": "org.openbravo.erpCommon.ad_callouts.SE_PaymentMethod_FinAccount"
             },
@@ -188,9 +183,8 @@
             "visibility": "readOnly",
             "required": true,
             "grid": true,
-            "form": true,
+            "form": false,
             "defaultValue": "0",
-            "section": "principal",
             "callout": {
               "className": "org.openbravo.erpCommon.ad_callouts.SE_Payment_MultiCurrency"
             },
@@ -211,14 +205,13 @@
             "visibility": "readOnly",
             "required": true,
             "grid": false,
-            "form": true,
+            "form": false,
             "reference": "Financial_Account",
             "inputMode": "dependent",
             "dependsOn": {
               "field": "paymentMethod",
               "filterKey": "Fin_Paymentmethod_ID"
             },
-            "section": "principal",
             "callout": {
               "className": "org.openbravo.erpCommon.ad_callouts.SE_Payment_FinAccount"
             },
@@ -238,14 +231,13 @@
             "visibility": "readOnly",
             "required": true,
             "grid": false,
-            "form": true,
+            "form": false,
             "reference": "Currency",
             "inputMode": "dependent",
             "dependsOn": {
               "field": "account",
               "filterKey": "FIN_Financial_Account_ID"
             },
-            "section": "principal",
             "callout": {
               "className": "org.openbravo.erpCommon.ad_callouts.SE_Payment_MultiCurrency"
             },
@@ -369,7 +361,7 @@
             "visibility": "editable",
             "required": true,
             "grid": true,
-            "form": true,
+            "form": false,
             "defaultValue": "0"
           },
           {

--- a/artifacts/payment-in/custom/PaymentBottomPanel.jsx
+++ b/artifacts/payment-in/custom/PaymentBottomPanel.jsx
@@ -1,144 +1,330 @@
-import { useState, useEffect } from 'react';
-import RelatedDocuments from './RelatedDocuments';
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
 
 function fmtAmount(amount, currencyId) {
   const n = typeof amount === 'string' ? parseFloat(amount) : (amount ?? 0);
-  return new Intl.NumberFormat(undefined, {
-    style: 'currency',
-    currency: currencyId || 'EUR',
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(n);
+  try { return new Intl.NumberFormat(undefined, { style: 'currency', currency: currencyId || 'EUR', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(n); }
+  catch { return n.toFixed(2); }
 }
 
-/**
- * PaymentBottomPanel — Full-width bottom content for Payment In detail view.
- *
- * Layout (below the header form):
- *   1. Unallocated credit banner (only if remaining > 0)
- *   2. DOCS — related document chips
- *   3. NOTES — inline editable description field
- *
- * Activity is accessible via the topbar toggle (PaymentActivityToggle) which
- * opens a slide-in drawer containing PaymentActivityPanel.
- */
+function fmtDate(raw) {
+  if (!raw) return '';
+  try {
+    const d = new Date(raw);
+    return isNaN(d.getTime()) ? '' : d.toLocaleDateString(undefined, { day: '2-digit', month: '2-digit', year: 'numeric' });
+  } catch { return ''; }
+}
+
+function fmtInvoiceDate(raw) {
+  if (!raw) return '';
+  const d = new Date(raw);
+  return isNaN(d.getTime()) ? '' : d.toLocaleDateString('es-ES', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+const STATUS_MAP = {
+  RPPC: { label: 'Cleared', dot: '#059669', bg: '#d1fae5', color: '#065f46' },
+  RPR:  { label: 'Received', dot: '#059669', bg: '#d1fae5', color: '#065f46' },
+  RPAP: { label: 'Awaiting', dot: '#d97706', bg: '#fef3c7', color: '#92400e' },
+  RDNC: { label: 'Deposited', dot: '#2563eb', bg: '#dbeafe', color: '#1e40af' },
+  DR:   { label: 'Draft', dot: '#9ca3af', bg: '#f3f4f6', color: '#374151' },
+  RPVD: { label: 'Voided', dot: '#9ca3af', bg: '#f3f4f6', color: '#6b7280' },
+};
+
+const STATUS_LABELS = {
+  RPPC: 'Payment Cleared', DR: 'Draft', RPAP: 'Awaiting Payment',
+  RPR: 'Received', RDNC: 'Not Cleared', RPVD: 'Voided',
+};
+
+function fmtActivityDate(raw) {
+  if (!raw) return '';
+  try { return new Date(raw).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' }); }
+  catch { return ''; }
+}
+
+function isTechnicalDescription(value) {
+  if (!value || typeof value !== 'string') return true;
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+  return /^(Invoice No\.|Order No\.|Factura|Pedido|Payment)/i.test(trimmed);
+}
+
 export default function PaymentBottomPanel({
   recordId, data, token, apiBaseUrl, api,
-  notesField, onFieldChange, notesFocused, setNotesFocused,
+  summary, notesField, onFieldChange, notesFocused, setNotesFocused,
 }) {
   const [remaining, setRemaining] = useState(0);
+  const [linkedInvoices, setLinkedInvoices] = useState([]);
 
-  // Compute unallocated credit
+  const base = useMemo(() => (apiBaseUrl || '').replace(/\/[^/]+$/, ''), [apiBaseUrl]);
+  const hdrs = useMemo(() => ({ Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }), [token]);
+
   useEffect(() => {
-    if (!data?.id || !token || !apiBaseUrl) return;
-    const base = (apiBaseUrl || '').replace(/\/[^/]+$/, '');
-    const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
-
+    if (!data?.id || !token || !base) return;
+    let cancelled = false;
     (async () => {
       try {
-        const res = await fetch(
-          `${base}/payment-in/finPaymentScheduleDetail?parentId=${data.id}&_startRow=0&_endRow=100`,
-          { headers },
-        );
-        if (!res.ok) return;
+        const res = await fetch(`${base}/payment-in/finPaymentScheduleDetail?parentId=${data.id}&_startRow=0&_endRow=100`, { headers: hdrs });
+        if (!res.ok || cancelled) return;
         const details = (await res.json())?.response?.data || [];
-        const applied = details
-          .filter(d => d.invoicePaymentSchedule)
-          .reduce((sum, d) => sum + (parseFloat(d.amount) || 0), 0);
-        const total = parseFloat(data.amount) || 0;
-        setRemaining(Math.max(0, total - applied));
+        const applied = details.filter(d => d.invoicePaymentSchedule).reduce((sum, d) => sum + (parseFloat(d.amount) || 0), 0);
+        if (!cancelled) setRemaining(Math.max(0, (parseFloat(data.amount) || 0) - applied));
+        const scheduleIds = [...new Set(details.map(d => d.invoicePaymentSchedule).filter(Boolean))];
+        const invoices = [];
+        await Promise.all(scheduleIds.map(async (schedId) => {
+          try {
+            const r = await fetch(`${base}/sales-invoice/paymentPlan/${schedId}`, { headers: hdrs });
+            if (!r.ok) return;
+            const row = (await r.json())?.response?.data?.[0];
+            if (row?.invoice && !invoices.some(i => i.id === row.invoice)) {
+              const outstanding = parseFloat(row.outstandingAmount) || 0;
+              invoices.push({
+                id: row.invoice,
+                identifier: row['invoice$_identifier'] || '',
+                amount: row.amount,
+                isPaid: outstanding <= 0,
+              });
+            }
+          } catch { /* silent */ }
+        }));
+        if (!cancelled) setLinkedInvoices(invoices);
       } catch { /* silent */ }
     })();
-  }, [data?.id, data?.amount, token, apiBaseUrl]);
+    return () => { cancelled = true; };
+  }, [data?.id, data?.amount, token, base, hdrs]);
 
   const currency = data?.['currency$_identifier'] || 'EUR';
+  const bpName = data?.['businessPartner$_identifier'] || '';
+  const paymentDate = fmtDate(data?.paymentDate);
+  const paymentMethod = data?.['paymentMethod$_identifier'] || '';
+  const financialAccount = data?.['account$_identifier'] || data?.['finFinancialAccount$_identifier'] || '';
+  const status = data?.status;
+  const statusInfo = STATUS_MAP[status] || STATUS_MAP.DR;
+
+  // Activity timeline
+  const [persistedNotes, setPersistedNotes] = useState([]);
+  const [noteText, setNoteText] = useState('');
+  const [saving, setSaving] = useState(false);
+  const descriptionRef = useRef(data?.description || '');
+
+  useEffect(() => { descriptionRef.current = data?.description || ''; }, [data?.description]);
+
+  useEffect(() => {
+    if (!data?.description) { setPersistedNotes([]); return; }
+    const lines = data.description.split('\n').filter(l => l.trim());
+    const notes = [];
+    for (let idx = 0; idx < lines.length; idx++) {
+      const line = lines[idx];
+      const pipeIdx = line.indexOf('|');
+      if (pipeIdx > 0 && pipeIdx < 30) {
+        const maybeDateStr = line.slice(0, pipeIdx);
+        const parsed = new Date(maybeDateStr);
+        if (!isNaN(parsed.getTime())) {
+          notes.push({ key: `note-${idx}`, text: line.slice(pipeIdx + 1), date: fmtActivityDate(maybeDateStr), sortDate: parsed, isNote: true });
+        }
+      }
+    }
+    setPersistedNotes(notes);
+  }, [data?.description]);
+
+  const saveNote = useCallback(async (text) => {
+    if (!recordId || !token || !base) return false;
+    const timestamp = new Date().toISOString();
+    const newLine = `${timestamp}|${text}`;
+    const updatedDesc = descriptionRef.current ? `${descriptionRef.current}\n${newLine}` : newLine;
+    try {
+      const res = await fetch(`${base}/payment-in/finPayment/${recordId}`, { method: 'PATCH', headers: hdrs, body: JSON.stringify({ description: updatedDesc }) });
+      if (!res.ok) return false;
+      descriptionRef.current = updatedDesc;
+      return true;
+    } catch { return false; }
+  }, [recordId, token, base, hdrs]);
+
+  const handleAddNote = async () => {
+    const text = noteText.trim();
+    if (!text || saving) return;
+    setSaving(true);
+    if (await saveNote(text)) {
+      setPersistedNotes(prev => [...prev, { key: `note-${Date.now()}`, text, date: fmtActivityDate(new Date().toISOString()), sortDate: new Date(), isNote: true }]);
+      setNoteText('');
+    }
+    setSaving(false);
+  };
+
+  const activityEvents = useMemo(() => {
+    const events = [];
+    const sysDate = fmtActivityDate(data?.paymentDate || data?.creationDate);
+    const sysSortDate = new Date(data?.paymentDate || data?.creationDate || 0);
+    if (data?.paymentDate || data?.creationDate) {
+      events.push({ key: 'created', text: 'Payment created', date: sysDate, sortDate: sysSortDate, isNote: false });
+    }
+    for (const inv of linkedInvoices) {
+      const docNo = (inv.identifier || '').split(' - ')[0] || '';
+      events.push({ key: `inv-${inv.id}`, text: `Linked to Invoice #${docNo}`, date: sysDate, sortDate: sysSortDate, isNote: false });
+    }
+    const st = data?.status;
+    if (st && st !== 'DR') {
+      events.push({ key: 'status', text: `Status → ${STATUS_LABELS[st] || st}`, date: sysDate, sortDate: sysSortDate, isNote: false });
+    }
+    events.sort((a, b) => a.sortDate - b.sortDate);
+    return [...events, ...persistedNotes];
+  }, [data, linkedInvoices, persistedNotes]);
+
+  if (data && !financialAccount) {
+    console.log('[PaymentBottomPanel] account keys:', Object.keys(data).filter(k => k.toLowerCase().includes('account') || k.toLowerCase().includes('financial')));
+  }
+
+  const navigateToInvoice = (invoiceId) => {
+    const bp = window.location.pathname.replace(/\/payment-in\/.*$/, '');
+    window.location.href = `${bp}/sales-invoice/${invoiceId}`;
+  };
+
+  const fields = [
+    { label: 'Customer', value: bpName },
+    { label: 'Payment Date', value: paymentDate },
+    { label: 'Method', value: paymentMethod },
+    { label: 'Deposit to', value: financialAccount, isAccount: true },
+  ];
 
   return (
-    <div>
-      {/* Separator between header form and content sections */}
-      <div style={{ borderTop: '1px solid #e5e7eb', margin: '8px 0 20px' }} />
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
 
-      {/* Unallocated credit banner — only when remaining > 0 */}
-      {remaining > 0 && (
-        <div
-          style={{
-            backgroundColor: '#fffbeb',
-            border: '1px solid #fde68a',
-            borderRadius: 6,
-            padding: '8px 14px',
-            marginBottom: 20,
-          }}
-        >
-          <span className="text-xs" style={{ color: '#92400e' }}>
-            This payment has <strong>{fmtAmount(remaining, currency)}</strong> of unallocated credit
+      {/* Hero */}
+      <div style={{ backgroundColor: '#F5F5F5', borderRadius: 10, padding: '14px 16px' }}>
+        {/* Amount + badge */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', paddingBottom: 14, borderBottom: '0.5px solid #E5E7EB', marginBottom: 0 }}>
+          <span style={{ fontSize: 28, fontWeight: 500, color: '#111827', lineHeight: 1.2 }}>{fmtAmount(data?.amount, currency)}</span>
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '4px 12px', borderRadius: 9999, backgroundColor: statusInfo.bg, color: statusInfo.color, fontSize: 12, fontWeight: 500, whiteSpace: 'nowrap' }}>
+            <span style={{ width: 8, height: 8, borderRadius: '50%', backgroundColor: statusInfo.dot }} />
+            {statusInfo.label}
           </span>
+        </div>
+
+        {/* Detail grid — 4 columns */}
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr 1fr', backgroundColor: '#fff', borderRadius: 8, border: '0.5px solid #d1d5db', overflow: 'hidden', marginTop: 14 }}>
+          {fields.map((f, i) => (
+            <div key={f.label} style={{ padding: '14px 18px', borderLeft: i > 0 ? '0.5px solid #d1d5db' : 'none' }}>
+              <div style={{ fontSize: 10, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: '#6B7280', marginBottom: 4 }}>{f.label}</div>
+              <div style={{ fontSize: 15, fontWeight: 500, color: f.isAccount ? '#2563eb' : '#111827', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'flex', alignItems: 'center', gap: 4 }}>
+                {f.isAccount && f.value && (
+                  <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#2563eb" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0 }}>
+                    <rect x="1" y="4" width="22" height="16" rx="2" ry="2" /><line x1="1" y1="10" x2="23" y2="10" />
+                  </svg>
+                )}
+                {f.value || '—'}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Unallocated credit */}
+      {remaining > 0 && (
+        <div style={{ backgroundColor: '#FFFBEB', borderLeft: '3px solid #F59E0B', borderRadius: '0 6px 6px 0', padding: '10px 14px' }}>
+          <span style={{ fontSize: 13, color: '#92400e' }}><strong>{fmtAmount(remaining, currency)}</strong> unallocated credit</span>
         </div>
       )}
 
-      {/* DOCS section — first section, separator above provides the top divider */}
-      <SectionBlock label="Docs" noBorder>
-        <RelatedDocuments
-          recordId={recordId}
-          data={data}
-          token={token}
-          apiBaseUrl={apiBaseUrl}
-          api={api}
-          layout="chips"
-        />
-      </SectionBlock>
+      {/* Invoice cards */}
+      {linkedInvoices.length > 0 && (
+        <div>
+          <span style={{ display: 'block', fontSize: 10, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: '#9ca3af', marginBottom: 6 }}>Invoice</span>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+            {linkedInvoices.map(inv => {
+              const parts = (inv.identifier || '').split(' - ');
+              const docNo = parts[0] || '';
+              const dateStr = fmtInvoiceDate(parts[1]);
+              const subtitle = [bpName, dateStr].filter(Boolean).join(' · ');
+              const badgeColor = inv.isPaid
+                ? { bg: '#d1fae5', color: '#065f46', dot: '#059669', label: 'Paid' }
+                : { bg: '#fef3c7', color: '#92400e', dot: '#d97706', label: 'Pending' };
+              return (
+                <button
+                  key={inv.id}
+                  type="button"
+                  onClick={() => navigateToInvoice(inv.id)}
+                  style={{ display: 'flex', alignItems: 'center', gap: 12, backgroundColor: '#F9FAFB', border: '0.5px solid #E5E7EB', borderRadius: 10, padding: '12px 14px', cursor: 'pointer', textAlign: 'left', width: '100%' }}
+                >
+                  <div style={{ width: 34, height: 34, borderRadius: 8, backgroundColor: '#dbeafe', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#2563eb" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" /><polyline points="14 2 14 8 20 8" /><line x1="16" y1="13" x2="8" y2="13" /><line x1="16" y1="17" x2="8" y2="17" />
+                    </svg>
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 13, fontWeight: 500, color: '#2563eb' }}>Invoice #{docNo}</div>
+                    {subtitle && <div style={{ fontSize: 12, color: '#6B7280', marginTop: 1 }}>{subtitle}</div>}
+                  </div>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexShrink: 0 }}>
+                    {inv.amount && <span style={{ fontSize: 13, fontWeight: 500, color: '#111827', fontVariantNumeric: 'tabular-nums' }}>{fmtAmount(inv.amount, currency)}</span>}
+                    <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '2px 8px', borderRadius: 9999, backgroundColor: badgeColor.bg, color: badgeColor.color, fontSize: 11, fontWeight: 500 }}>
+                      <span style={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: badgeColor.dot }} />
+                      {badgeColor.label}
+                    </span>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#d1d5db" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6" /></svg>
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
-      {/* NOTES section — inline editable description field */}
-      {notesField && (
-        <SectionBlock label="Notes">
-          {notesFocused ? (
-            <textarea
-              value={data?.[notesField] || ''}
-              onChange={(e) => onFieldChange?.(notesField, e.target.value)}
-              onBlur={() => setNotesFocused?.(false)}
-              placeholder="Add a note..."
-              rows={3}
-              autoFocus
-              className="w-full text-sm resize-none focus:outline-none focus:ring-1 focus:ring-primary/30"
-              style={{
-                backgroundColor: '#ffffff',
-                border: '1px solid #e5e7eb',
-                borderRadius: 6,
-                padding: '8px 12px',
-              }}
-            />
-          ) : (
-            <div
-              tabIndex={0}
-              role="textbox"
-              onClick={() => setNotesFocused?.(true)}
-              onFocus={() => setNotesFocused?.(true)}
-              className="w-full text-sm cursor-text"
-              style={{
-                padding: '7px 0',
-                minHeight: 28,
-                color: data?.[notesField] ? '#374151' : '#d1d5db',
-              }}
-            >
-              {data?.[notesField] || 'Add a note...'}
+      {/* Activity */}
+      <div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 6 }}>
+          <span style={{ fontSize: 10, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: '#9ca3af' }}>Activity</span>
+          {activityEvents.length > 0 && (
+            <span style={{ fontSize: 10, fontWeight: 500, backgroundColor: '#f3f4f6', color: '#6B7280', padding: '1px 6px', borderRadius: 9999 }}>{activityEvents.length}</span>
+          )}
+        </div>
+
+        <div style={{ border: '0.5px solid #E5E7EB', borderRadius: 10, overflow: 'hidden' }}>
+          {/* Timeline */}
+          {activityEvents.length > 0 && (
+            <div style={{ position: 'relative', paddingLeft: 28, padding: '14px 14px 14px 28px' }}>
+              <div style={{ position: 'absolute', left: 12, top: 20, bottom: 14, width: 1.5, backgroundColor: '#e5e7eb' }} />
+              {activityEvents.map((ev, i) => (
+                <div key={ev.key} style={{ position: 'relative', paddingBottom: i < activityEvents.length - 1 ? 16 : 0 }}>
+                  <span style={{ position: 'absolute', left: -20 + 1, top: 3, width: 8, height: 8, borderRadius: '50%', backgroundColor: ev.isNote ? '#EF9F27' : '#9ca3af' }} />
+                  {ev.isNote ? (
+                    <div>
+                      <div style={{ fontSize: 11, color: '#6B7280', marginBottom: 3 }}>{ev.userName || 'You'} · {ev.date}</div>
+                      <div style={{ backgroundColor: '#F5F5F5', borderRadius: 8, padding: '8px 12px', maxWidth: '85%' }}>
+                        <div style={{ fontSize: 13, color: '#111827' }}>{ev.text}</div>
+                      </div>
+                    </div>
+                  ) : (
+                    <div>
+                      <div style={{ fontSize: 13, color: '#374151' }}>{ev.text}</div>
+                      <div style={{ fontSize: 11, color: '#9ca3af', marginTop: 1 }}>{ev.date}</div>
+                    </div>
+                  )}
+                </div>
+              ))}
             </div>
           )}
-        </SectionBlock>
-      )}
-    </div>
-  );
-}
 
-/** Reusable section with label + top divider. Pass noBorder to skip the divider. */
-function SectionBlock({ label, children, noBorder }) {
-  return (
-    <div style={{ ...(noBorder ? {} : { borderTop: '1px solid #f3f4f6' }), paddingTop: 16, marginBottom: 16 }}>
-      <span
-        className="block text-[11px] font-medium uppercase"
-        style={{ color: '#111827', letterSpacing: '0.04em', marginBottom: 10 }}
-      >
-        {label}
-      </span>
-      {children}
+          {/* Add a note input */}
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center', padding: '10px 14px', borderTop: '0.5px solid #E5E7EB' }}>
+            <input
+              type="text"
+              value={noteText}
+              onChange={(e) => setNoteText(e.target.value)}
+              onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); handleAddNote(); } }}
+              placeholder="Add a note..."
+              disabled={saving}
+              style={{ flex: 1, fontSize: 13, padding: '7px 10px', border: '0.5px solid #E5E7EB', borderRadius: 6, outline: 'none', color: '#374151', backgroundColor: '#fff', boxSizing: 'border-box' }}
+            />
+            <button
+              type="button"
+              onClick={handleAddNote}
+              disabled={!noteText.trim() || saving}
+              style={{ fontSize: 13, fontWeight: 500, padding: '7px 14px', borderRadius: 6, border: 'none', backgroundColor: noteText.trim() ? '#18181b' : '#e5e7eb', color: noteText.trim() ? '#fff' : '#9ca3af', cursor: noteText.trim() && !saving ? 'pointer' : 'default', flexShrink: 0 }}
+            >
+              {saving ? '...' : 'Add'}
+            </button>
+          </div>
+        </div>
+      </div>
+
     </div>
   );
 }

--- a/artifacts/payment-in/decisions.json
+++ b/artifacts/payment-in/decisions.json
@@ -5,7 +5,6 @@
     "name": "Payment In",
     "salesTheme": true,
     "documentPreview": { "titlePrefix": "Payment" },
-    "notesField": "description",
     "relatedDocuments": true,
     "customComponents": {
       "bottomSection": "PaymentBottomPanel",
@@ -41,42 +40,43 @@
           "visibility": "readOnly",
           "grid": true,
           "searchable": true,
-          "inputMode": "date",
-          "section": "principal"
+          "form": false,
+          "inputMode": "date"
         },
         "businessPartner": {
           "visibility": "readOnly",
           "grid": true,
           "searchable": true,
-          "section": "principal"
+          "form": false
         },
         "amount": {
           "visibility": "readOnly",
           "grid": true,
-          "inputMode": "number",
-          "section": "principal"
+          "form": false,
+          "inputMode": "number"
         },
         "paymentMethod": {
           "visibility": "readOnly",
-          "inputMode": "search",
-          "section": "principal"
+          "form": false,
+          "inputMode": "search"
         },
         "account": {
           "visibility": "readOnly",
+          "form": false,
           "inputMode": "search",
           "dependsOn": {
             "field": "paymentMethod",
             "filterKey": "Fin_Paymentmethod_ID"
-          },
-          "section": "principal"
+          }
         },
         "referenceNo": {
           "visibility": "readOnly",
-          "inputMode": "text",
-          "section": "details"
+          "form": false,
+          "inputMode": "text"
         },
         "currency": {
           "visibility": "readOnly",
+          "form": false,
           "inputMode": "search",
           "dependsOn": {
             "field": "account",
@@ -85,8 +85,8 @@
           "section": "principal"
         },
         "description": {
-          "inputMode": "textarea",
-          "section": "collapsed"
+          "form": false,
+          "inputMode": "textarea"
         },
         "status": {
           "visibility": "readOnly",

--- a/artifacts/payment-in/generated/web/payment-in/FinPaymentForm.jsx
+++ b/artifacts/payment-in/generated/web/payment-in/FinPaymentForm.jsx
@@ -2,20 +2,7 @@ import { EntityForm } from '@/components/contract-ui';
 
 // @sf-generated-start fields:finPayment
 const fields = [
-  { key: 'referenceNo', column: 'Referenceno', type: 'text', label: 'Reference No.', readOnly: true, section: 'details' },
-  // @sf-custom-slot callout:SE_Payment_MultiCurrency
-  { key: 'paymentDate', column: 'Paymentdate', type: 'date', label: 'Payment Date', readOnly: true, section: 'principal', defaultValue: '@#Date@', readOnlyLogic: (record) => record['processed'] === true && record['status'] !== 'RPAE' },
-  // @sf-custom-slot callout:SE_Payment_BPartner
-  { key: 'businessPartner', column: 'C_Bpartner_ID', type: 'search', label: 'Received From', readOnly: true, section: 'principal', reference: 'BPartner', inputMode: 'search', visible: null, visibilitySource: 'server', displayLogicReason: 'server-macro', readOnlyLogic: (record) => record['processed'] === true },
-  { key: 'description', column: 'Description', type: 'textarea', label: 'Description', section: 'collapsed' },
-  // @sf-custom-slot callout:SE_PaymentMethod_FinAccount
-  { key: 'paymentMethod', column: 'Fin_Paymentmethod_ID', type: 'search', label: 'Payment Method', required: true, readOnly: true, section: 'principal', reference: 'Paymentmethod', inputMode: 'search', readOnlyLogic: (record) => record['processed'] === true && record['status'] !== 'RPAE' },
-  // @sf-custom-slot callout:SE_Payment_MultiCurrency
-  { key: 'amount', column: 'Amount', type: 'number', label: 'Amount', required: true, readOnly: true, section: 'principal', defaultValue: '0', readOnlySource: 'server', readOnlyLogicReason: 'session-variable' },
-  // @sf-custom-slot callout:SE_Payment_FinAccount
-  { key: 'account', column: 'Fin_Financial_Account_ID', type: 'dependent', label: 'Deposit To', required: true, readOnly: true, section: 'principal', reference: 'Financial_Account', inputMode: 'dependent', dependsOn: { field: 'paymentMethod', filterKey: 'Fin_Paymentmethod_ID' }, readOnlyLogic: (record) => record['processed'] === true && record['status'] !== 'RPAE' },
-  // @sf-custom-slot callout:SE_Payment_MultiCurrency
-  { key: 'currency', column: 'C_Currency_ID', type: 'dependent', label: 'Currency', required: true, readOnly: true, section: 'principal', reference: 'Currency', inputMode: 'dependent', dependsOn: { field: 'account', filterKey: 'FIN_Financial_Account_ID' }, readOnlySource: 'server', readOnlyLogicReason: 'session-variable' },
+
 ];
 // @sf-generated-end fields:finPayment
 

--- a/artifacts/payment-in/generated/web/payment-in/FinPaymentScheduleDetailForm.jsx
+++ b/artifacts/payment-in/generated/web/payment-in/FinPaymentScheduleDetailForm.jsx
@@ -3,7 +3,6 @@ import { EntityForm } from '@/components/contract-ui';
 // @sf-generated-start fields:finPaymentScheduleDetail
 const fields = [
   { key: 'dueDate', column: 'DueDate', type: 'date', label: 'Due Date', readOnly: true, section: 'other' },
-  { key: 'amount', column: 'Amount', type: 'number', label: 'Received Amount', required: true, section: 'principal', defaultValue: '0' },
   { key: 'invoicePaymentSchedule', column: 'FIN_Payment_Schedule_Invoice', type: 'search', label: 'Invoice Payment Schedule', section: 'principal', reference: 'Payment_Schedule', inputMode: 'search' },
 ];
 // @sf-generated-end fields:finPaymentScheduleDetail

--- a/artifacts/sales-invoice/contract.json
+++ b/artifacts/sales-invoice/contract.json
@@ -8,9 +8,6 @@
       "name": "Sales Invoice",
       "primaryEntity": "header",
       "category": "sales",
-      "documentPreview": {
-        "titlePrefix": "Invoice"
-      },
       "notesField": "description",
       "relatedDocuments": true,
       "hideDeleteWhenComplete": true,
@@ -35,7 +32,7 @@
         "Complete": {
           "add": true,
           "label": "Confirm & Send",
-          "columnName": "documentAction",
+          "columnName": "DocAction",
           "displayLogicRaw": "@documentStatus@='DR'"
         }
       },
@@ -254,7 +251,8 @@
                 "name": "Voided"
               }
             ],
-            "defaultValue": "DR"
+            "defaultValue": "DR",
+            "display": "dot"
           },
           {
             "name": "grandTotalAmount",

--- a/artifacts/sales-invoice/custom/ImportFromShipmentModal.jsx
+++ b/artifacts/sales-invoice/custom/ImportFromShipmentModal.jsx
@@ -1,0 +1,360 @@
+import { useState, useEffect, useMemo } from 'react';
+import { toast } from 'sonner';
+
+export default function ImportFromShipmentModal({ invoiceId, bpId, base, headers, onClose, onSuccess }) {
+  const [shipments, setShipments] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState(new Set());
+  const [expanded, setExpanded] = useState(new Set());
+  const [shipmentLines, setShipmentLines] = useState({});
+  const [loadingLines, setLoadingLines] = useState(new Set());
+  const [importing, setImporting] = useState(false);
+  const [search, setSearch] = useState('');
+  const [lineQuantities, setLineQuantities] = useState({});
+  const [alreadyImported, setAlreadyImported] = useState({ shipmentLines: new Set(), orderLines: new Set() });
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        // Fetch shipments and existing invoice lines in parallel
+        const [shipRes, invLinesRes] = await Promise.all([
+          fetch(`${base}/goods-shipment/goodsShipment?_startRow=0&_endRow=500`, { headers }),
+          fetch(`${base}/sales-invoice/lines?parentId=${invoiceId}&_startRow=0&_endRow=200`, { headers }),
+        ]);
+
+        // Get IDs of shipment lines and order lines already in this invoice
+        const alreadyImportedShipmentLines = new Set();
+        const alreadyImportedOrderLines = new Set();
+        if (invLinesRes.ok && !cancelled) {
+          const invLines = (await invLinesRes.json())?.response?.data || [];
+          invLines.forEach(il => {
+            if (il.goodsShipmentLine) alreadyImportedShipmentLines.add(il.goodsShipmentLine);
+            if (il.salesOrderLine) alreadyImportedOrderLines.add(il.salesOrderLine);
+          });
+        }
+
+        if (shipRes.ok && !cancelled) {
+          const all = (await shipRes.json())?.response?.data || [];
+          setShipments(all.filter(s =>
+            s.documentStatus === 'CO'
+            && s.businessPartner === bpId
+            && s.completelyInvoiced !== true
+          ));
+          setAlreadyImported({ shipmentLines: alreadyImportedShipmentLines, orderLines: alreadyImportedOrderLines });
+        }
+      } catch { /* silent */ }
+      finally { if (!cancelled) setLoading(false); }
+    })();
+    return () => { cancelled = true; };
+  }, [bpId, base, headers, invoiceId]);
+
+  const bpName = shipments[0]?.['businessPartner$_identifier'] || '';
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return shipments;
+    const q = search.toLowerCase();
+    return shipments.filter(s => (s.documentNo || '').toLowerCase().includes(q));
+  }, [shipments, search]);
+
+  const fetchLines = async (shipmentId) => {
+    if (shipmentLines[shipmentId] || loadingLines.has(shipmentId)) return;
+    setLoadingLines(prev => { const n = new Set(prev); n.add(shipmentId); return n; });
+    try {
+      const res = await fetch(`${base}/goods-shipment/goodsShipmentLine?parentId=${shipmentId}&_startRow=0&_endRow=200`, { headers });
+      if (res.ok) {
+        const json = await res.json();
+        const lines = json?.response?.data || [];
+
+        const shipment = shipments.find(s => s.id === shipmentId);
+        const orderId = shipment?.salesOrder;
+        let orderLineMap = {};
+        if (orderId) {
+          try {
+            const olRes = await fetch(`${base}/sales-order/lines?parentId=${orderId}&_startRow=0&_endRow=200`, { headers });
+            if (olRes.ok) {
+              const olJson = await olRes.json();
+              const orderLines = olJson?.response?.data || [];
+              orderLines.forEach(ol => { orderLineMap[ol.id] = ol; });
+            }
+          } catch { /* silent */ }
+        }
+
+        const enrichedLines = lines.map(l => {
+          const ol = orderLineMap[l.salesOrderLine] || {};
+          const imported = (alreadyImported.shipmentLines || alreadyImported).has?.(l.id) || (alreadyImported.orderLines?.has(l.salesOrderLine));
+          return { ...l, _unitPrice: Number(ol.unitPrice ?? ol.priceActual ?? 0), _lineNetAmount: Number(ol.lineNetAmount ?? 0), _alreadyImported: !!imported };
+        });
+
+        setShipmentLines(prev => ({ ...prev, [shipmentId]: enrichedLines }));
+        const qtyDefaults = {};
+        const newSelected = new Set();
+        enrichedLines.forEach(l => {
+          qtyDefaults[l.id] = Number(l.movementQuantity) || 0;
+          if (!l._alreadyImported) newSelected.add(l.id);
+        });
+        setLineQuantities(prev => ({ ...prev, ...qtyDefaults }));
+        setSelected(prev => { const n = new Set(prev); newSelected.forEach(id => n.add(id)); return n; });
+      }
+    } catch { /* silent */ }
+    finally { setLoadingLines(prev => { const n = new Set(prev); n.delete(shipmentId); return n; }); }
+  };
+
+  const toggleExpand = (shipmentId) => {
+    setExpanded(prev => {
+      const n = new Set(prev);
+      if (n.has(shipmentId)) { n.delete(shipmentId); } else { n.add(shipmentId); fetchLines(shipmentId); }
+      return n;
+    });
+  };
+
+  const toggleLine = (lineId) => {
+    setSelected(prev => { const n = new Set(prev); n.has(lineId) ? n.delete(lineId) : n.add(lineId); return n; });
+  };
+
+  const toggleShipment = (shipmentId) => {
+    const lines = shipmentLines[shipmentId] || [];
+    if (lines.length === 0) return;
+    const lineIds = lines.map(l => l.id);
+    const allSelected = lineIds.every(id => selected.has(id));
+    setSelected(prev => {
+      const n = new Set(prev);
+      if (allSelected) { lineIds.forEach(id => n.delete(id)); } else { lineIds.forEach(id => n.add(id)); }
+      return n;
+    });
+  };
+
+  const getShipmentCheckState = (shipmentId) => {
+    const lines = shipmentLines[shipmentId] || [];
+    if (lines.length === 0) return { checked: false, indeterminate: false };
+    const count = lines.filter(l => selected.has(l.id)).length;
+    if (count === 0) return { checked: false, indeterminate: false };
+    if (count === lines.length) return { checked: true, indeterminate: false };
+    return { checked: false, indeterminate: true };
+  };
+
+  const handleImport = async () => {
+    if (selected.size === 0 || importing) return;
+    setImporting(true);
+    try {
+      let lineNo = 10;
+      let errors = 0;
+      for (const shipment of shipments) {
+        const lines = (shipmentLines[shipment.id] || []).filter(l => selected.has(l.id));
+        if (lines.length === 0) continue;
+
+        // Fetch order line prices for this shipment
+        const orderLineMap = {};
+        if (shipment.salesOrder) {
+          try {
+            const olRes = await fetch(`${base}/sales-order/lines?parentId=${shipment.salesOrder}&_startRow=0&_endRow=200`, { headers });
+            if (olRes.ok) {
+              ((await olRes.json())?.response?.data || []).forEach(ol => { orderLineMap[ol.id] = ol; });
+            }
+          } catch { /* silent */ }
+        }
+
+        for (const line of lines) {
+          const ol = orderLineMap[line.salesOrderLine] || {};
+          const qty = lineQuantities[line.id] ?? (Number(line.movementQuantity) || 0);
+          const lineBody = {
+            parentId: invoiceId,
+            product: line.product,
+            invoicedQuantity: qty,
+            unitPrice: Number(ol.unitPrice) || 0,
+            tax: ol.tax || null,
+            uOM: line.uOM || ol.uOM || null,
+            lineNo,
+            goodsShipmentLine: line.id,
+            salesOrderLine: line.salesOrderLine || null,
+          };
+          const res = await fetch(`${base}/sales-invoice/lines`, {
+            method: 'POST', headers, body: JSON.stringify(lineBody),
+          });
+          const resJson = await res.json().catch(() => null);
+          if (!res.ok) errors++;
+          lineNo += 10;
+        }
+      }
+      if (errors > 0) {
+        toast.warning(`Imported with ${errors} error(s) — review the invoice`);
+        console.warn('[ImportFromShipment] Completed with errors:', errors);
+      } else {
+        toast.success(`${lineNo / 10 - 1} lines imported`);
+      }
+      onSuccess();
+    } catch (err) { toast.error(err.message || 'Failed to import'); }
+    finally { setImporting(false); }
+  };
+
+  const fmtDate = (d) => d ? new Date(d).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) : '-';
+  const fmtNum = (v) => v != null ? Number(v).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : '-';
+
+  return (
+    <div onClick={onClose} style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, zIndex: 9999, display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: 'rgba(0,0,0,0.3)' }}>
+      <div onClick={e => e.stopPropagation()} style={{ width: 580, maxHeight: '80vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', borderRadius: 12, backgroundColor: '#fff', boxShadow: '0 8px 30px rgba(0,0,0,0.12)', border: '0.5px solid #E5E7EB' }}>
+
+        <div style={{ padding: '14px 16px', borderBottom: '2px solid #E5E7EB' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <span style={{ fontSize: 14, fontWeight: 600, color: '#111827' }}>Import from Shipment</span>
+            <button type="button" onClick={onClose} style={{ fontSize: 18, lineHeight: 1, padding: '2px 6px', borderRadius: 4, background: 'none', border: 'none', cursor: 'pointer', color: '#6B7280' }}>&times;</button>
+          </div>
+          {bpName && <div style={{ fontSize: 13, color: '#9ca3af', marginTop: 2 }}>{bpName}</div>}
+        </div>
+
+        <div style={{ padding: '10px 16px 0' }}>
+          <input
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search shipment..."
+            style={{ width: '100%', fontSize: 13, padding: '7px 10px', border: '0.5px solid #E5E7EB', borderRadius: 6, outline: 'none', color: '#111827' }}
+          />
+        </div>
+
+        <div style={{ flex: 1, overflowY: 'auto', padding: 0 }}>
+          {loading ? (
+            <p style={{ fontSize: 13, color: '#9ca3af', padding: '24px 0', textAlign: 'center' }}>Loading...</p>
+          ) : filtered.length === 0 ? (
+            <p style={{ fontSize: 13, color: '#9ca3af', padding: '24px 0', textAlign: 'center' }}>
+              {shipments.length === 0 ? 'No pending shipments to invoice for this customer.' : 'No shipments match your search.'}
+            </p>
+          ) : (
+            filtered.map(s => {
+              const isExpanded = expanded.has(s.id);
+              const isLoadingLns = loadingLines.has(s.id);
+              const lines = shipmentLines[s.id] || [];
+              const checkState = getShipmentCheckState(s.id);
+              const hasAnySelected = checkState.checked || checkState.indeterminate;
+              const orderRef = (s['salesOrder$_identifier'] || '').split(' - ')[0] || '';
+              const shipmentTotal = lines.length > 0
+                ? lines.reduce((sum, l) => sum + (l._lineNetAmount || 0), 0)
+                : null;
+              return (
+                <div key={s.id} style={{ borderLeft: (isExpanded || hasAnySelected) ? '3px solid var(--color-border-info, #3b82f6)' : '3px solid transparent' }}>
+                  <div
+                    style={{ display: 'flex', alignItems: 'center', padding: '10px 12px', borderBottom: '0.5px solid #F3F4F6', cursor: 'pointer' }}
+                    onMouseEnter={e => { e.currentTarget.style.background = '#F9FAFB'; }}
+                    onMouseLeave={e => { e.currentTarget.style.background = 'transparent'; }}
+                    onClick={() => toggleExpand(s.id)}
+                  >
+                    <span style={{ fontSize: 11, color: '#9ca3af', width: 16, textAlign: 'center', transition: 'transform 0.15s', transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)', flexShrink: 0 }}>▶</span>
+                    <input
+                      type="checkbox"
+                      checked={checkState.checked}
+                      ref={el => { if (el) el.indeterminate = checkState.indeterminate; }}
+                      onChange={e => { e.stopPropagation(); toggleShipment(s.id); }}
+                      onClick={e => e.stopPropagation()}
+                      style={{ accentColor: '#3b82f6', cursor: 'pointer', margin: '0 8px', flexShrink: 0 }}
+                    />
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+                        <span style={{ fontSize: 13, fontWeight: 600, color: '#111827' }}>{s.documentNo || s.id}</span>
+                        <span style={{ fontSize: 12, color: '#6B7280' }}>{fmtDate(s.movementDate)}</span>
+                      </div>
+                    </div>
+                    <span style={{ fontSize: 12, color: '#9ca3af', fontVariantNumeric: 'tabular-nums', flexShrink: 0, marginLeft: 8 }}>
+                      {shipmentTotal != null ? fmtNum(shipmentTotal) : (orderRef ? `#${orderRef}` : '')}
+                    </span>
+                  </div>
+
+                  {isExpanded && (
+                    <div style={{ background: 'var(--color-background-secondary, #F9FAFB)' }}>
+                      {isLoadingLns ? (
+                        <div style={{ padding: '8px 12px 8px 48px', fontSize: 12, color: '#9ca3af' }}>Loading lines...</div>
+                      ) : lines.length === 0 ? (
+                        <div style={{ padding: '8px 12px 8px 48px', fontSize: 12, color: '#9ca3af' }}>No lines found</div>
+                      ) : (
+                        <>
+                          <div style={{ display: 'flex', padding: '4px 12px 4px 48px', fontSize: 11, fontWeight: 600, color: '#9ca3af', textTransform: 'uppercase', letterSpacing: '0.5px', borderBottom: '0.5px solid #E5E7EB' }}>
+                            <span style={{ flex: 1 }}>Product</span>
+                            <span style={{ width: 70, textAlign: 'right' }}>Qty</span>
+                            <span style={{ width: 80, textAlign: 'right' }}>Price</span>
+                            <span style={{ width: 80, textAlign: 'right' }}>Amount</span>
+                          </div>
+                          {lines.map(line => {
+                            const imported = line._alreadyImported;
+                            const lineSelected = !imported && selected.has(line.id);
+                            const productName = line['product$_identifier'] || line.id;
+                            const maxQty = Number(line.movementQuantity) || 0;
+                            const currentQty = lineQuantities[line.id] ?? maxQty;
+                            const qtyEdited = currentQty !== maxQty;
+                            const unitPrice = line._unitPrice || null;
+                            const lineTotal = unitPrice != null ? unitPrice * currentQty : null;
+                            return (
+                              <div
+                                key={line.id}
+                                onClick={() => !imported && toggleLine(line.id)}
+                                style={{
+                                  display: 'flex', alignItems: 'center', padding: '6px 12px 6px 48px', borderBottom: '0.5px solid #F3F4F6',
+                                  cursor: imported ? 'default' : 'pointer',
+                                  background: lineSelected ? '#eff6ff' : 'transparent',
+                                  opacity: imported ? 0.4 : 1,
+                                }}
+                              >
+                                <input
+                                  type="checkbox"
+                                  checked={lineSelected}
+                                  disabled={imported}
+                                  onChange={() => !imported && toggleLine(line.id)}
+                                  onClick={e => e.stopPropagation()}
+                                  style={{ accentColor: '#3b82f6', cursor: imported ? 'not-allowed' : 'pointer', marginRight: 8, flexShrink: 0 }}
+                                />
+                                <span style={{ fontSize: 13, color: imported ? '#9ca3af' : lineSelected ? '#2563eb' : '#111827', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: lineSelected ? 500 : 400 }}>
+                                  {productName}{imported && <span style={{ fontSize: 11, marginLeft: 6, color: '#9ca3af' }}>already imported</span>}
+                                </span>
+                                <span style={{ width: 70, flexShrink: 0, textAlign: 'right' }}>
+                                  <input
+                                    type="number"
+                                    min={1}
+                                    max={maxQty}
+                                    value={currentQty}
+                                    onClick={e => e.stopPropagation()}
+                                    onChange={e => {
+                                      const v = Math.max(1, Math.min(maxQty, Number(e.target.value) || 1));
+                                      setLineQuantities(prev => ({ ...prev, [line.id]: v }));
+                                    }}
+                                    style={{
+                                      width: 60, fontSize: 12, padding: '3px 4px', borderRadius: 4, textAlign: 'center', fontVariantNumeric: 'tabular-nums', outline: 'none',
+                                      border: qtyEdited ? '1px solid var(--color-border-warning, #f59e0b)' : '0.5px solid var(--color-border-secondary, #d1d5db)',
+                                      background: qtyEdited ? 'var(--color-background-warning, #fffbeb)' : '#fff',
+                                    }}
+                                  />
+                                </span>
+                                <span style={{ width: 80, fontSize: 12, color: '#6B7280', fontVariantNumeric: 'tabular-nums', textAlign: 'right', flexShrink: 0 }}>
+                                  {unitPrice != null ? fmtNum(unitPrice) : '-'}
+                                </span>
+                                <span style={{ width: 80, fontSize: 12, color: '#6B7280', fontVariantNumeric: 'tabular-nums', textAlign: 'right', flexShrink: 0 }}>
+                                  {lineTotal != null ? fmtNum(lineTotal) : '-'}
+                                </span>
+                              </div>
+                            );
+                          })}
+                        </>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: '#F8F9FA', borderTop: '1px solid #E5E7EB', padding: '10px 16px' }}>
+          <span style={{ fontSize: 12, color: selected.size > 0 ? 'var(--color-text-info, #2563eb)' : '#6B7280', fontWeight: selected.size > 0 ? 500 : 400 }}>
+            {selected.size > 0 ? `${selected.size} line${selected.size > 1 ? 's' : ''} selected` : 'Select lines to import'}
+          </span>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button type="button" onClick={onClose} style={{ fontSize: 13, padding: '5px 14px', borderRadius: 6, border: '1px solid #E5E7EB', background: 'transparent', color: '#6B7280', cursor: 'pointer' }}>Cancel</button>
+            <button
+              type="button" onClick={handleImport} disabled={selected.size === 0 || importing}
+              style={{ fontSize: 13, fontWeight: 500, padding: '5px 14px', borderRadius: 6, border: 'none', background: '#18181b', color: '#fff', cursor: (selected.size === 0 || importing) ? 'not-allowed' : 'pointer', opacity: (selected.size === 0 || importing) ? 0.4 : 1 }}
+            >
+              {importing ? 'Importing...' : `Import selected${selected.size > 0 ? ` (${selected.size})` : ''}`}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/artifacts/sales-invoice/custom/InvoiceBottomPanel.jsx
+++ b/artifacts/sales-invoice/custom/InvoiceBottomPanel.jsx
@@ -1,4 +1,8 @@
+import { useState, useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { toast } from 'sonner';
 import RelatedDocuments from './RelatedDocuments';
+import ImportFromShipmentModal from './ImportFromShipmentModal';
 
 function fmt(val, curr) {
   const n = typeof val === 'string' ? parseFloat(val) : (val ?? 0);
@@ -19,6 +23,7 @@ export default function InvoiceBottomPanel({
   notesField, onFieldChange, notesFocused, setNotesFocused,
 }) {
   const currency = data?.['currency$_identifier'] || '';
+
   const subtotalField = summary?.find(f => f.type === 'amount' && (f.key.toLowerCase().includes('summed') || f.key.toLowerCase().includes('totallines') || f.key.toLowerCase().includes('lineamount')));
   const totalField = summary?.find(f => f.type === 'amount' && (f.key.toLowerCase().includes('grand') || (f.key.toLowerCase().includes('total') && !f.key.toLowerCase().includes('line'))));
   const subtotal = subtotalField ? data?.[subtotalField.key] : null;
@@ -26,7 +31,8 @@ export default function InvoiceBottomPanel({
   const taxes = (subtotal != null && total != null) ? total - subtotal : null;
 
   return (
-    <div className="mt-4 border-t border-border/50 flex" style={{ borderTopWidth: '0.5px' }}>
+    <div className="flex flex-col">
+      <div className="flex">
       {/* ── Left column: Docs + Notes ── */}
       <div className="flex-1 min-w-0 py-4 px-1 bg-muted/30 rounded-bl-lg">
         {/* DOCS */}
@@ -106,6 +112,100 @@ export default function InvoiceBottomPanel({
           )}
         </div>
       </div>
+      </div>
     </div>
   );
 }
+
+function InvoiceLinesEmptyState({ data, onAddLine, recordId, token, apiBaseUrl }) {
+  const [showImportModal, setShowImportModal] = useState(false);
+  const isDraft = data?.documentStatus === 'DR';
+  const bpId = data?.businessPartner;
+  const base = useMemo(() => (apiBaseUrl || '').replace(/\/[^/]+$/, ''), [apiBaseUrl]);
+  const headers = useMemo(() => ({ Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }), [token]);
+
+  return (
+    <div style={{ margin: '24px 16px', padding: '32px 24px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-lg)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+      <div style={{ width: 40, height: 40, borderRadius: 'var(--border-radius-md)', background: 'var(--color-background-tertiary)', display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 12 }}>
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#9ca3af" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+          <line x1="8" y1="13" x2="16" y2="13" />
+          <line x1="8" y1="17" x2="13" y2="17" />
+        </svg>
+      </div>
+      <span style={{ fontSize: 14, fontWeight: 500, color: 'var(--color-text-primary)', marginBottom: 4 }}>No lines yet</span>
+      <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', marginBottom: 20 }}>Add lines manually or import from a shipment</span>
+      {isDraft && (
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button type="button" onClick={onAddLine} style={{ display: 'inline-flex', alignItems: 'center', gap: 5, borderRadius: 8, padding: '6px 14px', fontSize: 13, fontWeight: 500, background: '#18181b', color: '#fff', border: 'none', cursor: 'pointer' }}>
+            + Add Lines
+          </button>
+          {bpId && (
+            <button type="button" onClick={() => setShowImportModal(true)} style={{ display: 'inline-flex', alignItems: 'center', gap: 5, border: '0.5px solid #888', borderRadius: 8, padding: '6px 14px', fontSize: 13, fontWeight: 500, color: 'var(--color-text-secondary)', background: 'transparent', cursor: 'pointer' }}>
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                <polyline points="17 8 12 3 7 8" />
+                <line x1="12" y1="3" x2="12" y2="15" />
+              </svg>
+              Import from Shipment
+            </button>
+          )}
+        </div>
+      )}
+      {showImportModal && createPortal(
+        <ImportFromShipmentModal
+          invoiceId={recordId}
+          bpId={bpId}
+          base={base}
+          headers={headers}
+          onClose={() => setShowImportModal(false)}
+          onSuccess={() => { setShowImportModal(false); toast.success('Lines imported from shipment'); window.location.reload(); }}
+        />,
+        document.body,
+      )}
+    </div>
+  );
+}
+
+function InvoiceLineActions({ data, recordId, token, apiBaseUrl }) {
+  const [showImportModal, setShowImportModal] = useState(false);
+  const isDraft = data?.documentStatus === 'DR';
+  const bpId = data?.businessPartner;
+  const base = useMemo(() => (apiBaseUrl || '').replace(/\/[^/]+$/, ''), [apiBaseUrl]);
+  const headers = useMemo(() => ({ Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }), [token]);
+
+  if (!isDraft || !bpId) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setShowImportModal(true)}
+        style={{ all: 'unset', display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 12, color: 'var(--color-text-secondary, #6b7280)', cursor: 'pointer' }}
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+          <polyline points="17 8 12 3 7 8" />
+          <line x1="12" y1="3" x2="12" y2="15" />
+        </svg>
+        Import from Shipment
+      </button>
+      {showImportModal && createPortal(
+        <ImportFromShipmentModal
+          invoiceId={recordId}
+          bpId={bpId}
+          base={base}
+          headers={headers}
+          onClose={() => setShowImportModal(false)}
+          onSuccess={() => { setShowImportModal(false); toast.success('Lines imported from shipment'); window.location.reload(); }}
+        />,
+        document.body,
+      )}
+    </>
+  );
+}
+
+InvoiceBottomPanel.linesEmptyState = InvoiceLinesEmptyState;
+InvoiceBottomPanel.detailExtraActions = InvoiceLineActions;
+

--- a/artifacts/sales-invoice/custom/InvoiceTopbarExtra.jsx
+++ b/artifacts/sales-invoice/custom/InvoiceTopbarExtra.jsx
@@ -412,6 +412,7 @@ function ViewPaymentsModal({ recordId, invoiceData, installments, grandTotal, to
                   {isExpanded && (
                     <InlineRegisterForm
                       invoiceId={recordId}
+                      invoiceData={invoiceData}
                       installment={inst}
                       currency={currency}
                       base={base}
@@ -448,7 +449,7 @@ function ViewPaymentsModal({ recordId, invoiceData, installments, grandTotal, to
 
 // ─── INLINE REGISTER FORM (expands inside installment row) ───────────────────
 
-function InlineRegisterForm({ invoiceId, installment, currency, base, headers, onCancel, onSuccess }) {
+function InlineRegisterForm({ invoiceId, invoiceData, installment, currency, base, headers, onCancel, onSuccess }) {
   const installmentOutstanding = parseFloat(installment.outstandingAmount) || 0;
   const [amount, setAmount] = useState(installmentOutstanding);
   const [date, setDate] = useState(new Date().toISOString().slice(0, 10));
@@ -456,22 +457,47 @@ function InlineRegisterForm({ invoiceId, installment, currency, base, headers, o
   const [accounts, setAccounts] = useState([]);
   const [loadingAccounts, setLoadingAccounts] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [resolvedOrgId, setResolvedOrgId] = useState('');
 
   useEffect(() => {
     (async () => {
       try {
-        const res = await fetch(`${base}/payment-in/finPayment/selectors/Fin_Financial_Account_ID?_startRow=0&_endRow=50`, { headers });
-        if (res.ok) {
-          const json = await res.json();
-          const items = json.items || json?.response?.data || [];
-          const mapped = items.map(a => ({ id: a.id, name: a.label || a._identifier || a.name }));
-          setAccounts(mapped);
-          if (mapped.length > 0) setAccountId(mapped[0].id);
+        // Find an existing payment for this invoice to get the correct account
+        const pmId = invoiceData?.paymentMethod;
+        const bpId = invoiceData?.businessPartner;
+        let mapped = [];
+
+        // Strategy 1: Find the account from existing payments for this BP + payment method
+        if (pmId && bpId) {
+          try {
+            const payRes = await fetch(`${base}/payment-in/finPayment?businessPartner=${bpId}&_startRow=0&_endRow=5`, { headers });
+            if (payRes.ok) {
+              const payments = (await payRes.json())?.response?.data || [];
+              const matching = payments.find(p => p.paymentMethod === pmId && p.account);
+              if (matching) {
+                mapped = [{ id: matching.account, name: matching['account$_identifier'] || 'Account' }];
+                if (matching.organization) setResolvedOrgId(matching.organization);
+              }
+            }
+          } catch { /* silent */ }
         }
+
+        // Strategy 2: Fallback to selector
+        if (mapped.length === 0) {
+          const res = await fetch(`${base}/payment-in/finPayment/selectors/Fin_Financial_Account_ID?_startRow=0&_endRow=50`, { headers });
+          if (res.ok) {
+            const json = await res.json();
+            const items = json.items || json?.response?.data || [];
+            mapped = items.map(a => ({ id: a.id, name: a.label || a._identifier || a.name }));
+          }
+        }
+
+        setAccounts(mapped);
+        if (mapped.length > 0) setAccountId(mapped[0].id);
       } catch { /* silent */ }
       finally { setLoadingAccounts(false); }
     })();
-  }, [base, headers]);
+  }, [base, headers, invoiceData?.paymentMethod, invoiceData?.businessPartner]);
 
   const amountExceeded = amount > installmentOutstanding;
 
@@ -481,17 +507,35 @@ function InlineRegisterForm({ invoiceId, installment, currency, base, headers, o
     if (!accountId) { toast.error('Select an account'); return; }
     setSaving(true);
     try {
-      const res = await fetch(`${base}/sales-invoice/header/${invoiceId}/action/aPRMAddpayment`, {
+      const res = await fetch(`${base}/sales-invoice/header/${invoiceId}/action/EM_APRM_Addpayment`, {
         method: 'POST', headers,
-        body: JSON.stringify({ fieldValues: {
-          amount: String(amount),
-          paymentDate: date,
+        body: JSON.stringify({
+          fin_payment_id: 'null',
+          trxtype: 'BPW',
+          ad_org_id: invoiceData.organization || resolvedOrgId || '',
+          payment_documentno: '<>',
+          c_currency_id: invoiceData.currency,
+          received_from: invoiceData.businessPartner,
+          fin_paymentmethod_id: invoiceData.paymentMethod,
+          actual_payment: String(amount),
+          converted_amount: String(amount),
+          expected_payment: String(installmentOutstanding),
+          payment_date: date,
           fin_financial_account_id: accountId,
-        } }),
+          conversion_rate: '1',
+          transaction_type: 'I',
+          document_action: '345',
+          issotrx: true,
+          reference_no: '',
+          difference: '',
+        }),
       });
+      const resJson = await res.json().catch(() => null);
       if (!res.ok) {
-        const err = await res.json().catch(() => null);
-        throw new Error(err?.response?.message || err?.message || `Failed (${res.status})`);
+        throw new Error(resJson?.response?.message || resJson?.message || `Failed (${res.status})`);
+      }
+      if (resJson?.response?.error || resJson?.response?.status === -1) {
+        throw new Error(resJson?.response?.error?.message || resJson?.response?.message?.text || 'Payment failed');
       }
       onSuccess();
     } catch (err) { toast.error(err.message); }

--- a/artifacts/sales-invoice/custom/InvoiceTopbarExtra.jsx
+++ b/artifacts/sales-invoice/custom/InvoiceTopbarExtra.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { toast } from 'sonner';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import SendDocumentModal, { SendDocumentButton } from '@/components/contract-ui/SendDocumentModal';
 
 const STATUS_LABELS = {
   RPAP: 'Awaiting Payment', RPPC: 'Payment Cleared', RPR: 'Payment Received',
@@ -55,6 +56,7 @@ const BADGE_STYLES = {
  */
 export default function InvoiceTopbarExtra({ data, recordId, token, apiBaseUrl, api }) {
   const [showPaymentsModal, setShowPaymentsModal] = useState(false);
+  const [showSendModal, setShowSendModal] = useState(false);
   const [installments, setInstallments] = useState([]);
   const [installmentsLoading, setInstallmentsLoading] = useState(true);
 
@@ -87,7 +89,19 @@ export default function InvoiceTopbarExtra({ data, recordId, token, apiBaseUrl, 
 
   useEffect(() => { fetchInstallments(); }, [fetchInstallments]);
 
-  if (!data?.documentStatus || isDraft) return null;
+  // Auto-open Send modal after Confirm & Send
+  // Flag set by HeaderPage event listener, checked here on mount
+  useEffect(() => {
+    if (isCompleted && recordId) {
+      const key = `invoice:sendAfterConfirm:${recordId}`;
+      if (sessionStorage.getItem(key)) {
+        sessionStorage.removeItem(key);
+        setShowSendModal(true);
+      }
+    }
+  }, [isCompleted, recordId]);
+
+  if (!data?.documentStatus) return null;
 
   // Derive badge status from installments
   const badgeInfo = useMemo(() => {
@@ -135,6 +149,27 @@ export default function InvoiceTopbarExtra({ data, recordId, token, apiBaseUrl, 
     installments.reduce((sum, i) => sum + (parseFloat(i.outstandingAmount) || 0), 0),
     [installments],
   );
+
+  // Draft — only show Send button
+  if (isDraft) {
+    return (
+      <>
+        <SendDocumentButton onClick={() => setShowSendModal(true)} />
+        {showSendModal && (
+          <SendDocumentModal
+            documentType="Invoice"
+            documentNo={data?.documentNo}
+            bpName={data?.['businessPartner$_identifier']}
+            bpEmail={data?.['userContact$_identifier']}
+            documentId={data?.id}
+            windowName="sales-invoice"
+            token={token}
+            onClose={() => setShowSendModal(false)}
+          />
+        )}
+      </>
+    );
+  }
 
   // While loading, show a subtle placeholder
   if (installmentsLoading) {
@@ -206,6 +241,8 @@ export default function InvoiceTopbarExtra({ data, recordId, token, apiBaseUrl, 
         <span style={{ opacity: 0.6, marginLeft: 4 }}>View &rarr;</span>
       </button>
 
+      <SendDocumentButton onClick={() => setShowSendModal(true)} />
+
       {/* View payments modal — installment breakdown */}
       {showPaymentsModal && (
         <ViewPaymentsModal
@@ -223,6 +260,20 @@ export default function InvoiceTopbarExtra({ data, recordId, token, apiBaseUrl, 
           onPaymentAdded={() => {
             fetchInstallments();
           }}
+        />
+      )}
+
+      {/* Send Invoice modal */}
+      {showSendModal && (
+        <SendDocumentModal
+          documentType="Invoice"
+          documentNo={data?.documentNo}
+          bpName={data?.['businessPartner$_identifier']}
+          bpEmail={data?.['userContact$_identifier']}
+          documentId={data?.id}
+          windowName="sales-invoice"
+          token={token}
+          onClose={() => setShowSendModal(false)}
         />
       )}
     </>
@@ -530,6 +581,190 @@ function InlineRegisterForm({ invoiceId, installment, currency, base, headers, o
         >
           {saving ? 'Saving...' : 'Confirm'}
         </button>
+      </div>
+    </div>
+  );
+}
+
+// SendInvoiceModal moved to shared SendDocumentModal component
+// Kept here as dead code marker — safe to delete
+function _REMOVED_SendInvoiceModal({ invoiceData, token, onClose }) {
+  const docNo = invoiceData?.documentNo || '';
+  const bpName = invoiceData?.['businessPartner$_identifier'] || '';
+  const bpEmail = invoiceData?.['userContact$_identifier'] || '';
+  const invoiceId = invoiceData?.id;
+
+  const hasEmail = bpEmail && bpEmail.includes('@');
+  const [to, setTo] = useState(hasEmail ? bpEmail : '');
+  const [subject, setSubject] = useState(`Invoice #${docNo} — ${bpName}`);
+  const [message, setMessage] = useState('');
+  const [sending, setSending] = useState(false);
+  const [pdfLoading, setPdfLoading] = useState(true);
+  const [pdfError, setPdfError] = useState(null);
+  const [downloading, setDownloading] = useState(false);
+  const iframeRef = useCallback(node => { if (node) renderPreview(node); }, []);
+
+  const reportId = 'print-sales-invoice';
+
+  const renderPreview = async (iframe) => {
+    if (!invoiceId || !token) return;
+    setPdfLoading(true);
+    setPdfError(null);
+    try {
+      const res = await fetch(`/api/reports/${reportId}/render`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ format: 'html', params: { documentId: invoiceId } }),
+      });
+      if (!res.ok) throw new Error(`Preview failed (${res.status})`);
+      const html = await res.text();
+      iframe.src = 'about:blank';
+      iframe.onload = () => {
+        try { const doc = iframe.contentDocument; doc.open(); doc.write(html); doc.close(); } catch {}
+        iframe.onload = null;
+      };
+    } catch (err) {
+      setPdfError(err.message);
+    }
+    setPdfLoading(false);
+  };
+
+  const handleDownload = async () => {
+    if (downloading) return;
+    setDownloading(true);
+    try {
+      const res = await fetch(`/api/reports/${reportId}/render`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ format: 'html', params: { documentId: invoiceId } }),
+      });
+      if (!res.ok) throw new Error('Failed to render');
+      const html = await res.text();
+      const pdfRes = await fetch('/jsreport/api/report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ template: { content: html, engine: 'none', recipe: 'chrome-pdf', chrome: { format: 'A4', marginTop: '10mm', marginBottom: '10mm', marginLeft: '10mm', marginRight: '10mm' } }, data: {} }),
+      });
+      if (!pdfRes.ok) throw new Error('PDF generation failed');
+      const blob = await pdfRes.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `invoice-${docNo}.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toast.error(err.message);
+    }
+    setDownloading(false);
+  };
+
+  const handleSend = () => {
+    setSending(true);
+    setTimeout(() => {
+      toast.success('Invoice sent ✓');
+      setSending(false);
+      onClose();
+    }, 800);
+  };
+
+  return (
+    <div onClick={onClose} style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, zIndex: 9999, display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: 'rgba(0,0,0,0.3)' }}>
+      <div onClick={e => e.stopPropagation()} style={{ width: 800, height: 560, display: 'flex', flexDirection: 'column', overflow: 'hidden', borderRadius: 12, backgroundColor: '#fff', boxShadow: '0 8px 30px rgba(0,0,0,0.12)', border: '0.5px solid #E5E7EB' }}>
+
+        {/* Header */}
+        <div style={{ padding: '12px 16px', background: '#F5F5F5', borderBottom: '1px solid #E5E5E5', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#374151" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="22" y1="2" x2="11" y2="13" />
+              <polygon points="22 2 15 22 11 13 2 9 22 2" />
+            </svg>
+            <span style={{ fontSize: 15, fontWeight: 600, color: '#111827' }}>Send Invoice #{docNo}</span>
+          </div>
+          <button type="button" onClick={onClose} style={{ fontSize: 18, lineHeight: 1, padding: '2px 6px', borderRadius: 4, background: 'none', border: 'none', cursor: 'pointer', color: '#9ca3af' }}>&times;</button>
+        </div>
+
+        {/* Body — two columns */}
+        <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+          {/* Left column — PDF preview (60%) */}
+          <div style={{ width: '60%', display: 'flex', flexDirection: 'column', borderRight: '0.5px solid #E5E7EB' }}>
+            <div style={{ flex: 1, position: 'relative', background: '#EFEFEF' }}>
+              {pdfLoading && (
+                <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#9ca3af', fontSize: 13 }}>Loading preview...</div>
+              )}
+              {pdfError && (
+                <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', color: '#9ca3af', padding: 24, textAlign: 'center', gap: 8 }}>
+                  <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="#d1d5db" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+                  <span style={{ fontSize: 14, fontWeight: 500, color: '#6B7280' }}>PDF preview</span>
+                  <span style={{ fontSize: 13, color: '#9ca3af', maxWidth: 200 }}>The invoice PDF will appear here once document templates are configured</span>
+                </div>
+              )}
+              <iframe ref={iframeRef} style={{ width: '100%', height: '100%', border: 'none', opacity: pdfLoading ? 0 : 1 }} title="Invoice preview" />
+            </div>
+            <button
+              type="button"
+              onClick={handleDownload}
+              disabled={downloading}
+              style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, padding: '8px 16px', borderTop: '0.5px solid #E5E7EB', background: '#fff', border: 'none', borderTop: '0.5px solid #E5E7EB', fontSize: 13, color: '#374151', cursor: downloading ? 'wait' : 'pointer', flexShrink: 0 }}
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+              {downloading ? 'Downloading...' : 'Download PDF'}
+            </button>
+          </div>
+
+          {/* Right column — Email fields (40%) */}
+          <div style={{ width: '40%', padding: 16, display: 'flex', flexDirection: 'column', gap: 12, overflowY: 'auto' }}>
+            <div>
+              <label style={{ fontSize: 12, fontWeight: 500, color: '#6B7280', display: 'block', marginBottom: 4 }}>To</label>
+              <input
+                type="email"
+                value={to}
+                onChange={e => setTo(e.target.value)}
+                placeholder="email@company.com"
+                style={{ width: '100%', fontSize: 13, padding: '8px 10px', border: `0.5px solid ${!to && !hasEmail ? '#ef4444' : '#d1d5db'}`, borderRadius: 6, outline: 'none', color: '#111827', boxSizing: 'border-box' }}
+              />
+              {!to && !hasEmail && (
+                <span style={{ fontSize: 11, color: '#ef4444', marginTop: 3, display: 'block' }}>No email found for this contact</span>
+              )}
+            </div>
+            <div>
+              <label style={{ fontSize: 12, fontWeight: 500, color: '#6B7280', display: 'block', marginBottom: 4 }}>Subject</label>
+              <input
+                type="text"
+                value={subject}
+                onChange={e => setSubject(e.target.value)}
+                style={{ width: '100%', fontSize: 13, padding: '8px 10px', border: '0.5px solid #d1d5db', borderRadius: 6, outline: 'none', color: '#111827', boxSizing: 'border-box' }}
+              />
+            </div>
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <label style={{ fontSize: 12, fontWeight: 500, color: '#6B7280', display: 'block', marginBottom: 4 }}>Message</label>
+              <textarea
+                value={message}
+                onChange={e => setMessage(e.target.value)}
+                placeholder="Add a personal message..."
+                style={{ width: '100%', flex: 1, minHeight: 80, fontSize: 13, padding: '8px 10px', border: '0.5px solid #d1d5db', borderRadius: 6, outline: 'none', color: '#111827', resize: 'none', boxSizing: 'border-box' }}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: '#F5F5F5', borderTop: '1px solid #E5E5E5', padding: '10px 16px', flexShrink: 0 }}>
+          <button type="button" onClick={onClose} style={{ fontSize: 13, padding: '6px 14px', borderRadius: 6, border: '1px solid #E5E7EB', background: 'transparent', color: '#6B7280', cursor: 'pointer' }}>Cancel</button>
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={!to.trim() || sending}
+            style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, fontWeight: 500, padding: '6px 16px', borderRadius: 6, border: 'none', background: '#18181b', color: '#fff', cursor: (!to.trim() || sending) ? 'not-allowed' : 'pointer', opacity: (!to.trim() || sending) ? 0.4 : 1 }}
+          >
+            {sending ? 'Sending...' : (
+              <>
+                Send
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+              </>
+            )}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/artifacts/sales-invoice/custom/__tests__/ImportFromShipmentModal.test.js
+++ b/artifacts/sales-invoice/custom/__tests__/ImportFromShipmentModal.test.js
@@ -1,0 +1,68 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dirname, '..', 'ImportFromShipmentModal.jsx'), 'utf8');
+
+describe('ImportFromShipmentModal', () => {
+  it('exports a default function component', () => {
+    assert.match(src, /export default function ImportFromShipmentModal/);
+  });
+
+  it('accepts invoiceId, bpId, base, headers, onClose, and onSuccess props', () => {
+    assert.match(src, /\{\s*invoiceId.*bpId.*base.*headers.*onClose.*onSuccess\s*\}/);
+  });
+
+  it('fetches shipments and existing invoice lines in parallel', () => {
+    assert.match(src, /Promise\.all/);
+    assert.match(src, /goods-shipment\/goodsShipment/);
+    assert.match(src, /sales-invoice\/lines\?parentId=/);
+  });
+
+  it('filters shipments by CO status, matching business partner, and not fully invoiced', () => {
+    assert.match(src, /documentStatus\s*===\s*'CO'/);
+    assert.match(src, /businessPartner\s*===\s*bpId/);
+    assert.match(src, /completelyInvoiced\s*!==\s*true/);
+  });
+
+  it('tracks already-imported shipment lines and order lines', () => {
+    assert.match(src, /alreadyImported/);
+    assert.match(src, /goodsShipmentLine/);
+    assert.match(src, /salesOrderLine/);
+  });
+
+  it('supports search filtering by document number', () => {
+    assert.match(src, /search/);
+    assert.match(src, /documentNo.*toLowerCase.*includes/s);
+  });
+
+  it('fetches shipment lines on expand with order line price enrichment', () => {
+    assert.match(src, /fetchLines/);
+    assert.match(src, /goods-shipment\/goodsShipmentLine\?parentId=/);
+    assert.match(src, /sales-order\/lines\?parentId=/);
+  });
+
+  it('marks lines as already imported and disables their selection', () => {
+    assert.match(src, /_alreadyImported/);
+    assert.match(src, /disabled.*imported/s);
+  });
+
+  it('creates invoice lines via POST to sales-invoice/lines', () => {
+    assert.match(src, /sales-invoice\/lines/);
+    assert.match(src, /method:\s*'POST'/);
+  });
+
+  it('uses toast for success, warning, and error feedback', () => {
+    assert.match(src, /toast\.success/);
+    assert.match(src, /toast\.warning/);
+    assert.match(src, /toast\.error/);
+  });
+
+  it('supports line and shipment level toggle selection', () => {
+    assert.match(src, /toggleLine/);
+    assert.match(src, /toggleShipment/);
+  });
+});

--- a/artifacts/sales-invoice/decisions.json
+++ b/artifacts/sales-invoice/decisions.json
@@ -4,12 +4,10 @@
     "category": "sales",
     "name": "Sales Invoice",
     "salesTheme": true,
-    "documentPreview": {
-      "titlePrefix": "Invoice"
-    },
     "relatedDocuments": true,
     "notesField": "description",
     "hideDeleteWhenComplete": true,
+    "hidePrint": true,
     "customComponents": {
       "headerTable": "InvoiceHeaderTable",
       "bottomSection": "InvoiceBottomPanel",
@@ -21,7 +19,7 @@
     ],
     "secondaryTabs": {},
     "processOverrides": {
-      "Complete": { "add": true, "label": "Confirm & Send", "columnName": "documentAction", "displayLogicRaw": "@documentStatus@='DR'" }
+      "Complete": { "add": true, "label": "Confirm & Send", "columnName": "DocAction", "displayLogicRaw": "@documentStatus@='DR'" }
     }
   },
   "entities": {
@@ -119,7 +117,8 @@
           "visibility": "readOnly",
           "grid": true,
           "searchable": true,
-          "form": false
+          "form": false,
+          "display": "dot"
         },
         "processed": {
           "visibility": "readOnly",

--- a/artifacts/sales-invoice/generated/web/sales-invoice/HeaderPage.jsx
+++ b/artifacts/sales-invoice/generated/web/sales-invoice/HeaderPage.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { ListView, DetailView } from '@/components/contract-ui';
 import { toast } from 'sonner';
 import HeaderTable from '../../../custom/InvoiceHeaderTable';
@@ -31,7 +32,7 @@ const extraBadges = [];
 
 // @sf-generated-start processes:header
 const processes = [
-  { name: 'Complete', label: 'Confirm & Send', style: 'positive', columnName: 'documentAction',
+  { name: 'Complete', label: 'Confirm & Send', style: 'positive', columnName: 'DocAction',
     displayLogicRaw: "@documentStatus@='DR'" },
 ];
 // @sf-generated-end processes:header
@@ -321,6 +322,16 @@ const api = {
 // @sf-generated-start component:HeaderPage
 export default function HeaderPage({ windowName, recordId, ...props }) {
   // @sf-custom-slot hooks:HeaderPage
+  useEffect(() => {
+    const handler = (e) => {
+      if (e.detail?.entity === 'header' && e.detail?.process?.columnName === 'DocAction' && e.detail?.recordId) {
+        sessionStorage.setItem(`invoice:sendAfterConfirm:${e.detail.recordId}`, '1');
+      }
+    };
+    window.addEventListener('neo:processSuccess', handler);
+    return () => window.removeEventListener('neo:processSuccess', handler);
+  }, []);
+  // @sf-custom-slot-end hooks:HeaderPage
   if (recordId) {
     return (
       <DetailView
@@ -341,8 +352,8 @@ export default function HeaderPage({ windowName, recordId, ...props }) {
         recordId={recordId}
         breadcrumb={breadcrumb}
       api={api}
-        documentPreview={{ titlePrefix: 'Invoice', pdfUrl: null }}
         hideDeleteWhenComplete
+        hidePrint
         notesField="description"
         customTabs={[{ key: 'related', label: 'Related Documents', Component: RelatedDocuments }]}
         bottomSection={InvoiceBottomPanel}

--- a/artifacts/sales-invoice/generated/web/sales-invoice/HeaderPage.jsx
+++ b/artifacts/sales-invoice/generated/web/sales-invoice/HeaderPage.jsx
@@ -321,7 +321,7 @@ const api = {
 
 // @sf-generated-start component:HeaderPage
 export default function HeaderPage({ windowName, recordId, ...props }) {
-  // @sf-custom-slot hooks:HeaderPage
+  // @sf-custom-start hooks:HeaderPage
   useEffect(() => {
     const handler = (e) => {
       if (e.detail?.entity === 'header' && e.detail?.process?.columnName === 'DocAction' && e.detail?.recordId) {
@@ -331,7 +331,7 @@ export default function HeaderPage({ windowName, recordId, ...props }) {
     window.addEventListener('neo:processSuccess', handler);
     return () => window.removeEventListener('neo:processSuccess', handler);
   }, []);
-  // @sf-custom-slot-end hooks:HeaderPage
+  // @sf-custom-end hooks:HeaderPage
   if (recordId) {
     return (
       <DetailView
@@ -353,7 +353,6 @@ export default function HeaderPage({ windowName, recordId, ...props }) {
         breadcrumb={breadcrumb}
       api={api}
         hideDeleteWhenComplete
-        hidePrint
         notesField="description"
         customTabs={[{ key: 'related', label: 'Related Documents', Component: RelatedDocuments }]}
         bottomSection={InvoiceBottomPanel}

--- a/artifacts/sales-invoice/generated/web/sales-invoice/HeaderTable.jsx
+++ b/artifacts/sales-invoice/generated/web/sales-invoice/HeaderTable.jsx
@@ -5,7 +5,7 @@ const columns = [
   { key: 'documentNo', column: 'DocumentNo', type: 'string', label: 'Document No.' },
   { key: 'invoiceDate', column: 'DateInvoiced', type: 'date', label: 'Invoice Date' },
   { key: 'businessPartner', column: 'C_BPartner_ID', type: 'string', label: 'Business Partner' },
-  { key: 'documentStatus', column: 'DocStatus', type: 'status', label: 'Document Status' },
+  { key: 'documentStatus', column: 'DocStatus', type: 'status', label: 'Document Status', display: 'dot' },
   { key: 'grandTotalAmount', column: 'GrandTotal', type: 'amount', label: 'Total Gross Amount' },
   { key: 'paymentComplete', column: 'Ispaid', type: 'boolean', label: 'Payment Complete' },
 ];

--- a/artifacts/sales-order/contract.json
+++ b/artifacts/sales-order/contract.json
@@ -1,19 +1,19 @@
 {
   "version": "0.5.0",
-  "generatedAt": "2026-04-01T16:22:19.607Z",
-  "checksum": "55b55cead4b5c870",
+  "generatedAt": "2026-04-01T17:22:38.274Z",
+  "checksum": "911376dc8e55553d",
   "frontendContract": {
     "window": {
       "id": "143",
       "name": "Sales Order",
       "primaryEntity": "header",
       "category": "sales",
-      "documentPreview": {
-        "titlePrefix": "Order"
-      },
       "notesField": "description",
       "relatedDocuments": true,
       "hideDeleteWhenComplete": true,
+      "customComponents": {
+        "topbarRight": "OrderCreateInvoice"
+      },
       "menuActions": [
         {
           "key": "duplicate",
@@ -30,7 +30,7 @@
         "Complete": {
           "add": true,
           "label": "Complete",
-          "columnName": "documentAction",
+          "columnName": "DocAction",
           "displayLogicRaw": "@documentStatus@='DR'"
         }
       },
@@ -593,6 +593,9 @@
       "notesField": "description",
       "relatedDocuments": true,
       "hideDeleteWhenComplete": true,
+      "customComponents": {
+        "topbarRight": "OrderCreateInvoice"
+      },
       "menuActions": [
         {
           "key": "duplicate",

--- a/artifacts/sales-order/custom/OrderCreateInvoice.jsx
+++ b/artifacts/sales-order/custom/OrderCreateInvoice.jsx
@@ -1,0 +1,325 @@
+import { useState, useEffect, useMemo } from 'react';
+import { createPortal } from 'react-dom';
+import { toast } from 'sonner';
+import SendDocumentModal, { SendDocumentButton } from '@/components/contract-ui/SendDocumentModal';
+
+export default function OrderCreateInvoice({ data, recordId, token, apiBaseUrl }) {
+  const [loading, setLoading] = useState(false);
+  const [showPreview, setShowPreview] = useState(false);
+  const [showSend, setShowSend] = useState(false);
+
+  const isCompleted = data?.documentStatus === 'CO';
+
+  const base = useMemo(() => (apiBaseUrl || '').replace(/\/[^/]+$/, ''), [apiBaseUrl]);
+  const headers = useMemo(() => ({
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  }), [token]);
+
+  const handleCreateInvoice = async (linesPayload) => {
+    if (loading) return;
+    setLoading(true);
+    try {
+      const body = linesPayload && linesPayload.length > 0
+        ? { lines: linesPayload }
+        : {};
+      const res = await fetch(
+        `${base}/sales-order/header/${recordId}/action/createDraftInvoice`,
+        { method: 'POST', headers, body: JSON.stringify(body) },
+      );
+      if (!res.ok) {
+        const err = await res.json().catch(() => null);
+        throw new Error(err?.response?.message || err?.message || `Failed (${res.status})`);
+      }
+      const json = await res.json();
+      const invoiceId = json?.response?.data?.id;
+      const docNo = json?.response?.data?.documentNo || '';
+
+      if (invoiceId) {
+        const currentPath = window.location.pathname;
+        const basePath = currentPath.replace(/\/sales-order\/.*$/, '');
+        const invoiceUrl = `${basePath}/sales-invoice/${invoiceId}`;
+        toast.custom((t) => (
+          <div style={{ background: '#16a34a', color: '#fff', borderRadius: 10, padding: '14px 18px', display: 'flex', alignItems: 'center', gap: 14, boxShadow: '0 8px 30px rgba(0,0,0,0.18)', minWidth: 380 }}>
+            <div style={{ width: 32, height: 32, borderRadius: '50%', background: 'rgba(255,255,255,0.2)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"><polyline points="20 6 9 17 4 12" /></svg>
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 14, fontWeight: 600, whiteSpace: 'nowrap' }}>Invoice #{docNo} created as Draft</div>
+              <div style={{ fontSize: 12, opacity: 0.8, marginTop: 2 }}>Review before confirming</div>
+            </div>
+            <button
+              onClick={() => { toast.dismiss(t); window.location.href = invoiceUrl; }}
+              style={{ border: '1px solid rgba(255,255,255,0.4)', borderRadius: 6, padding: '6px 14px', fontSize: 13, fontWeight: 500, color: '#fff', background: 'rgba(255,255,255,0.15)', cursor: 'pointer', whiteSpace: 'nowrap' }}
+            >
+              View Invoice →
+            </button>
+          </div>
+        ), { duration: 10000 });
+      } else {
+        toast.success('Invoice created as Draft');
+      }
+    } catch (err) {
+      toast.error(err.message || 'Failed to create invoice');
+    } finally {
+      setLoading(false);
+      setShowPreview(false);
+    }
+  };
+
+  return (
+    <>
+      {isCompleted && <button
+        type="button"
+        onClick={() => setShowPreview(true)}
+        disabled={loading}
+        className="inline-flex items-center gap-1.5 text-[13px] font-medium transition-colors"
+        style={{ padding: '4px 12px', borderRadius: 6, border: '1px solid var(--color-border-info, #93c5fd)', background: 'var(--color-background-info, #eff6ff)', color: 'var(--color-text-info, #2563eb)', opacity: loading ? 0.6 : 1, cursor: loading ? 'not-allowed' : 'pointer' }}
+        onMouseEnter={e => { e.currentTarget.style.background = 'var(--color-background-info-hover, #dbeafe)'; }}
+        onMouseLeave={e => { e.currentTarget.style.background = 'var(--color-background-info, #eff6ff)'; }}
+      >
+        <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+          <line x1="16" y1="13" x2="8" y2="13" />
+          <line x1="16" y1="17" x2="8" y2="17" />
+        </svg>
+        Create Invoice
+      </button>}
+      <SendDocumentButton onClick={() => setShowSend(true)} />
+      {showPreview && createPortal(
+        <InvoicePreviewModal
+          orderId={recordId}
+          orderData={data}
+          base={base}
+          headers={headers}
+          loading={loading}
+          onConfirm={handleCreateInvoice}
+          onClose={() => setShowPreview(false)}
+          routerBase={window.location.pathname.replace(/\/sales-order\/.*$/, '')}
+        />,
+        document.body,
+      )}
+      {showSend && createPortal(
+        <SendDocumentModal
+          documentType="Order"
+          documentNo={data?.documentNo}
+          bpName={data?.['businessPartner$_identifier']}
+          bpEmail={data?.['userContact$_identifier']}
+          documentId={recordId}
+          windowName="sales-order"
+          token={token}
+          onClose={() => setShowSend(false)}
+        />,
+        document.body,
+      )}
+    </>
+  );
+}
+
+function InvoicePreviewModal({ orderId, orderData, base, headers, loading, onConfirm, onClose, routerBase }) {
+  const [lines, setLines] = useState([]);
+  const [loadingLines, setLoadingLines] = useState(true);
+  const [existingDraft, setExistingDraft] = useState(null);
+  const [dismissedWarning, setDismissedWarning] = useState(false);
+  const [lineQuantities, setLineQuantities] = useState({});
+
+  const currency = orderData?.['currency$_identifier'] || '';
+  const bpName = orderData?.['businessPartner$_identifier'] || '';
+  const orderNo = orderData?.documentNo || '';
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [linesRes, draftRes] = await Promise.all([
+          fetch(`${base}/sales-order/lines?parentId=${orderId}&_startRow=0&_endRow=200`, { headers }),
+          fetch(`${base}/sales-order/header/${orderId}/action/checkDraftInvoice`, { headers }),
+        ]);
+        if (!cancelled && linesRes.ok) {
+          setLines((await linesRes.json())?.response?.data || []);
+        }
+        if (!cancelled && draftRes.ok) {
+          const draftData = (await draftRes.json())?.response?.data;
+          if (draftData?.exists) setExistingDraft(draftData);
+        }
+      } catch { /* silent */ }
+      finally { if (!cancelled) setLoadingLines(false); }
+    })();
+    return () => { cancelled = true; };
+  }, [orderId, base, headers]);
+
+  const invoiceableLines = useMemo(() =>
+    lines.filter(l => {
+      const ordered = Number(l.orderedQuantity) || 0;
+      const invoiced = Number(l.invoicedQuantity) || 0;
+      return ordered > invoiced;
+    }).map(l => {
+      const ordered = Number(l.orderedQuantity) || 0;
+      const delivered = Number(l.deliveredQuantity) || 0;
+      const invoiced = Number(l.invoicedQuantity) || 0;
+      const qtyToInvoice = Math.max(delivered, ordered) - invoiced;
+      const unitPrice = Number(l.unitPrice) || 0;
+      return { ...l, qtyToInvoice, unitPrice, lineTotal: qtyToInvoice * unitPrice };
+    }),
+    [lines],
+  );
+
+  useEffect(() => {
+    if (invoiceableLines.length > 0 && Object.keys(lineQuantities).length === 0) {
+      const defaults = {};
+      invoiceableLines.forEach(l => { defaults[l.id] = l.qtyToInvoice; });
+      setLineQuantities(defaults);
+    }
+  }, [invoiceableLines]);
+
+  const alreadyInvoicedLines = useMemo(() =>
+    lines.filter(l => (Number(l.invoicedQuantity) || 0) > 0),
+    [lines],
+  );
+
+  const total = useMemo(() =>
+    invoiceableLines.reduce((sum, l) => {
+      const qty = lineQuantities[l.id] ?? l.qtyToInvoice;
+      return sum + qty * l.unitPrice;
+    }, 0),
+    [invoiceableLines, lineQuantities],
+  );
+
+  const fmtNum = (v) => v != null ? Number(v).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : '-';
+
+  return (
+    <div onClick={onClose} style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, zIndex: 9999, display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: 'rgba(0,0,0,0.3)' }}>
+      <div onClick={e => e.stopPropagation()} style={{ width: 560, maxHeight: '80vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', borderRadius: 12, backgroundColor: '#fff', boxShadow: '0 8px 30px rgba(0,0,0,0.12)', border: '0.5px solid #E5E7EB' }}>
+
+        <div style={{ padding: '14px 16px', borderBottom: '2px solid #E5E7EB' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <span style={{ fontSize: 14, fontWeight: 600, color: '#111827' }}>Create Invoice</span>
+            <button type="button" onClick={onClose} style={{ fontSize: 18, lineHeight: 1, padding: '2px 6px', borderRadius: 4, background: 'none', border: 'none', cursor: 'pointer', color: '#6B7280' }}>&times;</button>
+          </div>
+          <div style={{ fontSize: 13, color: '#9ca3af', marginTop: 2 }}>
+            Order {orderNo}{bpName ? ` · ${bpName}` : ''}
+          </div>
+        </div>
+
+        {existingDraft && !dismissedWarning && (
+          <div style={{ padding: '12px 20px', background: '#FAEEDA', borderBottom: '0.5px solid #EF9F27', display: 'flex', gap: 10, flexShrink: 0 }}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#854F0B" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ flexShrink: 0, marginTop: 1 }}><path d="M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
+            <div>
+              <div style={{ fontSize: 13, fontWeight: 500, color: '#633806' }}>This order already has a Draft invoice</div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 4 }}>
+                <button
+                  type="button"
+                  onClick={() => { onClose(); window.location.href = `${routerBase}/sales-invoice/${existingDraft.id}`; }}
+                  style={{ fontSize: 12, color: '#185FA5', background: 'none', border: 'none', padding: 0, cursor: 'pointer', textDecoration: 'underline' }}
+                >View existing invoice →</button>
+                <span style={{ color: '#854F0B', fontSize: 12 }}>·</span>
+                <button
+                  type="button"
+                  onClick={() => setDismissedWarning(true)}
+                  style={{ fontSize: 12, color: '#854F0B', background: 'none', border: 'none', padding: 0, cursor: 'pointer', textDecoration: 'underline' }}
+                >Create another anyway</button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div style={{ flex: 1, overflowY: 'auto', padding: 0 }}>
+          {loadingLines ? (
+            <p style={{ fontSize: 13, color: '#9ca3af', padding: '24px 0', textAlign: 'center' }}>Loading order lines...</p>
+          ) : invoiceableLines.length === 0 ? (
+            <div style={{ padding: '32px 24px', textAlign: 'center' }}>
+              <div style={{ width: 40, height: 40, borderRadius: 8, background: '#f3f4f6', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', marginBottom: 12 }}>
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#9ca3af" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                  <circle cx="12" cy="12" r="10" />
+                  <line x1="15" y1="9" x2="9" y2="15" />
+                  <line x1="9" y1="9" x2="15" y2="15" />
+                </svg>
+              </div>
+              <p style={{ fontSize: 14, fontWeight: 500, color: '#111827', marginBottom: 4 }}>Nothing to invoice</p>
+              <p style={{ fontSize: 13, color: '#9ca3af' }}>
+                {alreadyInvoicedLines.length > 0
+                  ? 'All delivered quantities have already been invoiced.'
+                  : 'No lines have been delivered yet. Ship the order first.'}
+              </p>
+            </div>
+          ) : (
+            <>
+              <div style={{ display: 'flex', padding: '8px 16px', fontSize: 11, fontWeight: 600, color: '#9ca3af', textTransform: 'uppercase', letterSpacing: '0.5px', borderBottom: '0.5px solid #E5E7EB', background: '#F9FAFB' }}>
+                <span style={{ flex: 1 }}>Product</span>
+                <span style={{ width: 70, textAlign: 'right' }}>Qty</span>
+                <span style={{ width: 80, textAlign: 'right' }}>Price</span>
+                <span style={{ width: 90, textAlign: 'right' }}>Amount</span>
+              </div>
+              {invoiceableLines.map(line => {
+                const productName = line['product$_identifier'] || line.id;
+                const currentQty = lineQuantities[line.id] ?? line.qtyToInvoice;
+                const qtyEdited = currentQty !== line.qtyToInvoice;
+                const lineAmount = currentQty * line.unitPrice;
+                return (
+                  <div key={line.id} style={{ display: 'flex', alignItems: 'center', padding: '8px 16px', borderBottom: '0.5px solid #F3F4F6' }}>
+                    <span style={{ flex: 1, fontSize: 13, color: '#111827', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{productName}</span>
+                    <span style={{ width: 70, textAlign: 'right' }}>
+                      <input
+                        type="number"
+                        min={1}
+                        max={line.qtyToInvoice}
+                        value={currentQty}
+                        onChange={e => {
+                          const v = Math.max(1, Math.min(line.qtyToInvoice, Number(e.target.value) || 1));
+                          setLineQuantities(prev => ({ ...prev, [line.id]: v }));
+                        }}
+                        style={{
+                          width: 56, fontSize: 12, padding: '3px 4px', borderRadius: 4, textAlign: 'center',
+                          fontVariantNumeric: 'tabular-nums', outline: 'none',
+                          border: qtyEdited ? '1px solid #f59e0b' : '0.5px solid #d1d5db',
+                          background: qtyEdited ? '#fffbeb' : '#fff',
+                        }}
+                      />
+                    </span>
+                    <span style={{ width: 80, fontSize: 12, color: '#6B7280', fontVariantNumeric: 'tabular-nums', textAlign: 'right' }}>
+                      {fmtNum(line.unitPrice)}
+                    </span>
+                    <span style={{ width: 90, fontSize: 13, color: '#111827', fontVariantNumeric: 'tabular-nums', textAlign: 'right', fontWeight: 500 }}>
+                      {fmtNum(lineAmount)}
+                    </span>
+                  </div>
+                );
+              })}
+            </>
+          )}
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: '#F5F5F5', borderTop: '1px solid #E5E5E5', padding: '10px 16px' }}>
+          <span style={{ fontSize: 13, color: '#6B7280', fontVariantNumeric: 'tabular-nums' }}>
+            {invoiceableLines.length > 0 && (
+              <>
+                {invoiceableLines.length} line{invoiceableLines.length !== 1 ? 's' : ''}
+                {' · '}<span style={{ fontWeight: 500, color: '#378ADD' }}>Total: {fmtNum(total)}{currency ? ` ${currency}` : ''}</span>
+              </>
+            )}
+          </span>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button type="button" onClick={onClose} style={{ fontSize: 13, padding: '6px 14px', borderRadius: 6, border: '1px solid #E5E7EB', background: 'transparent', color: '#6B7280', cursor: 'pointer' }}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                const payload = invoiceableLines.map(l => ({
+                  orderLineId: l.id,
+                  quantity: String(lineQuantities[l.id] ?? l.qtyToInvoice),
+                }));
+                onConfirm(payload);
+              }}
+              disabled={invoiceableLines.length === 0 || loading}
+              style={{ fontSize: 13, fontWeight: 500, padding: '6px 14px', borderRadius: 6, border: 'none', background: '#18181b', color: '#fff', cursor: (invoiceableLines.length === 0 || loading) ? 'not-allowed' : 'pointer', opacity: (invoiceableLines.length === 0 || loading) ? 0.4 : 1 }}
+            >
+              {loading ? 'Creating...' : 'Create Invoice'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/artifacts/sales-order/custom/__tests__/OrderCreateInvoice.test.js
+++ b/artifacts/sales-order/custom/__tests__/OrderCreateInvoice.test.js
@@ -1,0 +1,63 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dirname, '..', 'OrderCreateInvoice.jsx'), 'utf8');
+
+describe('OrderCreateInvoice', () => {
+  it('exports a default function component', () => {
+    assert.match(src, /export default function OrderCreateInvoice/);
+  });
+
+  it('accepts data, recordId, token, and apiBaseUrl props', () => {
+    assert.match(src, /\{\s*data.*recordId.*token.*apiBaseUrl\s*\}/);
+  });
+
+  it('only shows Create Invoice button when document is completed', () => {
+    assert.match(src, /isCompleted/);
+    assert.match(src, /documentStatus\s*===\s*'CO'/);
+  });
+
+  it('creates draft invoice via POST to sales-order action endpoint', () => {
+    assert.match(src, /sales-order\/header\/.*\/action\/createDraftInvoice/);
+    assert.match(src, /method:\s*'POST'/);
+  });
+
+  it('includes a SendDocumentButton for sending orders', () => {
+    assert.match(src, /SendDocumentButton/);
+    assert.match(src, /SendDocumentModal/);
+  });
+
+  it('renders InvoicePreviewModal via createPortal', () => {
+    assert.match(src, /createPortal/);
+    assert.match(src, /InvoicePreviewModal/);
+  });
+
+  it('passes documentType Order to SendDocumentModal', () => {
+    assert.match(src, /documentType="Order"/);
+  });
+
+  it('checks for existing draft invoices in preview modal', () => {
+    assert.match(src, /checkDraftInvoice/);
+    assert.match(src, /existingDraft/);
+  });
+
+  it('calculates invoiceable quantities (delivered/ordered minus invoiced)', () => {
+    assert.match(src, /orderedQuantity/);
+    assert.match(src, /deliveredQuantity/);
+    assert.match(src, /invoicedQuantity/);
+    assert.match(src, /qtyToInvoice/);
+  });
+
+  it('uses toast for invoice creation feedback', () => {
+    assert.match(src, /toast\.custom|toast\.success|toast\.error/);
+  });
+
+  it('navigates to invoice detail after creation', () => {
+    assert.match(src, /sales-invoice\//);
+    assert.match(src, /View Invoice/);
+  });
+});

--- a/artifacts/sales-order/decisions.json
+++ b/artifacts/sales-order/decisions.json
@@ -4,18 +4,19 @@
     "category": "sales",
     "name": "Sales Order",
     "salesTheme": true,
-    "documentPreview": {
-      "titlePrefix": "Order"
-    },
     "notesField": "description",
     "relatedDocuments": true,
     "hideDeleteWhenComplete": true,
+    "hidePrint": true,
     "menuActions": [
       { "key": "duplicate", "label": "Duplicate" },
       { "key": "cancel", "label": "Cancel", "destructive": true, "visibleWhenStatus": "CO" }
     ],
     "processOverrides": {
-      "Complete": { "add": true, "label": "Complete", "columnName": "documentAction", "displayLogicRaw": "@documentStatus@='DR'" }
+      "Complete": { "add": true, "label": "Complete", "columnName": "DocAction", "displayLogicRaw": "@documentStatus@='DR'" }
+    },
+    "customComponents": {
+      "topbarRight": "OrderCreateInvoice"
     }
   },
   "entities": {
@@ -346,7 +347,7 @@
           "visibility": "system"
         },
         "deliveredQuantity": {
-          "visibility": "discarded"
+          "visibility": "system"
         },
         "replacedorderlineId": {
           "name": "replacedOrderLine",
@@ -364,7 +365,7 @@
           "section": "principal"
         },
         "invoicedQuantity": {
-          "visibility": "discarded"
+          "visibility": "system"
         },
         "replacedorderline": {
           "visibility": "discarded"

--- a/artifacts/sales-order/generated/web/sales-order/HeaderPage.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/HeaderPage.jsx
@@ -5,6 +5,7 @@ import HeaderForm from './HeaderForm';
 import LinesTable from './LinesTable';
 import LinesForm from './LinesForm';
 import RelatedDocuments from '../../../custom/RelatedDocuments';
+import OrderCreateInvoice from '../../../custom/OrderCreateInvoice';
 import catalogs from './mockCatalogs';
 
 
@@ -28,7 +29,7 @@ const extraBadges = [];
 
 // @sf-generated-start processes:header
 const processes = [
-  { name: 'Complete', label: 'Complete', style: 'positive', columnName: 'documentAction',
+  { name: 'Complete', label: 'Complete', style: 'positive', columnName: 'DocAction',
     displayLogicRaw: "@documentStatus@='DR'" },
 ];
 // @sf-generated-end processes:header
@@ -355,10 +356,11 @@ export default function HeaderPage({ windowName, recordId, ...props }) {
         recordId={recordId}
         breadcrumb={breadcrumb}
       api={api}
-        documentPreview={{ titlePrefix: 'Order', pdfUrl: null }}
         hideDeleteWhenComplete
+        hidePrint
         notesField="description"
         customTabs={[{ key: 'related', label: 'Related Documents', Component: RelatedDocuments }]}
+        topbarRight={OrderCreateInvoice}
         menuActions={({ status }) => [
           { key: 'duplicate', label: 'Duplicate', onClick: () => {}, },
           { key: 'cancel', label: 'Cancel', destructive: true, visible: status === 'CO', onClick: () => {}, }

--- a/artifacts/sales-quotation/contract.json
+++ b/artifacts/sales-quotation/contract.json
@@ -8,9 +8,6 @@
       "name": "Sales Quotation",
       "primaryEntity": "quotation",
       "category": "sales",
-      "documentPreview": {
-        "titlePrefix": "Quotation"
-      },
       "notesField": "description",
       "relatedDocuments": true,
       "hideDeleteWhenComplete": true,
@@ -30,7 +27,7 @@
         "Complete": {
           "add": true,
           "label": "Confirm",
-          "columnName": "documentAction",
+          "columnName": "DocAction",
           "displayLogicRaw": "@documentStatus@='DR'"
         },
         "Convert to Order": {
@@ -47,7 +44,10 @@
         }
       },
       "salesTheme": true,
-      "layoutType": "default"
+      "layoutType": "default",
+      "customComponents": {
+        "topbarRight": "QuotationTopbarActions"
+      }
     },
     "entities": {
       "quotation": {
@@ -256,7 +256,8 @@
                 "name": "Voided"
               }
             ],
-            "defaultValue": "DR"
+            "defaultValue": "DR",
+            "display": "dot"
           },
           {
             "name": "grandTotalAmount",

--- a/artifacts/sales-quotation/custom/QuotationTopbarActions.jsx
+++ b/artifacts/sales-quotation/custom/QuotationTopbarActions.jsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import { createPortal } from 'react-dom';
+import SendDocumentModal, { SendDocumentButton } from '@/components/contract-ui/SendDocumentModal';
+
+export default function QuotationTopbarActions({ data, recordId, token, apiBaseUrl }) {
+  const [showSend, setShowSend] = useState(false);
+
+  if (!data?.documentStatus) return null;
+
+  return (
+    <>
+      <SendDocumentButton onClick={() => setShowSend(true)} />
+      {showSend && createPortal(
+        <SendDocumentModal
+          documentType="Quotation"
+          documentNo={data?.documentNo}
+          bpName={data?.['businessPartner$_identifier']}
+          bpEmail={data?.['userContact$_identifier']}
+          documentId={recordId}
+          windowName="sales-quotation"
+          token={token}
+          onClose={() => setShowSend(false)}
+        />,
+        document.body,
+      )}
+    </>
+  );
+}

--- a/artifacts/sales-quotation/custom/__tests__/QuotationTopbarActions.test.js
+++ b/artifacts/sales-quotation/custom/__tests__/QuotationTopbarActions.test.js
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dirname, '..', 'QuotationTopbarActions.jsx'), 'utf8');
+
+describe('QuotationTopbarActions', () => {
+  it('exports a default function component', () => {
+    assert.match(src, /export default function QuotationTopbarActions/);
+  });
+
+  it('accepts data, recordId, token, and apiBaseUrl props', () => {
+    assert.match(src, /\{\s*data.*recordId.*token.*apiBaseUrl\s*\}/);
+  });
+
+  it('returns null when documentStatus is missing', () => {
+    assert.match(src, /data\?\.documentStatus.*return null/s);
+  });
+
+  it('renders a SendDocumentButton', () => {
+    assert.match(src, /SendDocumentButton/);
+  });
+
+  it('renders SendDocumentModal via createPortal when triggered', () => {
+    assert.match(src, /createPortal/);
+    assert.match(src, /SendDocumentModal/);
+  });
+
+  it('passes documentType Quotation to SendDocumentModal', () => {
+    assert.match(src, /documentType="Quotation"/);
+  });
+
+  it('passes windowName sales-quotation to SendDocumentModal', () => {
+    assert.match(src, /windowName="sales-quotation"/);
+  });
+
+  it('imports SendDocumentModal and SendDocumentButton from contract-ui', () => {
+    assert.match(src, /from\s+['"]@\/components\/contract-ui\/SendDocumentModal['"]/);
+  });
+});

--- a/artifacts/sales-quotation/decisions.json
+++ b/artifacts/sales-quotation/decisions.json
@@ -4,18 +4,19 @@
     "category": "sales",
     "name": "Sales Quotation",
     "salesTheme": true,
-    "documentPreview": {
-      "titlePrefix": "Quotation"
-    },
     "notesField": "description",
     "relatedDocuments": true,
     "hideDeleteWhenComplete": true,
+    "hidePrint": true,
+    "customComponents": {
+      "topbarRight": "QuotationTopbarActions"
+    },
     "menuActions": [
       { "key": "duplicate", "label": "Duplicate" },
       { "key": "cancel", "label": "Cancel", "destructive": true, "visibleWhenStatus": "CO" }
     ],
     "processOverrides": {
-      "Complete": { "add": true, "label": "Confirm", "columnName": "documentAction", "displayLogicRaw": "@documentStatus@='DR'" },
+      "Complete": { "add": true, "label": "Confirm", "columnName": "DocAction", "displayLogicRaw": "@documentStatus@='DR'" },
       "Convert to Order": { "exclude": true },
       "Void": { "label": "Void", "style": "destructive", "displayLogicRaw": "@documentStatus@='CO'" },
       "Reactivate": { "label": "Reactivate", "displayLogicRaw": "@documentStatus@='VO'" }
@@ -98,7 +99,8 @@
           "visibility": "readOnly",
           "grid": true,
           "searchable": true,
-          "form": false
+          "form": false,
+          "display": "dot"
         },
         "invoiceAddress": {
           "visibility": "discarded"

--- a/artifacts/sales-quotation/generated/web/sales-quotation/QuotationPage.jsx
+++ b/artifacts/sales-quotation/generated/web/sales-quotation/QuotationPage.jsx
@@ -5,6 +5,7 @@ import QuotationForm from './QuotationForm';
 import QuotationLineTable from './QuotationLineTable';
 import QuotationLineForm from './QuotationLineForm';
 import RelatedDocuments from '../../../custom/RelatedDocuments';
+import QuotationTopbarActions from '../../../custom/QuotationTopbarActions';
 import catalogs from './mockCatalogs';
 
 
@@ -32,7 +33,7 @@ const processes = [
     displayLogicRaw: "@documentStatus@='CO'" },
   { name: 'Reactivate', label: 'Reactivate', style: 'positive',
     displayLogicRaw: "@documentStatus@='VO'" },
-  { name: 'Complete', label: 'Confirm', style: 'positive', columnName: 'documentAction',
+  { name: 'Complete', label: 'Confirm', style: 'positive', columnName: 'DocAction',
     displayLogicRaw: "@documentStatus@='DR'" },
 ];
 // @sf-generated-end processes:quotation
@@ -350,10 +351,11 @@ export default function QuotationPage({ windowName, recordId, ...props }) {
         recordId={recordId}
         breadcrumb={breadcrumb}
       api={api}
-        documentPreview={{ titlePrefix: 'Quotation', pdfUrl: null }}
         hideDeleteWhenComplete
+        hidePrint
         notesField="description"
         customTabs={[{ key: 'related', label: 'Related Documents', Component: RelatedDocuments }]}
+        topbarRight={QuotationTopbarActions}
         menuActions={({ status }) => [
           { key: 'duplicate', label: 'Duplicate', onClick: () => {}, },
           { key: 'cancel', label: 'Cancel', destructive: true, visible: status === 'CO', onClick: () => {}, }

--- a/artifacts/sales-quotation/generated/web/sales-quotation/QuotationTable.jsx
+++ b/artifacts/sales-quotation/generated/web/sales-quotation/QuotationTable.jsx
@@ -6,7 +6,7 @@ const columns = [
   { key: 'orderDate', column: 'DateOrdered', type: 'date', label: 'Quotation Date' },
   { key: 'businessPartner', column: 'C_BPartner_ID', type: 'string', label: 'Business Partner' },
   { key: 'validUntil', column: 'validuntil', type: 'date', label: 'Valid Until' },
-  { key: 'documentStatus', column: 'DocStatus', type: 'status', label: 'Document Status' },
+  { key: 'documentStatus', column: 'DocStatus', type: 'status', label: 'Document Status', display: 'dot' },
   { key: 'grandTotalAmount', column: 'GrandTotal', type: 'amount', label: 'Total Gross Amount' },
 ];
 // @sf-generated-end columns:quotation

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -643,6 +643,9 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
     customComponentImports.push(`import ${customComponents.topbarRight} from '../../../custom/${customComponents.topbarRight}';`);
     customComponentProps.push(`\n        topbarRight={${customComponents.topbarRight}}`);
   }
+  if (customComponents.bulkActions) {
+    customComponentImports.push(`import ${customComponents.bulkActions} from '../../../custom/${customComponents.bulkActions}';`);
+  }
   if (customComponents.sidePanel) {
     customComponentImports.push(`import ${customComponents.sidePanel} from '../../../custom/${customComponents.sidePanel}';`);
     customComponentProps.push(`\n        sidePanel={${customComponents.sidePanel}}`);
@@ -747,7 +750,8 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
     formFooterProp = `\n        formFooter={${compName}}`;
   }
 
-  return `import { ListView, DetailView } from '@/components/contract-ui';${menuActionsConfig.length > 0 ? `\nimport { toast } from 'sonner';` : ''}
+  return `import { useEffect } from 'react';
+import { ListView, DetailView } from '@/components/contract-ui';${menuActionsConfig.length > 0 ? `\nimport { toast } from 'sonner';` : ''}
 ${headerTableImport}
 import ${headerName}Form from './${headerName}Form';${detailEntity ? `
 import ${detailName}Table from './${detailName}Table';

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -116,9 +116,10 @@ export function generateTableComponent(entityName, contract) {
       : '';
     const labelPart = f.label ? `, label: '${f.label.replace(/'/g, "\\'")}'` : '';
     const badgePart = f.badge ? ', badge: true' : '';
+    const badgeLabelsPart = f.badgeLabels ? `, badgeLabels: ${JSON.stringify(f.badgeLabels)}` : '';
     const summablePart = f.summable ? ', summable: true' : '';
     const displayPart = f.display ? `, display: '${f.display}'` : '';
-    return `  { key: '${f.name}', column: '${f.column}', type: '${type}'${labelPart}${enumLabelsPart}${selectionPart}${badgePart}${summablePart}${displayPart} },`;
+    return `  { key: '${f.name}', column: '${f.column}', type: '${type}'${labelPart}${enumLabelsPart}${selectionPart}${badgePart}${badgeLabelsPart}${summablePart}${displayPart} },`;
   }).join('\n');
 
   const filtersArray = searchableFields.map(f => `'${f}'`).join(', ');
@@ -512,6 +513,7 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
   const notesField = windowConfig.notesField ?? null;
   const relatedDocuments = windowConfig.relatedDocuments ?? false;
   const hideDeleteWhenComplete = windowConfig.hideDeleteWhenComplete ?? false;
+  const hidePrint = windowConfig.hidePrint ?? false;
   const customComponents = windowConfig.customComponents ?? {};
   const menuActionsConfig = windowConfig.menuActions ?? [];
   const statusBar = windowConfig.statusBar ?? null;
@@ -626,6 +628,9 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
 
   // hideDeleteWhenComplete prop
   const hideDeleteProp = hideDeleteWhenComplete ? '\n        hideDeleteWhenComplete' : '';
+
+  // hidePrint prop
+  const hidePrintProp = hidePrint ? '\n        hidePrint' : '';
 
   // Custom component props (bottomSection, topbarRight)
   const customComponentImports = [];
@@ -813,7 +818,7 @@ export default function ${compName}({ windowName, recordId, ...props }) {
         detailLabel="${entityDetailLabel}"` : ''}
         windowName={windowName}
         recordId={recordId}
-        breadcrumb={breadcrumb}${apiProp}${detailTabIndexProp}${secondaryTabsProp}${formFooterProp}${documentPreviewProp}${hideDeleteProp}${notesFieldProp}${customTabsProp}${customCompPropsBlock}${menuActionsProp}${draftModeProp}${headerContentProp}${detailSortByProp}${salesThemeProp}
+        breadcrumb={breadcrumb}${apiProp}${detailTabIndexProp}${secondaryTabsProp}${formFooterProp}${documentPreviewProp}${hideDeleteProp}${hidePrintProp}${notesFieldProp}${customTabsProp}${customCompPropsBlock}${menuActionsProp}${draftModeProp}${headerContentProp}${detailSortByProp}${salesThemeProp}
         {...props}${sidebarContentProp}
       />
     );

--- a/cli/src/resolve-curated.js
+++ b/cli/src/resolve-curated.js
@@ -527,6 +527,9 @@ export async function resolveCurated(schemaRaw, rulesRaw, decisions) {
   if (windowDecisions.hideDeleteWhenComplete) {
     schema.window.hideDeleteWhenComplete = true;
   }
+  if (windowDecisions.hidePrint) {
+    schema.window.hidePrint = true;
+  }
   if (windowDecisions.customComponents) {
     schema.window.customComponents = windowDecisions.customComponents;
   }

--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -522,7 +522,7 @@ function LookupButton({ selectorUrl, token, onSelect, title }) {
  *  - loading: boolean (shows skeleton when true)
  *  - addRow: { active, fields, onAdd, onCancel, catalogs, onFieldChange } — inline add row config
  */
-export function DataTable({ entity, columns = [], filters = [], data = [], onRowSelect, onNavigate, onRowClick, selectedRowId, selectedId, compact, loading, addRow, selectable = true, onSelectionChange, sortColumn, sortDirection, onColumnsReady, token, apiBaseUrl, showFooterTotals = true, selectorContext }) {
+export function DataTable({ entity, columns = [], filters = [], data = [], onRowSelect, onNavigate, onRowClick, selectedRowId, selectedId, compact, loading, addRow, selectable = true, isRowSelectable, onSelectionChange, sortColumn, sortDirection, onColumnsReady, token, apiBaseUrl, showFooterTotals = true, selectorContext }) {
   const t = useLabel();
   const [searchQuery, setSearchQuery] = useState('');
   const [columnFilters, setColumnFilters] = useState({});
@@ -696,20 +696,23 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
   const allSelected = filteredData.length > 0 && selectedRows.size === filteredData.length;
   const someSelected = selectedRows.size > 0 && !allSelected;
 
+  const selectableData = isRowSelectable ? filteredData.filter(isRowSelectable) : filteredData;
+
   const toggleAll = (e) => {
     e.stopPropagation();
     if (allSelected) {
       setSelectedRows(new Set());
       onSelectionChange?.([]);
     } else {
-      const allIds = new Set(filteredData.map(r => r.id));
+      const allIds = new Set(selectableData.map(r => r.id));
       setSelectedRows(allIds);
-      onSelectionChange?.(filteredData);
+      onSelectionChange?.(selectableData);
     }
   };
 
   const toggleRow = (e, row) => {
     e.stopPropagation();
+    if (isRowSelectable && !isRowSelectable(row)) return;
     setSelectedRows(prev => {
       const next = new Set(prev);
       if (next.has(row.id)) next.delete(row.id);
@@ -825,17 +828,22 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
                       isSelectedLine ? 'hover:bg-zinc-600' : (onRowClick || onNavigate) ? 'hover:bg-muted/50' : '',
                     ].filter(Boolean).join(' ')}
                   >
-                    {selectable && (
-                      <TableCell className="w-10 px-3" onClick={(e) => e.stopPropagation()}>
-                        <input
-                          type="checkbox"
-                          checked={isChecked}
-                          onChange={(e) => toggleRow(e, row)}
-                          onClick={(e) => e.stopPropagation()}
-                          className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary cursor-pointer"
-                        />
-                      </TableCell>
-                    )}
+                    {selectable && (() => {
+                      const rowDisabled = isRowSelectable && !isRowSelectable(row);
+                      return (
+                        <TableCell className="w-10 px-3" onClick={(e) => e.stopPropagation()}>
+                          <input
+                            type="checkbox"
+                            checked={isChecked}
+                            disabled={rowDisabled}
+                            onChange={(e) => toggleRow(e, row)}
+                            onClick={(e) => e.stopPropagation()}
+                            className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary cursor-pointer"
+                            style={rowDisabled ? { opacity: 0.3, cursor: 'not-allowed' } : undefined}
+                          />
+                        </TableCell>
+                      );
+                    })()}
                     {columns.map(col => (
                       <TableCell key={col.key} className={col.type === 'amount' ? 'text-right' : ''}>
                         {renderCellValue(row, col)}

--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -726,7 +726,7 @@ export function DetailView({
                 </Button>
               </>
             ) : (
-              <Button size="sm" className="gap-1.5" data-testid="action-save" onClick={async () => {
+              <Button size="sm" className="gap-1.5" data-testid="action-save" disabled={isDocumentReadOnly} onClick={async () => {
                 const saved = await hook.handleSave(data);
                 if (saved) {
                   if (onAfterSave) {

--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -106,6 +106,7 @@ export function DetailView({
   extraActions = [],
   menuActions = [],
   hideDeleteWhenComplete = false,
+  hidePrint = false,
   CustomLines = null,
   customLinesLabel = 'Invoices',
   sidePanel = null,
@@ -120,6 +121,8 @@ export function DetailView({
   onAfterSave,
 }) {
   const hook = useEntity(entity, detailEntity, { token, apiBaseUrl });
+  const LinesEmptyState = bottomSection?.linesEmptyState ?? null;
+  const DetailExtraActions = bottomSection?.detailExtraActions ?? null;
   // Static hooks for up to 4 secondary tabs (React rules forbid dynamic hook calls)
   const secondaryHook0 = useEntity(entity, secondaryTabs[0]?.isFormTab ? null : (secondaryTabs[0]?.key ?? null), { token, apiBaseUrl });
   const secondaryHook1 = useEntity(entity, secondaryTabs[1]?.isFormTab ? null : (secondaryTabs[1]?.key ?? null), { token, apiBaseUrl });
@@ -590,7 +593,7 @@ export function DetailView({
               </button>
             )}
             {/* Print document — shown when documentPreview is not provided */}
-            {!documentPreview && !isNew && recordId && (
+            {!documentPreview && !hidePrint && !isNew && recordId && (
               <button
                 onClick={() => setShowPrint(true)}
                 className="h-9 w-9 flex items-center justify-center rounded-lg border border-border text-muted-foreground hover:text-foreground transition-colors"
@@ -823,6 +826,15 @@ export function DetailView({
 
                 {/* Tab content: Lines */}
                 {tabs[activeTab]?.key === 'lines' && DetailTable && (
+                  hook.children.length === 0 && !addingLine && LinesEmptyState && hook.editing && !isDocumentReadOnly ? (
+                    <LinesEmptyState
+                      data={data}
+                      onAddLine={() => { setAddingLine(true); setEditingChild(null); }}
+                      recordId={data?.id || recordId}
+                      token={token}
+                      apiBaseUrl={apiBaseUrl}
+                    />
+                  ) : (
                   <div className="pt-3 flex items-start gap-4">
                     {/* Table + add button */}
                     <div className="flex-1 min-w-0">
@@ -927,13 +939,20 @@ export function DetailView({
                         </div>
                       )}
 
-                      {allEntryFields.length > 0 && hook.editing && !isDocumentReadOnly && (
-                        <button
-                          onClick={() => { setAddingLine(!addingLine); setEditingChild(null); }}
-                          className="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 mt-3 font-medium"
-                        >
-                          + Add {detailLabel || 'line'}
-                        </button>
+                      {hook.editing && !isDocumentReadOnly && (allEntryFields.length > 0 || DetailExtraActions) && (
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: 6, borderTop: '0.5px solid var(--color-border-tertiary, #e5e7eb)', padding: '10px 16px' }}>
+                          {allEntryFields.length > 0 && (
+                            <button
+                              onClick={() => { setAddingLine(!addingLine); setEditingChild(null); }}
+                              style={{ all: 'unset', fontSize: 13, fontWeight: 500, color: 'var(--color-text-info, #2563eb)', cursor: 'pointer' }}
+                            >
+                              + Add Lines
+                            </button>
+                          )}
+                          {DetailExtraActions && (
+                            <DetailExtraActions data={data} recordId={data?.id || recordId} token={token} apiBaseUrl={apiBaseUrl} />
+                          )}
+                        </div>
                       )}
                     </div>
 
@@ -1051,6 +1070,7 @@ export function DetailView({
                       </div>
                     )}
                   </div>
+                  )
                 )}
 
                 {/* Tab content: CustomLines (replaces standard lines table) */}

--- a/tools/app-shell/src/components/contract-ui/ListView.jsx
+++ b/tools/app-shell/src/components/contract-ui/ListView.jsx
@@ -25,6 +25,8 @@ export function ListView({
   hideCreate = false,
   headerContent = null,
   api = null,
+  bulkActions = null,
+  isRowSelectable = null,
 }) {
   const hook = useEntity(entity, null, { token, apiBaseUrl });
   const navigate = useNavigate();
@@ -171,6 +173,7 @@ export function ListView({
                 <Printer className="h-3.5 w-3.5" />
                 Print ({selectedRows.length})
               </Button>
+              {bulkActions && bulkActions({ selectedRows, clearSelection: () => setSelectedRows([]), token, apiBaseUrl, windowName, api })}
               <Button variant="outline" size="sm" className="text-muted-foreground" onClick={() => setSelectedRows([])}>
                 Clear
               </Button>
@@ -337,6 +340,7 @@ export function ListView({
                     data={hook.items}
                     onNavigate={(row) => navigate(`/${windowName}/${row.id}`)}
                     onSelectionChange={setSelectedRows}
+                    isRowSelectable={isRowSelectable}
                     compact={false}
                     sortColumn={hook.sortColumn}
                     sortDirection={hook.sortDirection}

--- a/tools/app-shell/src/components/contract-ui/ProductSearchDrawer.jsx
+++ b/tools/app-shell/src/components/contract-ui/ProductSearchDrawer.jsx
@@ -89,7 +89,7 @@ export default function ProductSearchDrawer({
   const resolvedImageUrl = imageEntityUrl || (neoBaseUrl ? `${neoBaseUrl}/product/product` : null);
   const fetchAllImages = useCallback(() => {
     if (!resolvedImageUrl || !token) return;
-    fetch(`${resolvedImageUrl}?_limit=500`, {
+    fetch(`${resolvedImageUrl}?_startRow=0&_endRow=500`, {
       headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
     })
       .then(r => r.ok ? r.json() : null)
@@ -97,7 +97,10 @@ export default function ProductSearchDrawer({
         const rows = data?.response?.data || [];
         const map = {};
         for (const row of rows) {
-          if (row.searchKey && row.image) map[row.searchKey] = row.image;
+          if (row.image) {
+            if (row.searchKey) map[row.searchKey] = row.image;
+            if (row.id) map[row.id] = row.image;
+          }
         }
         setImageMap(map);
       })
@@ -291,7 +294,7 @@ export default function ProductSearchDrawer({
                           : 'hover:bg-muted/50'
                         }`}
                       >
-                        <Avatar name={name} id={item.id} imageUrl={image} imageId={getImageId(item) || imageMap[item.searchKey]} neoBaseUrl={neoBaseUrl} token={token} />
+                        <Avatar name={name} id={item.id} imageUrl={image} imageId={getImageId(item) || imageMap[item.searchKey] || imageMap[item.id]} neoBaseUrl={neoBaseUrl} token={token} />
                         <div className="flex-1 min-w-0">
                           <p className="text-sm font-medium text-foreground truncate">{name}</p>
                           {code && <p className="text-xs text-muted-foreground">{code}</p>}
@@ -315,7 +318,7 @@ export default function ProductSearchDrawer({
           {/* Footer */}
           {results.length > 0 && (
             <div className="px-4 py-1.5 border-t border-border flex items-center justify-between text-xs text-muted-foreground">
-              <span>{results.length}{totalCount > results.length ? ` of ${totalCount}` : ''} product{totalCount !== 1 ? 's' : ''}</span>
+              <span>{results.length} product{results.length !== 1 ? 's' : ''}</span>
               <span className="flex items-center gap-2">
                 <kbd className="px-1 py-0.5 rounded bg-muted border border-border text-[10px]">↑↓</kbd> navigate
                 <kbd className="px-1 py-0.5 rounded bg-muted border border-border text-[10px]">↵</kbd> select

--- a/tools/app-shell/src/components/contract-ui/SendDocumentModal.jsx
+++ b/tools/app-shell/src/components/contract-ui/SendDocumentModal.jsx
@@ -1,0 +1,211 @@
+import { useState, useCallback } from 'react';
+import { toast } from 'sonner';
+
+/**
+ * Reusable Send/Download modal for any document (invoice, order, quotation, shipment).
+ *
+ * Props:
+ * - documentType: display label e.g. "Invoice", "Order", "Quotation", "Shipment"
+ * - documentNo: document number
+ * - bpName: business partner name
+ * - bpEmail: pre-filled email (optional)
+ * - documentId: record ID for PDF rendering
+ * - windowName: for report ID resolution (e.g. "sales-invoice")
+ * - token: auth token
+ * - onClose: callback to close modal
+ */
+export default function SendDocumentModal({ documentType = 'Document', documentNo, bpName, bpEmail, documentId, windowName, token, onClose }) {
+  const hasEmail = bpEmail && bpEmail.includes('@');
+  const [to, setTo] = useState(hasEmail ? bpEmail : '');
+  const [subject, setSubject] = useState(`${documentType} #${documentNo} — ${bpName}`);
+  const [message, setMessage] = useState('');
+  const [sending, setSending] = useState(false);
+  const [pdfLoading, setPdfLoading] = useState(true);
+  const [pdfError, setPdfError] = useState(null);
+  const [downloading, setDownloading] = useState(false);
+
+  const reportId = `print-${windowName}`;
+
+  const iframeRef = useCallback(node => {
+    if (!node || !documentId || !token) return;
+    (async () => {
+      setPdfLoading(true);
+      setPdfError(null);
+      try {
+        const res = await fetch(`/api/reports/${reportId}/render`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+          body: JSON.stringify({ format: 'html', params: { documentId } }),
+        });
+        if (!res.ok) throw new Error(`Preview failed (${res.status})`);
+        const html = await res.text();
+        node.src = 'about:blank';
+        node.onload = () => {
+          try { const doc = node.contentDocument; doc.open(); doc.write(html); doc.close(); } catch {}
+          node.onload = null;
+        };
+      } catch (err) {
+        setPdfError(err.message);
+      }
+      setPdfLoading(false);
+    })();
+  }, [documentId, token, reportId]);
+
+  const handleDownload = async () => {
+    if (downloading) return;
+    setDownloading(true);
+    try {
+      const res = await fetch(`/api/reports/${reportId}/render`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        body: JSON.stringify({ format: 'html', params: { documentId } }),
+      });
+      if (!res.ok) throw new Error('Failed to render');
+      const html = await res.text();
+      const pdfRes = await fetch('/jsreport/api/report', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ template: { content: html, engine: 'none', recipe: 'chrome-pdf', chrome: { format: 'A4', marginTop: '10mm', marginBottom: '10mm', marginLeft: '10mm', marginRight: '10mm' } }, data: {} }),
+      });
+      if (!pdfRes.ok) throw new Error('PDF generation failed');
+      const blob = await pdfRes.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${windowName}-${documentNo}.pdf`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      toast.error(err.message);
+    }
+    setDownloading(false);
+  };
+
+  const handleSend = () => {
+    setSending(true);
+    setTimeout(() => {
+      toast.success(`${documentType} sent ✓`);
+      setSending(false);
+      onClose();
+    }, 800);
+  };
+
+  return (
+    <div onClick={onClose} style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, zIndex: 9999, display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: 'rgba(0,0,0,0.3)' }}>
+      <div onClick={e => e.stopPropagation()} style={{ width: 800, height: 560, display: 'flex', flexDirection: 'column', overflow: 'hidden', borderRadius: 12, backgroundColor: '#fff', boxShadow: '0 8px 30px rgba(0,0,0,0.12)', border: '0.5px solid #E5E7EB' }}>
+
+        <div style={{ padding: '12px 16px', background: '#F5F5F5', borderBottom: '1px solid #E5E5E5', display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexShrink: 0 }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#374151" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="22" y1="2" x2="11" y2="13" />
+              <polygon points="22 2 15 22 11 13 2 9 22 2" />
+            </svg>
+            <span style={{ fontSize: 15, fontWeight: 600, color: '#111827' }}>Send {documentType} #{documentNo}</span>
+          </div>
+          <button type="button" onClick={onClose} style={{ fontSize: 18, lineHeight: 1, padding: '2px 6px', borderRadius: 4, background: 'none', border: 'none', cursor: 'pointer', color: '#9ca3af' }}>&times;</button>
+        </div>
+
+        <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+          <div style={{ width: '60%', display: 'flex', flexDirection: 'column', borderRight: '0.5px solid #E5E7EB' }}>
+            <div style={{ flex: 1, position: 'relative', background: '#EFEFEF' }}>
+              {pdfLoading && (
+                <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#9ca3af', fontSize: 13 }}>Loading preview...</div>
+              )}
+              {pdfError && (
+                <div style={{ position: 'absolute', inset: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', color: '#9ca3af', padding: 24, textAlign: 'center', gap: 8 }}>
+                  <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="#d1d5db" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>
+                  <span style={{ fontSize: 14, fontWeight: 500, color: '#6B7280' }}>PDF preview</span>
+                  <span style={{ fontSize: 13, color: '#9ca3af', maxWidth: 220 }}>The PDF will appear here once document templates are configured</span>
+                </div>
+              )}
+              <iframe ref={iframeRef} style={{ width: '100%', height: '100%', border: 'none', opacity: pdfLoading ? 0 : 1 }} title="Document preview" />
+            </div>
+            <button
+              type="button"
+              onClick={handleDownload}
+              disabled={downloading}
+              style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, padding: '8px 16px', background: '#fff', border: 'none', borderTop: '0.5px solid #E5E7EB', fontSize: 13, color: '#374151', cursor: downloading ? 'wait' : 'pointer', flexShrink: 0 }}
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><path d="M21 15v4a2 2 0 01-2 2H5a2 2 0 01-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+              {downloading ? 'Downloading...' : 'Download PDF'}
+            </button>
+          </div>
+
+          <div style={{ width: '40%', padding: 16, display: 'flex', flexDirection: 'column', gap: 12, overflowY: 'auto' }}>
+            <div>
+              <label style={{ fontSize: 12, fontWeight: 500, color: '#6B7280', display: 'block', marginBottom: 4 }}>To</label>
+              <input
+                type="email"
+                value={to}
+                onChange={e => setTo(e.target.value)}
+                placeholder="email@company.com"
+                style={{ width: '100%', fontSize: 13, padding: '8px 10px', border: `0.5px solid ${!to && !hasEmail ? '#ef4444' : '#d1d5db'}`, borderRadius: 6, outline: 'none', color: '#111827', boxSizing: 'border-box' }}
+              />
+              {!to && !hasEmail && (
+                <span style={{ fontSize: 11, color: '#ef4444', marginTop: 3, display: 'block' }}>No email found for this contact</span>
+              )}
+            </div>
+            <div>
+              <label style={{ fontSize: 12, fontWeight: 500, color: '#6B7280', display: 'block', marginBottom: 4 }}>Subject</label>
+              <input
+                type="text"
+                value={subject}
+                onChange={e => setSubject(e.target.value)}
+                style={{ width: '100%', fontSize: 13, padding: '8px 10px', border: '0.5px solid #d1d5db', borderRadius: 6, outline: 'none', color: '#111827', boxSizing: 'border-box' }}
+              />
+            </div>
+            <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <label style={{ fontSize: 12, fontWeight: 500, color: '#6B7280', display: 'block', marginBottom: 4 }}>Message</label>
+              <textarea
+                value={message}
+                onChange={e => setMessage(e.target.value)}
+                placeholder="Add a personal message..."
+                style={{ width: '100%', flex: 1, minHeight: 80, fontSize: 13, padding: '8px 10px', border: '0.5px solid #d1d5db', borderRadius: 6, outline: 'none', color: '#111827', resize: 'none', boxSizing: 'border-box' }}
+              />
+            </div>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: '#F5F5F5', borderTop: '1px solid #E5E5E5', padding: '10px 16px', flexShrink: 0 }}>
+          <button type="button" onClick={onClose} style={{ fontSize: 13, padding: '6px 14px', borderRadius: 6, border: '1px solid #E5E7EB', background: 'transparent', color: '#6B7280', cursor: 'pointer' }}>Cancel</button>
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={!to.trim() || sending}
+            style={{ display: 'inline-flex', alignItems: 'center', gap: 6, fontSize: 13, fontWeight: 500, padding: '6px 16px', borderRadius: 6, border: 'none', background: '#18181b', color: '#fff', cursor: (!to.trim() || sending) ? 'not-allowed' : 'pointer', opacity: (!to.trim() || sending) ? 0.4 : 1 }}
+          >
+            {sending ? 'Sending...' : (
+              <>
+                Send
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Reusable Send button with instant tooltip. Place in topbarRight components.
+ */
+export function SendDocumentButton({ onClick }) {
+  return (
+    <div style={{ position: 'relative' }} className="group">
+      <button
+        type="button"
+        onClick={onClick}
+        className="h-9 w-9 flex items-center justify-center rounded-lg border border-border text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <line x1="22" y1="2" x2="11" y2="13" />
+          <polygon points="22 2 15 22 11 13 2 9 22 2" />
+        </svg>
+      </button>
+      <span className="pointer-events-none absolute -bottom-8 left-1/2 -translate-x-1/2 whitespace-nowrap rounded bg-zinc-800 px-2 py-1 text-[11px] text-white opacity-0 group-hover:opacity-100 transition-opacity" style={{ zIndex: 50 }}>
+        Send / Download
+      </span>
+    </div>
+  );
+}

--- a/tools/app-shell/src/components/contract-ui/__tests__/SendDocumentModal.test.js
+++ b/tools/app-shell/src/components/contract-ui/__tests__/SendDocumentModal.test.js
@@ -1,0 +1,62 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dirname, '..', 'SendDocumentModal.jsx'), 'utf8');
+
+describe('SendDocumentModal', () => {
+  it('exports a default function component', () => {
+    assert.match(src, /export default function SendDocumentModal/);
+  });
+
+  it('exports a named SendDocumentButton component', () => {
+    assert.match(src, /export function SendDocumentButton/);
+  });
+
+  it('accepts documentType, documentNo, bpName, bpEmail, documentId, windowName, token, and onClose props', () => {
+    assert.match(src, /documentType.*documentNo.*bpName.*bpEmail.*documentId.*windowName.*token.*onClose/);
+  });
+
+  it('builds reportId from windowName', () => {
+    assert.match(src, /print-\$\{windowName\}/);
+  });
+
+  it('renders PDF preview via iframe and report render API', () => {
+    assert.match(src, /\/api\/reports\/.*\/render/);
+    assert.match(src, /iframe/);
+  });
+
+  it('supports PDF download via jsreport API', () => {
+    assert.match(src, /\/jsreport\/api\/report/);
+    assert.match(src, /chrome-pdf/);
+    assert.match(src, /\.download\s*=/);
+  });
+
+  it('pre-fills email from bpEmail when it contains @', () => {
+    assert.match(src, /bpEmail.*includes\('@'\)/);
+  });
+
+  it('pre-fills subject with document type and number', () => {
+    assert.match(src, /\$\{documentType\}.*#\$\{documentNo\}/);
+  });
+
+  it('disables Send button when email is empty or sending', () => {
+    assert.match(src, /!to\.trim\(\)\s*\|\|\s*sending/);
+  });
+
+  it('uses toast for send confirmation', () => {
+    assert.match(src, /toast\.success/);
+  });
+
+  it('handles PDF rendering errors gracefully', () => {
+    assert.match(src, /pdfError/);
+    assert.match(src, /Preview failed/);
+  });
+
+  it('generates download filename from windowName and documentNo', () => {
+    assert.match(src, /\$\{windowName\}-\$\{documentNo\}\.pdf/);
+  });
+});

--- a/tools/app-shell/src/hooks/useEntity.js
+++ b/tools/app-shell/src/hooks/useEntity.js
@@ -330,6 +330,7 @@ export function useEntity(entity, childEntity, { token, apiBaseUrl, childSortBy 
       });
       if (res.ok) {
         toast.success(process.label ? `${process.label} completed` : 'Process completed');
+        window.dispatchEvent(new CustomEvent('neo:processSuccess', { detail: { process, entity, recordId: selected.id } }));
         fetchById(selected.id);
         refresh();
       } else {


### PR DESCRIPTION
## Summary

Complete invoicing flow for the sales cycle: create, preview, confirm, and send invoices from Sales Orders and Goods Shipments.

### Invoice Creation
- **From Sales Order**: Preview modal with editable quantities per line, creates invoice in Draft via custom NeoHandler (`CreateDraftInvoiceHandler`)
- **From Goods Shipment** (individual): Same preview modal with prices from linked order lines
- **From Goods Shipment** (bulk): Select multiple shipments → consolidated invoice with line selection per shipment
- **Import from Shipment**: In Sales Invoice Draft, import lines from pending shipments with duplicate detection

### Confirm & Send
- "Confirm & Send" button completes the invoice (DR → CO) and auto-opens Send modal
- Send/Download modal with PDF preview (left) + email form (right) — shared across all sales windows
- Send button placeholder (real email integration in 2nd iteration)

### UI Improvements
- `Invoiced`/`Pending` badges in Goods Shipment grid
- Document status dot badges in all sales windows (Invoice, Order, Quotation, Shipment)
- Empty state for invoice lines with "Add Lines" + "Import from Shipment" CTAs
- Draft invoice warning with "View existing" link when creating duplicates
- Custom success toast with "View Invoice →" navigation

### Backend (com.etendoerp.go)
- `CreateDraftInvoiceHandler`: NeoHandler that creates invoices in Draft status
  - Supports Sales Order and Goods Shipment as source
  - Accepts custom line quantities and line selection
  - Bulk shipment consolidation with BP validation
  - `checkDraftInvoice` endpoint for existing draft detection
- `NeoServlet`: Fix to pass requestBody to action hook context
- NEO field config: enabled `completelyInvoiced`, `deliveredQty`, `invoicedQty`, `DocAction`, `GenerateTo`, `salesOrderLine`

### Generator & Shared Components
- `hidePrint` support in generator, resolve-curated, and DetailView
- `badgeLabels` support in generator and DataTable
- `bulkActions` extension point in ListView
- `isRowSelectable` support in DataTable
- `SendDocumentModal` shared component
- `neo:processSuccess` event in useEntity for post-process hooks

## Test plan
- [ ] Create invoice from Sales Order (CO) → verify Draft with correct lines/totals
- [ ] Create invoice from Goods Shipment → verify Draft with prices from order
- [ ] Bulk invoice from multiple shipments → verify consolidated lines
- [ ] Import from Shipment in Sales Invoice → verify no duplicates
- [ ] Confirm & Send → verify CO status + Send modal auto-opens
- [ ] Send/Download modal in all 4 sales windows
- [ ] Badges in Goods Shipment grid (Invoiced/Pending)
- [ ] Document status dots in all sales window grids

🤖 Generated with [Claude Code](https://claude.com/claude-code)