### PR TITLE
Feature ETP-3809: Improve i18n in app-shell: default es_ES, column labels, dates

### DIFF
--- a/tools/app-shell/src/components/contract-ui/Chatter.jsx
+++ b/tools/app-shell/src/components/contract-ui/Chatter.jsx
@@ -5,13 +5,15 @@ import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
+import { useLocaleSwitch } from '@/i18n/LocaleProvider';
 import { MessageSquare, Send, ChevronDown } from 'lucide-react';
 
 /**
  * Format a timestamp into a human-readable relative string.
  * Handles Date objects, ISO strings, and Unix timestamps (ms).
+ * The locale is used only for the absolute-date fallback (>= 7 days old).
  */
-function formatRelativeTime(timestamp) {
+function formatRelativeTime(timestamp, locale = 'es_ES') {
   if (!timestamp) return '';
   const date = timestamp instanceof Date ? timestamp : new Date(timestamp);
   const now = new Date();
@@ -26,7 +28,7 @@ function formatRelativeTime(timestamp) {
   if (diffHours < 24) return `${diffHours} hour${diffHours !== 1 ? 's' : ''} ago`;
   if (diffDays === 1) return 'yesterday';
   if (diffDays < 7) return `${diffDays} days ago`;
-  return date.toLocaleDateString(navigator.language, { year: 'numeric', month: '2-digit', day: '2-digit' });
+  return date.toLocaleDateString(locale.replace('_', '-'), { year: 'numeric', month: '2-digit', day: '2-digit' });
 }
 
 /**
@@ -40,6 +42,7 @@ function getInitial(author) {
  * A single message row in the chatter.
  */
 function MessageItem({ message }) {
+  const { locale } = useLocaleSwitch();
   const isSystem = message.type === 'system';
 
   if (isSystem) {
@@ -50,7 +53,7 @@ function MessageItem({ message }) {
           {message.text}
           {message.timestamp && (
             <span className="ml-2 text-[10px] text-muted-foreground/60">
-              {formatRelativeTime(message.timestamp)}
+              {formatRelativeTime(message.timestamp, locale)}
             </span>
           )}
         </p>
@@ -71,7 +74,7 @@ function MessageItem({ message }) {
           <span className="text-sm font-medium truncate">{message.author || 'Unknown'}</span>
           {message.timestamp && (
             <span className="text-[11px] text-muted-foreground shrink-0">
-              {formatRelativeTime(message.timestamp)}
+              {formatRelativeTime(message.timestamp, locale)}
             </span>
           )}
         </div>

--- a/tools/app-shell/src/components/contract-ui/Chatter.jsx
+++ b/tools/app-shell/src/components/contract-ui/Chatter.jsx
@@ -26,7 +26,7 @@ function formatRelativeTime(timestamp) {
   if (diffHours < 24) return `${diffHours} hour${diffHours !== 1 ? 's' : ''} ago`;
   if (diffDays === 1) return 'yesterday';
   if (diffDays < 7) return `${diffDays} days ago`;
-  return date.toLocaleDateString();
+  return date.toLocaleDateString(navigator.language, { year: 'numeric', month: '2-digit', day: '2-digit' });
 }
 
 /**

--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -728,6 +728,10 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
   const ui = useUI();
   const dictionary = useLocale();
   const { locale } = useLocaleSwitch();
+  const dateFormatter = useMemo(
+    () => new Intl.DateTimeFormat(locale.replace('_', '-'), { year: 'numeric', month: '2-digit', day: '2-digit' }),
+    [locale]
+  );
   const [searchQuery, setSearchQuery] = useState('');
   const [columnFilters, setColumnFilters] = useState(initialColumnFilters ?? {});
   const [selectedRows, setSelectedRows] = useState(new Set());
@@ -967,7 +971,7 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
       const raw = row[col.key];
       // Parse date-only strings (yyyy-MM-dd) as local to avoid timezone shift
       const parsed = raw ? (/^\d{4}-\d{2}-\d{2}$/.test(raw) ? new Date(raw + 'T00:00:00') : new Date(raw)) : null;
-      const formatted = parsed && !isNaN(parsed) ? parsed.toLocaleDateString(locale.replace('_', '-'), { year: 'numeric', month: '2-digit', day: '2-digit' }) : '\u2014';
+      const formatted = parsed && !isNaN(parsed) ? dateFormatter.format(parsed) : '\u2014';
       return <span>{formatted}</span>;
     }
     if (col.type === 'amount') {

--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -12,6 +12,7 @@ import { buildUrlWithParams } from '@/lib/buildUrlWithParams.js';
 import { getCatalogOptions } from '@/lib/selectorCatalog.js';
 import { getStatusDotColor, getStatusGridPillClass, getStatusPillClass, statusLabel } from '@/lib/statusBadge.js';
 import { resolveIdentifier } from '@/lib/resolveIdentifier.js';
+import { resolveColumnLabel } from '@/lib/resolveColumnLabel.js';
 import { formatAmount } from '@/lib/formatAmount.js';
 import ProductSearchDrawer from './ProductSearchDrawer.jsx';
 import InternalConsumptionProductSearchDrawer from './InternalConsumptionProductSearchDrawer.jsx';
@@ -933,7 +934,7 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
               onCheckedChange={(nextChecked) => {
                 void handleInlineToggle(row, col, nextChecked);
               }}
-              aria-label={col.labels?.[locale] ?? col.labels?.en_US ?? t(col.column) ?? col.label ?? col.key}
+              aria-label={resolveColumnLabel(col, locale, t)}
             />
           </div>
         );
@@ -966,7 +967,7 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
       const raw = row[col.key];
       // Parse date-only strings (yyyy-MM-dd) as local to avoid timezone shift
       const parsed = raw ? (/^\d{4}-\d{2}-\d{2}$/.test(raw) ? new Date(raw + 'T00:00:00') : new Date(raw)) : null;
-      const formatted = parsed && !isNaN(parsed) ? parsed.toLocaleDateString() : '\u2014';
+      const formatted = parsed && !isNaN(parsed) ? parsed.toLocaleDateString(locale.replace('_', '-'), { year: 'numeric', month: '2-digit', day: '2-digit' }) : '\u2014';
       return <span>{formatted}</span>;
     }
     if (col.type === 'amount') {
@@ -1049,7 +1050,7 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
                 </TableHead>
               )}
               {columns.map(col => {
-                const colLabel = col.labels?.[locale] ?? col.labels?.en_US ?? col.label ?? t(col.column) ?? col.key;
+                const colLabel = resolveColumnLabel(col, locale, t);
                 const isSorted = sortColumn === col.key;
                 const isRight = col.type === 'amount';
                 return (

--- a/tools/app-shell/src/i18n/LocaleProvider.jsx
+++ b/tools/app-shell/src/i18n/LocaleProvider.jsx
@@ -10,7 +10,7 @@ const localeModules = import.meta.glob('../locales/*.json', { eager: true });
  * Accepts a locale prop (e.g., "en_US") and resolves the matching JSON file.
  * Optionally accepts setLocale callback for locale switching.
  */
-export function LocaleProvider({ locale = 'en_US', setLocale, children }) {
+export function LocaleProvider({ locale = 'es_ES', setLocale, children }) {
   const dictionary = useMemo(() => {
     const key = `../locales/${locale}.json`;
     return localeModules[key]?.default ?? localeModules[key] ?? {};
@@ -45,5 +45,5 @@ export function useLocale() {
  */
 export function useLocaleSwitch() {
   const ctx = useContext(LocaleContext);
-  return { locale: ctx?.locale ?? 'en_US', setLocale: ctx?.setLocale ?? null };
+  return { locale: ctx?.locale ?? 'es_ES', setLocale: ctx?.setLocale ?? null };
 }

--- a/tools/app-shell/src/i18n/__tests__/useLocaleState.test.js
+++ b/tools/app-shell/src/i18n/__tests__/useLocaleState.test.js
@@ -5,15 +5,15 @@ import assert from 'node:assert/strict';
 // localStorage key and default value behavior.
 
 const STORAGE_KEY = 'schema-forge-locale';
-const DEFAULT_LOCALE = 'en_US';
+const DEFAULT_LOCALE = 'es_ES';
 
 describe('useLocaleState logic', () => {
   it('STORAGE_KEY is schema-forge-locale', () => {
     assert.equal(STORAGE_KEY, 'schema-forge-locale');
   });
 
-  it('DEFAULT_LOCALE is en_US', () => {
-    assert.equal(DEFAULT_LOCALE, 'en_US');
+  it('DEFAULT_LOCALE is es_ES', () => {
+    assert.equal(DEFAULT_LOCALE, 'es_ES');
   });
 
   it('useLocaleState module exports the hook', async () => {

--- a/tools/app-shell/src/i18n/useLocaleState.js
+++ b/tools/app-shell/src/i18n/useLocaleState.js
@@ -1,13 +1,13 @@
 import { useState, useCallback } from 'react';
 
 const STORAGE_KEY = 'schema-forge-locale';
-const DEFAULT_LOCALE = 'en_US';
+const DEFAULT_LOCALE = 'es_ES';
 
 /**
  * Hook that manages the active locale with localStorage persistence.
  * Returns [locale, setLocale] similar to useState.
  *
- * On mount, reads from localStorage (falls back to 'en_US').
+ * On mount, reads from localStorage (falls back to 'es_ES').
  * On setLocale, writes to localStorage and updates state.
  */
 export function useLocaleState() {

--- a/tools/app-shell/src/lib/__tests__/resolveColumnLabel.test.js
+++ b/tools/app-shell/src/lib/__tests__/resolveColumnLabel.test.js
@@ -1,0 +1,75 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveColumnLabel } from '../resolveColumnLabel.js';
+
+const translate = (key) => {
+  const dictionary = {
+    C_BPartner_ID: 'Tercero',
+    DateOrdered: 'Fecha de pedido',
+  };
+  return dictionary[key] ?? null;
+};
+
+describe('resolveColumnLabel', () => {
+  it('prefers col.labels for the active locale over everything else', () => {
+    const col = {
+      key: 'orderDate',
+      column: 'DateOrdered',
+      label: 'Order Date',
+      labels: { es_ES: 'Fecha del pedido', en_US: 'Order Date (contract)' },
+    };
+    assert.equal(resolveColumnLabel(col, 'es_ES', translate), 'Fecha del pedido');
+  });
+
+  it('falls back to col.labels.en_US when the locale override is missing', () => {
+    const col = {
+      key: 'orderDate',
+      column: 'DateOrdered',
+      label: 'Order Date',
+      labels: { en_US: 'Order Date (contract)' },
+    };
+    assert.equal(resolveColumnLabel(col, 'es_ES', translate), 'Order Date (contract)');
+  });
+
+  // Regression: i18n dictionary must win over the contract-embedded English label.
+  // Before the fix, `col.label` was placed BEFORE `translate(col.column)` in the
+  // fallback chain, so the English contract label silently overrode the Spanish
+  // translation maintained in es_ES.json.
+  it('prefers the i18n dictionary over col.label when col.labels is missing', () => {
+    const col = {
+      key: 'businessPartner',
+      column: 'C_BPartner_ID',
+      label: 'Business Partner',
+    };
+    assert.equal(resolveColumnLabel(col, 'es_ES', translate), 'Tercero');
+  });
+
+  it('falls back to col.label when the i18n dictionary has no entry', () => {
+    const col = {
+      key: 'unknown',
+      column: 'UnknownColumn',
+      label: 'Unknown Label',
+    };
+    assert.equal(resolveColumnLabel(col, 'es_ES', translate), 'Unknown Label');
+  });
+
+  it('falls back to col.key as last resort', () => {
+    const col = { key: 'someKey', column: 'UnknownColumn' };
+    assert.equal(resolveColumnLabel(col, 'es_ES', translate), 'someKey');
+  });
+
+  it('works when translate is not provided', () => {
+    const col = { key: 'orderDate', column: 'DateOrdered', label: 'Order Date' };
+    assert.equal(resolveColumnLabel(col, 'es_ES'), 'Order Date');
+  });
+
+  it('returns undefined for a null column', () => {
+    assert.equal(resolveColumnLabel(null, 'es_ES', translate), undefined);
+  });
+
+  it('treats an empty translate result as a miss and falls back to col.label', () => {
+    const emptyTranslate = () => null;
+    const col = { key: 'orderDate', column: 'DateOrdered', label: 'Order Date' };
+    assert.equal(resolveColumnLabel(col, 'es_ES', emptyTranslate), 'Order Date');
+  });
+});

--- a/tools/app-shell/src/lib/resolveColumnLabel.js
+++ b/tools/app-shell/src/lib/resolveColumnLabel.js
@@ -1,0 +1,24 @@
+/**
+ * Resolve the display label for a DataTable column.
+ *
+ * Priority order (highest to lowest):
+ *   1. col.labels[locale]   — explicit per-locale override in the contract
+ *   2. col.labels.en_US     — contract fallback in English
+ *   3. translate(col.column) — i18n dictionary lookup (es_ES.json / en_US.json)
+ *   4. col.label            — AD hardcoded label (typically English)
+ *   5. col.key              — technical key (last resort)
+ *
+ * The i18n dictionary MUST win over `col.label`, otherwise contract-embedded
+ * English labels silently override the translations the user maintains in
+ * the locale JSON files.
+ */
+export function resolveColumnLabel(col, locale, translate) {
+  if (!col) return undefined;
+  return (
+    col.labels?.[locale] ??
+    col.labels?.en_US ??
+    (typeof translate === 'function' ? translate(col.column) : null) ??
+    col.label ??
+    col.key
+  );
+}


### PR DESCRIPTION
## Summary
- Change default locale from `en_US` to `es_ES` in `LocaleProvider` and `useLocaleState` (plus test) — Spanish is the primary client locale.
- Add shared helper `lib/resolveColumnLabel.js` (with unit tests) and use it in `DataTable.jsx` so the i18n dictionary wins over AD-hardcoded `col.label`. Resolution order: `labels[locale]` → `labels.en_US` → `t(col.column)` → `col.label` → `col.key`.
- Make date formatting locale-aware in `Chatter.jsx` and `DataTable.jsx` by passing the active locale and `{ year, month: '2-digit', day: '2-digit' }` to `toLocaleDateString()`.

## Jira
[ETP-3809](https://etendoproject.atlassian.net/browse/ETP-3809) — under epic ETP-3504 (Etendo Next / New New UI).

## Test plan
- [ ] `node --test tools/app-shell/src/lib/__tests__/resolveColumnLabel.test.js`
- [ ] `node --test tools/app-shell/src/i18n/__tests__/useLocaleState.test.js`
- [ ] Load a window with a DataTable in `es_ES` and verify column headers use translations (not the hardcoded AD English label).
- [ ] Verify dates in DataTable and Chatter render with the locale-aware 2-digit day/month, 4-digit year format.
- [ ] Fresh localStorage: app loads in `es_ES` by default.

[ETP-3809]: https://etendoproject.atlassian.net/browse/ETP-3809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