### PR TITLE
Feature ETP-3588: Pass entity to tab panels, drop duplicate FK auto-pick

### DIFF
--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -251,33 +251,23 @@ export function DetailView({
     }
   }, [isNew, hook.editing, hook.handleNew]);
 
-  // Resolve $_identifier for default FK values and auto-select first option for
-  // mandatory combo selectors (inputMode: "selector") that have no value.
-  // This matches classic Etendo behavior: TableDir combos pre-select the first record
-  // when the field is mandatory, while search fields don't (they require user input).
+  // Resolve $_identifier for default FK values that came from the backend /defaults.
+  // Backend handles auto-picking the first option for MANDATORY FK combos
+  // (see NeoDefaultsService.tryInjectFirstFromLookup). The frontend no longer
+  // auto-selects first option — that was forcing non-mandatory FKs like uOMForWeight
+  // to get populated even when Classic leaves them blank.
   useEffect(() => {
     if (!isNew || !hook.editing || !catalogsLoaded || !api?.selectors) return;
     for (const sel of api.selectors) {
       const val = hook.editing[sel.field];
+      if (!val) continue;
+      // Value is set but no identifier — resolve it from loaded catalog
+      if (hook.editing[sel.field + '$_identifier']) continue;
       const options = getCatalogOptions(catalogs, sel.entity, sel);
       if (!Array.isArray(options) || options.length === 0) continue;
-
-      if (val) {
-        // Has a value — resolve its identifier if missing
-        if (!hook.editing[sel.field + '$_identifier']) {
-          const match = options.find(o => o.id === val);
-          if (match) {
-            hook.handleChange(sel.field + '$_identifier', match.label || match.name || match._identifier);
-          }
-        }
-      } else if (sel.inputMode === 'selector') {
-        // Combo/dropdown with no value — auto-select first option (Etendo TableDir behavior).
-        // Only for editable fields; search/dependent fields require explicit user selection.
-        const first = options[0];
-        if (first) {
-          hook.handleChange(sel.field, first.id);
-          hook.handleChange(sel.field + '$_identifier', first.label || first.name || first._identifier);
-        }
+      const match = options.find(o => o.id === val);
+      if (match) {
+        hook.handleChange(sel.field + '$_identifier', match.label || match.name || match._identifier);
       }
     }
   }, [isNew, hook.editing, catalogsLoaded, catalogs, api]);
@@ -900,7 +890,7 @@ export function DetailView({
           const activeTab = primaryTabs.find(t => t.key === activePrimaryTab);
           return activeTab?.Panel ? (
             <div className={`flex-1 overflow-auto pb-6 min-w-0 ${sidePanel || sidebarContent ? 'pl-6 pr-2' : 'px-6'}`}>
-              <activeTab.Panel data={data} token={token} apiBaseUrl={apiBaseUrl} catalogs={catalogs} api={api} editing={hook.editing} onChange={handleChangeWithCallout} />
+              <activeTab.Panel entity={entity} data={data} token={token} apiBaseUrl={apiBaseUrl} catalogs={catalogs} api={api} editing={hook.editing} onChange={handleChangeWithCallout} />
             </div>
           ) : null;
         })() : null}

--- a/tools/app-shell/src/windows/custom/product/ProductAdditionalInfoPanel.jsx
+++ b/tools/app-shell/src/windows/custom/product/ProductAdditionalInfoPanel.jsx
@@ -18,7 +18,7 @@ function FieldGroup({ title, description, children }) {
   );
 }
 
-export default function ProductAdditionalInfoPanel({ data, token, apiBaseUrl, catalogs, api, editing, onChange }) {
+export default function ProductAdditionalInfoPanel({ entity, data, token, apiBaseUrl, catalogs, api, editing, onChange }) {
   const ui = useUI();
   return (
     <div className="space-y-4 pt-0 pb-6">
@@ -27,6 +27,7 @@ export default function ProductAdditionalInfoPanel({ data, token, apiBaseUrl, ca
         description={ui('commercialDescription')}
       >
         <EntityForm
+          entity={entity}
           fields={[
             { key: 'taxCategory', column: 'C_TaxCategory_ID', type: 'selector', label: 'Tax Category', required: true, section: 'other', reference: 'TaxCategory', inputMode: 'selector' },
             { key: 'sale', column: 'IsSold', type: 'checkbox', label: 'Sale', section: 'other', defaultValue: 'Y' },
@@ -48,6 +49,7 @@ export default function ProductAdditionalInfoPanel({ data, token, apiBaseUrl, ca
         description={ui('logisticsDescription')}
       >
         <EntityForm
+          entity={entity}
           fields={[
             { key: 'stocked', column: 'IsStocked', type: 'checkbox', label: 'Stocked', section: 'other', defaultValue: 'Y' },
             { key: 'returnable', column: 'Returnable', type: 'checkbox', label: 'Returnable', section: 'other', defaultValue: 'Y' },


### PR DESCRIPTION
Two frontend fixes that complement the backend default-resolution work:

- DetailView: pass entity prop to primary tab Panel components so their EntityForms build the correct selectorUrl. Without this the URL was /sws/neo/<spec>/undefined/selectors/<column> and all selector fetches inside Additional Info returned 404.
- DetailView: remove the frontend useEffect that auto-picked the first option for any inputMode:'selector' field. It did not check mandatory, so non-mandatory FKs like uOMForWeight got populated with the first catalog entry (Gram). Pre-fill is now only driven by the backend /defaults response (mandatory FKs), matching Classic behavior.
- ProductAdditionalInfoPanel: accept and forward the entity prop to both inner EntityForms so they reach the server selector correctly.