### PR TITLE
Feature ETP-3569: Import from PO in goods receipt and invoice UI fixes

### DIFF
--- a/artifacts/sales-invoice/custom/InvoiceTopbarExtra.jsx
+++ b/artifacts/sales-invoice/custom/InvoiceTopbarExtra.jsx
@@ -101,9 +101,7 @@ export default function InvoiceTopbarExtra({ data, recordId, token, apiBaseUrl, 
     }
   }, [isCompleted, recordId]);
 
-  if (!data?.documentStatus) return null;
-
-  // Derive badge status from installments
+  // Derive badge status from installments (must be before any early return)
   const badgeInfo = useMemo(() => {
     if (installmentsLoading || installments.length === 0) return null;
 
@@ -149,6 +147,8 @@ export default function InvoiceTopbarExtra({ data, recordId, token, apiBaseUrl, 
     installments.reduce((sum, i) => sum + (parseFloat(i.outstandingAmount) || 0), 0),
     [installments],
   );
+
+  if (!data?.documentStatus) return null;
 
   // Draft — only show Send button
   if (isDraft) {

--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -833,6 +833,7 @@ export function DetailView({
                       recordId={data?.id || recordId}
                       token={token}
                       apiBaseUrl={apiBaseUrl}
+                      onRefresh={() => hook.refetch?.()}
                     />
                   ) : (
                   <div className="pt-3 flex items-start gap-4">
@@ -950,7 +951,7 @@ export function DetailView({
                             </button>
                           )}
                           {DetailExtraActions && (
-                            <DetailExtraActions data={data} recordId={data?.id || recordId} token={token} apiBaseUrl={apiBaseUrl} />
+                            <DetailExtraActions data={data} recordId={data?.id || recordId} token={token} apiBaseUrl={apiBaseUrl} onRefresh={() => hook.refetch?.()} />
                           )}
                         </div>
                       )}

--- a/tools/app-shell/src/windows/custom/goods-receipt/GoodsReceiptBottomPanel.jsx
+++ b/tools/app-shell/src/windows/custom/goods-receipt/GoodsReceiptBottomPanel.jsx
@@ -1,0 +1,113 @@
+import { useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { toast } from 'sonner';
+import ImportFromPurchaseOrderModal from './ImportFromPurchaseOrderModal.jsx';
+
+function ReceiptLinesEmptyState({ data, onAddLine, recordId, token, apiBaseUrl }) {
+  const [showImportModal, setShowImportModal] = useState(false);
+  const isDraft = data?.documentStatus === 'DR';
+  const bpId = data?.businessPartner;
+  const base = useMemo(() => (apiBaseUrl || '').replace(/\/[^/]+$/, ''), [apiBaseUrl]);
+  const headers = useMemo(() => ({ Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }), [token]);
+
+  return (
+    <div style={{ margin: '24px 16px', padding: '32px 24px', background: 'var(--color-background-secondary)', borderRadius: 'var(--border-radius-lg)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center' }}>
+      <div style={{ width: 40, height: 40, borderRadius: 'var(--border-radius-md)', background: 'var(--color-background-tertiary)', display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 12 }}>
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#9ca3af" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+          <polyline points="14 2 14 8 20 8" />
+          <line x1="8" y1="13" x2="16" y2="13" />
+          <line x1="8" y1="17" x2="13" y2="17" />
+        </svg>
+      </div>
+      <span style={{ fontSize: 14, fontWeight: 500, color: 'var(--color-text-primary)', marginBottom: 4 }}>No lines yet</span>
+      <span style={{ fontSize: 13, color: 'var(--color-text-secondary)', marginBottom: 20 }}>Add lines manually or import from a purchase order</span>
+
+      {isDraft && (
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button type="button" onClick={onAddLine} style={{ display: 'inline-flex', alignItems: 'center', gap: 5, borderRadius: 8, padding: '6px 14px', fontSize: 13, fontWeight: 500, background: '#18181b', color: '#fff', border: 'none', cursor: 'pointer' }}>
+            + Add Lines
+          </button>
+          {bpId && (
+            <button type="button" onClick={() => setShowImportModal(true)} style={{ display: 'inline-flex', alignItems: 'center', gap: 5, border: '0.5px solid #888', borderRadius: 8, padding: '6px 14px', fontSize: 13, fontWeight: 500, color: 'var(--color-text-secondary)', background: 'transparent', cursor: 'pointer' }}>
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                <polyline points="17 8 12 3 7 8" />
+                <line x1="12" y1="3" x2="12" y2="15" />
+              </svg>
+              Import from Purchase Order
+            </button>
+          )}
+        </div>
+      )}
+
+      {showImportModal && createPortal(
+        <ImportFromPurchaseOrderModal
+          receiptId={recordId}
+          bpId={bpId}
+          base={base}
+          headers={headers}
+          onClose={() => setShowImportModal(false)}
+          onSuccess={() => {
+            setShowImportModal(false);
+            toast.success('Lines imported from purchase order');
+            window.location.reload();
+          }}
+        />,
+        document.body,
+      )}
+    </div>
+  );
+}
+
+function ReceiptLineActions({ data, recordId, token, apiBaseUrl }) {
+  const [showImportModal, setShowImportModal] = useState(false);
+  const isDraft = data?.documentStatus === 'DR';
+  const bpId = data?.businessPartner;
+  const base = useMemo(() => (apiBaseUrl || '').replace(/\/[^/]+$/, ''), [apiBaseUrl]);
+  const headers = useMemo(() => ({ Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }), [token]);
+
+  if (!isDraft || !bpId) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setShowImportModal(true)}
+        style={{ all: 'unset', display: 'inline-flex', alignItems: 'center', gap: 4, fontSize: 12, color: 'var(--color-text-secondary, #6b7280)', cursor: 'pointer' }}
+      >
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+          <polyline points="17 8 12 3 7 8" />
+          <line x1="12" y1="3" x2="12" y2="15" />
+        </svg>
+        Import from Purchase Order
+      </button>
+
+      {showImportModal && createPortal(
+        <ImportFromPurchaseOrderModal
+          receiptId={recordId}
+          bpId={bpId}
+          base={base}
+          headers={headers}
+          onClose={() => setShowImportModal(false)}
+          onSuccess={() => {
+            setShowImportModal(false);
+            toast.success('Lines imported from purchase order');
+            window.location.reload();
+          }}
+        />,
+        document.body,
+      )}
+    </>
+  );
+}
+
+function GoodsReceiptBottomPanel() {
+  return null;
+}
+
+GoodsReceiptBottomPanel.linesEmptyState = ReceiptLinesEmptyState;
+GoodsReceiptBottomPanel.detailExtraActions = ReceiptLineActions;
+
+export default GoodsReceiptBottomPanel;

--- a/tools/app-shell/src/windows/custom/goods-receipt/GoodsReceiptBottomPanel.jsx
+++ b/tools/app-shell/src/windows/custom/goods-receipt/GoodsReceiptBottomPanel.jsx
@@ -3,7 +3,7 @@ import { createPortal } from 'react-dom';
 import { toast } from 'sonner';
 import ImportFromPurchaseOrderModal from './ImportFromPurchaseOrderModal.jsx';
 
-function ReceiptLinesEmptyState({ data, onAddLine, recordId, token, apiBaseUrl }) {
+function ReceiptLinesEmptyState({ data, onAddLine, recordId, token, apiBaseUrl, onRefresh }) {
   const [showImportModal, setShowImportModal] = useState(false);
   const isDraft = data?.documentStatus === 'DR';
   const bpId = data?.businessPartner;
@@ -51,7 +51,7 @@ function ReceiptLinesEmptyState({ data, onAddLine, recordId, token, apiBaseUrl }
           onSuccess={() => {
             setShowImportModal(false);
             toast.success('Lines imported from purchase order');
-            window.location.reload();
+            onRefresh?.();
           }}
         />,
         document.body,
@@ -60,7 +60,7 @@ function ReceiptLinesEmptyState({ data, onAddLine, recordId, token, apiBaseUrl }
   );
 }
 
-function ReceiptLineActions({ data, recordId, token, apiBaseUrl }) {
+function ReceiptLineActions({ data, recordId, token, apiBaseUrl, onRefresh }) {
   const [showImportModal, setShowImportModal] = useState(false);
   const isDraft = data?.documentStatus === 'DR';
   const bpId = data?.businessPartner;
@@ -94,7 +94,7 @@ function ReceiptLineActions({ data, recordId, token, apiBaseUrl }) {
           onSuccess={() => {
             setShowImportModal(false);
             toast.success('Lines imported from purchase order');
-            window.location.reload();
+            onRefresh?.();
           }}
         />,
         document.body,

--- a/tools/app-shell/src/windows/custom/goods-receipt/ImportFromPurchaseOrderModal.jsx
+++ b/tools/app-shell/src/windows/custom/goods-receipt/ImportFromPurchaseOrderModal.jsx
@@ -1,0 +1,409 @@
+import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
+export default function ImportFromPurchaseOrderModal({ receiptId, bpId, base, headers, onClose, onSuccess }) {
+  const [orders, setOrders] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState(new Set());
+  const [expanded, setExpanded] = useState(new Set());
+  const [orderLines, setOrderLines] = useState({});
+  const [loadingLines, setLoadingLines] = useState(new Set());
+  const [importing, setImporting] = useState(false);
+  const [search, setSearch] = useState('');
+  const [lineQuantities, setLineQuantities] = useState({});
+  const [importedByOrderLine, setImportedByOrderLine] = useState({});
+  const [nextLineNo, setNextLineNo] = useState(10);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const [ordersRes, receiptLinesRes] = await Promise.all([
+          fetch(`${base}/purchase-order/header?_startRow=0&_endRow=500`, { headers }),
+          fetch(`${base}/goods-receipt/goodsReceiptLine?parentId=${receiptId}&_startRow=0&_endRow=300`, { headers }),
+        ]);
+
+        const importedQtyMap = {};
+        let maxLineNo = 0;
+        if (receiptLinesRes.ok && !cancelled) {
+          const existingLines = (await receiptLinesRes.json())?.response?.data || [];
+          existingLines.forEach((line) => {
+            const lineNo = Number(line.lineNo || line.line || 0) || 0;
+            if (lineNo > maxLineNo) maxLineNo = lineNo;
+            if (line.salesOrderLine) {
+              importedQtyMap[line.salesOrderLine] = (importedQtyMap[line.salesOrderLine] || 0) + (Number(line.movementQuantity) || 0);
+            }
+          });
+        }
+
+        if (ordersRes.ok && !cancelled) {
+          const allOrders = (await ordersRes.json())?.response?.data || [];
+          setOrders(allOrders.filter((order) => order.documentStatus === 'CO' && order.businessPartner === bpId));
+          setImportedByOrderLine(importedQtyMap);
+          setNextLineNo(Math.max(10, maxLineNo + 10));
+        }
+      } catch {
+        // silent
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [base, bpId, headers, receiptId]);
+
+  const bpName = orders[0]?.['businessPartner$_identifier'] || '';
+
+  const filtered = useMemo(() => {
+    if (!search.trim()) return orders;
+    const q = search.toLowerCase();
+    return orders.filter((order) => (order.documentNo || '').toLowerCase().includes(q));
+  }, [orders, search]);
+
+  const fetchLines = async (orderId) => {
+    if (orderLines[orderId] || loadingLines.has(orderId)) return;
+
+    setLoadingLines((prev) => {
+      const next = new Set(prev);
+      next.add(orderId);
+      return next;
+    });
+
+    try {
+      const res = await fetch(`${base}/purchase-order/lines?parentId=${orderId}&_startRow=0&_endRow=300`, { headers });
+      if (res.ok) {
+        const lines = (await res.json())?.response?.data || [];
+        const enriched = lines.map((line) => {
+          const orderedQty = Number(line.orderedQuantity) || 0;
+          const deliveredQty = Number(line.deliveredQuantity) || 0;
+          const undeliveredQty = Math.max(orderedQty - deliveredQty, 0);
+          const alreadyInReceipt = Number(importedByOrderLine[line.id]) || 0;
+          const availableQty = Math.max(undeliveredQty - alreadyInReceipt, 0);
+          return {
+            ...line,
+            _undeliveredQty: undeliveredQty,
+            _alreadyInReceipt: alreadyInReceipt,
+            _availableQty: availableQty,
+            _selectable: availableQty > 0,
+          };
+        });
+
+        setOrderLines((prev) => ({ ...prev, [orderId]: enriched }));
+
+        const qtyDefaults = {};
+        const selectableIds = [];
+        enriched.forEach((line) => {
+          qtyDefaults[line.id] = line._availableQty;
+          if (line._selectable) selectableIds.push(line.id);
+        });
+
+        setLineQuantities((prev) => ({ ...prev, ...qtyDefaults }));
+        setSelected((prev) => {
+          const next = new Set(prev);
+          selectableIds.forEach((id) => next.add(id));
+          return next;
+        });
+      }
+    } catch {
+      // silent
+    } finally {
+      setLoadingLines((prev) => {
+        const next = new Set(prev);
+        next.delete(orderId);
+        return next;
+      });
+    }
+  };
+
+  const toggleExpand = (orderId) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(orderId)) {
+        next.delete(orderId);
+      } else {
+        next.add(orderId);
+        fetchLines(orderId);
+      }
+      return next;
+    });
+  };
+
+  const toggleLine = (lineId, selectable) => {
+    if (!selectable) return;
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(lineId)) next.delete(lineId);
+      else next.add(lineId);
+      return next;
+    });
+  };
+
+  const toggleOrder = (orderId) => {
+    const lines = (orderLines[orderId] || []).filter((line) => line._selectable);
+    if (lines.length === 0) return;
+
+    const lineIds = lines.map((line) => line.id);
+    const allSelected = lineIds.every((id) => selected.has(id));
+
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (allSelected) lineIds.forEach((id) => next.delete(id));
+      else lineIds.forEach((id) => next.add(id));
+      return next;
+    });
+  };
+
+  const getOrderCheckState = (orderId) => {
+    const lines = (orderLines[orderId] || []).filter((line) => line._selectable);
+    if (lines.length === 0) return { checked: false, indeterminate: false };
+
+    const count = lines.filter((line) => selected.has(line.id)).length;
+    if (count === 0) return { checked: false, indeterminate: false };
+    if (count === lines.length) return { checked: true, indeterminate: false };
+    return { checked: false, indeterminate: true };
+  };
+
+  const handleImport = async () => {
+    if (selected.size === 0 || importing) return;
+    setImporting(true);
+
+    try {
+      let lineNo = nextLineNo;
+      let importedCount = 0;
+      let errors = 0;
+
+      for (const order of orders) {
+        const lines = (orderLines[order.id] || []).filter((line) => selected.has(line.id));
+        if (lines.length === 0) continue;
+
+        for (const line of lines) {
+          const qty = Number(lineQuantities[line.id] ?? line._availableQty);
+          const safeQty = Math.max(0, Math.min(line._availableQty, qty));
+          if (safeQty <= 0) continue;
+
+          const body = {
+            parentId: receiptId,
+            product: line.product,
+            movementQuantity: safeQty,
+            uOM: line.uOM || null,
+            salesOrderLine: line.id,
+            description: line.description || null,
+            lineNo,
+          };
+
+          const res = await fetch(`${base}/goods-receipt/goodsReceiptLine`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(body),
+          });
+
+          if (!res.ok) errors += 1;
+          else importedCount += 1;
+
+          lineNo += 10;
+        }
+      }
+
+      if (importedCount > 0) {
+        if (errors > 0) toast.warning(`Imported ${importedCount} line(s) with ${errors} error(s)`);
+        else toast.success(`${importedCount} line(s) imported from purchase order`);
+        onSuccess();
+        return;
+      }
+
+      if (errors > 0) toast.error('Could not import selected lines');
+      else toast.info('No lines were imported');
+    } catch (err) {
+      toast.error(err.message || 'Failed to import lines');
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const fmtDate = (d) => (d ? new Date(d).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) : '-');
+  const fmtNum = (v) => Number(v || 0).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+  return (
+    <div onClick={onClose} style={{ position: 'fixed', top: 0, left: 0, right: 0, bottom: 0, zIndex: 9999, display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: 'rgba(0,0,0,0.3)' }}>
+      <div onClick={(e) => e.stopPropagation()} style={{ width: 620, maxHeight: '80vh', display: 'flex', flexDirection: 'column', overflow: 'hidden', borderRadius: 12, backgroundColor: '#fff', boxShadow: '0 8px 30px rgba(0,0,0,0.12)', border: '0.5px solid #E5E7EB' }}>
+        <div style={{ padding: '14px 16px', borderBottom: '2px solid #E5E7EB' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+            <span style={{ fontSize: 14, fontWeight: 600, color: '#111827' }}>Import from Purchase Order</span>
+            <button type="button" onClick={onClose} style={{ fontSize: 18, lineHeight: 1, padding: '2px 6px', borderRadius: 4, background: 'none', border: 'none', cursor: 'pointer', color: '#6B7280' }}>&times;</button>
+          </div>
+          {bpName && <div style={{ fontSize: 13, color: '#9ca3af', marginTop: 2 }}>{bpName}</div>}
+        </div>
+
+        <div style={{ padding: '10px 16px 0' }}>
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search purchase order..."
+            style={{ width: '100%', fontSize: 13, padding: '7px 10px', border: '0.5px solid #E5E7EB', borderRadius: 6, outline: 'none', color: '#111827' }}
+          />
+        </div>
+
+        <div style={{ flex: 1, overflowY: 'auto', padding: 0 }}>
+          {loading ? (
+            <p style={{ fontSize: 13, color: '#9ca3af', padding: '24px 0', textAlign: 'center' }}>Loading...</p>
+          ) : filtered.length === 0 ? (
+            <p style={{ fontSize: 13, color: '#9ca3af', padding: '24px 0', textAlign: 'center' }}>
+              {orders.length === 0 ? 'No completed purchase orders with pending quantities for this vendor.' : 'No orders match your search.'}
+            </p>
+          ) : (
+            filtered.map((order) => {
+              const isExpanded = expanded.has(order.id);
+              const isLoadingLines = loadingLines.has(order.id);
+              const lines = orderLines[order.id] || [];
+              const checkState = getOrderCheckState(order.id);
+              const hasAnySelected = checkState.checked || checkState.indeterminate;
+              const orderTotal = Number(order.grandTotalAmount) || null;
+
+              return (
+                <div key={order.id} style={{ borderLeft: (isExpanded || hasAnySelected) ? '3px solid var(--color-border-info, #3b82f6)' : '3px solid transparent' }}>
+                  <div
+                    style={{ display: 'flex', alignItems: 'center', padding: '10px 12px', borderBottom: '0.5px solid #F3F4F6', cursor: 'pointer' }}
+                    onMouseEnter={(e) => {
+                      e.currentTarget.style.background = '#F9FAFB';
+                    }}
+                    onMouseLeave={(e) => {
+                      e.currentTarget.style.background = 'transparent';
+                    }}
+                    onClick={() => toggleExpand(order.id)}
+                  >
+                    <span style={{ fontSize: 11, color: '#9ca3af', width: 16, textAlign: 'center', transition: 'transform 0.15s', transform: isExpanded ? 'rotate(90deg)' : 'rotate(0deg)', flexShrink: 0 }}>▶</span>
+                    <input
+                      type="checkbox"
+                      checked={checkState.checked}
+                      ref={(el) => {
+                        if (el) el.indeterminate = checkState.indeterminate;
+                      }}
+                      onChange={(e) => {
+                        e.stopPropagation();
+                        toggleOrder(order.id);
+                      }}
+                      onClick={(e) => e.stopPropagation()}
+                      style={{ accentColor: '#3b82f6', cursor: 'pointer', margin: '0 8px', flexShrink: 0 }}
+                    />
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+                        <span style={{ fontSize: 13, fontWeight: 600, color: '#111827' }}>{order.documentNo || order.id}</span>
+                        <span style={{ fontSize: 12, color: '#6B7280' }}>{fmtDate(order.orderDate)}</span>
+                      </div>
+                    </div>
+                    <span style={{ fontSize: 12, color: '#9ca3af', fontVariantNumeric: 'tabular-nums', flexShrink: 0, marginLeft: 8 }}>
+                      {orderTotal != null ? fmtNum(orderTotal) : ''}
+                    </span>
+                  </div>
+
+                  {isExpanded && (
+                    <div style={{ background: 'var(--color-background-secondary, #F9FAFB)' }}>
+                      {isLoadingLines ? (
+                        <div style={{ padding: '8px 12px 8px 48px', fontSize: 12, color: '#9ca3af' }}>Loading lines...</div>
+                      ) : lines.length === 0 ? (
+                        <div style={{ padding: '8px 12px 8px 48px', fontSize: 12, color: '#9ca3af' }}>No lines found</div>
+                      ) : (
+                        <>
+                          <div style={{ display: 'flex', padding: '4px 12px 4px 48px', fontSize: 11, fontWeight: 600, color: '#9ca3af', textTransform: 'uppercase', letterSpacing: '0.5px', borderBottom: '0.5px solid #E5E7EB' }}>
+                            <span style={{ flex: 1 }}>Product</span>
+                            <span style={{ width: 90, textAlign: 'right' }}>Pending</span>
+                            <span style={{ width: 90, textAlign: 'right' }}>Import Qty</span>
+                          </div>
+                          {lines.map((line) => {
+                            const selectable = line._selectable;
+                            const lineSelected = selectable && selected.has(line.id);
+                            const productName = line['product$_identifier'] || line.id;
+                            const maxQty = Number(line._availableQty) || 0;
+                            const currentQty = lineQuantities[line.id] ?? maxQty;
+
+                            return (
+                              <div
+                                key={line.id}
+                                onClick={() => toggleLine(line.id, selectable)}
+                                style={{
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  padding: '6px 12px 6px 48px',
+                                  borderBottom: '0.5px solid #F3F4F6',
+                                  cursor: selectable ? 'pointer' : 'default',
+                                  background: lineSelected ? '#eff6ff' : 'transparent',
+                                  opacity: selectable ? 1 : 0.45,
+                                }}
+                              >
+                                <input
+                                  type="checkbox"
+                                  checked={lineSelected}
+                                  disabled={!selectable}
+                                  onChange={() => toggleLine(line.id, selectable)}
+                                  onClick={(e) => e.stopPropagation()}
+                                  style={{ accentColor: '#3b82f6', cursor: selectable ? 'pointer' : 'not-allowed', marginRight: 8, flexShrink: 0 }}
+                                />
+                                <span style={{ fontSize: 13, color: selectable ? (lineSelected ? '#2563eb' : '#111827') : '#9ca3af', flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', fontWeight: lineSelected ? 500 : 400 }}>
+                                  {productName}
+                                  {!selectable && <span style={{ fontSize: 11, marginLeft: 6, color: '#9ca3af' }}>already fully received</span>}
+                                </span>
+                                <span style={{ width: 90, fontSize: 12, color: '#6B7280', fontVariantNumeric: 'tabular-nums', textAlign: 'right', flexShrink: 0 }}>
+                                  {fmtNum(line._availableQty)}
+                                </span>
+                                <span style={{ width: 90, flexShrink: 0, textAlign: 'right' }}>
+                                  <input
+                                    type="number"
+                                    min={1}
+                                    max={maxQty}
+                                    disabled={!selectable}
+                                    value={currentQty}
+                                    onClick={(e) => e.stopPropagation()}
+                                    onChange={(e) => {
+                                      const value = Math.max(1, Math.min(maxQty, Number(e.target.value) || 1));
+                                      setLineQuantities((prev) => ({ ...prev, [line.id]: value }));
+                                    }}
+                                    style={{
+                                      width: 72,
+                                      fontSize: 12,
+                                      padding: '3px 4px',
+                                      borderRadius: 4,
+                                      textAlign: 'center',
+                                      fontVariantNumeric: 'tabular-nums',
+                                      outline: 'none',
+                                      border: '0.5px solid var(--color-border-secondary, #d1d5db)',
+                                      background: selectable ? '#fff' : '#f3f4f6',
+                                    }}
+                                  />
+                                </span>
+                              </div>
+                            );
+                          })}
+                        </>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: '#F8F9FA', borderTop: '1px solid #E5E7EB', padding: '10px 16px' }}>
+          <span style={{ fontSize: 12, color: selected.size > 0 ? 'var(--color-text-info, #2563eb)' : '#6B7280', fontWeight: selected.size > 0 ? 500 : 400 }}>
+            {selected.size > 0 ? `${selected.size} line${selected.size > 1 ? 's' : ''} selected` : 'Select lines to import'}
+          </span>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button type="button" onClick={onClose} style={{ fontSize: 13, padding: '5px 14px', borderRadius: 6, border: '1px solid #E5E7EB', background: 'transparent', color: '#6B7280', cursor: 'pointer' }}>Cancel</button>
+            <button
+              type="button"
+              onClick={handleImport}
+              disabled={selected.size === 0 || importing}
+              style={{ fontSize: 13, fontWeight: 500, padding: '5px 14px', borderRadius: 6, border: 'none', background: '#18181b', color: '#fff', cursor: (selected.size === 0 || importing) ? 'not-allowed' : 'pointer', opacity: (selected.size === 0 || importing) ? 0.4 : 1 }}
+            >
+              {importing ? 'Importing...' : `Import selected${selected.size > 0 ? ` (${selected.size})` : ''}`}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tools/app-shell/src/windows/custom/goods-receipt/index.jsx
+++ b/tools/app-shell/src/windows/custom/goods-receipt/index.jsx
@@ -1,5 +1,6 @@
 import GoodsReceiptLineTable from '@generated/goods-receipt/generated/web/goods-receipt/GoodsReceiptLineTable';
 import GeneratedApp from '@generated/goods-receipt/generated/web/goods-receipt/index.jsx';
+import GoodsReceiptBottomPanel from './GoodsReceiptBottomPanel.jsx';
 import RelatedDocuments from './RelatedDocuments.jsx';
 
 // Lines table columns without lineNo
@@ -22,6 +23,7 @@ export default function GoodsReceiptWindow(props) {
       DetailTable={CustomLinesTable}
       secondaryTabs={[]}
       notesField="description"
+      bottomSection={GoodsReceiptBottomPanel}
       customTabs={[{ key: 'related', label: 'Related Documents', Component: RelatedDocuments }]}
     />
   );

--- a/tools/app-shell/src/windows/custom/purchase-invoice/InvoicePreviewModal.jsx
+++ b/tools/app-shell/src/windows/custom/purchase-invoice/InvoicePreviewModal.jsx
@@ -6,7 +6,7 @@ import { formatAmount } from '@/lib/formatAmount.js';
 import { getStatusBadgeProps, statusLabel } from '@/lib/statusBadge.js';
 import AddPaymentModal from './AddPaymentModal.jsx';
 
-const TOP_TABS = ['Estadísticas', 'Mensajes', 'Historial'];
+const TOP_TABS = ['Stats', 'Messages', 'History'];
 
 const ACCEPTED_TYPES = {
   'application/pdf': 'pdf',
@@ -23,18 +23,18 @@ const ACCEPT_ATTR = Object.keys(ACCEPTED_TYPES).join(',');
  * InvoicePreviewModal — Holded-style preview popup for a purchase invoice.
  *
  * Layout:
- *   Top bar: title, action buttons, tab switcher (Estadísticas | Mensajes | Historial)
+ *   Top bar: title, action buttons, tab switcher (Stats | Messages | History)
  *   Body: 50% document drop zone | 50% sidebar (content driven by active top tab)
  *
- * Estadísticas tab sidebar:
- *   General section  → invoice header fields
- *   Pagos section    → paymentPlan rows + Añadir pago
- *   Archivos section → placeholder
+ * Stats tab sidebar:
+ *   General section   → invoice header fields
+ *   Payments section  → paymentPlan rows + Add payment
+ *   Files section     → placeholder
  *
  * Animation: fade + slide-up on open, reverse on close.
  */
 export default function InvoicePreviewModal({ invoice, token, apiBaseUrl, windowName, onClose, onEdit }) {
-  const [activeTab, setActiveTab] = useState('Estadísticas');
+  const [activeTab, setActiveTab] = useState('Stats');
   const [paymentPlan, setPaymentPlan] = useState([]);
   const [loadingPayments, setLoadingPayments] = useState(false);
   const [showAddPayment, setShowAddPayment] = useState(false);
@@ -165,7 +165,7 @@ export default function InvoicePreviewModal({ invoice, token, apiBaseUrl, window
   const grandTotal = Number(invoice.grandTotalAmount ?? 0);
   const totalOutstanding = Math.max(0, grandTotal - totalPaid);
 
-  // "Añadir pago" is only available when invoice is Completed (CO) with outstanding balance
+  // "Add payment" is only available when invoice is Completed (CO) with outstanding balance
   const isDraft = status === 'DR' || status === 'draft';
   const isFullyPaid = totalOutstanding <= 0 && allPayments.length > 0;
   const isCompleted = status === 'CO' || status === 'complete' || status === 'completed';
@@ -227,11 +227,11 @@ export default function InvoicePreviewModal({ invoice, token, apiBaseUrl, window
                 onClick={canAddPayment ? () => setShowAddPayment(true) : undefined}
               >
                 <Plus size={13} />
-                Añadir pago
+                Add payment
               </Button>
               <Button size="sm" variant="outline" className="gap-1.5" onClick={handleEdit}>
                 <Edit2 size={13} />
-                Editar
+                Edit
               </Button>
               <button className="p-1.5 text-gray-400 hover:text-gray-600 border border-gray-200 rounded-lg transition-colors">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><circle cx="5" cy="12" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="19" cy="12" r="2"/></svg>
@@ -331,15 +331,15 @@ export default function InvoicePreviewModal({ invoice, token, apiBaseUrl, window
                       </div>
                     </div>
                     {isDragOver ? (
-                      <p className="text-sm font-medium text-blue-600">Suelta el archivo aquí</p>
+                      <p className="text-sm font-medium text-blue-600">Drop file here</p>
                     ) : (
                       <>
-                        <p className="text-sm font-medium text-gray-600 mt-1">Sube tu documento</p>
+                        <p className="text-sm font-medium text-gray-600 mt-1">Upload your document</p>
                         <button
                           className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors"
                           onClick={(e) => { e.stopPropagation(); fileInputRef.current?.click(); }}
                         >
-                          Click aquí para importar tu archivo
+                          Click here to upload your file
                         </button>
                         <p className="text-xs text-gray-400">PDF, JPG, PNG, WebP, GIF</p>
                       </>
@@ -358,8 +358,8 @@ export default function InvoicePreviewModal({ invoice, token, apiBaseUrl, window
 
             {/* Right panel: 50% — tab content */}
             <div className="w-1/2 overflow-y-auto">
-              {activeTab === 'Estadísticas' && (
-                <EstadisticasPanel
+              {activeTab === 'Stats' && (
+                <StatsPanel
                   invoice={invoice}
                   partnerName={partnerName}
                   badgeProps={badgeProps}
@@ -374,11 +374,11 @@ export default function InvoicePreviewModal({ invoice, token, apiBaseUrl, window
                   onAddPayment={() => setShowAddPayment(true)}
                 />
               )}
-              {activeTab === 'Mensajes' && (
-                <EmptyPanel icon="💬" text="No hay mensajes aún" />
+              {activeTab === 'Messages' && (
+                <EmptyPanel icon="💬" text="No messages yet" />
               )}
-              {activeTab === 'Historial' && (
-                <EmptyPanel icon="🕐" text="Sin actividad registrada" />
+              {activeTab === 'History' && (
+                <EmptyPanel icon="🕐" text="No activity recorded" />
               )}
             </div>
           </div>
@@ -398,7 +398,7 @@ export default function InvoicePreviewModal({ invoice, token, apiBaseUrl, window
   );
 }
 
-// ── Estadísticas panel: General + Pagos + Archivos sections ──
+// ── Stats panel: General + Payments + Files sections ──
 
 function SectionCard({ title, done, children }) {
   return (
@@ -424,13 +424,13 @@ function InfoRow({ label, value, link }) {
   );
 }
 
-function EstadisticasPanel({ invoice, partnerName, badgeProps, statusLabel: sl, allPayments, loadingPayments, totalPaid, totalOutstanding, canAddPayment, isDraft, isFullyPaid, onAddPayment }) {
+function StatsPanel({ invoice, partnerName, badgeProps, statusLabel: sl, allPayments, loadingPayments, totalPaid, totalOutstanding, canAddPayment, isDraft, isFullyPaid, onAddPayment }) {
   const invoiceDate = invoice.invoiceDate
-    ? new Date(invoice.invoiceDate).toLocaleDateString('es-ES')
+    ? new Date(invoice.invoiceDate).toLocaleDateString('en-GB')
     : '—';
 
   const dueDate = invoice.dueDate
-    ? new Date(invoice.dueDate).toLocaleDateString('es-ES')
+    ? new Date(invoice.dueDate).toLocaleDateString('en-GB')
     : '—';
 
   const isPaid = allPayments.length > 0 && totalOutstanding <= 0;
@@ -440,22 +440,22 @@ function EstadisticasPanel({ invoice, partnerName, badgeProps, statusLabel: sl, 
       {/* General */}
       <SectionCard title="General" done={true}>
         <InfoRow label="Total" value={formatAmount(invoice.grandTotalAmount)} />
-        <InfoRow label="Número de documento" value={invoice.documentNo} />
-        <InfoRow label="Contacto" value={partnerName} link />
-        <InfoRow label="Fecha" value={invoiceDate} />
-        <InfoRow label="Vencimiento" value={dueDate} />
+        <InfoRow label="Document number" value={invoice.documentNo} />
+        <InfoRow label="Contact" value={partnerName} link />
+        <InfoRow label="Date" value={invoiceDate} />
+        <InfoRow label="Due date" value={dueDate} />
         <div className="flex justify-between items-center py-1.5 text-sm">
-          <span className="text-gray-500">Estado</span>
+          <span className="text-gray-500">Status</span>
           <Badge {...badgeProps}>{sl}</Badge>
         </div>
       </SectionCard>
 
-      {/* Pagos */}
-      <SectionCard title="Pagos" done={isPaid}>
+      {/* Payments */}
+      <SectionCard title="Payments" done={isPaid}>
         {loadingPayments ? (
-          <p className="text-xs text-gray-400 py-2 text-center">Cargando...</p>
+          <p className="text-xs text-gray-400 py-2 text-center">Loading...</p>
         ) : allPayments.length === 0 ? (
-          <p className="text-xs text-gray-400 py-2 text-center">Sin pagos registrados</p>
+          <p className="text-xs text-gray-400 py-2 text-center">No payments recorded</p>
         ) : (
           <div className="space-y-2 mb-3">
             {allPayments.map((row, i) => {
@@ -470,7 +470,7 @@ function EstadisticasPanel({ invoice, partnerName, badgeProps, statusLabel: sl, 
 
               let ref = '—';
               if (row._local) {
-                ref = row.paymentMethod$_identifier || 'PAGOS';
+                ref = row.paymentMethod$_identifier || 'PAYMENT';
               } else {
                 ref = row.documentNo || '—';
               }
@@ -486,7 +486,7 @@ function EstadisticasPanel({ invoice, partnerName, badgeProps, statusLabel: sl, 
                     <div>
                       <span className="text-gray-700 font-medium truncate max-w-[80px] block">{ref}</span>
                       {row._local && (
-                        <span className="text-[10px] text-amber-600 font-medium">pendiente sincronizar</span>
+                        <span className="text-[10px] text-amber-600 font-medium">pending sync</span>
                       )}
                     </div>
                   </div>
@@ -505,10 +505,10 @@ function EstadisticasPanel({ invoice, partnerName, badgeProps, statusLabel: sl, 
           title={
             !canAddPayment
               ? isDraft
-                ? 'No se pueden añadir pagos a una factura en borrador'
+                ? 'Cannot add payments to a draft invoice'
                 : isFullyPaid
-                  ? 'La factura ya está completamente pagada'
-                  : 'La factura debe estar completada para añadir pagos'
+                  ? 'Invoice is fully paid'
+                  : 'Invoice must be completed to add payments'
               : undefined
           }
           className={`w-full py-2 text-sm font-medium border rounded-lg transition-colors ${
@@ -517,17 +517,17 @@ function EstadisticasPanel({ invoice, partnerName, badgeProps, statusLabel: sl, 
               : 'text-gray-400 border-gray-200 bg-gray-50 cursor-not-allowed'
           }`}
         >
-          Añadir pago
+          Add payment
         </button>
       </SectionCard>
 
-      {/* Archivos */}
-      <SectionCard title="Archivos">
+      {/* Files */}
+      <SectionCard title="Files">
         <button
           disabled
           className="w-full py-2 text-sm text-gray-400 border border-dashed border-gray-300 rounded-lg cursor-default"
         >
-          Añadir archivo adjunto
+          Add attachment
         </button>
       </SectionCard>
     </div>

--- a/tools/app-shell/src/windows/custom/purchase-invoice/InvoicePreviewModal.jsx
+++ b/tools/app-shell/src/windows/custom/purchase-invoice/InvoicePreviewModal.jsx
@@ -179,24 +179,24 @@ export default function InvoicePreviewModal({ invoice, token, apiBaseUrl, window
       : 'opacity-100 transition-opacity duration-[280ms]';
 
   const cardClass = animState === 'opening'
-    ? 'opacity-0 translate-y-4 scale-[0.98]'
+    ? 'translate-x-full'
     : animState === 'closing'
-      ? 'opacity-0 translate-y-4 scale-[0.98] transition-all duration-[280ms]'
+      ? 'translate-x-full transition-transform duration-[280ms]'
       : animState === 'closingUp'
-        ? 'opacity-0 -translate-y-8 scale-[0.98] transition-all duration-[280ms]'
-        : 'opacity-100 translate-y-0 scale-100 transition-all duration-[280ms]';
+        ? 'opacity-0 translate-x-full transition-all duration-[280ms]'
+        : 'translate-x-0 transition-transform duration-[280ms]';
 
   return (
     <>
       {/* Backdrop */}
       <div
-        className={`fixed inset-0 z-50 bg-black/30 flex items-center justify-center p-4 ${backdropClass}`}
+        className={`fixed inset-0 z-50 bg-black/30 ${backdropClass}`}
         onClick={handleClose}
       >
-        {/* Modal card */}
+        {/* Side panel — slides in from the right, preserving all original content */}
         <div
-          className={`bg-white rounded-2xl shadow-2xl overflow-hidden flex flex-col ${cardClass}`}
-          style={{ width: '90vw', height: '88vh', maxWidth: '1200px' }}
+          className={`absolute right-0 top-0 bottom-0 bg-white shadow-2xl overflow-hidden flex flex-col ${cardClass}`}
+          style={{ width: '80vw', maxWidth: '1100px' }}
           onClick={(e) => e.stopPropagation()}
         >
           {/* ── Top bar ── */}


### PR DESCRIPTION
## Summary

- Add "Import from Purchase Order" feature to Goods Receipt window: empty state and toolbar action that open a modal to select and import PO lines as receipt lines
- Fix React Rules of Hooks violation in `InvoiceTopbarExtra` (moved early return after all `useMemo` calls)
- Convert `InvoicePreviewModal` (purchase invoice) from centered modal to right side-panel with slide animation

## Test plan

- [ ] Goods Receipt (draft, with business partner): verify empty state shows "Import from Purchase Order" button
- [ ] Goods Receipt (draft, with BP): open import modal, expand a PO, select lines, import — receipt lines appear
- [ ] Goods Receipt (draft, without BP): verify import button is hidden
- [ ] Goods Receipt (completed): verify import button/empty state not shown
- [ ] Sales Invoice detail: verify topbar payment badge renders correctly (no hooks error in console)
- [ ] Purchase Invoice: verify preview modal slides in from the right