### PR TITLE
Hotfix ETP-3585: Hide process button when no lines exist

### DIFF
--- a/artifacts/physical-inventory/contract.json
+++ b/artifacts/physical-inventory/contract.json
@@ -1,13 +1,18 @@
 {
   "version": "0.16.0",
-  "generatedAt": "2026-04-06T13:09:44.381Z",
-  "checksum": "c7ab77bb72a53e01",
+  "generatedAt": "2026-04-06T18:44:12.236Z",
+  "checksum": "c29a907f9de7a2c7",
   "frontendContract": {
     "window": {
       "id": "168",
       "name": "Physical Inventory",
       "primaryEntity": "inventory",
       "category": "warehouse",
+      "processOverrides": {
+        "processNow": {
+          "requiresLines": true
+        }
+      },
       "statusField": "processed",
       "layoutType": "default"
     },
@@ -375,6 +380,11 @@
       "name": "Physical Inventory",
       "primaryEntity": "inventory",
       "category": "warehouse",
+      "processOverrides": {
+        "processNow": {
+          "requiresLines": true
+        }
+      },
       "statusField": "processed"
     },
     "entities": {

--- a/artifacts/physical-inventory/decisions.json
+++ b/artifacts/physical-inventory/decisions.json
@@ -3,7 +3,12 @@
   "window": {
     "category": "warehouse",
     "name": "Physical Inventory",
-    "statusField": "processed"
+    "statusField": "processed",
+    "processOverrides": {
+      "processNow": {
+        "requiresLines": true
+      }
+    }
   },
   "entities": {
     "header": {

--- a/artifacts/physical-inventory/generated/web/physical-inventory/InventoryPage.jsx
+++ b/artifacts/physical-inventory/generated/web/physical-inventory/InventoryPage.jsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { ListView, DetailView } from '@/components/contract-ui';
 import InventoryTable from './InventoryTable';
 import InventoryForm from './InventoryForm';
@@ -25,7 +26,7 @@ const extraBadges = [];
 // @sf-generated-start processes:inventory
 const processes = [
   { name: 'processNow', label: 'Process Inventory Count', style: 'positive',
-    displayLogicRaw: "@Processed@='N'" },
+    displayLogicRaw: "@Processed@='N'", requiresLines: true },
 ];
 // @sf-generated-end processes:inventory
 
@@ -173,6 +174,7 @@ const api = {
 // @sf-generated-start component:InventoryPage
 export default function InventoryPage({ windowName, recordId, ...props }) {
   // @sf-custom-slot hooks:InventoryPage
+  
   if (recordId) {
     return (
       <DetailView

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -446,7 +446,8 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
       const label = ovr.label || f.label || toLabel(f.name);
       const dlRawVal = ovr.displayLogicRaw || f.displayLogic?.raw;
       const dlRaw = dlRawVal ? `,\n    displayLogicRaw: "${dlRawVal.replace(/"/g, '\\"')}"` : '';
-      return `  { name: '${f.name}', label: '${label.replace(/'/g, "\\'")}', style: '${style}'${dlRaw} },`;
+      const requiresLinesPart = ovr.requiresLines ? `, requiresLines: true` : '';
+      return `  { name: '${f.name}', label: '${label.replace(/'/g, "\\'")}', style: '${style}'${dlRaw}${requiresLinesPart} },`;
     }).filter(Boolean),
     // Extra processes defined purely in decisions.json (not in backend contract)
     ...Object.entries(processOverrides)
@@ -458,7 +459,8 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
         const dlRaw = ovr.displayLogicRaw
           ? `,\n    displayLogicRaw: "${ovr.displayLogicRaw.replace(/"/g, '\\"')}"`
           : '';
-        return `  { name: '${name}', label: '${label.replace(/'/g, "\\'")}', style: '${style}'${colPart}${dlRaw} },`;
+        const requiresLinesPart = ovr.requiresLines ? `, requiresLines: true` : '';
+        return `  { name: '${name}', label: '${label.replace(/'/g, "\\'")}', style: '${style}'${colPart}${dlRaw}${requiresLinesPart} },`;
       }),
   ].join('\n');
 

--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -694,6 +694,7 @@ export function DetailView({
               .filter(p => p.displayLogicRaw
                 ? evalDisplayLogicRaw(p.displayLogicRaw, data)
                 : displayLogic?.visibility?.[p.name] !== false)
+              .filter(p => !p.requiresLines || hook.children.length > 0)
               .map(p => {
                 const isPrimary = p.style === 'positive';
                 const btnClass = salesTheme


### PR DESCRIPTION
Add requiresLines flag to process definitions. When set, DetailView hides the process button until at least one child line exists.

  Physical inventory: processNow marked requiresLines:true so 'Process Inventory Count' only appears once lines are loaded.