### PR TITLE
Feature ETP-3797: Auto-sync develop into epic via GitHub Action

### DIFF
--- a/.github/workflows/sync-develop-to-epic.yml
+++ b/.github/workflows/sync-develop-to-epic.yml
@@ -1,0 +1,75 @@
+name: Sync develop into epic/ETP-3504
+
+# Keeps a single rolling PR open: develop -> epic/ETP-3504.
+# On every push to develop the PR's diff updates automatically (same head branch).
+# This workflow only ensures the PR exists, has the right label, assignee and auto-merge.
+#
+# Why a PR (not a direct merge): runs all required checks (test, core-approval,
+# pr-architecture-alert, ...) against the merge result before it lands, surfaces
+# conflicts in the GitHub UI, and respects branch protection on the epic.
+#
+# See proposal: docs/plans/2026-04-16-auto-sync-develop-to-epic.md
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  ensure-sync-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create epic-sync \
+            --description "Auto-sync PRs from develop into epic branches" \
+            --color BFD4F2 \
+            2>/dev/null || true
+
+      - name: Ensure rolling PR develop -> epic/ETP-3504
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          existing=$(gh pr list \
+            --base epic/ETP-3504 \
+            --head develop \
+            --state open \
+            --json number,url \
+            --jq '.[0] // empty')
+
+          if [ -z "$existing" ]; then
+            echo "No open sync PR found, creating one..."
+            pr_url=$(gh pr create \
+              --base epic/ETP-3504 \
+              --head develop \
+              --title "Epic ETP-3504: Sync develop into epic" \
+              --body "Rolling auto-sync of \`develop\` into \`epic/ETP-3504\`.
+
+This PR is updated automatically on every push to \`develop\`.
+
+**Merge with regular merge (no squash)** to preserve history — see [\`docs/branch-workflow.md\`](../blob/epic/ETP-3504/docs/branch-workflow.md).
+
+If this PR shows merge conflicts, resolve them by merging \`develop\` into \`epic/ETP-3504\` locally and pushing the result." \
+              --label epic-sync \
+              --assignee sebastianbarrozo)
+            echo "Created sync PR: $pr_url"
+            # Best-effort: enable auto-merge with regular merge method (no squash).
+            # Will no-op if auto-merge is disabled at repo level or required checks
+            # are not configured.
+            gh pr merge "$pr_url" --auto --merge \
+              || echo "auto-merge could not be enabled (continuing — PR is still open)"
+          else
+            pr_number=$(echo "$existing" | jq -r '.number')
+            pr_url=$(echo "$existing" | jq -r '.url')
+            echo "Sync PR already open: #$pr_number ($pr_url) — refreshed automatically by the push."
+          fi

--- a/.github/workflows/sync-develop-to-epic.yml
+++ b/.github/workflows/sync-develop-to-epic.yml
@@ -2,11 +2,14 @@ name: Sync develop into epic/ETP-3504
 
 # Keeps a single rolling PR open: develop -> epic/ETP-3504.
 # On every push to develop the PR's diff updates automatically (same head branch).
-# This workflow only ensures the PR exists, has the right label, assignee and auto-merge.
+# This workflow ensures the PR exists, has the right label and assignee, and that
+# auto-merge is armed. The work is idempotent and re-applied on every run, not
+# only at PR creation, so the PR self-heals if state drifts (label removed, auto-
+# merge disabled by hand, etc.).
 #
-# Why a PR (not a direct merge): runs all required checks (test, core-approval,
-# pr-architecture-alert, ...) against the merge result before it lands, surfaces
-# conflicts in the GitHub UI, and respects branch protection on the epic.
+# Why a PR (not a direct merge): runs all required checks (test, ...) against the
+# merge result before it lands, surfaces conflicts in the GitHub UI, and respects
+# branch protection on the epic.
 #
 # See proposal: docs/plans/2026-04-16-auto-sync-develop-to-epic.md
 
@@ -15,9 +18,17 @@ on:
     branches: [develop]
   workflow_dispatch:
 
+# Serialize concurrent runs (e.g. several quick pushes to develop). Without this,
+# two runs can both observe "no PR" and race to create it; the loser fails because
+# GitHub rejects duplicate PRs for the same head/base.
+concurrency:
+  group: sync-develop-to-epic
+  cancel-in-progress: false
+
 permissions:
-  contents: read
-  pull-requests: write
+  contents: write       # gh pr merge --auto needs this
+  pull-requests: write  # PR create / edit / comment
+  issues: write         # gh label create + setting labels/assignees (issues API)
 
 jobs:
   ensure-sync-pr:
@@ -25,21 +36,45 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Ensure label exists
+      - name: Ensure epic-sync label exists
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh label create epic-sync \
-            --description "Auto-sync PRs from develop into epic branches" \
-            --color BFD4F2 \
-            2>/dev/null || true
+          set -euo pipefail
+          if ! gh label list --limit 1000 --json name --jq '.[].name' | grep -qx 'epic-sync'; then
+            gh label create epic-sync \
+              --description "Auto-sync PRs from develop into epic branches" \
+              --color BFD4F2
+          fi
 
-      - name: Ensure rolling PR develop -> epic/ETP-3504
+      - name: Ensure rolling PR develop -> epic/ETP-3504 (idempotent)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
+          PR_BODY=$(cat <<'BODY'
+          Rolling auto-sync of `develop` into `epic/ETP-3504`.
+
+          This PR is updated automatically on every push to `develop` and lands as
+          soon as required checks are green (auto-merge with `--merge`, no squash).
+
+          **Branch protection rules apply** — see `docs/branch-workflow.md`.
+
+          ### If this PR shows merge conflicts
+
+          Do **not** merge `develop` into `epic/ETP-3504` directly — that bypasses
+          the epic's branch protection. Instead:
+
+          1. Create a temporary branch from `epic/ETP-3504`.
+          2. Merge `develop` into that branch locally and resolve conflicts.
+          3. Push the temporary branch and open a PR from it into `epic/ETP-3504`.
+
+          Once that PR lands, this rolling sync PR will auto-update and become mergeable again.
+          BODY
+          )
+
+          # Look up an existing open sync PR (head=develop, base=epic/ETP-3504).
           existing=$(gh pr list \
             --base epic/ETP-3504 \
             --head develop \
@@ -49,27 +84,33 @@ jobs:
 
           if [ -z "$existing" ]; then
             echo "No open sync PR found, creating one..."
-            pr_url=$(gh pr create \
-              --base epic/ETP-3504 \
-              --head develop \
-              --title "Epic ETP-3504: Sync develop into epic" \
-              --body "Rolling auto-sync of \`develop\` into \`epic/ETP-3504\`.
-
-This PR is updated automatically on every push to \`develop\`.
-
-**Merge with regular merge (no squash)** to preserve history — see [\`docs/branch-workflow.md\`](../blob/epic/ETP-3504/docs/branch-workflow.md).
-
-If this PR shows merge conflicts, resolve them by merging \`develop\` into \`epic/ETP-3504\` locally and pushing the result." \
-              --label epic-sync \
-              --assignee sebastianbarrozo)
-            echo "Created sync PR: $pr_url"
-            # Best-effort: enable auto-merge with regular merge method (no squash).
-            # Will no-op if auto-merge is disabled at repo level or required checks
-            # are not configured.
-            gh pr merge "$pr_url" --auto --merge \
-              || echo "auto-merge could not be enabled (continuing — PR is still open)"
+            if ! pr_url=$(gh pr create \
+                --base epic/ETP-3504 \
+                --head develop \
+                --title "Epic ETP-3504: Sync develop into epic" \
+                --body "$PR_BODY" \
+                --label epic-sync \
+                --assignee sebastianbarrozo); then
+              # A concurrent run may have created the PR between our list and create.
+              echo "gh pr create failed — re-querying for an existing PR..."
+              pr_url=$(gh pr list \
+                --base epic/ETP-3504 \
+                --head develop \
+                --state open \
+                --json url \
+                --jq '.[0].url // empty')
+              [ -n "$pr_url" ] || { echo "No PR after retry — failing."; exit 1; }
+            fi
+            echo "PR ready: $pr_url"
           else
-            pr_number=$(echo "$existing" | jq -r '.number')
             pr_url=$(echo "$existing" | jq -r '.url')
-            echo "Sync PR already open: #$pr_number ($pr_url) — refreshed automatically by the push."
+            echo "Sync PR already open: $pr_url — re-applying label/assignee."
+            gh pr edit "$pr_url" --add-label epic-sync --add-assignee sebastianbarrozo \
+              || echo "Could not re-apply label/assignee (continuing)."
           fi
+
+          # Re-arm auto-merge on every run. No-op if already armed; recovers if a
+          # previous run failed to enable it. Best-effort — if auto-merge is off at
+          # the repo level the call fails and the PR stays open for manual merge.
+          gh pr merge "$pr_url" --auto --merge \
+            || echo "auto-merge could not be enabled (continuing — PR is still open)"

--- a/docs/plans/2026-04-16-auto-sync-develop-to-epic.md
+++ b/docs/plans/2026-04-16-auto-sync-develop-to-epic.md
@@ -1,0 +1,211 @@
+# Auto-sync `develop` → `epic/ETP-3504`
+
+## Context
+
+The epic branch `epic/ETP-3504` is long-lived and integrates many feature PRs.
+Meanwhile `develop` keeps moving (fixes from other epics, hotfixes, etc.).
+Today the sync is manual: someone has to remember to merge `develop` into the epic
+periodically (the latest one is commit `fcb6916b`, "Resolve merge conflicts with develop").
+
+We want this to happen automatically on every push to `develop`, so the epic branch
+never drifts more than one commit away from `develop`.
+
+## Objective
+
+On every push to `develop`, propagate the new commits to `epic/ETP-3504`:
+- Without losing history (no squash, per project rule).
+- Surfacing conflicts loudly instead of silently failing.
+- Without bypassing branch protection on the epic.
+
+## Options
+
+### Option A — GitHub Action: direct merge `develop` → `epic`
+
+Workflow triggered on `push` to `develop`. It checks out the epic, merges `develop`,
+and pushes. If the merge has conflicts, the job fails and notifies (Slack / GH issue / PR comment).
+
+```yaml
+# .github/workflows/sync-develop-to-epic.yml
+name: Sync develop → epic/ETP-3504
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: epic/ETP-3504
+          token: ${{ secrets.EPIC_SYNC_TOKEN }}  # PAT or GH App with write to epic
+
+      - name: Configure git
+        run: |
+          git config user.name  "epic-sync-bot"
+          git config user.email "epic-sync-bot@users.noreply.github.com"
+
+      - name: Merge develop
+        id: merge
+        run: |
+          git fetch origin develop:develop
+          git merge --no-ff develop -m "Epic ETP-3504: Auto-merge develop ($(git rev-parse --short develop))"
+
+      - name: Push
+        run: git push origin epic/ETP-3504
+
+      - name: Open issue on conflict
+        if: failure() && steps.merge.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Auto-sync develop → epic/ETP-3504 has conflicts',
+              body: 'Workflow run: ' + context.serverUrl + '/' + context.repo.owner + '/' + context.repo.repo + '/actions/runs/' + context.runId,
+              labels: ['epic-sync', 'conflict'],
+            });
+```
+
+**Pros**
+- Simple, one workflow file, no external service.
+- Push happens immediately, the epic stays at most ~minutes behind `develop`.
+- Preserves history (`--no-ff` merge, no squash → respects project rule).
+
+**Cons**
+- Needs a token with write access on the epic branch (PAT, GH App, or branch protection exception for the bot).
+- Conflicts → workflow fails; someone still has to resolve them manually. The auto-issue softens this but does not eliminate it.
+- No CI runs against the merged result before pushing (we'd be pushing untested code into the epic).
+
+### Option B — GitHub Action: open/update PR `develop` → `epic`
+
+Same trigger, but instead of pushing directly, open (or update) a PR `develop → epic/ETP-3504`.
+Optionally set `auto-merge` so it merges as soon as required checks pass.
+
+```yaml
+# .github/workflows/sync-develop-to-epic.yml
+name: Sync develop → epic/ETP-3504
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  sync-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create or update sync PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -e
+          existing=$(gh pr list --base epic/ETP-3504 --head develop --state open --json number --jq '.[0].number')
+          if [ -z "$existing" ]; then
+            gh pr create \
+              --base epic/ETP-3504 \
+              --head develop \
+              --title "Epic ETP-3504: Sync develop" \
+              --body "Automatic sync of \`develop\` into \`epic/ETP-3504\`. Merge with **regular merge** (no squash) to preserve history." \
+              --label epic-sync
+          else
+            echo "PR #$existing already open, will be updated by the new push automatically."
+          fi
+```
+
+**Pros**
+- All required checks (`test.yml`, `core-approval.yml`, `pr-architecture-alert.yml`, etc.) run against the merge before it lands → much safer.
+- No need for elevated tokens or branch-protection exceptions.
+- Conflicts are visible in the PR UI, where reviewers can fix them.
+- Plays nicely with the project rule "agents NEVER merge to develop/main" — this PR goes the other direction (develop → epic), still respects branch protection.
+
+**Cons**
+- Not "fully automatic": a human (or `gh pr merge --auto --merge`) has to land the PR.
+- Same PR keeps growing as `develop` moves; CI re-runs each push.
+
+### Option C — Mergify / Kodiak (external bot)
+
+Configure a YAML rule in `.mergify.yml`:
+
+```yaml
+pull_request_rules:
+  - name: Keep epic in sync with develop
+    conditions:
+      - base=epic/ETP-3504
+      - head=develop
+    actions:
+      merge:
+        method: merge   # never squash
+```
+
+Combined with a Mergify "queue" or scheduled action that opens the sync PR.
+
+**Pros**
+- Battle-tested, extensive rule engine (auto-rebase, conditional merging, queues).
+- No GH Action maintenance.
+
+**Cons**
+- External SaaS dependency, needs install + auth on the org.
+- Overkill if Option A or B already covers our needs.
+
+### Option D — Scheduled cron (nightly sync)
+
+Same as Option A but trigger on `schedule: '0 6 * * *'` instead of `push`.
+
+**Pros**
+- Predictable, low noise (one merge per day).
+
+**Cons**
+- Epic can drift a full day → bigger conflicts when they appear.
+- Doesn't react to urgent fixes landing on `develop`.
+
+## Recommendation
+
+**Option B (open/update PR) as the default**, with the following tweaks:
+- Auto-create the PR on every push to `develop`.
+- Add `--label epic-sync` so we can filter/track these PRs separately.
+- Enable GH "auto-merge" with method = merge (never squash) so it lands as soon as
+  the existing required checks (`test`, `core-approval`, etc.) pass.
+- On conflict, the PR stays open and waits for a human — which is the right behavior
+  for a long-lived epic with multiple parallel features.
+
+Reasons:
+- Respects the project rule of preserving history (`--merge`, no squash).
+- Reuses existing CI without adding new tokens or branch-protection exceptions.
+- Conflicts are surfaced in the place where they're easiest to resolve (the PR).
+- Keeps the epic branch always reflecting a state that has passed CI.
+
+If we ever decide that "PR fatigue" is too high, we can graduate to Option A
+(direct merge with auto-issue on conflict) — the migration is trivial.
+
+## Open questions
+
+- Do we want a single rolling PR that keeps getting updated, or a fresh PR per push?
+  Recommendation: single rolling PR (less noise, simpler tracking).
+- Who should be the assignee/reviewer of the auto-PR? `sebastianbarrozo`?
+- Should we extend the same automation to the **etendo-go** sibling repo
+  (per `docs/branch-workflow.md` both repos share branches)? Almost certainly yes
+  — same workflow, different repo.
+- Do we want a Slack/Telegram notification on conflict, on top of the PR staying open?
+
+## Next steps
+
+1. Confirm Option B with the user.
+2. Decide on rolling PR vs per-push PR.
+3. Implement `.github/workflows/sync-develop-to-epic.yml` in this repo.
+4. Mirror the workflow in `com.etendoerp.go`.
+5. Validate with a manual `workflow_dispatch` run before relying on the `push` trigger.


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that maintains a single **rolling PR** `develop -> epic/ETP-3504` on every push to `develop`.

Behavior:
- If no open sync PR exists → creates one with label `epic-sync`, assignee `sebastianbarrozo`, and tries to enable auto-merge with `--merge` (no squash, per `docs/branch-workflow.md`).
- If a sync PR is already open → no-op (the push to `develop` refreshes its diff automatically).
- Conflicts stay visible in the PR UI for a human to resolve.

## Why a PR (not a direct merge)

- All existing required checks (`test`, `core-approval`, `pr-architecture-alert`, ...) run against the merge result *before* it lands on the epic.
- No need for an elevated token or branch-protection exception.
- Conflicts surface in the place where they're easiest to resolve.

## Files

- `.github/workflows/sync-develop-to-epic.yml`
- `docs/plans/2026-04-16-auto-sync-develop-to-epic.md` (proposal with all options considered)

## Out of scope

- Mirroring the workflow in `com.etendoerp.go` (follow-up if it works well here).
- Email/Telegram notification on conflicts (GitHub does email assignees on PR creation; conflict state itself is not auto-emailed). Can be added later via an SMTP action if needed.

## Test plan

- [ ] After merge, manually trigger the workflow via `workflow_dispatch` on `develop` and confirm a sync PR is created (or detected) with the right label and assignee.
- [ ] Make a tiny commit on `develop`, confirm the rolling PR diff updates automatically.
- [ ] Verify auto-merge enables (Settings → General → "Allow auto-merge" must be on at the repo level).

Jira: ETP-3797