### PR TITLE
Feature ETP-3659: Document NeoHandler extension pattern in CLAUDE.md and docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -37,6 +37,17 @@ Use these repository instructions as the primary context for coding tasks.
 - Ensure every kept business rule has behavioral test coverage.
 - Ensure every process includes at least 3 edge cases.
 
+## Extending NEO Headless — NeoHandler Pattern
+
+Never add window-specific logic to `NeoSelectorService`, `NeoDefaultsService`, `NeoCrudHandler`, or `NeoServlet` in `com.etendoerp.go`. Use the `NeoHandler` CDI extension point:
+
+1. Set `Java_Qualifier` on the `ETGO_SF_ENTITY` record (e.g. `"internal-consumption-line"`).
+2. Implement `NeoHandler` with `@ApplicationScoped @Named("internal-consumption-line")`.
+3. `handle()` = pre-hook (return `null` to continue); `afterHandle()` = post-hook.
+4. Place under `modules/com.etendoerp.go/src/com/etendoerp/go/schemaforge/handlers/`.
+
+Full reference: `docs/neo-headless-extensibility.md`
+
 ## References
 
 - `AGENTS.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,18 @@ Behavior-changing code updates must include corresponding documentation updates 
 
 Final deployment step is typically `make deploy` (or `make deploy MODULE_WEB={path}`).
 
+## Extending NEO Headless — NeoHandler Pattern
+
+Never add window-specific logic to `NeoSelectorService`, `NeoDefaultsService`, `NeoCrudHandler`, or `NeoServlet`.
+Use the `NeoHandler` CDI extension point in `com.etendoerp.go` instead:
+
+1. Set `Java_Qualifier` on the `ETGO_SF_ENTITY` record (e.g. `"internal-consumption-line"`).
+2. Create a CDI bean annotated `@ApplicationScoped @Named("internal-consumption-line")` implementing `NeoHandler`.
+3. `handle()` runs before default CRUD (return `null` to continue); `afterHandle()` runs after.
+4. Place under `modules/com.etendoerp.go/src/com/etendoerp/go/schemaforge/handlers/`.
+
+Full reference: `docs/neo-headless-extensibility.md`
+
 ## Primary References
 
 - `docs/architecture-overview.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,3 +296,28 @@ Legacy override: `make deploy LEGACY_DEPLOY=1 MODULE_WEB={path}`. No Tomcat rest
 
 Project knowledge → this CLAUDE.md or `docs/`. Bugs/issues → `feedback.md`. Per-window → `artifacts/`.
 Auto-memory (NOT committed) only for: GitHub usernames, local paths, personal prefs.
+
+## Extending NEO Headless — NeoHandler Pattern (com.etendoerp.go)
+
+**Never add window-specific logic to generic Java services** (`NeoSelectorService`, `NeoDefaultsService`, `NeoCrudHandler`, `NeoServlet`). Any custom behavior for a specific window must live in a dedicated `NeoHandler` CDI bean.
+
+**How it works:**
+1. Set `Java_Qualifier` on the `ETGO_SF_ENTITY` record (e.g. `"internal-consumption-line"`).
+2. `NeoServlet` reads it and routes through `handleWithHooks(qualifier, context)`.
+3. Discovers handlers via `WeldUtils.getInstances(NeoHandler.class)`, matched by `@Named(qualifier)`.
+
+**Minimal implementation:**
+```java
+@ApplicationScoped
+@Named("internal-consumption-line")   // matches ETGO_SF_ENTITY.Java_Qualifier
+public class InternalConsumptionLineHandler implements NeoHandler {
+    @Override public NeoResponse handle(NeoContext context) { return null; }      // pre-hook
+    @Override public NeoResponse afterHandle(NeoContext context) { return null; } // post-hook
+}
+```
+
+- `handle()` → `null` continues to default CRUD; `NeoResponse` short-circuits.
+- `afterHandle()` → `null` keeps default result; `NeoResponse` replaces it.
+- Place handlers in: `{etendo_root}/modules/com.etendoerp.go/src/com/etendoerp/go/schemaforge/handlers/`
+
+Full reference: `docs/neo-headless-extensibility.md`

