### PR TITLE
Feature ETP-3775: Redesign epic rollout aggregation

### DIFF
--- a/.github/workflows/epic-rollup-entry.yml
+++ b/.github/workflows/epic-rollup-entry.yml
@@ -1,0 +1,117 @@
+name: Epic Rollup Entry
+
+on:
+  pull_request:
+    branches: [epic/ETP-3504]
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  epic-rollup-entry:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Collect merged PR rollout data
+        uses: actions/github-script@v7
+        env:
+          OUTPUT_PATH: epic-rollup-entry.json
+        with:
+          script: |
+            const fs = require('fs');
+            const reviewMarker = '<!-- copilot-pr-review -->';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const pull_number = context.payload.pull_request.number;
+
+            const [comments, reviews] = await Promise.all([
+              github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: pull_number,
+                per_page: 100,
+              }),
+              github.paginate(github.rest.pulls.listReviews, {
+                owner,
+                repo,
+                pull_number,
+                per_page: 100,
+              }),
+            ]);
+
+            const latestReview = [
+              ...comments
+                .filter((comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(reviewMarker))
+                .map((comment) => ({ body: comment.body, timestamp: comment.created_at || '' })),
+              ...reviews
+                .filter((review) => review.user?.login === 'github-actions[bot]' && review.body?.includes(reviewMarker))
+                .map((review) => ({ body: review.body, timestamp: review.submitted_at || review.created_at || '' })),
+            ]
+              .sort((left, right) => left.timestamp.localeCompare(right.timestamp))
+              .at(-1);
+
+            const payload = {
+              pullRequest: {
+                number: context.payload.pull_request.number,
+                title: context.payload.pull_request.title,
+                url: context.payload.pull_request.html_url,
+                author: context.payload.pull_request.user?.login || 'unknown',
+                mergedAt: context.payload.pull_request.merged_at,
+              },
+              body: context.payload.pull_request.body || '',
+              reviewReportBody: latestReview?.body || '',
+            };
+
+            fs.writeFileSync(process.env.OUTPUT_PATH, JSON.stringify(payload, null, 2));
+
+      - name: Render rollout entry
+        run: node cli/src/epic-rollup-report.js --mode entry --input epic-rollup-entry.json --out epic-rollup-entry.md
+
+      - name: Publish rollout entry comment
+        uses: actions/github-script@v7
+        env:
+          REPORT_PATH: epic-rollup-entry.md
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- epic-rollup-entry -->';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const body = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existingComment = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/epic-rollup-report.yml
+++ b/.github/workflows/epic-rollup-report.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
+            const entryMarker = '<!-- epic-rollup-entry -->';
             const reviewMarker = '<!-- copilot-pr-review -->';
             const owner = context.repo.owner;
             const repo = context.repo.repo;
@@ -68,31 +69,40 @@ jobs:
 
             const normalizedPullRequests = [];
             for (const pullRequest of [...includedPullRequests.values()].sort((left, right) => left.number - right.number)) {
-              const [comments, reviews] = await Promise.all([
-                github.paginate(github.rest.issues.listComments, {
-                  owner,
-                  repo,
-                  issue_number: pullRequest.number,
-                  per_page: 100,
-                }),
-                github.paginate(github.rest.pulls.listReviews, {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: pullRequest.number,
+                per_page: 100,
+              });
+
+              const latestEntry = comments
+                .filter((comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(entryMarker))
+                .sort((left, right) => (left.created_at || '').localeCompare(right.created_at || ''))
+                .at(-1);
+
+              let latestReviewBody = '';
+              if (!latestEntry) {
+                const reviews = await github.paginate(github.rest.pulls.listReviews, {
                   owner,
                   repo,
                   pull_number: pullRequest.number,
                   per_page: 100,
-                }),
-              ]);
+                });
 
-              const latestReview = [
-                ...comments
-                  .filter((comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(reviewMarker))
-                  .map((comment) => ({ body: comment.body, timestamp: comment.created_at || '' })),
-                ...reviews
-                  .filter((review) => review.user?.login === 'github-actions[bot]' && review.body?.includes(reviewMarker))
-                  .map((review) => ({ body: review.body, timestamp: review.submitted_at || review.created_at || '' })),
-              ]
-                .sort((left, right) => left.timestamp.localeCompare(right.timestamp))
-                .at(-1);
+                const latestReview = [
+                  ...comments
+                    .filter((comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(reviewMarker))
+                    .map((comment) => ({ body: comment.body, timestamp: comment.created_at || '' })),
+                  ...reviews
+                    .filter((review) => review.user?.login === 'github-actions[bot]' && review.body?.includes(reviewMarker))
+                    .map((review) => ({ body: review.body, timestamp: review.submitted_at || review.created_at || '' })),
+                ]
+                  .sort((left, right) => left.timestamp.localeCompare(right.timestamp))
+                  .at(-1);
+
+                latestReviewBody = latestReview?.body || '';
+              }
 
               normalizedPullRequests.push({
                 number: pullRequest.number,
@@ -101,7 +111,8 @@ jobs:
                 author: pullRequest.user?.login || 'unknown',
                 mergedAt: pullRequest.merged_at,
                 body: pullRequest.body || '',
-                reviewReportBody: latestReview?.body || '',
+                rollupEntryBody: latestEntry?.body || '',
+                reviewReportBody: latestReviewBody,
               });
             }
 

--- a/cli/src/epic-rollup-report.js
+++ b/cli/src/epic-rollup-report.js
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 
 export const EPIC_ROLLUP_MARKER = '<!-- epic-rollup-report -->';
+export const EPIC_ROLLUP_ENTRY_MARKER = '<!-- epic-rollup-entry -->';
 const REVIEW_MARKER = '<!-- copilot-pr-review -->';
 
 function getArg(args, name) {
@@ -112,12 +113,70 @@ function renderReviewFindings(reviewReport) {
   return sections.join('\n');
 }
 
-export function renderEpicRollupReport({ epicPullRequest, includedPullRequests }) {
-  const sortedPullRequests = [...includedPullRequests].sort((left, right) => left.number - right.number);
-  const blockerCount = sortedPullRequests.filter((pullRequest) => pullRequest.reviewReport.blockers.length).length;
-  const warningCount = sortedPullRequests.filter((pullRequest) => pullRequest.reviewReport.warnings.length).length;
+function normalizeRollupEntry(source) {
+  const mergedSource = source.pullRequest ? { ...source.pullRequest, ...source } : source;
+  return {
+    number: mergedSource.number,
+    title: mergedSource.title,
+    url: mergedSource.url,
+    author: mergedSource.author || 'unknown',
+    mergedAt: mergedSource.mergedAt || null,
+    summaryBullets: mergedSource.summaryBullets || extractSummaryBullets(mergedSource.body || ''),
+    reviewReport: mergedSource.reviewReport || parseReviewReport(mergedSource.reviewReportBody || ''),
+  };
+}
 
-  const reportSections = sortedPullRequests.map((pullRequest) => [
+export function renderEpicRollupEntry(source) {
+  const entry = normalizeRollupEntry(source);
+  return [
+    EPIC_ROLLUP_ENTRY_MARKER,
+    '## Epic rollout entry',
+    '',
+    `Feature PR: [#${entry.number} ${entry.title}](${entry.url})`,
+    `Merged into epic: ${formatDate(entry.mergedAt)}`,
+    '',
+    '```json',
+    JSON.stringify(entry, null, 2),
+    '```',
+  ].join('\n');
+}
+
+export function parseRollupEntry(body) {
+  if (!body?.includes(EPIC_ROLLUP_ENTRY_MARKER)) {
+    return null;
+  }
+
+  const match = body.match(/```json\n([\s\S]*?)\n```/);
+  if (!match) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(match[1]);
+    return normalizeRollupEntry(parsed);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeReportPullRequest(pullRequest) {
+  const parsedEntry = parseRollupEntry(pullRequest.rollupEntryBody || '');
+  if (parsedEntry) {
+    return parsedEntry;
+  }
+
+  return normalizeRollupEntry(pullRequest);
+}
+
+export function renderEpicRollupReport({ epicPullRequest, includedPullRequests }) {
+  const normalizedPullRequests = [...includedPullRequests]
+    .map((pullRequest) => normalizeReportPullRequest(pullRequest))
+    .sort((left, right) => left.number - right.number);
+
+  const blockerCount = normalizedPullRequests.filter((pullRequest) => pullRequest.reviewReport.blockers.length).length;
+  const warningCount = normalizedPullRequests.filter((pullRequest) => pullRequest.reviewReport.warnings.length).length;
+
+  const reportSections = normalizedPullRequests.map((pullRequest) => [
     `### PR #${pullRequest.number}: [${pullRequest.title}](${pullRequest.url})`,
     `- Author: @${pullRequest.author}`,
     `- Merged into epic: ${formatDate(pullRequest.mergedAt)}`,
@@ -136,7 +195,7 @@ export function renderEpicRollupReport({ epicPullRequest, includedPullRequests }
     '',
     '## Overview',
     '',
-    `- Included PRs (${sortedPullRequests.length})`,
+    `- Included PRs (${normalizedPullRequests.length})`,
     `- PRs with blocking findings: ${blockerCount}`,
     `- PRs with warnings: ${warningCount}`,
     '',
@@ -150,23 +209,22 @@ const isCli = process.argv[1] && fileURLToPath(import.meta.url) === process.argv
 
 if (isCli) {
   const args = process.argv.slice(2);
+  const mode = getArg(args, 'mode') || 'report';
   const inputPath = getArg(args, 'input');
   const outputPath = getArg(args, 'out');
 
   if (!inputPath || !outputPath) {
-    console.error('Usage: node cli/src/epic-rollup-report.js --input <path> --out <path>');
+    console.error('Usage: node cli/src/epic-rollup-report.js --mode <entry|report> --input <path> --out <path>');
     process.exit(1);
   }
 
   const input = readJson(inputPath);
-  const normalizedInput = {
-    epicPullRequest: input.epicPullRequest,
-    includedPullRequests: (input.includedPullRequests || []).map((pullRequest) => ({
-      ...pullRequest,
-      summaryBullets: pullRequest.summaryBullets || extractSummaryBullets(pullRequest.body || ''),
-      reviewReport: pullRequest.reviewReport || parseReviewReport(pullRequest.reviewReportBody || ''),
-    })),
-  };
+  const output = mode === 'entry'
+    ? renderEpicRollupEntry(input)
+    : renderEpicRollupReport({
+      epicPullRequest: input.epicPullRequest,
+      includedPullRequests: input.includedPullRequests || [],
+    });
 
-  writeFileSync(outputPath, renderEpicRollupReport(normalizedInput));
+  writeFileSync(outputPath, output);
 }

--- a/cli/test/epic-rollup-report.test.js
+++ b/cli/test/epic-rollup-report.test.js
@@ -3,6 +3,8 @@ import { strict as assert } from 'node:assert';
 import {
   extractSummaryBullets,
   parseReviewReport,
+  parseRollupEntry,
+  renderEpicRollupEntry,
   renderEpicRollupReport,
 } from '../src/epic-rollup-report.js';
 
@@ -66,6 +68,36 @@ Justify it.
   });
 });
 
+describe('rollup entry round-trip', () => {
+  it('renders a stored entry comment and parses it back', () => {
+    const markdown = renderEpicRollupEntry({
+      number: 321,
+      title: 'Add Copilot PR review gate',
+      url: 'https://github.com/acme/repo/pull/321',
+      author: 'sebastianbarrozo',
+      mergedAt: '2026-04-14T20:18:29Z',
+      summaryBullets: [
+        'add deterministic PR review automation',
+        'document the Copilot review gate',
+      ],
+      reviewReport: {
+        outcome: 'Request changes',
+        blockers: ['Duplicated added block'],
+        warnings: ['New npm dependency added'],
+      },
+    });
+
+    const entry = parseRollupEntry(markdown);
+    assert.equal(entry.number, 321);
+    assert.deepEqual(entry.summaryBullets, [
+      'add deterministic PR review automation',
+      'document the Copilot review gate',
+    ]);
+    assert.deepEqual(entry.reviewReport.blockers, ['Duplicated added block']);
+    assert.deepEqual(entry.reviewReport.warnings, ['New npm dependency added']);
+  });
+});
+
 describe('renderEpicRollupReport', () => {
   it('renders included PR summaries and review findings', () => {
     const markdown = renderEpicRollupReport({
@@ -78,20 +110,22 @@ describe('renderEpicRollupReport', () => {
       },
       includedPullRequests: [
         {
-          number: 321,
-          title: 'Add Copilot PR review gate',
-          url: 'https://github.com/acme/repo/pull/321',
-          author: 'sebastianbarrozo',
-          mergedAt: '2026-04-14T20:18:29Z',
-          summaryBullets: [
-            'add deterministic PR review automation',
-            'document the Copilot review gate',
-          ],
-          reviewReport: {
-            outcome: 'Request changes',
-            blockers: ['Duplicated added block'],
-            warnings: ['New npm dependency added'],
-          },
+          rollupEntryBody: renderEpicRollupEntry({
+            number: 321,
+            title: 'Add Copilot PR review gate',
+            url: 'https://github.com/acme/repo/pull/321',
+            author: 'sebastianbarrozo',
+            mergedAt: '2026-04-14T20:18:29Z',
+            summaryBullets: [
+              'add deterministic PR review automation',
+              'document the Copilot review gate',
+            ],
+            reviewReport: {
+              outcome: 'Request changes',
+              blockers: ['Duplicated added block'],
+              warnings: ['New npm dependency added'],
+            },
+          }),
         },
         {
           number: 322,

--- a/docs/ops/epic-rollup-report.md
+++ b/docs/ops/epic-rollup-report.md
@@ -14,16 +14,15 @@ Reviewing that information PR-by-PR is noisy and slow.
 
 ## Decision
 
-We add a second reporting layer on top of the existing PR review gate:
+We add a two-step reporting flow on top of the existing PR review gate:
 
 1. Feature PRs targeting `epic/ETP-3504` continue to receive the `architecture-check` review comment and status check.
-2. A dedicated workflow, `.github/workflows/epic-rollup-report.yml`, runs only when a PR targets `develop` and its head branch is `epic/ETP-3504`.
-3. The workflow collects the feature PRs included in that epic promotion, extracts their latest `<!-- copilot-pr-review -->` result, and renders a single markdown report.
-4. The report is posted back to the `epic -> develop` PR and uploaded as a workflow artifact.
-
+2. A dedicated workflow, `.github/workflows/epic-rollup-entry.yml`, runs when a feature PR is merged into `epic/ETP-3504`. It converts that PR into a compact stored rollout entry comment.
+3. The existing `.github/workflows/epic-rollup-report.yml` workflow still runs on `epic/ETP-3504 -> develop`, but it now prefers those stored entry comments instead of recomputing everything from raw PR data.
+4. The final report is posted back to the `epic -> develop` PR and uploaded as a workflow artifact.
 ## What the report shows
 
-For each included feature PR, the report includes:
+For each included feature PR, the final report includes data captured at epic-merge time:
 
 - PR number, title, author, and merge date into the epic
 - the `## Summary` bullets from the feature PR body, when present
@@ -38,13 +37,15 @@ The top of the report also includes an overview count:
 
 ## Implementation notes
 
-- `cli/src/epic-rollup-report.js` is zero-dependency and only renders/parses markdown and JSON.
-- The workflow gathers GitHub API data with `actions/github-script` because commit-to-PR association and comment retrieval are GitHub-specific concerns.
-- Included feature PRs are discovered from merge commits already present in the `epic -> develop` PR commit list. This avoids maintaining a separate ledger.
-- The report comment uses its own marker, `<!-- epic-rollup-report -->`, so reruns update the same comment instead of posting duplicates.
+- `cli/src/epic-rollup-report.js` is zero-dependency and now handles both stored-entry rendering/parsing and final report rendering.
+- `.github/workflows/epic-rollup-entry.yml` creates one bot-managed `<!-- epic-rollup-entry -->` comment per merged feature PR.
+- `.github/workflows/epic-rollup-report.yml` aggregates those stored entries for `epic -> develop`, with a live fallback for older PRs that do not yet have an entry comment.
+- Included feature PRs are still discovered from merge commits already present in the `epic -> develop` PR commit list, which matches the repository policy of preserving merge commits.
+- The final report comment uses its own marker, `<!-- epic-rollup-report -->`, so reruns update the same comment instead of posting duplicates.
 
 ## Files involved
 
+- `.github/workflows/epic-rollup-entry.yml`
 - `.github/workflows/epic-rollup-report.yml`
 - `cli/src/epic-rollup-report.js`
 - `cli/test/epic-rollup-report.test.js`


### PR DESCRIPTION
## Summary
- add a per-PR rollout entry workflow that stores normalized epic intake data when feature PRs merge into `epic/ETP-3504`
- refit the `epic -> develop` rollout report to consume stored entry comments and only fall back to raw review parsing for older PRs
- update tests and rollout documentation for the new two-step aggregation model

## Test Plan
- [x] `node --test cli/test/epic-rollup-report.test.js`
- [x] `make test`
