### PR TITLE
Feature ETP-3654: Fix jsreport routing and reports manifest for staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -39,6 +39,9 @@ jobs:
         run: npm run build --workspace=tools/app-shell
         # .env.production (committed) provides VITE_MOCK=false and VITE_API_BASE=/etendo
 
+      - name: Generate reports manifest
+        run: node etendo_schema_forge/cli/src/generate-reports-manifest.js
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -62,6 +65,13 @@ jobs:
             --include "registerSW.js" \
             --include "manifest.webmanifest" \
             --include "sw.js" \
+            --cache-control "no-cache, no-store, must-revalidate"
+
+      - name: Upload reports manifest (${{ steps.target.outputs.env_label }})
+        run: |
+          aws s3 cp tools/app-shell/dist/api/reports \
+            s3://${{ steps.target.outputs.s3_bucket }}/api/reports \
+            --content-type "application/json" \
             --cache-control "no-cache, no-store, must-revalidate"
 
       - name: Invalidate CloudFront cache (${{ steps.target.outputs.env_label }})

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ dev: ## Start app-shell dev server (http://localhost:3100)
 
 build: ## Build app-shell for production
 	cd tools/app-shell && npm run build
+	node cli/src/generate-reports-manifest.js
 
 # --- Setup ---
 

--- a/cli/src/generate-reports-manifest.js
+++ b/cli/src/generate-reports-manifest.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * Generates api/reports static manifest for production.
+ * Output: tools/app-shell/dist/api/reports (no extension, served as application/json via S3 metadata)
+ *
+ * This file is created as part of `make build` so that `aws s3 sync dist/` always
+ * includes it — preventing the manifest from being deleted by automated deployments.
+ */
+
+import { readFileSync, readdirSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ARTIFACTS_DIR = join(__dirname, '../../artifacts');
+const OUT_DIR = join(__dirname, '../../tools/app-shell/dist/api');
+const OUT_FILE = join(OUT_DIR, 'reports');
+
+const VALID_SOURCES = new Set(['jasper-migration', 'manual', 'sql', 'neo']);
+
+function listReports() {
+  const reports = [];
+  for (const dir of readdirSync(ARTIFACTS_DIR, { withFileTypes: true })) {
+    if (!dir.isDirectory()) continue;
+    const contractPath = join(ARTIFACTS_DIR, dir.name, 'report-contract.json');
+    if (!existsSync(contractPath)) continue;
+    try {
+      const c = JSON.parse(readFileSync(contractPath, 'utf8'));
+      if (
+        c.reportId &&
+        c.outputs?.length > 0 &&
+        c.type !== 'document' &&
+        (VALID_SOURCES.has(c.source) || c.mockDataFile)
+      ) {
+        reports.push({
+          id: c.reportId,
+          title: c.title,
+          type: c.type,
+          category: c.category || 'other',
+          orientation: c.orientation,
+          outputs: c.outputs,
+          parameters: c.parameters || [],
+        });
+      }
+    } catch {
+      // skip malformed
+    }
+  }
+  return reports;
+}
+
+const reports = listReports();
+mkdirSync(OUT_DIR, { recursive: true });
+writeFileSync(OUT_FILE, JSON.stringify(reports));
+console.log(`reports manifest: ${reports.length} reports → dist/api/reports`);

--- a/tools/app-shell/src/layout/Sidebar.jsx
+++ b/tools/app-shell/src/layout/Sidebar.jsx
@@ -199,11 +199,15 @@ export default function AppSidebar({ menuGroups, expanded, onToggle }) {
                         {tMenu(g.group)}
                       </p>
                       {g.items.map((item) => {
-                        const isItemActive = item.name === currentPath;
+                        const itemPath = item.path || item.name;
+                        const currentFull = currentPath + location.search;
+                        const isItemActive = item.path?.includes('?')
+                          ? currentFull === itemPath
+                          : currentPath === item.name;
                         return (
                           <NavLink
                             key={item.name}
-                            to={`/${item.name}`}
+                            to={`/${itemPath}`}
                             className={cn(
                               'block px-2 py-1.5 text-sm rounded-md transition-colors',
                               isItemActive


### PR DESCRIPTION
## Summary

- **Sidebar fix**: el sidebar colapsado usaba `item.name` como ruta de navegación en lugar de `item.path`, causando que las ventanas `report-viewer-*` mostraran el placeholder genérico en vez de `ReportViewerPage`
- **Reports manifest**: nuevo script `generate-reports-manifest.js` que genera `dist/api/reports` (JSON estático) a partir de los `report-contract.json` de los artifacts — se incluye en el build para que el `s3 sync --delete` no lo borre en deploys automáticos
- **Deploy workflow**: agrega paso para ejecutar el manifest generator y subir `api/reports` a S3 con `Content-Type: application/json` y `no-cache`
- **Makefile**: `build` target incluye la generación del manifest

## Context

jsreport corre en ECS Fargate (`jsreport-service`) detrás del ALB de staging. El frontend llama a `/jsreport/api/report` como path relativo — CloudFront lo redirige al ALB via un behavior + CF Function que reescribe el prefix. El manifest estático permite que `ReportViewerPage` liste los reportes disponibles sin necesitar un servidor Node en producción.

## Test plan

- [ ] Navegar a Reports desde el sidebar colapsado en Purchases/Finance/Inventory → debe abrir `ReportViewerPage` con los reportes filtrados por categoría
- [ ] `GET /api/reports` devuelve JSON con la lista de reportes (no HTML del SPA)
- [ ] `GET /jsreport/api/ping` devuelve `pong`
- [ ] Generar un reporte PDF desde la UI sin errores de jsreport 403