### PR TITLE
Feature ETP-3661: Invoice from quotation — navigation and tax fixes

### DIFF
--- a/artifacts/sales-invoice/custom/RelatedDocuments.jsx
+++ b/artifacts/sales-invoice/custom/RelatedDocuments.jsx
@@ -26,8 +26,12 @@ export default function RelatedDocuments({ recordId, data, token, apiBaseUrl }) 
 
     if (orderId) {
       promises.push(
-        fetchById('sales-order', 'header', orderId, token, apiBaseUrl)
-          .then(d => setOrder(d))
+        (async () => {
+          const quotation = await fetchById('sales-quotation', 'quotation', orderId, token, apiBaseUrl).catch(() => null);
+          if (quotation) { setOrder({ ...quotation, _isQuotation: true }); return; }
+          const order = await fetchById('sales-order', 'header', orderId, token, apiBaseUrl).catch(() => null);
+          if (order) setOrder(order);
+        })()
       );
 
       promises.push(
@@ -52,17 +56,18 @@ export default function RelatedDocuments({ recordId, data, token, apiBaseUrl }) 
   const chips = [];
 
   if (order) {
+    const isQuotation = order._isQuotation;
     chips.push(
       <DocChip
         key="order"
-        icon={CHIP_ICONS.order}
-        iconColor={CHIP_COLORS.order}
-        title={ui('orderDoc', { number: order.documentNo })}
+        icon={isQuotation ? CHIP_ICONS.quotation : CHIP_ICONS.order}
+        iconColor={isQuotation ? CHIP_COLORS.quotation : CHIP_COLORS.order}
+        title={isQuotation ? ui('quotationDoc', { number: order.documentNo }) : ui('orderDoc', { number: order.documentNo })}
         amount={order.grandTotalAmount}
         currency={order['currency$_identifier']}
         status={order.documentStatus}
         statusLabel={ui(STATUS_KEYS[order.documentStatus] || order.documentStatus)}
-        onClick={() => navigate(`/sales-order/${order.id}`)}
+        onClick={() => navigate(`/${isQuotation ? 'sales-quotation' : 'sales-order'}/${order.id}`)}
       />
     );
   }

--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -174,10 +174,15 @@ export function DetailView({
     }
     if (!parentRecordId) return next;
     if (detailEntity) {
+      // DateInvoiced is required by the C_Tax validationRule:
+      // VALIDFROM <= COALESCE(@DateInvoiced@, @DateOrdered@)
+      // Without it, COALESCE(null,null)=null → VALIDFROM<=null is always FALSE → no taxes returned.
+      const invoiceDate = headerData?.invoiceDate ?? headerData?.orderDate ?? null;
       next[detailEntity] = {
         parentId: parentRecordId,
-        ...(isSOTrx ? { isSOTrx } : {}),
+        ...(isSOTrx ? { isSOTrx, IsSOTrx: isSOTrx } : {}),
         ...(priceListId ? { priceList: priceListId } : {}),
+        ...(invoiceDate ? { DateInvoiced: invoiceDate } : {}),
       };
     }
     for (const tab of secondaryTabs) {


### PR DESCRIPTION
## Summary

- Invoice related documents panel now detects if the linked order is actually a quotation and navigates to `/sales-quotation/` with the correct quotation chip icon/color.
- Injects `DateInvoiced` into the detail entity selector context so the C_Tax validation rule resolves correctly and taxes appear on invoice lines.
- Removes debug `console.log` statements from `useEntity` and `DetailView`.
- Adds `CL` (Closed - Invoiced) status to `QuotationStatusBadge` and shows linked invoices in the quotation's Related Documents panel.

## Test plan

- [ ] Create invoice from quotation — Related Documents on the invoice shows a quotation chip (not order), clicking navigates to the quotation.
- [ ] Add a line to a sales invoice — tax selector returns results (DateInvoiced injected).
- [ ] Quotation with CL status shows "Closed - Invoiced" purple badge.
- [ ] Quotation's Related Documents shows linked invoices.