### PR TITLE
Feature ETP-3785: ListView toolbar cleanup and sidebar active highlight

### DIFF
--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -568,6 +568,7 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
   const hideEyeCount = windowConfig.hideEyeCount ?? false;
   const customComponents = windowConfig.customComponents ?? {};
   const menuActionsConfig = windowConfig.menuActions ?? [];
+  const newActionsConfig = windowConfig.newActions ?? [];
   const statusBar = windowConfig.statusBar ?? null;
   const detailSortBy = windowConfig.detailSortBy ?? null;
   const titleField = windowConfig.titleField ?? null;
@@ -753,6 +754,11 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
   if (customComponents.newRecordComponent) {
     customComponentImports.push(`import ${customComponents.newRecordComponent} from '@/windows/custom/${specName}/${customComponents.newRecordComponent}';`);
   }
+  // newActions — import component modals if declared
+  const newActionsWithComponents = newActionsConfig.filter(a => a.component);
+  for (const action of newActionsWithComponents) {
+    customComponentImports.push(`import ${action.component} from '@/windows/custom/${specName}/${action.component}';`);
+  }
   const customCompImportBlock = customComponentImports.length > 0
     ? customComponentImports.join('\n') + '\n'
     : '';
@@ -902,7 +908,34 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
     ? `\nconst labelOverrides = ${JSON.stringify(labelOverridesConfig, null, 2)};\n`
     : '';
 
