### PR TITLE
Feature ETP-3661: Enable invoice directly from quotation

### DIFF
--- a/artifacts/sales-quotation/contract.json
+++ b/artifacts/sales-quotation/contract.json
@@ -1,7 +1,7 @@
 {
   "version": "0.2.0",
-  "generatedAt": "2026-04-20T14:29:58.192Z",
-  "checksum": "0e0b5a79faa4b8a9",
+  "generatedAt": "2026-04-20T17:51:17.718Z",
+  "checksum": "33d3a205addd4ae2",
   "frontendContract": {
     "window": {
       "id": "6CB5B67ED33F47DFA334079D3EA2340E",
@@ -423,7 +423,8 @@
               "source": "false"
             }
           }
-        ]
+        ],
+        "javaQualifier": "salesQuotationHeaderHandler"
       },
       "quotationLine": {
         "tableName": "C_OrderLine",
@@ -1496,7 +1497,8 @@
             "visibility": "system",
             "required": true
           }
-        ]
+        ],
+        "javaQualifier": "salesQuotationHeaderHandler"
       },
       "quotationLine": {
         "tableName": "C_OrderLine",

--- a/artifacts/sales-quotation/custom/QuotationConfirmModal.jsx
+++ b/artifacts/sales-quotation/custom/QuotationConfirmModal.jsx
@@ -78,8 +78,8 @@ export default function QuotationConfirmModal({
     setError(null);
 
     try {
-      // Step 1: Process DocAction=CO (skip if already confirmed)
-      if (!alreadyProcessed) {
+      // Step 1: Process DocAction=CO (only for order path — invoice path reads lines directly)
+      if (selected === 'order' && !alreadyProcessed) {
         const processRes = await fetch(
           `${entityUrl}/${quotationId}/action/DocAction`,
           { method: 'POST', headers, body: JSON.stringify({ fieldValues: {} }) },
@@ -143,19 +143,24 @@ export default function QuotationConfirmModal({
         setCreatedDoc({ type: 'order', id: null, documentNo: '?', total: '', status: 'Draft' });
 
       } else {
-        // TODO: The createDraftInvoice endpoint for quotations may not exist yet.
         const res = await fetch(
           `${entityUrl}/${quotationId}/action/createDraftInvoice`,
-          { method: 'POST', headers, body: JSON.stringify({ fieldValues: {} }) },
+          { method: 'POST', headers, body: JSON.stringify({}) },
         );
         if (!res.ok) {
           const err = await res.json().catch(() => null);
           throw new Error(
-            ui('sqOrderConfirmedInvoiceError')
-            + (err?.response?.message || err?.message || `Error (${res.status})`)
+            err?.response?.message || err?.message || `Error (${res.status})`
           );
         }
-        setCreatedDoc({ type: 'invoice', id: null, documentNo: '?', total: '', status: '' });
+        const doc = (await res.json())?.response?.data;
+        setCreatedDoc({
+          type: 'invoice',
+          id: doc?.id ?? null,
+          documentNo: doc?.documentNo ?? '',
+          total: fmtNum(doc?.grandTotalAmount ?? grandTotal),
+          status: 'Draft',
+        });
       }
     } catch (err) {
       setError(err.message || ui('soErrorOccurred'));
@@ -285,12 +290,11 @@ export default function QuotationConfirmModal({
             subtitle={ui('sqCreateOrderDesc')}
           />
           <OptionCard
-            selected={false}
-            onClick={() => {}}
+            selected={selected === 'invoice'}
+            onClick={() => setSelected('invoice')}
             icon={<FileText size={16} />}
             title={ui('soInvoiceDirectly')}
             subtitle={ui('sqInvoiceDirectlyDesc')}
-            disabled
           />
         </div>
 

--- a/artifacts/sales-quotation/decisions.json
+++ b/artifacts/sales-quotation/decisions.json
@@ -238,7 +238,8 @@
         "cashVAT": {
           "visibility": "discarded"
         }
-      }
+      },
+      "javaQualifier": "salesQuotationHeaderHandler"
     },
     "lines": {
       "javaQualifier": "orderLineHandler",

--- a/tools/app-shell/src/locales/en_US.json
+++ b/tools/app-shell/src/locales/en_US.json
@@ -17170,7 +17170,7 @@
     "sqWhatToDo": "How do you want to confirm?",
     "sqCreateOrder": "Create sales order",
     "sqCreateOrderDesc": "For products with stock, deliveries or orders with multiple shipments.",
-    "sqInvoiceDirectlyDesc": "Coming soon — for now, create the order and invoice from there.",
+    "sqInvoiceDirectlyDesc": "For services or sales without physical delivery. No shipment.",
     "sqConfirmActionOrder": "Confirm → Sales order",
     "sqOrderCreated": "Order created",
     "sqViewOrder": "View order →",

--- a/tools/app-shell/src/locales/es_ES.json
+++ b/tools/app-shell/src/locales/es_ES.json
@@ -17409,7 +17409,7 @@
     "sqWhatToDo": "¿Cómo querés confirmar?",
     "sqCreateOrder": "Crear pedido de venta",
     "sqCreateOrderDesc": "Para productos con stock, entregas o pedidos con múltiples envíos.",
-    "sqInvoiceDirectlyDesc": "Próximamente — por ahora, creá el pedido y facturá desde ahí.",
+    "sqInvoiceDirectlyDesc": "Para servicios o ventas sin entrega física. Sin albarán.",
     "sqConfirmActionOrder": "Confirmar → Pedido de venta",
     "sqOrderCreated": "Pedido creado",
     "sqViewOrder": "Ver pedido →",


### PR DESCRIPTION
## Summary

- Enable "Facturar directamente" option in `QuotationConfirmModal` (was disabled as "coming soon")
- Skip `DocAction=CO` for the invoice path — `C_Order_Post` rejects quotations with `ActionNotAllowedHere`
- Add `javaQualifier: salesQuotationHeaderHandler` to `sales-quotation` decisions.json and regenerate contract so NEO routes custom actions correctly
- Update i18n description for `sqInvoiceDirectlyDesc` (ES + EN)

## Test plan

- [ ] Open a Sales Quotation and click "Confirmar" — both options visible (crear pedido / facturar directamente)
- [ ] Select "Facturar directamente" — draft invoice created with correct tax amounts, no `ActionNotAllowedHere` error
- [ ] Select "Crear pedido" — existing flow unaffected