### PR TITLE
Feature ETP-3797: Smoke-test auto-sync workflow

### DIFF
--- a/docs/plans/2026-04-16-auto-sync-develop-to-epic.md
+++ b/docs/plans/2026-04-16-auto-sync-develop-to-epic.md
@@ -209,3 +209,10 @@ If we ever decide that "PR fatigue" is too high, we can graduate to Option A
 3. Implement `.github/workflows/sync-develop-to-epic.yml` in this repo.
 4. Mirror the workflow in `com.etendoerp.go`.
 5. Validate with a manual `workflow_dispatch` run before relying on the `push` trigger.
+
+## Validation log
+
+- **2026-04-16** — End-to-end smoke test. After landing the workflow on
+  `develop`, the rerun on the merge commit (run `24525016090`, attempt 2) opened
+  the rolling sync PR `#340` (`develop -> epic/ETP-3504`) with the expected
+  label, assignee, and auto-merge armed (`MERGE`, no squash).


### PR DESCRIPTION
## Summary

Dummy PR to trigger a push to `develop` and validate that the rolling sync workflow (`.github/workflows/sync-develop-to-epic.yml`) reacts correctly.

Adds a single line to the proposal doc with the validation log entry — no code changes.

## Expected behavior on merge

1. Merge of this PR pushes a commit to `develop`.
2. `Sync develop into epic/ETP-3504` workflow fires.
3. Workflow finds existing rolling PR #340 (open) → re-applies label/assignee, re-arms auto-merge (idempotent path).
4. PR #340 diff updates with this new commit included.
5. If `test` is green on the merge result, PR #340 lands automatically into `epic/ETP-3504`.

Jira: ETP-3797