### PR TITLE
Feature ETP-3827: Fix first column styling and numeric alignment in DataTable

### DIFF
--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -613,18 +613,18 @@ function InlineAddRow({ columns, fields, onAdd, onCancel, data, catalogs, onFiel
           );
         }
 
+        const isNumeric = NUMERIC_FIELD_TYPES.has(field.type);
         return (
           <TableCell key={col.key} className="py-1 px-2">
             <input
               ref={isFirst ? firstInputRef : undefined}
-              type={NUMERIC_FIELD_TYPES.has(field.type) ? 'number' : 'text'}
+              type={isNumeric ? 'number' : 'text'}
               inputMode={field.inputMode}
               value={values[field.key] ?? ''}
               onChange={(e) => {
                 const raw = e.target.value;
-                const isNumericType = NUMERIC_FIELD_TYPES.has(field.type);
                 touchedFieldsRef.current.add(field.key);
-                if (isNumericType && raw !== '' && raw !== '-') {
+                if (isNumeric && raw !== '' && raw !== '-') {
                   const parsed = field.type === 'integer' ? parseInt(raw, 10) : parseFloat(raw);
                   handleChange(field.key, isNaN(parsed) ? raw : parsed);
                 } else {
@@ -634,7 +634,7 @@ function InlineAddRow({ columns, fields, onAdd, onCancel, data, catalogs, onFiel
               onKeyDown={handleKeyDown}
               placeholder={fieldLabel}
               required={field.required}
-              className="w-full h-8 text-sm rounded-md border border-input bg-background px-2 focus:ring-2 focus:ring-primary focus:outline-none"
+              className={`w-full h-8 text-sm rounded-md border border-input bg-background px-2 focus:ring-2 focus:ring-primary focus:outline-none${isNumeric ? ' text-right tabular-nums' : ''}`}
             />
           </TableCell>
         );
@@ -888,13 +888,12 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
         if (warehouseLabel) display = warehouseLabel;
       }
     }
-    // Link styling on first string column
     if (col === columns[0] && col.type === 'string') {
       const pill = col.pill;
       const pillLabel = pill && pill.when(row) ? pill.label : null;
       return (
         <span className="inline-flex items-center gap-2">
-          <span className="font-medium text-blue-600">{display}</span>
+          <span>{display}</span>
           {pillLabel && (
             <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full border ${pill.className || 'bg-gray-50 text-gray-600 border-gray-200'}`} style={{ borderWidth: '0.5px' }}>
               {pillLabel}
@@ -1080,7 +1079,7 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
               {columns.map(col => {
                 const colLabel = resolveColumnLabel(col, locale, t);
                 const isSorted = sortColumn === col.key;
-                const isRight = col.type === 'amount';
+                const isRight = NUMERIC_FIELD_TYPES.has(col.type);
                 return (
                   <TableHead key={col.key} className="align-top">
                     <div className="flex flex-col gap-1.5 pb-2">
@@ -1182,7 +1181,7 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
                       );
                     })()}
                     {columns.map(col => (
-                      <TableCell key={col.key} className={col.type === 'amount' ? 'text-right' : ''}>
+                      <TableCell key={col.key} className={NUMERIC_FIELD_TYPES.has(col.type) ? 'text-right tabular-nums' : ''}>
                         {renderCellValue(row, col)}
                       </TableCell>
                     ))}

--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -1079,7 +1079,7 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
               {columns.map(col => {
                 const colLabel = resolveColumnLabel(col, locale, t);
                 const isSorted = sortColumn === col.key;
-                const isRight = NUMERIC_FIELD_TYPES.has(col.type);
+                const isNumeric = NUMERIC_FIELD_TYPES.has(col.type);
                 return (
                   <TableHead key={col.key} className="align-top">
                     <div className="flex flex-col gap-1.5 pb-2">
@@ -1115,7 +1115,7 @@ export function DataTable({ entity, columns = [], filters = [], data = [], onRow
                             columnFilters[col.key]
                               ? 'border-primary/40 bg-primary/5 pr-6'
                               : 'border-border/35',
-                            isRight ? 'text-right' : '',
+                            isNumeric ? 'text-right' : '',
                           ].filter(Boolean).join(' ')}
                         />
                         {columnFilters[col.key] && (


### PR DESCRIPTION
## Summary

Two small UI bugs fixed in the shared `DataTable` component (`tools/app-shell/src/components/contract-ui/DataTable.jsx`). Because the change is in the generic component, it applies to **all windows** and no artifact regeneration is required.

- **First column rendered as a blue link in every window.** The first column with `type === 'string'` had hardcoded `font-medium text-blue-600`, making it look like a clickable link even though the whole row is already clickable. Removed the blue styling so the first column matches the rest of the cells. Pill behavior is preserved.
- **Numeric fields left-aligned in line subgrids when adding a new row.** The `InlineAddRow` input and body cells only right-aligned `amount` fields, so `number`, `integer`, `decimal`, and `quantity` stayed left-aligned. Extended `text-right tabular-nums` to all `NUMERIC_FIELD_TYPES` for:
  - The inline-add input (`DataTable.jsx:637`)
  - Body cells (`DataTable.jsx:1185`)
  - The column filter input (`DataTable.jsx:1082`)

Jira: [ETP-3827](https://etendoproject.atlassian.net/browse/ETP-3827)

## Test plan

- [ ] Open any window with a list (e.g. Sales Order): first column text is no longer blue/link-styled.
- [ ] Pill fields in the first column still render as pills.
- [ ] Open a window with a lines subgrid (e.g. Sales Order lines): click "Add row" and verify numeric inputs (`quantity`, `number`, `decimal`, `integer`, `amount`) are right-aligned with `tabular-nums`.
- [ ] Existing body cells for numeric columns render right-aligned across all windows.
- [ ] Column filter inputs for numeric columns are right-aligned.

[ETP-3827]: https://etendoproject.atlassian.net/browse/ETP-3827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