### PR TITLE
Feature ETP-3799: Create Contact modal

### DIFF
--- a/tools/app-shell/src/windows/custom/purchase-invoice/index.jsx
+++ b/tools/app-shell/src/windows/custom/purchase-invoice/index.jsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
 import { ListView } from '@/components/contract-ui';
 import { useUI } from '@/i18n';
@@ -9,6 +10,9 @@ import InvoicePreviewModal from './InvoicePreviewModal.jsx';
 import PurchaseInvoiceTopbar from './PurchaseInvoiceTopbar.jsx';
 import PurchaseInvoiceBottomPanel from './PurchaseInvoiceBottomPanel.jsx';
 import RelatedDocuments from './RelatedDocuments.jsx';
+import CreateContactModal from '@/components/contract-ui/CreateContactModal';
+import { CreateContactContext } from '@/components/contract-ui/CreateContactContext.js';
+import { useCreateContactModal } from '@/components/contract-ui/useCreateContactModal.js';
 
 /* eslint-disable react/prop-types */
 
@@ -50,6 +54,8 @@ export default function PurchaseInvoiceWindow(props) {
   const ui = useUI();
   const [savedRecord, setSavedRecord] = useState(null);
   const [previewRow, setPreviewRow] = useState(null);
+  const { bpApiBaseUrl, headers, createContactState, setCreateContactState, createContactCtxValue } =
+    useCreateContactModal({ apiBaseUrl, token });
   const breadcrumb = 'Purchases / Purchase Invoice';
   previewRowSetterRef = setPreviewRow;
 
@@ -75,20 +81,36 @@ export default function PurchaseInvoiceWindow(props) {
 
   if (recordId) {
     return (
-      <HeaderPage
-        {...props}
-        DetailTable={InvoiceLineTableCustom}
-        secondaryTabs={[]}
-        summary={summary}
-        extraBadges={[]}
-        topbarRight={PurchaseInvoiceTopbar}
-        bottomSection={PurchaseInvoiceBottomPanel}
-        notesField="description"
-        customTabs={customTabs}
-        breadcrumb={breadcrumb}
-        onAfterSave={true}
-        addLineGuard={(d) => !!d?.businessPartner}
-      />
+      <CreateContactContext.Provider value={createContactCtxValue}>
+        <HeaderPage
+          {...props}
+          DetailTable={InvoiceLineTableCustom}
+          secondaryTabs={[]}
+          summary={summary}
+          extraBadges={[]}
+          topbarRight={PurchaseInvoiceTopbar}
+          bottomSection={PurchaseInvoiceBottomPanel}
+          notesField="description"
+          customTabs={customTabs}
+          breadcrumb={breadcrumb}
+          onAfterSave={true}
+          addLineGuard={(d) => !!d?.businessPartner}
+        />
+        {createContactState && createPortal(
+          <CreateContactModal
+            bpApiBaseUrl={bpApiBaseUrl}
+            headers={headers}
+            initialQuery={createContactState.query}
+            documentType="purchase"
+            onClose={() => setCreateContactState(null)}
+            onCreated={(newBP) => {
+              createContactState.onSelect({ id: newBP.id, name: newBP.name });
+              setCreateContactState(null);
+            }}
+          />,
+          document.body,
+        )}
+      </CreateContactContext.Provider>
     );
   }
 

--- a/tools/app-shell/src/windows/custom/sales-invoice/index.jsx
+++ b/tools/app-shell/src/windows/custom/sales-invoice/index.jsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
 import { ListView } from '@/components/contract-ui';
 import { useUI } from '@/i18n';
@@ -8,6 +9,9 @@ import InvoicePreviewModal from '../purchase-invoice/InvoicePreviewModal.jsx';
 import SalesInvoiceTopbar from './SalesInvoiceTopbar.jsx';
 import InvoiceBottomPanel from '@generated/sales-invoice/custom/InvoiceBottomPanel.jsx';
 import RelatedDocuments from '@generated/sales-invoice/custom/RelatedDocuments.jsx';
+import CreateContactModal from '@/components/contract-ui/CreateContactModal';
+import { CreateContactContext } from '@/components/contract-ui/CreateContactContext.js';
+import { useCreateContactModal } from '@/components/contract-ui/useCreateContactModal.js';
 
 /* eslint-disable react/prop-types */
 
@@ -49,6 +53,8 @@ export default function SalesInvoiceWindow(props) {
   const ui = useUI();
   const [savedRecord, setSavedRecord] = useState(null);
   const [previewRow, setPreviewRow] = useState(null);
+  const { bpApiBaseUrl, headers, createContactState, setCreateContactState, createContactCtxValue } =
+    useCreateContactModal({ apiBaseUrl, token });
   const breadcrumb = 'Sales / Sales Invoice';
   previewRowSetterRef = setPreviewRow;
 
@@ -65,16 +71,32 @@ export default function SalesInvoiceWindow(props) {
 
   if (recordId) {
     return (
-      <HeaderPage
-        {...props}
-        bottomSection={InvoiceBottomPanel}
-        topbarRight={SalesInvoiceTopbar}
-        notesField="description"
-        customTabs={[{ key: 'related', label: ui('relatedDocuments'), Component: RelatedDocuments }]}
-        onAfterSave={true}
-        addLineGuard={(d) => !!d?.businessPartner}
-        breadcrumb={breadcrumb}
-      />
+      <CreateContactContext.Provider value={createContactCtxValue}>
+        <HeaderPage
+          {...props}
+          bottomSection={InvoiceBottomPanel}
+          topbarRight={SalesInvoiceTopbar}
+          notesField="description"
+          customTabs={[{ key: 'related', label: ui('relatedDocuments'), Component: RelatedDocuments }]}
+          onAfterSave={true}
+          addLineGuard={(d) => !!d?.businessPartner}
+          breadcrumb={breadcrumb}
+        />
+        {createContactState && createPortal(
+          <CreateContactModal
+            bpApiBaseUrl={bpApiBaseUrl}
+            headers={headers}
+            initialQuery={createContactState.query}
+            documentType="sale"
+            onClose={() => setCreateContactState(null)}
+            onCreated={(newBP) => {
+              createContactState.onSelect({ id: newBP.id, name: newBP.name });
+              setCreateContactState(null);
+            }}
+          />,
+          document.body,
+        )}
+      </CreateContactContext.Provider>
     );
   }
 


### PR DESCRIPTION
## Summary

- Add \"Nuevo contacto\" button in the business partner selector for Sales Invoice and Purchase Invoice windows

## Test plan

- [ ] Open a Sales Invoice record → business partner selector shows \"+ Nuevo contacto\"
- [ ] Open a Purchase Invoice record → same button appears
- [ ] Click \"+ Nuevo contacto\", fill in data → contact is created and selected in the field