### PR TITLE
Add workflow_dispatch to Deploy SPA workflow

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
       - epic/ETP-3504
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
Allows manual triggering of the deploy from the GitHub Actions UI — useful to redeploy without needing a code push.