### PR TITLE
Add statusField support and fix physical inventory bugs

### DIFF
--- a/artifacts/physical-inventory/contract.json
+++ b/artifacts/physical-inventory/contract.json
@@ -1,13 +1,14 @@
 {
-  "version": "0.10.0",
-  "generatedAt": "2026-03-31T21:06:15.340Z",
-  "checksum": "2ba65411be28db4e",
+  "version": "0.16.0",
+  "generatedAt": "2026-04-06T13:09:44.381Z",
+  "checksum": "c7ab77bb72a53e01",
   "frontendContract": {
     "window": {
       "id": "168",
       "name": "Physical Inventory",
       "primaryEntity": "inventory",
       "category": "warehouse",
+      "statusField": "processed",
       "layoutType": "default"
     },
     "entities": {
@@ -67,7 +68,8 @@
             "visibility": "editable",
             "required": false,
             "grid": false,
-            "form": true
+            "form": true,
+            "section": "other"
           },
           {
             "name": "processNow",
@@ -125,6 +127,7 @@
             "form": true,
             "reference": "Project",
             "inputMode": "search",
+            "section": "other",
             "displayLogic": {
               "raw": "@ACCT_DIMENSION_DISPLAY@",
               "evaluable": false,
@@ -133,20 +136,22 @@
             },
             "readOnlyLogic": {
               "raw": "@Posted@='Y'",
-              "evaluable": true
+              "evaluable": true,
+              "js": "record['posted'] === 'Y'"
             }
           },
           {
             "name": "processed",
             "apiKey": "processed",
             "column": "Processed",
-            "label": "Processed",
+            "label": "Status",
             "type": "boolean",
             "tsType": "boolean",
             "visibility": "readOnly",
             "required": true,
-            "grid": false,
-            "form": false
+            "grid": true,
+            "form": false,
+            "columnType": "status"
           }
         ],
         "searchableFields": [
@@ -260,7 +265,8 @@
             "form": true,
             "readOnlyLogic": {
               "raw": "@Processed@='Y'",
-              "evaluable": true
+              "evaluable": true,
+              "js": "record['processed'] === true"
             }
           },
           {
@@ -331,7 +337,8 @@
             "form": true,
             "readOnlyLogic": {
               "raw": "@Processed@='Y'",
-              "evaluable": true
+              "evaluable": true,
+              "js": "record['processed'] === true"
             }
           }
         ],
@@ -367,7 +374,8 @@
       "id": "168",
       "name": "Physical Inventory",
       "primaryEntity": "inventory",
