### PR TITLE
Feature ETP-3570: Fix wiring tests for shipment and return

### DIFF
--- a/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentForm.jsx
+++ b/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentForm.jsx
@@ -11,6 +11,7 @@ const fields = [
   { key: 'description', column: 'Description', type: 'textarea', label: 'Description', section: 'collapsed' },
   // @sf-custom-slot callout:SL_InOut_AccountingDate
   { key: 'movementDate', column: 'MovementDate', type: 'date', label: 'Movement Date', required: true, section: 'principal', defaultValue: '@#Date@', readOnlyLogic: (record) => record['processed'] === true },
+  { key: 'invoiced', column: 'IsInvoiced', type: 'text', label: 'Invoiced', readOnly: true, section: 'collapsed' },
 ];
 // @sf-generated-end fields:goodsShipment
 

--- a/artifacts/return-from-customer/generated/web/return-from-customer/CustomerReturnForm.jsx
+++ b/artifacts/return-from-customer/generated/web/return-from-customer/CustomerReturnForm.jsx
@@ -3,9 +3,13 @@ import { EntityForm } from '@/components/contract-ui';
 // @sf-generated-start fields:customerReturn
 const fields = [
   { key: 'documentNo', column: 'DocumentNo', type: 'text', required: true, readOnly: true, section: 'principal' },
+  { key: 'cReturnReasonID', column: 'C_Return_Reason_ID', type: 'search', label: 'Return Reason', section: 'principal', reference: 'ReturnReason', inputMode: 'search' },
   { key: 'orderDate', column: 'DateOrdered', type: 'date', required: true, section: 'principal' },
   { key: 'businessPartner', column: 'C_BPartner_ID', type: 'search', required: true, section: 'principal', reference: 'BPartner', inputMode: 'search' },
+  { key: 'partnerAddress', column: 'C_BPartner_Location_ID', type: 'dependent', label: 'Partner Address', required: true, section: 'principal', reference: 'BusinessPartnerLocation', inputMode: 'dependent', dependsOn: { field: 'businessPartner', filterKey: 'C_BPartner_ID' } },
   { key: 'warehouse', column: 'M_Warehouse_ID', type: 'search', required: true, section: 'principal', reference: 'Warehouse', inputMode: 'search' },
+  { key: 'description', column: 'Description', type: 'textarea', label: 'Description', section: 'collapsed' },
+  { key: 'salesRepresentative', column: 'SalesRep_ID', type: 'search', label: 'Sales Representative', section: 'collapsed', reference: 'User', inputMode: 'search' },
   { key: 'summedLineAmount', column: 'TotalLines', type: 'number', required: true, readOnly: true, section: 'summary' },
 ];
 // @sf-generated-end fields:customerReturn


### PR DESCRIPTION
## Summary
- Add missing `invoiced` field to GoodsShipmentForm
- Add missing fields to CustomerReturnForm: `cReturnReasonID`, `partnerAddress`, `description`, `salesRepresentative`

## Test plan
- [x] `make test` passes for goods-shipment wiring tests
- [x] `make test` passes for return-from-customer wiring tests
- [ ] Remaining `contacts` failures are Iván's scope