### PR TITLE
Feature ETP-3570: Fix asset paths for SPA deep links

### DIFF
--- a/tools/app-shell/vite.config.js
+++ b/tools/app-shell/vite.config.js
@@ -12,7 +12,7 @@ export default defineConfig(({ mode }) => {
   const ETENDO_URL = env.ETENDO_URL || process.env.ETENDO_URL || 'http://localhost:8080/etendo';
 
   return {
-  base: './',
+  base: '/',
   plugins: [
     react(),
     schemaApiPlugin(),


### PR DESCRIPTION
## Summary
- Changes Vite `base` from `'./'` to `'/'` so assets use absolute paths
- Fixes blank page on deep links in staging (e.g. `/payment-in/{id}`) where browser resolves `./assets/index.js` as `/payment-in/assets/index.js` resulting in 403

## Test plan
- [ ] Verify deep links work in staging after redeploy