--- a/docs/neo-headless-extensibility.md
+++ b/docs/neo-headless-extensibility.md
@@ -21,6 +21,18 @@ Default value overrides     Cross-entity side effects
 Selector filtering (HQL)    Audit logging
 ```
 
+## Golden Rule
+
+**Never add window-specific logic to generic services.**
+
+`NeoSelectorService`, `NeoDefaultsService`, `NeoCrudHandler`, and `NeoServlet` are shared by every window. Do NOT add `if (entity.equals("..."))` guards there. Any logic specific to one window belongs in a `NeoHandler` bean or a custom UI component.
+
+| Wrong | Right |
+|-------|-------|
+| `if (entity.equals("internalConsumptionLine"))` inside `NeoSelectorService` | `InternalConsumptionLineHandler implements NeoHandler` |
+| Patching `artifacts/*/generated/` files directly | Fix the generator (`cli/src/generate-frontend.js`) |
+| Window-specific JSX in `tools/app-shell/src/components/` | Custom component in `tools/app-shell/src/windows/custom/{window}/` |
+
 ---
 
 ## 1. Configuration-Only Extension Points
@@ -107,10 +119,11 @@ public interface NeoHandler {
 
 ### 2.2 Registration
 
-1. Annotate your class with `@Named("qualifierName")`
-2. Set `JAVA_QUALIFIER = 'qualifierName'` on the ETGO_SF_Entity record
+1. Annotate your class with `@ApplicationScoped` and `@Named("qualifierName")`.
+2. Set `JAVA_QUALIFIER = 'qualifierName'` on the ETGO_SF_Entity record.
 
 ```java
+@ApplicationScoped
 @Named("purchaseOrderHandler")
 public class PurchaseOrderHandler implements NeoHandler { ... }
 ```
@@ -119,7 +132,15 @@ public class PurchaseOrderHandler implements NeoHandler { ... }
 SFUpsertEntity?SpecID=...&TabID=...&JavaQualifier=purchaseOrderHandler
 ```
 
-CDI discovers the handler automatically — no servlet restart needed (just compile + deploy).
+Or in `src-db/database/sourcedata/ETGO_SF_ENTITY.xml`:
+```xml
+<JAVA_QUALIFIER><![CDATA[purchaseOrderHandler]]></JAVA_QUALIFIER>
+```
+
+Discovery: `NeoServlet.lookupHandler()` calls `WeldUtils.getInstances(NeoHandler.class)` and
+matches by `@Named` value — no servlet restart needed (just compile + deploy).
+
+Place handlers in: `src/com/etendoerp/go/schemaforge/handlers/` (one class per window/entity).
 
 ### 2.3 Hook Dispatch Flow
 
@@ -161,6 +182,9 @@ Final response written to client
 | `sfEntity` | SFEntity | The ETGO_SF_Entity config record |
 | `obContext` | OBContext | Current user/role/org/client |
 | `previousResult` | NeoResponse | Set before afterHandle() is called |
+
+| `token` | String | Auth Bearer token |
+| `apiBaseUrl` | String | Base URL for outbound API calls |
 
 **Note:** For sub-endpoints (selector, callout, etc.), `requestBody`, `recordId`, and `queryParams` are not populated in the hook context. The handler receives `endpointType` and `fieldName` for routing; the underlying service handles request parsing.
 


### PR DESCRIPTION
## Summary
  - Add NeoHandler extension pattern to `CLAUDE.md`, `AGENTS.md`, and `.github/copilot-instructions.md` so agents always know to use CDI hooks instead of modifying
  generic services
  - Enrich `docs/neo-headless-extensibility.md` with missing details: `@ApplicationScoped` annotation, `WeldUtils.getInstances()` discovery mechanism, XML wiring
  example, `handlers/` directory convention, `token`/`apiBaseUrl` in NeoContext table, and a new "Golden Rule" section with a Wrong/Right table