### PR TITLE
Feature ETP-3587: Add Location and Email columns to Contacts list view

### DIFF
--- a/artifacts/contacts/contract.json
+++ b/artifacts/contacts/contract.json
@@ -1,7 +1,7 @@
 {
   "version": "0.3.2",
-  "generatedAt": "2026-04-06T16:42:04.456Z",
-  "checksum": "326d01a57c4c8ab7",
+  "generatedAt": "2026-04-06T17:10:39.684Z",
+  "checksum": "74fee297ffc17a7f",
   "frontendContract": {
     "window": {
       "id": "123",
@@ -10,6 +10,9 @@
       "category": "people",
       "sidebarLayout": true,
       "breadcrumb": "",
+      "customComponents": {
+        "headerTable": "ContactsTable"
+      },
       "entityLabel": "Contact",
       "secondaryTabs": {
         "contact": {
@@ -2396,6 +2399,9 @@
       "category": "people",
       "sidebarLayout": true,
       "breadcrumb": "",
+      "customComponents": {
+        "headerTable": "ContactsTable"
+      },
       "entityLabel": "Contact",
       "secondaryTabs": {
         "contact": {

--- a/artifacts/contacts/custom/ContactsTable.jsx
+++ b/artifacts/contacts/custom/ContactsTable.jsx
@@ -1,0 +1,58 @@
+import { useState, useEffect, useRef } from 'react';
+import { DataTable } from '@/components/contract-ui';
+
+const BASE_COLUMNS = [
+  { key: 'name', column: 'Name', type: 'string', label: 'Commercial Name' },
+];
+
+const ENRICHED_COLUMNS = [
+  ...BASE_COLUMNS,
+  { key: '__location', type: 'string', label: 'Location',  render: (row) => row.__location ?? '—' },
+  { key: '__email',    type: 'string', label: 'Email',     render: (row) => row.__email    ?? '—' },
+];
+
+const filters = ['searchKey', 'name'];
+
+export default function ContactsTable({ data = [], token, apiBaseUrl, ...rest }) {
+  const [enrichedData, setEnrichedData] = useState(data);
+  const lastDataRef = useRef(null);
+
+  useEffect(() => {
+    if (!token || !apiBaseUrl || !data.length) {
+      setEnrichedData(data);
+      return;
+    }
+    if (lastDataRef.current === data) return;
+    lastDataRef.current = data;
+
+    const headers = { Authorization: `Bearer ${token}` };
+    Promise.all([
+      fetch(`${apiBaseUrl}/locationAddress?_startRow=0&_endRow=9999`, { headers })
+        .then(r => r.ok ? r.json() : null),
+      fetch(`${apiBaseUrl}/contact?_startRow=0&_endRow=9999`, { headers })
+        .then(r => r.ok ? r.json() : null),
+    ]).then(([locData, contactData]) => {
+      // Index first location address per BP
+      const locByBP = {};
+      for (const rec of (locData?.response?.data ?? [])) {
+        if (!locByBP[rec.businessPartner]) {
+          locByBP[rec.businessPartner] = rec['locationAddress$_identifier'] ?? rec.name ?? '';
+        }
+      }
+      // Index first contact email per BP
+      const emailByBP = {};
+      for (const rec of (contactData?.response?.data ?? [])) {
+        if (!emailByBP[rec.businessPartner] && rec.email) {
+          emailByBP[rec.businessPartner] = rec.email;
+        }
+      }
+      setEnrichedData(data.map(row => ({
+        ...row,
+        __location: locByBP[row.id] ?? null,
+        __email:    emailByBP[row.id] ?? null,
+      })));
+    }).catch(() => setEnrichedData(data));
+  }, [data, token, apiBaseUrl]);
+
+  return <DataTable columns={ENRICHED_COLUMNS} filters={filters} data={enrichedData} {...rest} />;
+}

--- a/artifacts/contacts/decisions.json
+++ b/artifacts/contacts/decisions.json
@@ -13,6 +13,9 @@
     "headerExtra": {
       "customForm": "BillingPreferencesForm"
     },
+    "customComponents": {
+      "headerTable": "ContactsTable"
+    },
     "secondaryTabs": {
       "contact": {
         "tabMode": "table-form",

--- a/artifacts/contacts/generated/web/contacts/BusinessPartnerPage.jsx
+++ b/artifacts/contacts/generated/web/contacts/BusinessPartnerPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { ListView, DetailView } from '@/components/contract-ui';
-import BusinessPartnerTable from './BusinessPartnerTable';
+import BusinessPartnerTable from '../../../custom/ContactsTable';
 import BusinessPartnerForm from './BusinessPartnerForm';
 import ContactTable from './ContactTable';
 import ContactForm from './ContactForm';

--- a/tools/app-shell/src/components/contract-ui/ListView.jsx
+++ b/tools/app-shell/src/components/contract-ui/ListView.jsx
@@ -345,6 +345,9 @@ export function ListView({
                     sortColumn={hook.sortColumn}
                     sortDirection={hook.sortDirection}
                     onColumnsReady={setTableColumns}
+                    api={api}
+                    token={token}
+                    apiBaseUrl={apiBaseUrl}
                   />
                 )
               }


### PR DESCRIPTION
- Add ContactsTable custom component that batch-fetches locationAddress and contact sub-entities and enriches each BP row with location identifier and first contact email
- Add customComponents.headerTable support in decisions.json to use custom table
- Forward api/token/apiBaseUrl props from ListView to Table component