-      "category": "warehouse"
+      "category": "warehouse",
+      "statusField": "processed"
     },
     "entities": {
       "inventory": {

--- a/artifacts/physical-inventory/decisions.json
+++ b/artifacts/physical-inventory/decisions.json
@@ -2,18 +2,13 @@
   "$schema": "decisions-v2",
   "window": {
     "category": "warehouse",
-    "name": "Physical Inventory"
+    "name": "Physical Inventory",
+    "statusField": "processed"
   },
   "entities": {
     "header": {
       "name": "inventory",
       "fields": {
-        "documentNo": {
-          "visibility": "readOnly",
-          "grid": true,
-          "searchable": true,
-          "readOnlyLogic": null
-        },
         "warehouse": {
           "grid": true,
           "searchable": true,
@@ -35,15 +30,15 @@
         "description": {
           "readOnlyLogic": null
         },
-        "docStatus": {
-          "visibility": "readOnly",
-          "grid": true,
-          "searchable": true
-        },
         "processed": {
           "visibility": "readOnly",
-          "grid": false,
-          "form": false
+          "label": "Status",
+          "grid": true,
+          "form": false,
+          "columnType": "status"
+        },
+        "project": {
+          "section": "other"
         },
         "processNow": {
           "visibility": "editable"

--- a/artifacts/physical-inventory/generated/web/physical-inventory/InventoryForm.jsx
+++ b/artifacts/physical-inventory/generated/web/physical-inventory/InventoryForm.jsx
@@ -5,9 +5,9 @@ const fields = [
   { key: 'movementDate', column: 'MovementDate', type: 'date', label: 'Movement Date', required: true, section: 'principal', defaultValue: '@#Date@' },
   { key: 'name', column: 'Name', type: 'text', label: 'Name', required: true, section: 'principal', defaultValue: '@#Date@' },
   { key: 'warehouse', column: 'M_Warehouse_ID', type: 'search', label: 'Warehouse', required: true, section: 'principal', reference: 'Warehouse', inputMode: 'search' },
-  { key: 'description', column: 'Description', type: 'textarea', label: 'Description', section: 'principal' },
+  { key: 'description', column: 'Description', type: 'textarea', label: 'Description', section: 'other' },
   { key: 'inventoryType', column: 'Inventory_Type', type: 'select', label: 'Inventory Type', required: true, readOnly: true, section: 'other', options: [{ value: 'C', label: 'Closing Inventory' }, { value: 'N', label: 'Normal' }, { value: 'O', label: 'Opening Inventory' }], defaultValue: 'N' },
-  { key: 'project', column: 'C_Project_ID', type: 'search', label: 'Project', section: 'other', reference: 'Project', inputMode: 'search', visible: null, visibilitySource: 'server', displayLogicReason: 'server-macro' },
+  { key: 'project', column: 'C_Project_ID', type: 'search', label: 'Project', section: 'other', reference: 'Project', inputMode: 'search', visible: null, visibilitySource: 'server', displayLogicReason: 'server-macro', readOnlyLogic: (record) => record['posted'] === 'Y' },
 ];
 // @sf-generated-end fields:inventory
 

--- a/artifacts/physical-inventory/generated/web/physical-inventory/InventoryLineForm.jsx
+++ b/artifacts/physical-inventory/generated/web/physical-inventory/InventoryLineForm.jsx
@@ -5,12 +5,12 @@ const fields = [
   { key: 'lineNo', column: 'Line', type: 'number', label: 'Line No.', section: 'principal', defaultValue: '@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM M_InventoryLine WHERE M_Inventory_ID=@M_Inventory_ID@' },
   // @sf-custom-slot callout:SL_Inventory_Product
   { key: 'product', column: 'M_Product_ID', type: 'search', label: 'Product', required: true, lookup: true, section: 'principal', reference: 'Product', inputMode: 'search' },
-  { key: 'description', column: 'Description', type: 'textarea', label: 'Description', section: 'principal' },
+  { key: 'description', column: 'Description', type: 'textarea', label: 'Description', section: 'principal', readOnlyLogic: (record) => record['processed'] === true },
   { key: 'quantityOrderBook', column: 'QuantityOrderBook', type: 'number', label: 'Quantity order book', readOnly: true, section: 'other', defaultValue: '0' },
   { key: 'quantityCount', column: 'QtyCount', type: 'number', label: 'User Count', required: true, section: 'principal' },
   { key: 'uOM', column: 'C_UOM_ID', type: 'selector', label: 'UOM', required: true, readOnly: true, section: 'other', reference: 'UOM', inputMode: 'selector' },
   { key: 'bookQuantity', column: 'QtyBook', type: 'number', label: 'System Count', required: true, readOnly: true, section: 'other' },
-  { key: 'cost', column: 'Cost', type: 'number', label: 'Cost', section: 'other' },
+  { key: 'cost', column: 'Cost', type: 'number', label: 'Cost', section: 'other', readOnlyLogic: (record) => record['processed'] === true },
 ];
 // @sf-generated-end fields:inventoryLine
 

--- a/artifacts/physical-inventory/generated/web/physical-inventory/InventoryPage.jsx
+++ b/artifacts/physical-inventory/generated/web/physical-inventory/InventoryPage.jsx
@@ -13,7 +13,7 @@ const summary = [
   { key: 'inventoryType', column: 'Inventory_Type', type: 'enum' },
 ];
 
-const statusField = null;
+const statusField = 'processed';
 // @sf-generated-end summary:inventory
 
 // @sf-custom-slot extraBadges:inventory

--- a/artifacts/physical-inventory/generated/web/physical-inventory/InventoryTable.jsx
+++ b/artifacts/physical-inventory/generated/web/physical-inventory/InventoryTable.jsx
@@ -6,6 +6,7 @@ const columns = [
   { key: 'name', column: 'Name', type: 'string', label: 'Name' },
   { key: 'warehouse', column: 'M_Warehouse_ID', type: 'string', label: 'Warehouse' },
   { key: 'inventoryType', column: 'Inventory_Type', type: 'enum', label: 'Inventory Type', enumLabels: { 'C': 'Closing Inventory', 'N': 'Normal', 'O': 'Opening Inventory' } },
+  { key: 'processed', column: 'Processed', type: 'status', label: 'Status' },
 ];
 // @sf-generated-end columns:inventory
 

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -399,7 +399,10 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
   // Prefer DocStatus column (document workflow status) if present, even when form:false.
   const allEntityFields = contract.frontendContract.entities[headerEntity]?.fields ?? [];
   const docStatusField = allEntityFields.find(f => f.column === 'DocStatus');
-  const statusField = docStatusField ?? allEntityFields.find(f => f.visibility === 'readOnly' && f.name.toLowerCase().includes('status'));
+  const statusFieldOverride = contract.frontendContract.window.statusField;
+  const statusField = statusFieldOverride
+    ? (allEntityFields.find(f => f.name === statusFieldOverride) ?? null)
+    : (docStatusField ?? allEntityFields.find(f => f.visibility === 'readOnly' && f.name.toLowerCase().includes('status')));
   const summaryFieldsOverride = contract.frontendContract.window.summaryFields;
   const summaryFields = Array.isArray(summaryFieldsOverride)
     ? summaryFieldsOverride.length === 0

--- a/cli/src/resolve-curated.js
+++ b/cli/src/resolve-curated.js
@@ -555,6 +555,9 @@ export async function resolveCurated(schemaRaw, rulesRaw, decisions) {
   if (windowDecisions.statusBar) {
     schema.window.statusBar = windowDecisions.statusBar;
   }
+  if (windowDecisions.statusField) {
+    schema.window.statusField = windowDecisions.statusField;
+  }
   if (Array.isArray(windowDecisions.summaryFields)) {
     schema.window.summaryFields = windowDecisions.summaryFields;
   }

--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -540,7 +540,7 @@ export function DetailView({
               <X className="h-3.5 w-3.5" />
               Cancel
             </Button>
-            {!topbarRight && statusField && data[statusField] && (() => {
+            {!topbarRight && statusField && data[statusField] != null && (() => {
               const _s = data[statusField];
               return (
                 <span className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-md text-[13px] font-medium ${getStatusPillClass(_s)}`}>
@@ -927,13 +927,16 @@ export function DetailView({
                         </div>
                       )}
 
-                      {allEntryFields.length > 0 && hook.editing && !isDocumentReadOnly && (
+                      {allEntryFields.length > 0 && hook.editing && !isDocumentReadOnly && !isNew && (
                         <button
                           onClick={() => { setAddingLine(!addingLine); setEditingChild(null); }}
                           className="flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700 mt-3 font-medium"
                         >
                           + Add {detailLabel || 'line'}
                         </button>
+                      )}
+                      {allEntryFields.length > 0 && isNew && (
+                        <p className="text-xs text-muted-foreground mt-3">Save the header first to add lines.</p>
                       )}
                     </div>
 

--- a/tools/app-shell/src/lib/statusBadge.js
+++ b/tools/app-shell/src/lib/statusBadge.js
@@ -4,6 +4,12 @@
  */
 export function getStatusBadgeProps(status) {
   const s = String(status ?? '').toLowerCase();
+  if (s === 'true' || s === 'processed') {
+    return { variant: 'default', className: 'bg-emerald-600 hover:bg-emerald-700 border-transparent text-white' };
+  }
+  if (s === 'false' || s === 'not processed') {
+    return { variant: 'secondary' };
+  }
   if (s === 'draft' || s === 'dr') {
     return { variant: 'secondary' };
   }
@@ -27,6 +33,8 @@ export function getStatusBadgeProps(status) {
 
 export function getStatusDotColor(status) {
   const s = String(status ?? '').toLowerCase();
+  if (s === 'true' || s === 'processed') return 'bg-emerald-500';
+  if (s === 'false' || s === 'not processed') return 'bg-gray-400';
   if (s === 'draft' || s === 'dr') return 'bg-gray-400';
   if (s === 'completed' || s === 'complete' || s === 'booked' || s === 'co' || s === 'rppc' || s === 'ppm' || s === 'pwnc' || s === 'rdnc') return 'bg-emerald-500';
   if (s === 'closed' || s === 'cl' || s === 'paid' || s === 'pa') return 'bg-blue-500';
@@ -38,6 +46,8 @@ export function getStatusDotColor(status) {
 
 export function getStatusPillClass(status) {
   const s = String(status ?? '').toLowerCase();
+  if (s === 'true' || s === 'processed') return 'bg-emerald-50 text-emerald-800';
+  if (s === 'false' || s === 'not processed') return 'bg-gray-100 text-gray-700';
   if (s === 'draft' || s === 'dr') return 'bg-gray-100 text-gray-700';
   if (s === 'completed' || s === 'complete' || s === 'booked' || s === 'co' || s === 'rppc' || s === 'ppm' || s === 'pwnc' || s === 'rdnc') return 'bg-emerald-50 text-emerald-800';
   if (s === 'closed' || s === 'cl' || s === 'paid' || s === 'pa') return 'bg-blue-50 text-blue-800';
@@ -49,6 +59,8 @@ export function getStatusPillClass(status) {
 
 export function statusLabel(status) {
   const MAP = {
+    // Boolean processed fields
+    true: 'Processed', false: 'Not Processed',
     // Document statuses
     DR: 'Draft', CO: 'Complete', VO: 'Void', IP: 'In Process',
     CL: 'Closed', PA: 'Paid', UE: 'Under Evaluation', CA: 'Cancelled',


### PR DESCRIPTION
This pull request introduces significant improvements to how the "processed" status is handled and displayed for the Physical Inventory window. The changes standardize the use of a `statusField`, enhance the status badge UI for boolean statuses, and improve logic for field visibility and status display. Additionally, there are UX improvements for line entry when creating new inventory records.

**Physical Inventory Contract and Decisions Updates:**

* Added a `statusField` property (`processed`) to the Physical Inventory window definition in both `contract.json` and `decisions.json`, making the processed status the canonical status field for the window. [[1]](diffhunk://#diff-b05ab5f1284e4ecca9fcfeedd3e8213dfd746423eaaf8dd843bcba4e003f7035L2-R11) [[2]](diffhunk://#diff-b05ab5f1284e4ecca9fcfeedd3e8213dfd746423eaaf8dd843bcba4e003f7035L370-R378) [[3]](diffhunk://#diff-2ca91fde34fbafeae5c713e4033ef121370ef8dd5a3d43c51ae3fa4fb01cbbe8L5-L16)
* Updated the `processed` field: changed its label to "Status", set it to display as a status column in the grid, and improved its configuration for visibility and column type. [[1]](diffhunk://#diff-b05ab5f1284e4ecca9fcfeedd3e8213dfd746423eaaf8dd843bcba4e003f7035L136-R154) [[2]](diffhunk://#diff-2ca91fde34fbafeae5c713e4033ef121370ef8dd5a3d43c51ae3fa4fb01cbbe8L38-R41)
* Added `section: "other"` to relevant fields for better form organization. [[1]](diffhunk://#diff-b05ab5f1284e4ecca9fcfeedd3e8213dfd746423eaaf8dd843bcba4e003f7035L70-R72) [[2]](diffhunk://#diff-b05ab5f1284e4ecca9fcfeedd3e8213dfd746423eaaf8dd843bcba4e003f7035R130) [[3]](diffhunk://#diff-2ca91fde34fbafeae5c713e4033ef121370ef8dd5a3d43c51ae3fa4fb01cbbe8L38-R41)
* Enhanced `readOnlyLogic` for several fields to include a `js` property, ensuring frontend logic matches backend status. [[1]](diffhunk://#diff-b05ab5f1284e4ecca9fcfeedd3e8213dfd746423eaaf8dd843bcba4e003f7035L136-R154) [[2]](diffhunk://#diff-b05ab5f1284e4ecca9fcfeedd3e8213dfd746423eaaf8dd843bcba4e003f7035L263-R269) [[3]](diffhunk://#diff-b05ab5f1284e4ecca9fcfeedd3e8213dfd746423eaaf8dd843bcba4e003f7035L334-R341)

**Frontend/Backend Logic and UI Enhancements:**

* Updated the code generation logic to prioritize the configured `statusField` when determining which field to use for status display in page components. [[1]](diffhunk://#diff-fd5221ba13747fd7e224efcfda1d3334b72367b3c1c970e880460da98c4e8ee6L402-R405) [[2]](diffhunk://#diff-dae458cd7a6e43de503db3bc8a3aa2b3d98527c22ae8cd5c566357e494ceb2bbR558-R560)
* Improved status badge rendering for boolean `processed` statuses (`true`/`false`), mapping them to "Processed"/"Not Processed" and applying appropriate colors and labels. [[1]](diffhunk://#diff-a47aad249e6aa5b6726668fcccfc6d41a54576568dcab7248fe47fd94bd8c07eR7-R12) [[2]](diffhunk://#diff-a47aad249e6aa5b6726668fcccfc6d41a54576568dcab7248fe47fd94bd8c07eR36-R37) [[3]](diffhunk://#diff-a47aad249e6aa5b6726668fcccfc6d41a54576568dcab7248fe47fd94bd8c07eR49-R50) [[4]](diffhunk://#diff-a47aad249e6aa5b6726668fcccfc6d41a54576568dcab7248fe47fd94bd8c07eR62-R63)
* Fixed status pill display logic to handle `null` values properly in the detail view.

**User Experience Improvements:**

* Prevented adding lines to new (unsaved) inventory records and provided a helpful message prompting users to save the header first.

These changes collectively ensure that the "processed" status is consistently treated as the main document status, provide a clearer and more user-friendly UI, and improve the robustness of status-related logic across the stack.