-  return `import { ${customComponents.newRecordComponent ? 'useState, ' : ''}useEffect } from 'react';
+  // newActions support — split button dropdown on the list view
+  const hasNewActions = newActionsConfig.length > 0;
+  const newActionsStatements = newActionsWithComponents.map(a => {
+    const stateName = `show${capitalize(a.key.replace(/-./g, m => m[1].toUpperCase()))}Modal`;
+    return `  const [${stateName}, set${capitalize(a.key.replace(/-./g, m => m[1].toUpperCase()))}Modal] = useState(false);`;
+  }).join('\n');
+  const newActionsPropValue = hasNewActions
+    ? `\n      newActions={[${newActionsConfig.map(a => {
+        const hasComp = !!a.component;
+        const stateSetter = hasComp
+          ? `set${capitalize(a.key.replace(/-./g, m => m[1].toUpperCase()))}Modal`
+          : null;
+        const onClick = hasComp
+          ? `() => ${stateSetter}(true)`
+          : `() => {}`;
+        return `\n        { key: '${a.key}', label: '${a.label}', onClick: ${onClick} }`;
+      }).join(',')}\n      ]}`
+    : '';
+  const newActionsModals = newActionsWithComponents.map(a => {
+    const stateName = `show${capitalize(a.key.replace(/-./g, m => m[1].toUpperCase()))}Modal`;
+    const setterName = `set${capitalize(a.key.replace(/-./g, m => m[1].toUpperCase()))}Modal`;
+    return `    {${stateName} && <${a.component} token={props.token} apiBaseUrl={props.apiBaseUrl} windowName={windowName} onClose={() => ${setterName}(false)} />}`;
+  }).join('\n');
+
+  const needsUseState = customComponents.newRecordComponent || newActionsWithComponents.length > 0;
+  const needsFragment = customComponents.newRecordComponent || newActionsWithComponents.length > 0;
+
+  return `import { ${needsUseState ? 'useState, ' : ''}useEffect } from 'react';
 import { ListView, DetailView } from '@/components/contract-ui';${menuActionsConfig.length > 0 ? `\nimport { toast } from 'sonner';` : ''}
 ${headerTableImport}
 import ${headerName}Form from './${headerName}Form';${detailEntity ? `
@@ -954,7 +987,7 @@ ${MARKERS.GENERATED_END(`addLineFields:${detailEntity}`)}` : ''}
 ${apiBlock}
 ${MARKERS.GENERATED_START(`component:${compName}`)}
 export default function ${compName}({ windowName, recordId, ...props }) {${customComponents.newRecordComponent ? `
-  const [showNewModal, setShowNewModal] = useState(false);` : ''}
+  const [showNewModal, setShowNewModal] = useState(false);` : ''}${newActionsWithComponents.length > 0 ? `\n${newActionsStatements}` : ''}
   if (recordId) {
     return (
       <DetailView
@@ -979,7 +1012,7 @@ export default function ${compName}({ windowName, recordId, ...props }) {${custo
     );
   }
 
-  return (${customComponents.newRecordComponent ? `
+  return (${needsFragment ? `
     <>` : ''}
     <ListView
       entity="${headerEntity}"
@@ -989,9 +1022,9 @@ export default function ${compName}({ windowName, recordId, ...props }) {${custo
       breadcrumb={breadcrumb}${apiProp}${isGallery ? `
       galleryRenderer={(gProps) => <${headerName}Gallery {...gProps} />}` : ''}${listKpiCardsProp}${listViewOptionsProp}${listBaseFilterProp}${quickFiltersProp}${bulkActionsProp}${hidePrintListProp}${hideMoreMenuListProp}${hideListFiltersProp}${hideLinkProp}${hideEyeCountProp}${labelOverridesListProp}
       {...props}${customComponents.newRecordComponent ? `
-      onNew={() => setShowNewModal(true)}` : ''}
+      onNew={() => setShowNewModal(true)}` : ''}${newActionsPropValue}
     />${customComponents.newRecordComponent ? `
-    {showNewModal && <${customComponents.newRecordComponent} token={props.token} apiBaseUrl={props.apiBaseUrl} windowName={windowName} onClose={() => setShowNewModal(false)} />}
+    {showNewModal && <${customComponents.newRecordComponent} token={props.token} apiBaseUrl={props.apiBaseUrl} windowName={windowName} onClose={() => setShowNewModal(false)} />}` : ''}${newActionsWithComponents.length > 0 ? `\n${newActionsModals}` : ''}${needsFragment ? `
     </>` : ''}
   );
 }

--- a/docs/decisions-reference.md
+++ b/docs/decisions-reference.md
@@ -77,6 +77,7 @@ Per-locale field label overrides. When the simplified interface needs to rename 
 | `hideDeleteWhenComplete` | boolean | `false` | — | Hides the delete button in the detail view when the document status is not Draft. Prevents accidental deletion of completed/processed records. |
 | `customComponents` | object | `null` | See below | Override generated components with custom ones from `artifacts/{window}/custom/`. The generator emits the correct imports and props automatically. |
 | `menuActions` | array | `[]` | See below | Additional actions in the detail view's "more" menu (triple dot). Each action can have visibility conditions based on document status. |
+| `newActions` | array | `[]` | See below | Additional actions in the split "New" button dropdown in the list view. Each action can optionally open a custom modal component. |
 | `processOverrides` | object | `{}` | See below | Override presentation and behavior of process buttons in the detail view. Keys are process names or column names. See Process Overrides subsection. |
 | `detailSortBy` | string | `null` | Any valid sort expression | Default sort order for the detail entity tab (e.g., `"sEQNoAsset asc"`). Passed directly to DetailView as the `detailSortBy` prop. |
 | `statusBar` | object | `null` | See below | Generates a summary status bar above the detail form showing key numeric fields and an optional progress indicator. |
@@ -169,6 +170,27 @@ Additional actions shown in the detail view's "more" menu (triple dot icon). Eac
 | `destructive` | boolean | If `true`, renders in red as a destructive action. |
 | `visibleWhenStatus` | string or string[] | Only show the action when document status matches. Omit to always show. |
 | `columnName` | string | If set, triggers the named process column via `hook.handleProcess`. If omitted, generates an empty `onClick` placeholder. |
+
+### New Actions (`window.newActions`)
+
+Additional actions shown in the dropdown of the split "New" button in the list view. The `ChevronDown` caret is only visible when at least one action is declared.
+
+```json
+{
+  "newActions": [
+    { "key": "import-csv", "label": "Import from CSV", "component": "ImportCsvModal" },
+    { "key": "duplicate", "label": "Duplicate last" }
+  ]
+}
+```
+
+| Property | Type | Purpose |
+|----------|------|---------|
+| `key` | string | Unique identifier for the action. Also used as `data-testid="action-new-{key}"`. |
+| `label` | string | Display label in the dropdown menu. |
+| `component` | string | Optional. Name of a custom component in `tools/app-shell/src/windows/custom/{window}/`. When set, the generator imports it, creates a `show{Key}Modal` state, and passes `onClick: () => setShow{Key}Modal(true)`. If omitted, generates an empty `onClick` placeholder. |
+
+The component receives: `token`, `apiBaseUrl`, `windowName`, `onClose`.
 
 ### Process Overrides (`window.processOverrides`)
 

--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -555,7 +555,7 @@ function LookupButton({ selectorUrl, token, onSelect, title }) {
  *  - loading: boolean (shows skeleton when true)
  *  - addRow: { active, fields, onAdd, onCancel, catalogs, onFieldChange } — inline add row config
  */
-export function DataTable({ entity, columns = [], filters = [], data = [], onRowSelect, onNavigate, onRowClick, selectedRowId, selectedId, compact, loading, addRow, selectable = true, isRowSelectable, onSelectionChange, sortColumn, sortDirection, onColumnsReady, token, apiBaseUrl, showFooterTotals = true, selectorContext, onDataMutated, labelOverrides }) {
+export function DataTable({ entity, columns = [], filters = [], data = [], onRowSelect, onNavigate, onRowClick, selectedRowId, selectedId, compact, loading, addRow, selectable = true, isRowSelectable, onSelectionChange, sortColumn, sortDirection, onSort, onColumnsReady, token, apiBaseUrl, showFooterTotals = true, selectorContext, onDataMutated, labelOverrides }) {
   const t = useLabel(labelOverrides);
   const tMenu = useMenuLabel();
   const ui = useUI();
@@ -869,16 +869,31 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
                 const isSorted = sortColumn === col.key;
                 const isRight = col.type === 'amount';
                 return (
-                  <TableHead key={col.key} className={`align-top ${isRight ? 'text-right' : ''}`}>
-                    <div className={`flex flex-col gap-1.5 pb-2 ${isRight ? 'items-end' : ''}`}>
-                      <span className="text-xs font-medium text-muted-foreground/70 tracking-wide">
-                        <FieldHighlight entityName={entity} fieldName={col.key}>
-                          {colLabel}
-                          {isSorted && (
-                            <span className="ml-1 text-primary/70">{sortDirection === 'asc' ? '\u25B2' : '\u25BC'}</span>
-                          )}
-                        </FieldHighlight>
-                      </span>
+                  <TableHead key={col.key} className="align-top">
+                    <div className="flex flex-col gap-1.5 pb-2">
+                      {onSort ? (
+                        <button
+                          type="button"
+                          className="text-xs font-medium text-muted-foreground/70 tracking-wide cursor-pointer select-none hover:text-foreground transition-colors bg-transparent border-0 p-0 text-left"
+                          onClick={() => onSort(col.key)}
+                        >
+                          <FieldHighlight entityName={entity} fieldName={col.key}>
+                            {colLabel}
+                            {isSorted && (
+                              <span className="ml-1 text-primary/70">{sortDirection === 'asc' ? '\u25B2' : '\u25BC'}</span>
+                            )}
+                          </FieldHighlight>
+                        </button>
+                      ) : (
+                        <span className="text-xs font-medium text-muted-foreground/70 tracking-wide">
+                          <FieldHighlight entityName={entity} fieldName={col.key}>
+                            {colLabel}
+                            {isSorted && (
+                              <span className="ml-1 text-primary/70">{sortDirection === 'asc' ? '\u25B2' : '\u25BC'}</span>
+                            )}
+                          </FieldHighlight>
+                        </span>
+                      )}
                       <div className="relative w-full">
                         <input
                           type="text"

--- a/tools/app-shell/src/components/contract-ui/ListView.jsx
+++ b/tools/app-shell/src/components/contract-ui/ListView.jsx
@@ -4,11 +4,17 @@ import { Button } from '@/components/ui/button.jsx';
 import { Skeleton } from '@/components/ui/skeleton.jsx';
 import { useEntity } from '@/hooks/useEntity';
 import { useMenuLabel, useLabel, useUI } from '@/i18n';
-import { Search, ArrowUpDown, SlidersHorizontal, Eye, ChevronDown, MoreVertical, Plus, CalendarDays, Link2, Sparkles, Bell, Mic, Printer, LayoutGrid, LayoutList, RefreshCw } from 'lucide-react';
+import { Search, ArrowUpDown, SlidersHorizontal, ChevronDown, MoreVertical, Plus, CalendarDays, Link2, Sparkles, Bell, Mic, Printer, LayoutGrid, LayoutList, RefreshCw } from 'lucide-react';
 import LocaleSwitcher from '@/components/LocaleSwitcher.jsx';
 import { UserAvatarButton } from '@/components/UserAvatarButton.jsx';
 import ReportDrawer from './ReportDrawer.jsx';
 import DocumentPrintDrawer, { printDocuments } from './DocumentPrintDrawer.jsx';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu.jsx';
 
 /**
  * Full-width list view for an entity.
@@ -36,6 +42,7 @@ export function ListView({
   baseFilter = null,
   quickFilters = null,
   onNew = null,
+  newActions = [],
   labelOverrides,
 }) {
   const [activeFilterIndex, setActiveFilterIndex] = useState(0);
@@ -89,6 +96,19 @@ export function ListView({
     }
     setShowSortPopover(false);
   }, [hook.sortColumn, hook.setSortColumn, hook.setSortDirection]);
+
+  // Header click: none → asc → desc → clear
+  const handleColumnSort = useCallback((colKey) => {
+    if (hook.sortColumn !== colKey) {
+      hook.setSortColumn(colKey);
+      hook.setSortDirection('asc');
+    } else if (hook.sortDirection === 'asc') {
+      hook.setSortDirection('desc');
+    } else {
+      hook.setSortColumn('creationDate');
+      hook.setSortDirection('desc');
+    }
+  }, [hook.sortColumn, hook.sortDirection, hook.setSortColumn, hook.setSortDirection]);
 
   const handleClearSort = useCallback(() => {
     hook.setSortColumn('creationDate');
@@ -233,9 +253,6 @@ export function ListView({
               )}
             </div>
             <div className="flex items-center gap-2">
-              <button className="h-9 w-9 flex items-center justify-center rounded-lg border border-border text-muted-foreground hover:text-foreground transition-colors">
-                <Search className="h-4 w-4" />
-              </button>
               {!(listViewOptions?.hideLink ?? hideLink) && (
                 <button className="h-9 w-9 flex items-center justify-center rounded-lg border border-border text-muted-foreground hover:text-foreground transition-colors">
                   <Link2 className="h-4 w-4" />
@@ -299,18 +316,6 @@ export function ListView({
               >
                 <RefreshCw className="h-4 w-4" />
               </button>
-              {!(listViewOptions?.hideEye ?? hideEyeCount) && (
-                <div className="flex items-center gap-1.5 ml-1">
-                  <button className="h-9 w-9 flex items-center justify-center rounded-lg border border-border text-muted-foreground hover:text-foreground transition-colors">
-                    <Eye className="h-4 w-4" />
-                  </button>
-                  {!(listViewOptions?.hideCounter ?? hideEyeCount) && !hook.loading && (
-                    <span className="text-sm text-muted-foreground tabular-nums">
-                      {hook.items.length}
-                    </span>
-                  )}
-                </div>
-              )}
               {!(listViewOptions?.hidePrint ?? hidePrint) && (
                 <Button
                   variant="outline"
@@ -350,12 +355,29 @@ export function ListView({
                   <Plus className="h-4 w-4" />
                   {ui('newRecord')}
                 </Button>
-                <div className="w-px bg-primary-foreground/20" />
-                <Button
-                  className="rounded-none rounded-r-lg px-2"
-                >
-                  <ChevronDown className="h-3.5 w-3.5" />
-                </Button>
+                {newActions.length > 0 && (
+                  <>
+                    <div className="w-px bg-primary-foreground/20" />
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button className="rounded-none rounded-r-lg px-2" data-testid="action-new-more">
+                          <ChevronDown className="h-3.5 w-3.5" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        {newActions.map((action) => (
+                          <DropdownMenuItem
+                            key={action.key}
+                            onClick={action.onClick}
+                            data-testid={`action-new-${action.key}`}
+                          >
+                            {action.label}
+                          </DropdownMenuItem>
+                        ))}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </>
+                )}
               </div>
               )}
             </div>
@@ -395,6 +417,7 @@ export function ListView({
                     compact={false}
                     sortColumn={hook.sortColumn}
                     sortDirection={hook.sortDirection}
+                    onSort={handleColumnSort}
                     onColumnsReady={setTableColumns}
                     api={api}
                     token={token}

--- a/tools/app-shell/src/layout/Sidebar.jsx
+++ b/tools/app-shell/src/layout/Sidebar.jsx
@@ -164,7 +164,7 @@ export default function AppSidebar({ menuGroups, expanded, onToggle }) {
                           className={cn(
                             'flex h-10 w-10 items-center justify-center rounded-xl transition-colors',
                             isItemActive || isGroupActive
-                              ? 'bg-foreground text-white shadow-sm'
+                              ? 'bg-[#FFD500] text-foreground shadow-sm'
                               : 'text-muted-foreground hover:bg-white hover:text-foreground'
                           )}
                         >
@@ -186,7 +186,7 @@ export default function AppSidebar({ menuGroups, expanded, onToggle }) {
                         className={cn(
                           'flex h-10 w-10 items-center justify-center rounded-xl transition-colors',
                           isGroupActive
-                            ? 'bg-foreground text-white shadow-sm'
+                            ? 'bg-[#FFD500] text-foreground shadow-sm'
                             : 'text-muted-foreground hover:bg-white hover:text-foreground'
                         )}
                       >
@@ -213,7 +213,7 @@ export default function AppSidebar({ menuGroups, expanded, onToggle }) {
                             className={cn(
                               'block px-2 py-1.5 text-sm rounded-md transition-colors',
                               isItemActive
-                                ? 'text-foreground bg-muted font-medium'
+                                ? 'text-foreground bg-[#FFD500] font-medium'
                                 : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
                             )}
                           >
@@ -246,10 +246,9 @@ export default function AppSidebar({ menuGroups, expanded, onToggle }) {
                     className={cn(
                       'flex w-full items-center gap-2.5 px-4 py-2 text-sm transition-colors',
                       isItemActive || isGroupActive
-                        ? 'text-foreground'
+                        ? 'bg-[#FFD500] text-foreground font-medium'
                         : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
                     )}
-                    style={isItemActive || isGroupActive ? { borderLeft: `3px solid ${color.accent}` } : undefined}
                   >
                     <Icon className="h-4 w-4 shrink-0" />
                     <span className="flex-1 text-left truncate">{tMenu(singleItem.label)}</span>
@@ -270,11 +269,12 @@ export default function AppSidebar({ menuGroups, expanded, onToggle }) {
                   onClick={() => toggleGroup(g.group)}
                   className={cn(
                     'flex w-full items-center gap-2.5 px-4 py-2 text-sm transition-colors',
-                    isGroupActive
-                      ? 'text-foreground'
-                      : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+                    isGroupActive && !isOpen
+                      ? 'bg-[#FFD500] text-foreground font-medium'
+                      : isGroupActive
+                        ? 'text-foreground'
+                        : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
                   )}
-                  style={isGroupActive ? { borderLeft: `3px solid ${color.accent}` } : undefined}
                 >
                   <Icon className="h-4 w-4 shrink-0" />
                   <span className="flex-1 text-left truncate">{tMenu(g.group)}</span>
@@ -296,9 +296,9 @@ export default function AppSidebar({ menuGroups, expanded, onToggle }) {
                           key={item.name}
                           to={`/${itemPath}`}
                           className={cn(
-                            'block px-3 py-1.5 text-sm rounded-md transition-colors',
+                            'block px-3 py-1.5 text-sm transition-colors',
                             isItemActive
-                              ? 'text-foreground font-semibold'
+                              ? 'bg-[#FFD500] text-foreground font-semibold'
                               : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
                           )}
                         >


### PR DESCRIPTION
## Summary

- Removed decorative Search and Eye buttons from ListView toolbar
- Added `newActions` prop for functional ChevronDown dropdown on New button
- Column header click cycles sort: none → asc → desc → clear
- Active sidebar item highlighted with Etendo yellow (`#FFD500`) across all states (collapsed icon, expanded item, expanded group when collapsed with active child)

## Files changed

- `tools/app-shell/src/components/contract-ui/ListView.jsx`
- `tools/app-shell/src/components/contract-ui/DataTable.jsx`
- `cli/src/generate-frontend.js`
- `docs/decisions-reference.md`
- `tools/app-shell/src/layout/Sidebar.jsx`

## Test plan

- [ ] Toolbar shows Refresh, Sort, Link, Print, New — no Search or Eye
- [ ] New button shows ChevronDown only when `newActions` configured
- [ ] Clicking column header cycles sort states correctly
- [ ] Active sidebar item shows yellow background in all collapse/expand states

🤖 Generated with [Claude Code](https://claude.com/claude-code)