### PR TITLE
Feature ETP-3569: Fix lines not refreshing after Import from Purchase Order

### DIFF
--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -886,7 +886,7 @@ export function DetailView({
                       recordId={data?.id || recordId}
                       token={token}
                       apiBaseUrl={apiBaseUrl}
-                      onRefresh={() => hook.refetch?.()}
+                      onRefresh={() => hook.fetchChildren?.(data?.id || recordId)}
                     />
                   ) : (
                   <div className={`pt-3 flex items-start gap-4${embedded ? ' pointer-events-none' : ''}`}>
@@ -1004,7 +1004,7 @@ export function DetailView({
                             </button>
                           )}
                           {DetailExtraActions && (
-                            <DetailExtraActions data={data} recordId={data?.id || recordId} token={token} apiBaseUrl={apiBaseUrl} onRefresh={() => hook.refetch?.()} />
+                            <DetailExtraActions data={data} recordId={data?.id || recordId} token={token} apiBaseUrl={apiBaseUrl} onRefresh={() => hook.fetchChildren?.(data?.id || recordId)} />
                           )}
                         </div>
                       )}
@@ -1141,7 +1141,7 @@ export function DetailView({
                       apiBaseUrl={apiBaseUrl}
                       api={api}
                       editing={hook.editing}
-                      onRefresh={() => hook.refetch?.()}
+                      onRefresh={() => hook.fetchChildren?.(data?.id || recordId)}
                     />
                   </div>
                 )}

--- a/tools/app-shell/src/hooks/useEntity.js
+++ b/tools/app-shell/src/hooks/useEntity.js
@@ -111,7 +111,7 @@ export function useEntity(entity, childEntity, { token, apiBaseUrl, childSortBy 
         setChildren(rows);
       })
       .catch(() => setChildren([]));
-  }, [apiBaseUrl, childEntity, token]);
+  }, [apiBaseUrl, childEntity, token, childSortBy]);
 
   const fetchById = useCallback((id) => {
     if (!id) return;
@@ -346,7 +346,7 @@ export function useEntity(entity, childEntity, { token, apiBaseUrl, childSortBy 
     items, selected, editing, children, loading, loadingMore, hasMore, saveError,
     handleSelect, handleNew, handleChange, handleSave, handleSaveAndProcess, handleDelete, handleProcess,
     handleAddChild, handleUpdateChild, handleDeleteChild,
-    refresh, fetchById, loadMore,
+    refresh, fetchById, fetchChildren, loadMore,
     sortColumn, sortDirection, setSortColumn, setSortDirection,
   };
 }

--- a/tools/app-shell/src/windows/custom/goods-receipt/GoodsReceiptBottomPanel.jsx
+++ b/tools/app-shell/src/windows/custom/goods-receipt/GoodsReceiptBottomPanel.jsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from 'react';
 import { createPortal } from 'react-dom';
-import { toast } from 'sonner';
 import ImportFromPurchaseOrderModal from './ImportFromPurchaseOrderModal.jsx';
 
 function ReceiptLinesEmptyState({ data, onAddLine, recordId, token, apiBaseUrl, onRefresh }) {
@@ -50,7 +49,6 @@ function ReceiptLinesEmptyState({ data, onAddLine, recordId, token, apiBaseUrl, 
           onClose={() => setShowImportModal(false)}
           onSuccess={() => {
             setShowImportModal(false);
-            toast.success('Lines imported from purchase order');
             onRefresh?.();
           }}
         />,
@@ -93,7 +91,6 @@ function ReceiptLineActions({ data, recordId, token, apiBaseUrl, onRefresh }) {
           onClose={() => setShowImportModal(false)}
           onSuccess={() => {
             setShowImportModal(false);
-            toast.success('Lines imported from purchase order');
             onRefresh?.();
           }}
         />,


### PR DESCRIPTION
## Summary

- `useEntity.js` never exposed `fetchChildren` in its return value, so `hook.refetch?.()` in `DetailView.jsx` was always `undefined` — silently doing nothing after the import
- Lines were correctly saved to the DB (POST 200) but the UI state was never refreshed
- Added `fetchChildren` to the hook's return and wired it into the 3 `onRefresh` callbacks in `DetailView`

## Changes

- **`useEntity.js`** — Exposed `fetchChildren` in return; fixed missing `childSortBy` dependency in its `useCallback`
- **`DetailView.jsx`** — Replaced `hook.refetch?.()` (undefined) with `hook.fetchChildren?.(data?.id || recordId)` in all 3 onRefresh usages
- **`GoodsReceiptBottomPanel.jsx`** — Removed duplicate `toast.success` (the modal already shows it) and unused `toast` import

## Test plan

- [ ] Open Goods Receipt in Draft status with no lines
- [ ] Click "Import from Purchase Order", select lines, click "Import selected"
- [ ] Verify lines appear immediately in the table without manual refresh
- [ ] Verify the Lines tab counter updates correctly
- [ ] Verify no duplicate toast notifications appear

Fixes: Import from Purchase Order lines not displaying until manual page refresh