### PR TITLE
Feature ETP-3654: Add action to build cloufront schema image

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,14 +1,10 @@
-name: Deploy SPA to staging
+name: Deploy SPA
 
 on:
   push:
     branches:
+      - develop
       - epic/ETP-3504
-
-env:
-  AWS_REGION:              eu-west-3
-  S3_BUCKET:               etendo-go-staging-ui
-  CLOUDFRONT_DISTRIBUTION: E2XAO6Y99940X9
 
 jobs:
   deploy:
@@ -17,6 +13,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Resolve deployment target
+        id: target
+        run: |
+          if [[ "${{ github.ref_name }}" == "develop" ]]; then
+            echo "s3_bucket=${{ vars.S3_BUCKET_STAGING }}" >> $GITHUB_OUTPUT
+            echo "cf_distribution=${{ vars.CF_DISTRIBUTION_STAGING }}" >> $GITHUB_OUTPUT
+            echo "env_label=staging" >> $GITHUB_OUTPUT
+          else
+            echo "s3_bucket=${{ vars.S3_BUCKET_EXPERIMENTAL }}" >> $GITHUB_OUTPUT
+            echo "cf_distribution=${{ vars.CF_DISTRIBUTION_EXPERIMENTAL }}" >> $GITHUB_OUTPUT
+            echo "env_label=experimental" >> $GITHUB_OUTPUT
+          fi
 
       - uses: actions/setup-node@v4
         with:
@@ -35,19 +44,19 @@ jobs:
         with:
           aws-access-key-id:     ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region:            ${{ env.AWS_REGION }}
+          aws-region:            ${{ vars.AWS_REGION }}
 
-      - name: Sync dist to S3
+      - name: Sync dist to S3 (${{ steps.target.outputs.env_label }})
         run: |
-          aws s3 sync tools/app-shell/dist/ s3://${{ env.S3_BUCKET }}/ \
+          aws s3 sync tools/app-shell/dist/ s3://${{ steps.target.outputs.s3_bucket }}/ \
             --delete \
             --cache-control "public, max-age=31536000, immutable" \
             --exclude "index.html" \
             --exclude "registerSW.js" \
             --exclude "manifest.webmanifest" \
             --exclude "sw.js"
-          # HTML, SW and manifest must not be cached long-term (no --cache-control override)
-          aws s3 sync tools/app-shell/dist/ s3://${{ env.S3_BUCKET }}/ \
+          # HTML, SW and manifest must not be cached long-term
+          aws s3 sync tools/app-shell/dist/ s3://${{ steps.target.outputs.s3_bucket }}/ \
             --exclude "*" \
             --include "index.html" \
             --include "registerSW.js" \
@@ -55,8 +64,8 @@ jobs:
             --include "sw.js" \
             --cache-control "no-cache, no-store, must-revalidate"
 
-      - name: Invalidate CloudFront cache
+      - name: Invalidate CloudFront cache (${{ steps.target.outputs.env_label }})
         run: |
           aws cloudfront create-invalidation \
-            --distribution-id ${{ env.CLOUDFRONT_DISTRIBUTION }} \
+            --distribution-id ${{ steps.target.outputs.cf_distribution }} \
             --paths "/*"


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to auto-deploy `tools/app-shell` on push
- `develop` → `etendo-go-staging-ui
- `epic/ETP-3504` → `etendo-go-experimental-ui`

## Test plan
- [ ] Push to `develop` triggers deploy to staging bucket
- [ ] Push to `epic/ETP-3504` triggers deploy to experimental bucket
- [ ] CloudFront invalidation runs after each S3 sync