### PR TITLE
Feature ETP-3661: Filter BusinessPartner selector by customer/vendor based on window category

### DIFF
--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -154,11 +154,18 @@ export function DetailView({
     const category = api?.window?.category;
     const isSOTrx = category === 'sales' ? 'Y' : category === 'purchases' ? 'N' : null;
 
+    // Derive isCustomer/isVendor from window category so the BusinessPartner selector
+    // shows only customers (sales) or vendors (purchases).
+    const isCustomer = category === 'sales' ? 'Y' : null;
+    const isVendor = category === 'purchases' ? 'Y' : null;
+
     const next = {};
-    // Primary entity (header): inject isSOTrx so the priceList selector filters by direction
+    // Primary entity (header): inject isSOTrx, isCustomer, isVendor
     if (entity) {
       next[entity] = {
         ...(isSOTrx ? { isSOTrx } : {}),
+        ...(isCustomer ? { isCustomer } : {}),
+        ...(isVendor ? { isVendor } : {}),
       };
     }
     if (!parentRecordId) return next;


### PR DESCRIPTION
## Summary

- **BusinessPartner selector filter**: Injects `isCustomer=Y` (sales windows) or `isVendor=Y` (purchase windows) into the selector context for the header entity, based on `api.window.category`. The backend (`resolveContextParamFilter`) already supported these params — this change wires the frontend to pass them. Sales Order and Sales Quotation now show only customers; Purchase Order shows only vendors.

## Test plan

- [ ] Open Sales Order → search Business Partner → only customers appear
- [ ] Open Sales Quotation → search Business Partner → only customers appear
- [ ] Open Purchase Order → search Business Partner → only vendors appear
- [ ] Other selectors (Warehouse, Price List, etc.) unaffected
- [ ] Windows without sales/purchases category unaffected