### PR TITLE
Feature ETP-3661: Remove more-details section from Purchase and Sales Order

### DIFF
--- a/artifacts/purchase-order/contract.json
+++ b/artifacts/purchase-order/contract.json
@@ -1,7 +1,7 @@
 {
   "version": "0.17.0",
-  "generatedAt": "2026-04-16T14:50:59.574Z",
-  "checksum": "ff822af570a3aab6",
+  "generatedAt": "2026-04-20T13:34:07.113Z",
+  "checksum": "ca88a51e721aea55",
   "frontendContract": {
     "window": {
       "id": "181",
@@ -205,10 +205,9 @@
             "visibility": "editable",
             "required": true,
             "grid": true,
-            "form": true,
+            "form": false,
             "reference": "Warehouse",
             "inputMode": "selector",
-            "section": "collapsed",
             "readOnlyLogic": {
               "raw": "@Processed@='Y'",
               "evaluable": true,
@@ -228,7 +227,7 @@
             "form": true,
             "reference": "PaymentMethod",
             "inputMode": "selector",
-            "section": "collapsed",
+            "section": "principal",
             "validationRule": {
               "code": "EXISTS (SELECT 1 FROM FIN_FinAcc_PaymentMethod fapm WHERE FIN_PaymentMethod.FIN_PaymentMethod_ID=fapm.FIN_PaymentMethod_ID\nAND fapm.Payin_Allow = (SELECT CASE WHEN '@IsSOTrx@'='Y' THEN 'Y' ELSE fapm.Payin_Allow END FROM DUAL)\nAND fapm.Payout_Allow = (SELECT CASE WHEN '@IsSOTrx@'='N' THEN 'Y' ELSE fapm.Payout_Allow END FROM DUAL))",
               "contextParams": [],
@@ -255,7 +254,7 @@
             "form": false,
             "reference": "PaymentTerm",
             "inputMode": "selector",
-            "section": "collapsed",
+            "section": "principal",
             "readOnlyLogic": {
               "raw": "@Processed@='Y'",
               "evaluable": true,
@@ -275,7 +274,7 @@
             "form": true,
             "reference": "PriceList",
             "inputMode": "selector",
-            "section": "collapsed",
+            "section": "principal",
             "validationRule": {
               "code": "M_PriceList.issopricelist = @isSOTrx@",
               "contextParams": [],
@@ -2178,6 +2177,14 @@
             "required": false
           },
           {
+            "name": "paymentMethod",
+            "apiKey": "paymentMethod",
+            "column": "FIN_Paymentmethod_ID",
+            "type": "foreignKey",
+            "visibility": "editable",
+            "required": false
+          },
+          {
             "name": "rMReceiveMaterials",
             "apiKey": "rMReceiveMaterials",
             "column": "RM_ReceiveMaterials",
@@ -2186,11 +2193,11 @@
             "required": false
           },
           {
-            "name": "paymentMethod",
-            "apiKey": "paymentMethod",
-            "column": "FIN_Paymentmethod_ID",
-            "type": "foreignKey",
-            "visibility": "editable",
+            "name": "rMCreateInvoice",
+            "apiKey": "rMCreateInvoice",
+            "column": "RM_CreateInvoice",
+            "type": "button",
+            "visibility": "system",
             "required": false
           },
           {
@@ -2200,14 +2207,6 @@
             "type": "foreignKey",
             "visibility": "editable",
             "required": true
-          },
-          {
-            "name": "rMCreateInvoice",
-            "apiKey": "rMCreateInvoice",
-            "column": "RM_CreateInvoice",
-            "type": "button",
-            "visibility": "system",
-            "required": false
           },
           {
             "name": "priceList",
@@ -2586,28 +2585,12 @@
             "required": false
           },
           {
-            "name": "invoiceTerms",
-            "apiKey": "invoiceTerms",
-            "column": "InvoiceRule",
-            "type": "enum",
-            "visibility": "system",
-            "required": true
-          },
-          {
-            "name": "active",
-            "apiKey": "active",
-            "column": "IsActive",
+            "name": "delivered",
+            "apiKey": "delivered",
+            "column": "IsDelivered",
             "type": "boolean",
             "visibility": "system",
             "required": true
-          },
-          {
-            "name": "reservationStatus",
-            "apiKey": "reservationStatus",
-            "column": "SO_Res_Status",
-            "type": "enum",
-            "visibility": "discarded",
-            "required": false
           },
           {
             "name": "deliveryLocation",
@@ -2706,12 +2689,28 @@
             "required": true
           },
           {
+            "name": "reservationStatus",
+            "apiKey": "reservationStatus",
+            "column": "SO_Res_Status",
+            "type": "enum",
+            "visibility": "discarded",
+            "required": false
+          },
+          {
             "name": "processNow",
             "apiKey": "processNow",
             "column": "Processing",
             "type": "button",
             "visibility": "system",
             "required": false
+          },
+          {
+            "name": "invoiceTerms",
+            "apiKey": "invoiceTerms",
+            "column": "InvoiceRule",
+            "type": "enum",
+            "visibility": "system",
+            "required": true
           },
           {
             "name": "accountingDate",
@@ -2738,9 +2737,9 @@
             "required": true
           },
           {
-            "name": "delivered",
-            "apiKey": "delivered",
-            "column": "IsDelivered",
+            "name": "active",
+            "apiKey": "active",
+            "column": "IsActive",
             "type": "boolean",
             "visibility": "system",
             "required": true
@@ -3266,6 +3265,14 @@
             "required": false
           },
           {
+            "name": "resourceAssignment",
+            "apiKey": "resourceAssignment",
+            "column": "S_ResourceAssignment_ID",
+            "type": "string",
+            "visibility": "system",
+            "required": false
+          },
+          {
             "name": "sOPOReference",
             "apiKey": "sOPOReference",
             "column": "Ref_OrderLine_ID",
@@ -3282,6 +3289,14 @@
             "required": true
           },
           {
+            "name": "salesOrder",
+            "apiKey": "salesOrder",
+            "column": "C_Order_ID",
+            "type": "foreignKey",
+            "visibility": "system",
+            "required": true
+          },
+          {
             "name": "priceAdjustment",
             "apiKey": "priceAdjustment",
             "column": "M_Offer_ID",
@@ -3290,19 +3305,19 @@
             "required": false
           },
           {
+            "name": "active",
+            "apiKey": "active",
+            "column": "IsActive",
+            "type": "boolean",
+            "visibility": "system",
+            "required": true
+          },
+          {
             "name": "cOrderDiscountID",
             "apiKey": "cOrderDiscountID",
             "column": "C_Order_Discount_ID",
             "type": "foreignKey",
             "visibility": "system",
-            "required": false
-          },
-          {
-            "name": "reservationStatus",
-            "apiKey": "reservationStatus",
-            "column": "SO_Res_Status",
-            "type": "enum",
-            "visibility": "discarded",
             "required": false
           },
           {
@@ -3322,6 +3337,14 @@
             "required": false
           },
           {
+            "name": "reservationStatus",
+            "apiKey": "reservationStatus",
+            "column": "SO_Res_Status",
+            "type": "enum",
+            "visibility": "discarded",
+            "required": false
+          },
+          {
             "name": "manageReservation",
             "apiKey": "manageReservation",
             "column": "Manage_Reservation",
@@ -3330,10 +3353,18 @@
             "required": false
           },
           {
-            "name": "directShipment",
-            "apiKey": "directShipment",
-            "column": "DirectShip",
-            "type": "boolean",
+            "name": "client",
+            "apiKey": "client",
+            "column": "AD_Client_ID",
+            "type": "foreignKey",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "id",
+            "apiKey": "id",
+            "column": "C_OrderLine_ID",
+            "type": "id",
             "visibility": "system",
             "required": true
           },
@@ -3346,43 +3377,11 @@
             "required": true
           },
           {
-            "name": "id",
-            "apiKey": "id",
-            "column": "C_OrderLine_ID",
-            "type": "id",
-            "visibility": "system",
-            "required": true
-          },
-          {
-            "name": "client",
-            "apiKey": "client",
-            "column": "AD_Client_ID",
-            "type": "foreignKey",
-            "visibility": "system",
-            "required": true
-          },
-          {
-            "name": "active",
-            "apiKey": "active",
-            "column": "IsActive",
-            "type": "boolean",
-            "visibility": "system",
-            "required": true
-          },
-          {
-            "name": "salesOrder",
-            "apiKey": "salesOrder",
-            "column": "C_Order_ID",
-            "type": "foreignKey",
-            "visibility": "system",
-            "required": true
-          },
-          {
-            "name": "dateDelivered",
-            "apiKey": "dateDelivered",
-            "column": "DateDelivered",
-            "type": "date",
-            "visibility": "system",
+            "name": "chargeAmount",
+            "apiKey": "chargeAmount",
+            "column": "ChargeAmt",
+            "type": "amount",
+            "visibility": "discarded",
             "required": false
           },
           {
@@ -3394,11 +3393,11 @@
             "required": false
           },
           {
-            "name": "chargeAmount",
-            "apiKey": "chargeAmount",
-            "column": "ChargeAmt",
-            "type": "amount",
-            "visibility": "discarded",
+            "name": "dateDelivered",
+            "apiKey": "dateDelivered",
+            "column": "DateDelivered",
+            "type": "date",
+            "visibility": "system",
             "required": false
           },
           {
@@ -3410,12 +3409,12 @@
             "required": true
           },
           {
-            "name": "resourceAssignment",
-            "apiKey": "resourceAssignment",
-            "column": "S_ResourceAssignment_ID",
-            "type": "string",
+            "name": "directShipment",
+            "apiKey": "directShipment",
+            "column": "DirectShip",
+            "type": "boolean",
             "visibility": "system",
-            "required": false
+            "required": true
           },
           {
             "name": "creationDate",
@@ -3530,30 +3529,6 @@
             "required": true
           },
           {
-            "name": "salesOrder",
-            "apiKey": "salesOrder",
-            "column": "C_Order_ID",
-            "type": "foreignKey",
-            "visibility": "system",
-            "required": true
-          },
-          {
-            "name": "salesOrderLine",
-            "apiKey": "salesOrderLine",
-            "column": "C_Orderline_ID",
-            "type": "foreignKey",
-            "visibility": "system",
-            "required": true
-          },
-          {
-            "name": "cOrderlinetaxID",
-            "apiKey": "cOrderlinetaxID",
-            "column": "C_Orderlinetax_ID",
-            "type": "id",
-            "visibility": "system",
-            "required": true
-          },
-          {
             "name": "organization",
             "apiKey": "organization",
             "column": "AD_Org_ID",
@@ -3573,6 +3548,30 @@
             "name": "client",
             "apiKey": "client",
             "column": "AD_Client_ID",
+            "type": "foreignKey",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "cOrderlinetaxID",
+            "apiKey": "cOrderlinetaxID",
+            "column": "C_Orderlinetax_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "salesOrderLine",
+            "apiKey": "salesOrderLine",
+            "column": "C_Orderline_ID",
+            "type": "foreignKey",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "salesOrder",
+            "apiKey": "salesOrder",
+            "column": "C_Order_ID",
             "type": "foreignKey",
             "visibility": "system",
             "required": true
@@ -3673,20 +3672,20 @@
             "required": false
           },
           {
-            "name": "salesOrderLine",
-            "apiKey": "salesOrderLine",
-            "column": "C_Orderline_ID",
-            "type": "foreignKey",
-            "visibility": "system",
-            "required": false
-          },
-          {
             "name": "active",
             "apiKey": "active",
             "column": "Isactive",
             "type": "boolean",
             "visibility": "system",
             "required": true
+          },
+          {
+            "name": "salesOrderLine",
+            "apiKey": "salesOrderLine",
+            "column": "C_Orderline_ID",
+            "type": "foreignKey",
+            "visibility": "system",
+            "required": false
           },
           {
             "name": "organization",
@@ -3808,19 +3807,19 @@
             "required": true
           },
           {
-            "name": "writeoffAmount",
-            "apiKey": "writeoffAmount",
-            "column": "Writeoffamt",
-            "type": "amount",
-            "visibility": "readOnly",
-            "required": false
-          },
-          {
             "name": "currency",
             "apiKey": "currency",
             "column": "C_Currency_ID",
             "type": "foreignKey",
             "visibility": "system",
+            "required": false
+          },
+          {
+            "name": "writeoffAmount",
+            "apiKey": "writeoffAmount",
+            "column": "Writeoffamt",
+            "type": "amount",
+            "visibility": "readOnly",
             "required": false
           },
           {
@@ -3888,12 +3887,20 @@
             "required": false
           },
           {
-            "name": "invoiceAmount",
-            "apiKey": "invoiceAmount",
-            "column": "Invoicedamt",
-            "type": "amount",
+            "name": "businessPartner",
+            "apiKey": "businessPartner",
+            "column": "C_Bpartner_ID",
+            "type": "foreignKey",
             "visibility": "system",
-            "required": false
+            "required": true
+          },
+          {
+            "name": "organization",
+            "apiKey": "organization",
+            "column": "AD_Org_ID",
+            "type": "foreignKey",
+            "visibility": "system",
+            "required": true
           },
           {
             "name": "finPaymentDetailVID",
@@ -3904,26 +3911,26 @@
             "required": true
           },
           {
-            "name": "orderPaymentPlan",
-            "apiKey": "orderPaymentPlan",
-            "column": "Fin_Payment_Sched_Ord_V_Id",
-            "type": "foreignKey",
+            "name": "invoiceAmount",
+            "apiKey": "invoiceAmount",
+            "column": "Invoicedamt",
+            "type": "amount",
             "visibility": "system",
             "required": false
-          },
-          {
-            "name": "businessPartner",
-            "apiKey": "businessPartner",
-            "column": "C_Bpartner_ID",
-            "type": "foreignKey",
-            "visibility": "system",
-            "required": true
           },
           {
             "name": "active",
             "apiKey": "active",
             "column": "Isactive",
             "type": "boolean",
+            "visibility": "system",
+            "required": false
+          },
+          {
+            "name": "orderPaymentPlan",
+            "apiKey": "orderPaymentPlan",
+            "column": "Fin_Payment_Sched_Ord_V_Id",
+            "type": "foreignKey",
             "visibility": "system",
             "required": false
           },
@@ -3942,14 +3949,6 @@
             "type": "string",
             "visibility": "system",
             "required": false
-          },
-          {
-            "name": "organization",
-            "apiKey": "organization",
-            "column": "AD_Org_ID",
-            "type": "foreignKey",
-            "visibility": "system",
-            "required": true
           },
           {
             "name": "activity",
@@ -3984,14 +3983,6 @@
             "required": false
           },
           {
-            "name": "salesRegion",
-            "apiKey": "salesRegion",
-            "column": "C_Salesregion_ID",
-            "type": "foreignKey",
-            "visibility": "system",
-            "required": false
-          },
-          {
             "name": "creationDate",
             "apiKey": "creationDate",
             "column": "Created",
@@ -4006,6 +3997,14 @@
             "type": "foreignKey",
             "visibility": "system",
             "required": true
+          },
+          {
+            "name": "salesRegion",
+            "apiKey": "salesRegion",
+            "column": "C_Salesregion_ID",
+            "type": "foreignKey",
+            "visibility": "system",
+            "required": false
           },
           {
             "name": "aPRMDisplayedAcc",
@@ -7476,28 +7475,12 @@
         "id": "t-338",
         "category": "system-field",
         "entity": "header",
-        "field": "invoiceTerms",
+        "field": "delivered",
         "runner": "node",
-        "description": "System field 'invoiceTerms' should exist in backend but not frontend for header"
+        "description": "System field 'delivered' should exist in backend but not frontend for header"
       },
       {
         "id": "t-339",
-        "category": "system-field",
-        "entity": "header",
-        "field": "active",
-        "runner": "node",
-        "description": "System field 'active' should exist in backend but not frontend for header"
-      },
-      {
-        "id": "t-340",
-        "category": "system-field",
-        "entity": "header",
-        "field": "reservationStatus",
-        "runner": "node",
-        "description": "System field 'reservationStatus' should exist in backend but not frontend for header"
-      },
-      {
-        "id": "t-341",
         "category": "system-field",
         "entity": "header",
         "field": "deliveryLocation",
@@ -7505,7 +7488,7 @@
         "description": "System field 'deliveryLocation' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-342",
+        "id": "t-340",
         "category": "system-field",
         "entity": "header",
         "field": "selfService",
@@ -7513,7 +7496,7 @@
         "description": "System field 'selfService' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-343",
+        "id": "t-341",
         "category": "system-field",
         "entity": "header",
         "field": "dropShipLocation",
@@ -7521,7 +7504,7 @@
         "description": "System field 'dropShipLocation' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-344",
+        "id": "t-342",
         "category": "system-field",
         "entity": "header",
         "field": "dropShipPartner",
@@ -7529,7 +7512,7 @@
         "description": "System field 'dropShipPartner' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-345",
+        "id": "t-343",
         "category": "system-field",
         "entity": "header",
         "field": "dropShipContact",
@@ -7537,7 +7520,7 @@
         "description": "System field 'dropShipContact' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-346",
+        "id": "t-344",
         "category": "system-field",
         "entity": "header",
         "field": "selected",
@@ -7545,7 +7528,7 @@
         "description": "System field 'selected' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-347",
+        "id": "t-345",
         "category": "system-field",
         "entity": "header",
         "field": "posted",
@@ -7553,7 +7536,7 @@
         "description": "System field 'posted' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-348",
+        "id": "t-346",
         "category": "system-field",
         "entity": "header",
         "field": "formOfPayment",
@@ -7561,7 +7544,7 @@
         "description": "System field 'formOfPayment' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-349",
+        "id": "t-347",
         "category": "system-field",
         "entity": "header",
         "field": "salesTransaction",
@@ -7569,7 +7552,7 @@
         "description": "System field 'salesTransaction' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-350",
+        "id": "t-348",
         "category": "system-field",
         "entity": "header",
         "field": "datePrinted",
@@ -7577,7 +7560,7 @@
         "description": "System field 'datePrinted' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-351",
+        "id": "t-349",
         "category": "system-field",
         "entity": "header",
         "field": "processed",
@@ -7585,12 +7568,28 @@
         "description": "System field 'processed' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-352",
+        "id": "t-350",
+        "category": "system-field",
+        "entity": "header",
+        "field": "reservationStatus",
+        "runner": "node",
+        "description": "System field 'reservationStatus' should exist in backend but not frontend for header"
+      },
+      {
+        "id": "t-351",
         "category": "system-field",
         "entity": "header",
         "field": "processNow",
         "runner": "node",
         "description": "System field 'processNow' should exist in backend but not frontend for header"
+      },
+      {
+        "id": "t-352",
+        "category": "system-field",
+        "entity": "header",
+        "field": "invoiceTerms",
+        "runner": "node",
+        "description": "System field 'invoiceTerms' should exist in backend but not frontend for header"
       },
       {
         "id": "t-353",
@@ -7612,9 +7611,9 @@
         "id": "t-355",
         "category": "system-field",
         "entity": "header",
-        "field": "delivered",
+        "field": "active",
         "runner": "node",
-        "description": "System field 'delivered' should exist in backend but not frontend for header"
+        "description": "System field 'active' should exist in backend but not frontend for header"
       },
       {
         "id": "t-356",
@@ -7884,12 +7883,20 @@
         "id": "t-389",
         "category": "system-field",
         "entity": "lines",
+        "field": "resourceAssignment",
+        "runner": "node",
+        "description": "System field 'resourceAssignment' should exist in backend but not frontend for lines"
+      },
+      {
+        "id": "t-390",
+        "category": "system-field",
+        "entity": "lines",
         "field": "sOPOReference",
         "runner": "node",
         "description": "System field 'sOPOReference' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-390",
+        "id": "t-391",
         "category": "system-field",
         "entity": "lines",
         "field": "descriptionOnly",
@@ -7897,87 +7904,7 @@
         "description": "System field 'descriptionOnly' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-391",
-        "category": "system-field",
-        "entity": "lines",
-        "field": "priceAdjustment",
-        "runner": "node",
-        "description": "System field 'priceAdjustment' should exist in backend but not frontend for lines"
-      },
-      {
         "id": "t-392",
-        "category": "system-field",
-        "entity": "lines",
-        "field": "cOrderDiscountID",
-        "runner": "node",
-        "description": "System field 'cOrderDiscountID' should exist in backend but not frontend for lines"
-      },
-      {
-        "id": "t-393",
-        "category": "system-field",
-        "entity": "lines",
-        "field": "reservationStatus",
-        "runner": "node",
-        "description": "System field 'reservationStatus' should exist in backend but not frontend for lines"
-      },
-      {
-        "id": "t-394",
-        "category": "system-field",
-        "entity": "lines",
-        "field": "warehouseRule",
-        "runner": "node",
-        "description": "System field 'warehouseRule' should exist in backend but not frontend for lines"
-      },
-      {
-        "id": "t-395",
-        "category": "system-field",
-        "entity": "lines",
-        "field": "createReservation",
-        "runner": "node",
-        "description": "System field 'createReservation' should exist in backend but not frontend for lines"
-      },
-      {
-        "id": "t-396",
-        "category": "system-field",
-        "entity": "lines",
-        "field": "manageReservation",
-        "runner": "node",
-        "description": "System field 'manageReservation' should exist in backend but not frontend for lines"
-      },
-      {
-        "id": "t-397",
-        "category": "system-field",
-        "entity": "lines",
-        "field": "directShipment",
-        "runner": "node",
-        "description": "System field 'directShipment' should exist in backend but not frontend for lines"
-      },
-      {
-        "id": "t-398",
-        "category": "system-field",
-        "entity": "lines",
-        "field": "id",
-        "runner": "node",
-        "description": "System field 'id' should exist in backend but not frontend for lines"
-      },
-      {
-        "id": "t-399",
-        "category": "system-field",
-        "entity": "lines",
-        "field": "client",
-        "runner": "node",
-        "description": "System field 'client' should exist in backend but not frontend for lines"
-      },
-      {
-        "id": "t-400",
-        "category": "system-field",
-        "entity": "lines",
-        "field": "active",
-        "runner": "node",
-        "description": "System field 'active' should exist in backend but not frontend for lines"
-      },
-      {
-        "id": "t-401",
         "category": "system-field",
         "entity": "lines",
         "field": "salesOrder",
@@ -7985,12 +7912,84 @@
         "description": "System field 'salesOrder' should exist in backend but not frontend for lines"
       },
       {
+        "id": "t-393",
+        "category": "system-field",
+        "entity": "lines",
+        "field": "priceAdjustment",
+        "runner": "node",
+        "description": "System field 'priceAdjustment' should exist in backend but not frontend for lines"
+      },
+      {
+        "id": "t-394",
+        "category": "system-field",
+        "entity": "lines",
+        "field": "active",
+        "runner": "node",
+        "description": "System field 'active' should exist in backend but not frontend for lines"
+      },
+      {
+        "id": "t-395",
+        "category": "system-field",
+        "entity": "lines",
+        "field": "cOrderDiscountID",
+        "runner": "node",
+        "description": "System field 'cOrderDiscountID' should exist in backend but not frontend for lines"
+      },
+      {
+        "id": "t-396",
+        "category": "system-field",
+        "entity": "lines",
+        "field": "warehouseRule",
+        "runner": "node",
+        "description": "System field 'warehouseRule' should exist in backend but not frontend for lines"
+      },
+      {
+        "id": "t-397",
+        "category": "system-field",
+        "entity": "lines",
+        "field": "createReservation",
+        "runner": "node",
+        "description": "System field 'createReservation' should exist in backend but not frontend for lines"
+      },
+      {
+        "id": "t-398",
+        "category": "system-field",
+        "entity": "lines",
+        "field": "reservationStatus",
+        "runner": "node",
+        "description": "System field 'reservationStatus' should exist in backend but not frontend for lines"
+      },
+      {
+        "id": "t-399",
+        "category": "system-field",
+        "entity": "lines",
+        "field": "manageReservation",
+        "runner": "node",
+        "description": "System field 'manageReservation' should exist in backend but not frontend for lines"
+      },
+      {
+        "id": "t-400",
+        "category": "system-field",
+        "entity": "lines",
+        "field": "client",
+        "runner": "node",
+        "description": "System field 'client' should exist in backend but not frontend for lines"
+      },
+      {
+        "id": "t-401",
+        "category": "system-field",
+        "entity": "lines",
+        "field": "id",
+        "runner": "node",
+        "description": "System field 'id' should exist in backend but not frontend for lines"
+      },
+      {
         "id": "t-402",
         "category": "system-field",
         "entity": "lines",
-        "field": "dateDelivered",
+        "field": "chargeAmount",
         "runner": "node",
-        "description": "System field 'dateDelivered' should exist in backend but not frontend for lines"
+        "description": "System field 'chargeAmount' should exist in backend but not frontend for lines"
       },
       {
         "id": "t-403",
@@ -8004,9 +8003,9 @@
         "id": "t-404",
         "category": "system-field",
         "entity": "lines",
-        "field": "chargeAmount",
+        "field": "dateDelivered",
         "runner": "node",
-        "description": "System field 'chargeAmount' should exist in backend but not frontend for lines"
+        "description": "System field 'dateDelivered' should exist in backend but not frontend for lines"
       },
       {
         "id": "t-405",
@@ -8020,9 +8019,9 @@
         "id": "t-406",
         "category": "system-field",
         "entity": "lines",
-        "field": "resourceAssignment",
+        "field": "directShipment",
         "runner": "node",
-        "description": "System field 'resourceAssignment' should exist in backend but not frontend for lines"
+        "description": "System field 'directShipment' should exist in backend but not frontend for lines"
       },
       {
         "id": "t-407",
@@ -8100,36 +8099,12 @@
         "id": "t-416",
         "category": "system-field",
         "entity": "lineTax",
-        "field": "salesOrder",
-        "runner": "node",
-        "description": "System field 'salesOrder' should exist in backend but not frontend for lineTax"
-      },
-      {
-        "id": "t-417",
-        "category": "system-field",
-        "entity": "lineTax",
-        "field": "salesOrderLine",
-        "runner": "node",
-        "description": "System field 'salesOrderLine' should exist in backend but not frontend for lineTax"
-      },
-      {
-        "id": "t-418",
-        "category": "system-field",
-        "entity": "lineTax",
-        "field": "cOrderlinetaxID",
-        "runner": "node",
-        "description": "System field 'cOrderlinetaxID' should exist in backend but not frontend for lineTax"
-      },
-      {
-        "id": "t-419",
-        "category": "system-field",
-        "entity": "lineTax",
         "field": "organization",
         "runner": "node",
         "description": "System field 'organization' should exist in backend but not frontend for lineTax"
       },
       {
-        "id": "t-420",
+        "id": "t-417",
         "category": "system-field",
         "entity": "lineTax",
         "field": "active",
@@ -8137,12 +8112,36 @@
         "description": "System field 'active' should exist in backend but not frontend for lineTax"
       },
       {
-        "id": "t-421",
+        "id": "t-418",
         "category": "system-field",
         "entity": "lineTax",
         "field": "client",
         "runner": "node",
         "description": "System field 'client' should exist in backend but not frontend for lineTax"
+      },
+      {
+        "id": "t-419",
+        "category": "system-field",
+        "entity": "lineTax",
+        "field": "cOrderlinetaxID",
+        "runner": "node",
+        "description": "System field 'cOrderlinetaxID' should exist in backend but not frontend for lineTax"
+      },
+      {
+        "id": "t-420",
+        "category": "system-field",
+        "entity": "lineTax",
+        "field": "salesOrderLine",
+        "runner": "node",
+        "description": "System field 'salesOrderLine' should exist in backend but not frontend for lineTax"
+      },
+      {
+        "id": "t-421",
+        "category": "system-field",
+        "entity": "lineTax",
+        "field": "salesOrder",
+        "runner": "node",
+        "description": "System field 'salesOrder' should exist in backend but not frontend for lineTax"
       },
       {
         "id": "t-422",
@@ -8180,17 +8179,17 @@
         "id": "t-426",
         "category": "system-field",
         "entity": "reservedStock",
-        "field": "salesOrderLine",
+        "field": "active",
         "runner": "node",
-        "description": "System field 'salesOrderLine' should exist in backend but not frontend for reservedStock"
+        "description": "System field 'active' should exist in backend but not frontend for reservedStock"
       },
       {
         "id": "t-427",
         "category": "system-field",
         "entity": "reservedStock",
-        "field": "active",
+        "field": "salesOrderLine",
         "runner": "node",
-        "description": "System field 'active' should exist in backend but not frontend for reservedStock"
+        "description": "System field 'salesOrderLine' should exist in backend but not frontend for reservedStock"
       },
       {
         "id": "t-428",
@@ -8284,12 +8283,20 @@
         "id": "t-439",
         "category": "system-field",
         "entity": "paymentDetails",
-        "field": "invoiceAmount",
+        "field": "businessPartner",
         "runner": "node",
-        "description": "System field 'invoiceAmount' should exist in backend but not frontend for paymentDetails"
+        "description": "System field 'businessPartner' should exist in backend but not frontend for paymentDetails"
       },
       {
         "id": "t-440",
+        "category": "system-field",
+        "entity": "paymentDetails",
+        "field": "organization",
+        "runner": "node",
+        "description": "System field 'organization' should exist in backend but not frontend for paymentDetails"
+      },
+      {
+        "id": "t-441",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "finPaymentDetailVID",
@@ -8297,20 +8304,12 @@
         "description": "System field 'finPaymentDetailVID' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-441",
-        "category": "system-field",
-        "entity": "paymentDetails",
-        "field": "orderPaymentPlan",
-        "runner": "node",
-        "description": "System field 'orderPaymentPlan' should exist in backend but not frontend for paymentDetails"
-      },
-      {
         "id": "t-442",
         "category": "system-field",
         "entity": "paymentDetails",
-        "field": "businessPartner",
+        "field": "invoiceAmount",
         "runner": "node",
-        "description": "System field 'businessPartner' should exist in backend but not frontend for paymentDetails"
+        "description": "System field 'invoiceAmount' should exist in backend but not frontend for paymentDetails"
       },
       {
         "id": "t-443",
@@ -8324,25 +8323,25 @@
         "id": "t-444",
         "category": "system-field",
         "entity": "paymentDetails",
-        "field": "client",
+        "field": "orderPaymentPlan",
         "runner": "node",
-        "description": "System field 'client' should exist in backend but not frontend for paymentDetails"
+        "description": "System field 'orderPaymentPlan' should exist in backend but not frontend for paymentDetails"
       },
       {
         "id": "t-445",
         "category": "system-field",
         "entity": "paymentDetails",
-        "field": "invoiceno",
+        "field": "client",
         "runner": "node",
-        "description": "System field 'invoiceno' should exist in backend but not frontend for paymentDetails"
+        "description": "System field 'client' should exist in backend but not frontend for paymentDetails"
       },
       {
         "id": "t-446",
         "category": "system-field",
         "entity": "paymentDetails",
-        "field": "organization",
+        "field": "invoiceno",
         "runner": "node",
-        "description": "System field 'organization' should exist in backend but not frontend for paymentDetails"
+        "description": "System field 'invoiceno' should exist in backend but not frontend for paymentDetails"
       },
       {
         "id": "t-447",
@@ -8380,25 +8379,25 @@
         "id": "t-451",
         "category": "system-field",
         "entity": "paymentDetails",
-        "field": "salesRegion",
-        "runner": "node",
-        "description": "System field 'salesRegion' should exist in backend but not frontend for paymentDetails"
-      },
-      {
-        "id": "t-452",
-        "category": "system-field",
-        "entity": "paymentDetails",
         "field": "creationDate",
         "runner": "node",
         "description": "System field 'creationDate' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-453",
+        "id": "t-452",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "createdBy",
         "runner": "node",
         "description": "System field 'createdBy' should exist in backend but not frontend for paymentDetails"
+      },
+      {
+        "id": "t-453",
+        "category": "system-field",
+        "entity": "paymentDetails",
+        "field": "salesRegion",
+        "runner": "node",
+        "description": "System field 'salesRegion' should exist in backend but not frontend for paymentDetails"
       },
       {
         "id": "t-454",
@@ -8712,23 +8711,23 @@
       {
         "id": "t-497",
         "category": "rule-declared",
-        "rule": "C_BPartner Location - Bill To",
-        "runner": "node",
-        "description": "Rule 'C_BPartner Location - Bill To' (validation) should be declared"
-      },
-      {
-        "id": "t-498",
-        "category": "rule-declared",
         "rule": "C_DocType PO/SO",
         "runner": "node",
         "description": "Rule 'C_DocType PO/SO' (validation) should be declared"
       },
       {
-        "id": "t-499",
+        "id": "t-498",
         "category": "rule-declared",
         "rule": "AD_User - Org Tree",
         "runner": "node",
         "description": "Rule 'AD_User - Org Tree' (validation) should be declared"
+      },
+      {
+        "id": "t-499",
+        "category": "rule-declared",
+        "rule": "C_BPartner Location - Bill To",
+        "runner": "node",
+        "description": "Rule 'C_BPartner Location - Bill To' (validation) should be declared"
       },
       {
         "id": "t-500",

--- a/artifacts/purchase-order/decisions.json
+++ b/artifacts/purchase-order/decisions.json
@@ -92,8 +92,7 @@
         },
         "warehouse": {
           "grid": true,
-          "form": true,
-          "section": "collapsed"
+          "form": false
         },
         "scheduledDeliveryDate": {
           "section": "principal",
@@ -103,15 +102,15 @@
         "paymentMethod": {
           "reference": "PaymentMethod",
           "form": true,
-          "section": "collapsed"
+          "section": "principal"
         },
         "paymentTerms": {
           "form": false,
-          "section": "collapsed"
+          "section": "principal"
         },
         "priceList": {
           "grid": true,
-          "section": "collapsed",
+          "section": "principal",
           "form": true
         },
         "invoiceAddress": {

--- a/artifacts/purchase-order/generated/web/purchase-order/HeaderForm.jsx
+++ b/artifacts/purchase-order/generated/web/purchase-order/HeaderForm.jsx
@@ -7,9 +7,8 @@ const fields = [
   { key: 'orderDate', column: 'DateOrdered', type: 'date', label: 'Order Date', required: true, section: 'principal', defaultValue: '@#Date@', readOnlyLogic: (record) => record['processed'] === true },
   { key: 'partnerAddress', column: 'C_BPartner_Location_ID', type: 'dependent', label: 'Partner Address', required: true, section: 'principal', reference: 'BusinessPartnerLocation', inputMode: 'dependent', dependsOn: { field: 'businessPartner', filterKey: 'C_BPartner_ID' }, readOnlyLogic: (record) => record['processed'] === true || record['documentStatus'] === 'TMP' },
   { key: 'scheduledDeliveryDate', column: 'DatePromised', type: 'date', label: 'Scheduled Delivery Date', required: true, section: 'principal', defaultValue: '@#Date@', readOnlyLogic: (record) => record['processed'] === true },
-  { key: 'warehouse', column: 'M_Warehouse_ID', type: 'selector', label: 'Warehouse', required: true, section: 'collapsed', reference: 'Warehouse', inputMode: 'selector', readOnlyLogic: (record) => record['processed'] === true },
-  { key: 'paymentMethod', column: 'FIN_Paymentmethod_ID', type: 'selector', label: 'Payment Method', section: 'collapsed', reference: 'PaymentMethod', inputMode: 'selector', readOnlyLogic: (record) => record['processed'] === true },
-  { key: 'priceList', column: 'M_PriceList_ID', type: 'selector', label: 'Price List', required: true, section: 'collapsed', reference: 'PriceList', inputMode: 'selector', readOnlyLogic: (record) => record['processed'] === true || record['documentStatus'] === 'TMP' },
+  { key: 'paymentMethod', column: 'FIN_Paymentmethod_ID', type: 'selector', label: 'Payment Method', section: 'principal', reference: 'PaymentMethod', inputMode: 'selector', readOnlyLogic: (record) => record['processed'] === true },
+  { key: 'priceList', column: 'M_PriceList_ID', type: 'selector', label: 'Price List', required: true, section: 'principal', reference: 'PriceList', inputMode: 'selector', readOnlyLogic: (record) => record['processed'] === true || record['documentStatus'] === 'TMP' },
 ];
 // @sf-generated-end fields:header
 
@@ -17,5 +16,5 @@ const fields = [
 export default function HeaderForm(props) {
   return <EntityForm fields={fields} {...props} />;
 }
-HeaderForm.hasCollapsedFields = true;
+HeaderForm.hasCollapsedFields = false;
 // @sf-generated-end component:HeaderForm

--- a/artifacts/sales-order/contract.json
+++ b/artifacts/sales-order/contract.json
@@ -1,7 +1,7 @@
 {
   "version": "0.15.0",
-  "generatedAt": "2026-04-16T13:46:42.082Z",
-  "checksum": "d4d446bd6324007b",
+  "generatedAt": "2026-04-20T13:34:07.228Z",
+  "checksum": "8faafdda83d5d7fa",
   "frontendContract": {
     "window": {
       "id": "143",
@@ -17,10 +17,6 @@
         "topbarExtra": "OrderDraftChips"
       },
       "menuActions": [
-        {
-          "key": "duplicate",
-          "label": "Duplicate"
-        },
         {
           "key": "cancel",
           "label": "Cancel",
@@ -161,7 +157,7 @@
             "form": true,
             "reference": "PriceList",
             "inputMode": "selector",
-            "section": "collapsed",
+            "section": "principal",
             "validationRule": {
               "code": "M_PriceList.issopricelist = @isSOTrx@",
               "contextParams": [],
@@ -191,7 +187,7 @@
             "form": true,
             "reference": "PaymentMethod",
             "inputMode": "selector",
-            "section": "collapsed",
+            "section": "principal",
             "validationRule": {
               "code": "EXISTS (SELECT 1 FROM FIN_FinAcc_PaymentMethod fapm WHERE FIN_PaymentMethod.FIN_PaymentMethod_ID=fapm.FIN_PaymentMethod_ID\nAND fapm.Payin_Allow = (SELECT CASE WHEN '@IsSOTrx@'='Y' THEN 'Y' ELSE fapm.Payin_Allow END FROM DUAL)\nAND fapm.Payout_Allow = (SELECT CASE WHEN '@IsSOTrx@'='N' THEN 'Y' ELSE fapm.Payout_Allow END FROM DUAL))",
               "contextParams": [],
@@ -215,10 +211,9 @@
             "visibility": "editable",
             "required": true,
             "grid": false,
-            "form": true,
+            "form": false,
             "reference": "Warehouse",
             "inputMode": "search",
-            "section": "collapsed",
             "readOnlyLogic": {
               "raw": "@Processed@='Y'",
               "evaluable": true,
@@ -356,8 +351,7 @@
             "visibility": "editable",
             "required": false,
             "grid": false,
-            "form": true,
-            "section": "collapsed"
+            "form": false
           },
           {
             "name": "deliveryStatus",
@@ -645,10 +639,6 @@
         "topbarExtra": "OrderDraftChips"
       },
       "menuActions": [
-        {
-          "key": "duplicate",
-          "label": "Duplicate"
-        },
         {
           "key": "cancel",
           "label": "Cancel",
@@ -1027,19 +1017,19 @@
             "required": false
           },
           {
-            "name": "quotation",
-            "apiKey": "quotation",
-            "column": "Quotation_ID",
-            "type": "foreignKey",
-            "visibility": "system",
-            "required": false
-          },
-          {
             "name": "deliveryStatus",
             "apiKey": "deliveryStatus",
             "column": "DeliveryStatus",
             "type": "integer",
             "visibility": "readOnly",
+            "required": false
+          },
+          {
+            "name": "quotation",
+            "apiKey": "quotation",
+            "column": "Quotation_ID",
+            "type": "foreignKey",
+            "visibility": "system",
             "required": false
           },
           {
@@ -1227,12 +1217,100 @@
             "required": false
           },
           {
+            "name": "datePrinted",
+            "apiKey": "datePrinted",
+            "column": "DatePrinted",
+            "type": "date",
+            "visibility": "system",
+            "required": false
+          },
+          {
+            "name": "salesTransaction",
+            "apiKey": "salesTransaction",
+            "column": "IsSOTrx",
+            "type": "boolean",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "formOfPayment",
+            "apiKey": "formOfPayment",
+            "column": "PaymentRule",
+            "type": "enum",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "posted",
+            "apiKey": "posted",
+            "column": "Posted",
+            "type": "button",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "priceIncludesTax",
+            "apiKey": "priceIncludesTax",
+            "column": "IsTaxIncluded",
+            "type": "boolean",
+            "visibility": "discarded",
+            "required": false
+          },
+          {
+            "name": "selected",
+            "apiKey": "selected",
+            "column": "IsSelected",
+            "type": "boolean",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "dropShipContact",
+            "apiKey": "dropShipContact",
+            "column": "DropShip_User_ID",
+            "type": "foreignKey",
+            "visibility": "system",
+            "required": false
+          },
+          {
+            "name": "dropShipPartner",
+            "apiKey": "dropShipPartner",
+            "column": "DropShip_BPartner_ID",
+            "type": "foreignKey",
+            "visibility": "system",
+            "required": false
+          },
+          {
             "name": "dropShipLocation",
             "apiKey": "dropShipLocation",
             "column": "DropShip_Location_ID",
             "type": "foreignKey",
             "visibility": "system",
             "required": false
+          },
+          {
+            "name": "selfService",
+            "apiKey": "selfService",
+            "column": "IsSelfService",
+            "type": "boolean",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "iNCOTERMSDescription",
+            "apiKey": "iNCOTERMSDescription",
+            "column": "Incotermsdescription",
+            "type": "text",
+            "visibility": "system",
+            "required": false
+          },
+          {
+            "name": "accountingDate",
+            "apiKey": "accountingDate",
+            "column": "DateAcct",
+            "type": "date",
+            "visibility": "system",
+            "required": true
           },
           {
             "name": "print",
@@ -1275,6 +1353,14 @@
             "required": true
           },
           {
+            "name": "active",
+            "apiKey": "active",
+            "column": "IsActive",
+            "type": "boolean",
+            "visibility": "system",
+            "required": true
+          },
+          {
             "name": "processNow",
             "apiKey": "processNow",
             "column": "Processing",
@@ -1291,98 +1377,10 @@
             "required": true
           },
           {
-            "name": "datePrinted",
-            "apiKey": "datePrinted",
-            "column": "DatePrinted",
-            "type": "date",
-            "visibility": "system",
-            "required": false
-          },
-          {
-            "name": "active",
-            "apiKey": "active",
-            "column": "IsActive",
-            "type": "boolean",
-            "visibility": "system",
-            "required": true
-          },
-          {
-            "name": "salesTransaction",
-            "apiKey": "salesTransaction",
-            "column": "IsSOTrx",
-            "type": "boolean",
-            "visibility": "system",
-            "required": true
-          },
-          {
-            "name": "formOfPayment",
-            "apiKey": "formOfPayment",
-            "column": "PaymentRule",
-            "type": "enum",
-            "visibility": "system",
-            "required": true
-          },
-          {
-            "name": "posted",
-            "apiKey": "posted",
-            "column": "Posted",
+            "name": "generateTemplate",
+            "apiKey": "generateTemplate",
+            "column": "Generatetemplate",
             "type": "button",
-            "visibility": "system",
-            "required": true
-          },
-          {
-            "name": "priceIncludesTax",
-            "apiKey": "priceIncludesTax",
-            "column": "IsTaxIncluded",
-            "type": "boolean",
-            "visibility": "discarded",
-            "required": false
-          },
-          {
-            "name": "accountingDate",
-            "apiKey": "accountingDate",
-            "column": "DateAcct",
-            "type": "date",
-            "visibility": "system",
-            "required": true
-          },
-          {
-            "name": "selected",
-            "apiKey": "selected",
-            "column": "IsSelected",
-            "type": "boolean",
-            "visibility": "system",
-            "required": true
-          },
-          {
-            "name": "dropShipContact",
-            "apiKey": "dropShipContact",
-            "column": "DropShip_User_ID",
-            "type": "foreignKey",
-            "visibility": "system",
-            "required": false
-          },
-          {
-            "name": "dropShipPartner",
-            "apiKey": "dropShipPartner",
-            "column": "DropShip_BPartner_ID",
-            "type": "foreignKey",
-            "visibility": "system",
-            "required": false
-          },
-          {
-            "name": "iNCOTERMSDescription",
-            "apiKey": "iNCOTERMSDescription",
-            "column": "Incotermsdescription",
-            "type": "text",
-            "visibility": "system",
-            "required": false
-          },
-          {
-            "name": "incoterms",
-            "apiKey": "incoterms",
-            "column": "C_Incoterms_ID",
-            "type": "foreignKey",
             "visibility": "system",
             "required": false
           },
@@ -1395,26 +1393,10 @@
             "required": false
           },
           {
-            "name": "generateTemplate",
-            "apiKey": "generateTemplate",
-            "column": "Generatetemplate",
-            "type": "button",
-            "visibility": "system",
-            "required": false
-          },
-          {
-            "name": "selfService",
-            "apiKey": "selfService",
-            "column": "IsSelfService",
-            "type": "boolean",
-            "visibility": "system",
-            "required": true
-          },
-          {
-            "name": "createPOLines",
-            "apiKey": "createPOLines",
-            "column": "Create_POLines",
-            "type": "button",
+            "name": "incoterms",
+            "apiKey": "incoterms",
+            "column": "C_Incoterms_ID",
+            "type": "foreignKey",
             "visibility": "system",
             "required": false
           },
@@ -1433,6 +1415,14 @@
             "type": "foreignKey",
             "visibility": "system",
             "required": true
+          },
+          {
+            "name": "createPOLines",
+            "apiKey": "createPOLines",
+            "column": "Create_POLines",
+            "type": "button",
+            "visibility": "system",
+            "required": false
           },
           {
             "name": "deliveryStatusPurchase",
@@ -1515,20 +1505,20 @@
             "required": false
           },
           {
-            "name": "goodsShipmentLine",
-            "apiKey": "goodsShipmentLine",
-            "column": "M_Inoutline_ID",
-            "type": "foreignKey",
-            "visibility": "discarded",
-            "required": false
-          },
-          {
             "name": "orderedQuantity",
             "apiKey": "orderedQuantity",
             "column": "QtyOrdered",
             "type": "quantity",
             "visibility": "editable",
             "required": true
+          },
+          {
+            "name": "goodsShipmentLine",
+            "apiKey": "goodsShipmentLine",
+            "column": "M_Inoutline_ID",
+            "type": "foreignKey",
+            "visibility": "discarded",
+            "required": false
           },
           {
             "name": "uOM",
@@ -1771,17 +1761,17 @@
             "required": false
           },
           {
-            "name": "standardPrice",
-            "apiKey": "standardPrice",
-            "column": "PriceStd",
+            "name": "baseGrossUnitPrice",
+            "apiKey": "baseGrossUnitPrice",
+            "column": "grosspricestd",
             "type": "price",
             "visibility": "system",
             "required": true
           },
           {
-            "name": "baseGrossUnitPrice",
-            "apiKey": "baseGrossUnitPrice",
-            "column": "grosspricestd",
+            "name": "standardPrice",
+            "apiKey": "standardPrice",
+            "column": "PriceStd",
             "type": "price",
             "visibility": "system",
             "required": true
@@ -2346,19 +2336,19 @@
       },
       {
         "entity": "header",
-        "field": "processNow",
-        "column": "Processing",
-        "url": "/sws/neo/sales-order/header/{id}/action/processNow",
-        "processId": "104",
-        "processType": "classic"
-      },
-      {
-        "entity": "header",
         "field": "posted",
         "column": "Posted",
         "url": "/sws/neo/sales-order/header/{id}/action/posted",
         "processId": "57496FB9CF9E4E8F847224017941570E",
         "processType": "obuiapp"
+      },
+      {
+        "entity": "header",
+        "field": "processNow",
+        "column": "Processing",
+        "url": "/sws/neo/sales-order/header/{id}/action/processNow",
+        "processId": "104",
+        "processType": "classic"
       },
       {
         "entity": "header",
@@ -3542,76 +3532,12 @@
         "id": "t-138",
         "category": "system-field",
         "entity": "header",
-        "field": "dropShipLocation",
-        "runner": "node",
-        "description": "System field 'dropShipLocation' should exist in backend but not frontend for header"
-      },
-      {
-        "id": "t-139",
-        "category": "system-field",
-        "entity": "header",
-        "field": "print",
-        "runner": "node",
-        "description": "System field 'print' should exist in backend but not frontend for header"
-      },
-      {
-        "id": "t-140",
-        "category": "system-field",
-        "entity": "header",
-        "field": "reinvoice",
-        "runner": "node",
-        "description": "System field 'reinvoice' should exist in backend but not frontend for header"
-      },
-      {
-        "id": "t-141",
-        "category": "system-field",
-        "entity": "header",
-        "field": "delivered",
-        "runner": "node",
-        "description": "System field 'delivered' should exist in backend but not frontend for header"
-      },
-      {
-        "id": "t-142",
-        "category": "system-field",
-        "entity": "header",
-        "field": "client",
-        "runner": "node",
-        "description": "System field 'client' should exist in backend but not frontend for header"
-      },
-      {
-        "id": "t-143",
-        "category": "system-field",
-        "entity": "header",
-        "field": "id",
-        "runner": "node",
-        "description": "System field 'id' should exist in backend but not frontend for header"
-      },
-      {
-        "id": "t-144",
-        "category": "system-field",
-        "entity": "header",
-        "field": "processNow",
-        "runner": "node",
-        "description": "System field 'processNow' should exist in backend but not frontend for header"
-      },
-      {
-        "id": "t-145",
-        "category": "system-field",
-        "entity": "header",
         "field": "datePrinted",
         "runner": "node",
         "description": "System field 'datePrinted' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-146",
-        "category": "system-field",
-        "entity": "header",
-        "field": "active",
-        "runner": "node",
-        "description": "System field 'active' should exist in backend but not frontend for header"
-      },
-      {
-        "id": "t-147",
+        "id": "t-139",
         "category": "system-field",
         "entity": "header",
         "field": "salesTransaction",
@@ -3619,7 +3545,7 @@
         "description": "System field 'salesTransaction' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-148",
+        "id": "t-140",
         "category": "system-field",
         "entity": "header",
         "field": "formOfPayment",
@@ -3627,7 +3553,7 @@
         "description": "System field 'formOfPayment' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-149",
+        "id": "t-141",
         "category": "system-field",
         "entity": "header",
         "field": "posted",
@@ -3635,7 +3561,7 @@
         "description": "System field 'posted' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-150",
+        "id": "t-142",
         "category": "system-field",
         "entity": "header",
         "field": "priceIncludesTax",
@@ -3643,15 +3569,7 @@
         "description": "System field 'priceIncludesTax' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-151",
-        "category": "system-field",
-        "entity": "header",
-        "field": "accountingDate",
-        "runner": "node",
-        "description": "System field 'accountingDate' should exist in backend but not frontend for header"
-      },
-      {
-        "id": "t-152",
+        "id": "t-143",
         "category": "system-field",
         "entity": "header",
         "field": "selected",
@@ -3659,7 +3577,7 @@
         "description": "System field 'selected' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-153",
+        "id": "t-144",
         "category": "system-field",
         "entity": "header",
         "field": "dropShipContact",
@@ -3667,7 +3585,7 @@
         "description": "System field 'dropShipContact' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-154",
+        "id": "t-145",
         "category": "system-field",
         "entity": "header",
         "field": "dropShipPartner",
@@ -3675,39 +3593,15 @@
         "description": "System field 'dropShipPartner' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-155",
+        "id": "t-146",
         "category": "system-field",
         "entity": "header",
-        "field": "iNCOTERMSDescription",
+        "field": "dropShipLocation",
         "runner": "node",
-        "description": "System field 'iNCOTERMSDescription' should exist in backend but not frontend for header"
+        "description": "System field 'dropShipLocation' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-156",
-        "category": "system-field",
-        "entity": "header",
-        "field": "incoterms",
-        "runner": "node",
-        "description": "System field 'incoterms' should exist in backend but not frontend for header"
-      },
-      {
-        "id": "t-157",
-        "category": "system-field",
-        "entity": "header",
-        "field": "deliveryNotes",
-        "runner": "node",
-        "description": "System field 'deliveryNotes' should exist in backend but not frontend for header"
-      },
-      {
-        "id": "t-158",
-        "category": "system-field",
-        "entity": "header",
-        "field": "generateTemplate",
-        "runner": "node",
-        "description": "System field 'generateTemplate' should exist in backend but not frontend for header"
-      },
-      {
-        "id": "t-159",
+        "id": "t-147",
         "category": "system-field",
         "entity": "header",
         "field": "selfService",
@@ -3715,15 +3609,103 @@
         "description": "System field 'selfService' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-160",
+        "id": "t-148",
         "category": "system-field",
         "entity": "header",
-        "field": "createPOLines",
+        "field": "iNCOTERMSDescription",
         "runner": "node",
-        "description": "System field 'createPOLines' should exist in backend but not frontend for header"
+        "description": "System field 'iNCOTERMSDescription' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-161",
+        "id": "t-149",
+        "category": "system-field",
+        "entity": "header",
+        "field": "accountingDate",
+        "runner": "node",
+        "description": "System field 'accountingDate' should exist in backend but not frontend for header"
+      },
+      {
+        "id": "t-150",
+        "category": "system-field",
+        "entity": "header",
+        "field": "print",
+        "runner": "node",
+        "description": "System field 'print' should exist in backend but not frontend for header"
+      },
+      {
+        "id": "t-151",
+        "category": "system-field",
+        "entity": "header",
+        "field": "reinvoice",
+        "runner": "node",
+        "description": "System field 'reinvoice' should exist in backend but not frontend for header"
+      },
+      {
+        "id": "t-152",
+        "category": "system-field",
+        "entity": "header",
+        "field": "delivered",
+        "runner": "node",
+        "description": "System field 'delivered' should exist in backend but not frontend for header"
+      },
+      {
+        "id": "t-153",
+        "category": "system-field",
+        "entity": "header",
+        "field": "client",
+        "runner": "node",
+        "description": "System field 'client' should exist in backend but not frontend for header"
+      },
+      {
+        "id": "t-154",
+        "category": "system-field",
+        "entity": "header",
+        "field": "id",
+        "runner": "node",
+        "description": "System field 'id' should exist in backend but not frontend for header"
+      },
+      {
+        "id": "t-155",
+        "category": "system-field",
+        "entity": "header",
+        "field": "active",
+        "runner": "node",
+        "description": "System field 'active' should exist in backend but not frontend for header"
+      },
+      {
+        "id": "t-156",
+        "category": "system-field",
+        "entity": "header",
+        "field": "processNow",
+        "runner": "node",
+        "description": "System field 'processNow' should exist in backend but not frontend for header"
+      },
+      {
+        "id": "t-157",
+        "category": "system-field",
+        "entity": "header",
+        "field": "generateTemplate",
+        "runner": "node",
+        "description": "System field 'generateTemplate' should exist in backend but not frontend for header"
+      },
+      {
+        "id": "t-158",
+        "category": "system-field",
+        "entity": "header",
+        "field": "deliveryNotes",
+        "runner": "node",
+        "description": "System field 'deliveryNotes' should exist in backend but not frontend for header"
+      },
+      {
+        "id": "t-159",
+        "category": "system-field",
+        "entity": "header",
+        "field": "incoterms",
+        "runner": "node",
+        "description": "System field 'incoterms' should exist in backend but not frontend for header"
+      },
+      {
+        "id": "t-160",
         "category": "system-field",
         "entity": "header",
         "field": "creationDate",
@@ -3731,12 +3713,20 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-162",
+        "id": "t-161",
         "category": "system-field",
         "entity": "header",
         "field": "createdBy",
         "runner": "node",
         "description": "System field 'createdBy' should exist in backend but not frontend for header"
+      },
+      {
+        "id": "t-162",
+        "category": "system-field",
+        "entity": "header",
+        "field": "createPOLines",
+        "runner": "node",
+        "description": "System field 'createPOLines' should exist in backend but not frontend for header"
       },
       {
         "id": "t-163",
@@ -4014,17 +4004,17 @@
         "id": "t-197",
         "category": "system-field",
         "entity": "lines",
-        "field": "standardPrice",
+        "field": "baseGrossUnitPrice",
         "runner": "node",
-        "description": "System field 'standardPrice' should exist in backend but not frontend for lines"
+        "description": "System field 'baseGrossUnitPrice' should exist in backend but not frontend for lines"
       },
       {
         "id": "t-198",
         "category": "system-field",
         "entity": "lines",
-        "field": "baseGrossUnitPrice",
+        "field": "standardPrice",
         "runner": "node",
-        "description": "System field 'baseGrossUnitPrice' should exist in backend but not frontend for lines"
+        "description": "System field 'standardPrice' should exist in backend but not frontend for lines"
       },
       {
         "id": "t-199",
@@ -6270,17 +6260,17 @@
         "id": "t-511",
         "category": "action-endpoint",
         "entity": "header",
-        "field": "processNow",
+        "field": "posted",
         "runner": "node",
-        "description": "Action endpoint for 'processNow' in header should exist"
+        "description": "Action endpoint for 'posted' in header should exist"
       },
       {
         "id": "t-512",
         "category": "action-endpoint",
         "entity": "header",
-        "field": "posted",
+        "field": "processNow",
         "runner": "node",
-        "description": "Action endpoint for 'posted' in header should exist"
+        "description": "Action endpoint for 'processNow' in header should exist"
       },
       {
         "id": "t-513",

--- a/artifacts/sales-order/decisions.json
+++ b/artifacts/sales-order/decisions.json
@@ -105,18 +105,18 @@
           "section": "principal"
         },
         "priceList": {
-          "section": "collapsed"
+          "section": "principal"
         },
         "paymentMethod": {
           "reference": "PaymentMethod",
-          "section": "collapsed"
+          "section": "principal"
         },
         "paymentTerms": {
           "visibility": "system"
         },
         "warehouse": {
           "inputMode": "search",
-          "section": "collapsed"
+          "form": false
         },
         "salesRepresentative": {
           "visibility": "system"
@@ -211,7 +211,7 @@
           "visibility": "system"
         },
         "description": {
-          "section": "collapsed"
+          "form": false
         },
         "reservationStatus": {
           "visibility": "discarded"

--- a/artifacts/sales-order/generated/web/sales-order/HeaderForm.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/HeaderForm.jsx
@@ -6,12 +6,10 @@ const fields = [
   { key: 'documentNo', column: 'DocumentNo', type: 'text', label: 'Document No.', required: true, readOnly: true, section: 'principal', readOnlyLogic: (record) => record['processed'] === true || record['documentStatus'] === 'TMP' },
   { key: 'orderDate', column: 'DateOrdered', type: 'date', label: 'Order Date', required: true, section: 'principal', defaultValue: '@#Date@', readOnlyLogic: (record) => record['processed'] === true },
   { key: 'partnerAddress', column: 'C_BPartner_Location_ID', type: 'dependent', label: 'Partner Address', required: true, section: 'principal', reference: 'BusinessPartnerLocation', inputMode: 'dependent', dependsOn: { field: 'businessPartner', filterKey: 'C_BPartner_ID' }, readOnlyLogic: (record) => record['processed'] === true || record['documentStatus'] === 'TMP' },
-  { key: 'priceList', column: 'M_PriceList_ID', type: 'selector', label: 'Price List', required: true, section: 'collapsed', reference: 'PriceList', inputMode: 'selector', readOnlyLogic: (record) => record['processed'] === true || record['documentStatus'] === 'TMP' },
-  { key: 'paymentMethod', column: 'FIN_Paymentmethod_ID', type: 'selector', label: 'Payment Method', section: 'collapsed', reference: 'PaymentMethod', inputMode: 'selector', readOnlyLogic: (record) => record['processed'] === true },
-  { key: 'warehouse', column: 'M_Warehouse_ID', type: 'search', label: 'Warehouse', required: true, section: 'collapsed', reference: 'Warehouse', inputMode: 'search', readOnlyLogic: (record) => record['processed'] === true },
+  { key: 'priceList', column: 'M_PriceList_ID', type: 'selector', label: 'Price List', required: true, section: 'principal', reference: 'PriceList', inputMode: 'selector', readOnlyLogic: (record) => record['processed'] === true || record['documentStatus'] === 'TMP' },
+  { key: 'paymentMethod', column: 'FIN_Paymentmethod_ID', type: 'selector', label: 'Payment Method', section: 'principal', reference: 'PaymentMethod', inputMode: 'selector', readOnlyLogic: (record) => record['processed'] === true },
   { key: 'grandTotalAmount', column: 'GrandTotal', type: 'number', label: 'Total Gross Amount', required: true, readOnly: true, section: 'summary' },
   { key: 'summedLineAmount', column: 'TotalLines', type: 'number', label: 'Total Net Amount', required: true, readOnly: true, section: 'summary' },
-  { key: 'description', column: 'Description', type: 'textarea', label: 'Description', section: 'collapsed' },
 ];
 // @sf-generated-end fields:header
 
@@ -19,5 +17,5 @@ const fields = [
 export default function HeaderForm(props) {
   return <EntityForm fields={fields} {...props} />;
 }
-HeaderForm.hasCollapsedFields = true;
+HeaderForm.hasCollapsedFields = false;
 // @sf-generated-end component:HeaderForm

--- a/artifacts/sales-order/generated/web/sales-order/HeaderPage.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/HeaderPage.jsx
@@ -263,19 +263,19 @@ const api = {
     },
     {
       "entity": "header",
-      "field": "processNow",
-      "column": "Processing",
-      "url": "/sws/neo/sales-order/header/{id}/action/processNow",
-      "processId": "104",
-      "processType": "classic"
-    },
-    {
-      "entity": "header",
       "field": "posted",
       "column": "Posted",
       "url": "/sws/neo/sales-order/header/{id}/action/posted",
       "processId": "57496FB9CF9E4E8F847224017941570E",
       "processType": "obuiapp"
+    },
+    {
+      "entity": "header",
+      "field": "processNow",
+      "column": "Processing",
+      "url": "/sws/neo/sales-order/header/{id}/action/processNow",
+      "processId": "104",
+      "processType": "classic"
     },
     {
       "entity": "header",
@@ -390,7 +390,6 @@ export default function HeaderPage({ windowName, recordId, ...props }) {
         topbarRight={OrderCreateInvoice}
         topbarExtra={OrderDraftChips}
         menuActions={({ status }) => [
-          { key: 'duplicate', label: 'Duplicate', onClick: () => {}, },
           { key: 'cancel', label: 'Cancel', destructive: true, visible: status === 'CO', onClick: () => {}, }
         ]}
         salesTheme

--- a/artifacts/sales-order/generated/web/sales-order/index.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/index.jsx
@@ -199,19 +199,19 @@ const api = {
     },
     {
       "entity": "header",
-      "field": "processNow",
-      "column": "Processing",
-      "url": "/sws/neo/sales-order/header/{id}/action/processNow",
-      "processId": "104",
-      "processType": "classic"
-    },
-    {
-      "entity": "header",
       "field": "posted",
       "column": "Posted",
       "url": "/sws/neo/sales-order/header/{id}/action/posted",
       "processId": "57496FB9CF9E4E8F847224017941570E",
       "processType": "obuiapp"
+    },
+    {
+      "entity": "header",
+      "field": "processNow",
+      "column": "Processing",
+      "url": "/sws/neo/sales-order/header/{id}/action/processNow",
+      "processId": "104",
+      "processType": "classic"
     },
     {
       "entity": "header",


### PR DESCRIPTION
## Summary
- Moved all fields from the collapsed "Más detalles" section to the principal header section in Purchase Order and Sales Order
- Removed `warehouse` and `description` from the header form
- Changes made exclusively in `decisions.json` — regenerated `contract.json` and frontend files via pipeline

## Test plan
- [ ] Open Purchase Order — verify no "Más detalles" collapsible section appears
- [ ] Open Sales Order — verify no "Más detalles" collapsible section appears
- [ ] Verify `paymentMethod`, `paymentTerms`, `priceList` are visible in Purchase Order header
- [ ] Verify `paymentMethod`, `priceList` are visible in Sales Order header
- [ ] Verify `warehouse` and `description` are not shown in either header form