### PR TITLE
Feature ETP-3803: Persist navigator favorites via AD_PREFERENCE

### DIFF
--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -825,7 +825,7 @@ export function DetailView({
   useSetPageMeta({
     title: title || windowTitle,
     breadcrumb: fullBreadcrumb,
-    onAddToFavorites: favKey ? () => toggleFavorite(favKey, windowTitle) : undefined,
+    onAddToFavorites: favKey ? () => toggleFavorite(favKey, entityLabel || breadcrumb?.split(' / ').at(-1).trim() || windowName) : undefined,
     isFavorite: favActive,
   }, [favActive, title]);
 

--- a/tools/app-shell/src/components/contract-ui/ListView.jsx
+++ b/tools/app-shell/src/components/contract-ui/ListView.jsx
@@ -70,7 +70,7 @@ export function ListView({
     title: label,
     breadcrumb: fullBreadcrumb,
     recordCount: hook.items.length,
-    onAddToFavorites: favKey ? () => toggleFavorite(favKey, label) : undefined,
+    onAddToFavorites: favKey ? () => toggleFavorite(favKey, entityLabel || entity) : undefined,
     isFavorite: favActive,
   }, [favActive, hook.items.length]);
   const [selectedRows, setSelectedRows] = useState([]);

--- a/tools/app-shell/src/components/layout/FavoritesContext.jsx
+++ b/tools/app-shell/src/components/layout/FavoritesContext.jsx
@@ -4,13 +4,16 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import { useAuth } from '@/auth/AuthContext.jsx';
+import { buildHeaders } from '@/auth/api.js';
 
 const FavoritesContext = createContext(null);
 
 const STORAGE_PREFIX = 'sf_favorites_';
+const FAVORITES_ENDPOINT = '/sws/neo/favorites';
 
 function storageKey(username) {
   return `${STORAGE_PREFIX}${username || 'anonymous'}`;
@@ -38,51 +41,85 @@ function writeFavorites(username, list) {
 }
 
 export function FavoritesProvider({ children }) {
-  const { username } = useAuth();
+  const { username, token } = useAuth();
   const [favorites, setFavorites] = useState(() => readFavorites(username));
+  const fetchedRef = useRef(false);
 
+  // Reset to localStorage when user changes (login/logout)
   useEffect(() => {
+    fetchedRef.current = false;
     setFavorites(readFavorites(username));
   }, [username]);
+
+  // Fetch from server on login — server wins over localStorage
+  useEffect(() => {
+    if (!token || !username || fetchedRef.current) return;
+    let cancelled = false;
+    fetch(FAVORITES_ENDPOINT, { headers: buildHeaders(token), credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!cancelled && Array.isArray(data)) {
+          fetchedRef.current = true;
+          writeFavorites(username, data);
+          setFavorites(data);
+        }
+      })
+      .catch(() => {
+        /* localStorage fallback stays active */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [token, username]);
+
+  const syncToServer = useCallback(
+    (list) => {
+      if (!token) return;
+      fetch(FAVORITES_ENDPOINT, {
+        method: 'PUT',
+        headers: buildHeaders(token),
+        body: JSON.stringify(list),
+        credentials: 'include',
+      }).catch(() => {});
+    },
+    [token]
+  );
 
   const addFavorite = useCallback(
     (name, label) => {
       if (!name) return;
-      setFavorites((prev) => {
-        if (prev.some((f) => f.name === name)) return prev;
-        const next = [...prev, { name, label: label || name }];
-        writeFavorites(username, next);
-        return next;
-      });
+      if (favorites.some((f) => f.name === name)) return;
+      const next = [...favorites, { name, label: label || name }];
+      setFavorites(next);
+      writeFavorites(username, next);
+      syncToServer(next);
     },
-    [username]
+    [favorites, username, syncToServer]
   );
 
   const removeFavorite = useCallback(
     (name) => {
       if (!name) return;
-      setFavorites((prev) => {
-        const next = prev.filter((f) => f.name !== name);
-        writeFavorites(username, next);
-        return next;
-      });
+      const next = favorites.filter((f) => f.name !== name);
+      setFavorites(next);
+      writeFavorites(username, next);
+      syncToServer(next);
     },
-    [username]
+    [favorites, username, syncToServer]
   );
 
   const toggleFavorite = useCallback(
     (name, label) => {
       if (!name) return;
-      setFavorites((prev) => {
-        const exists = prev.some((f) => f.name === name);
-        const next = exists
-          ? prev.filter((f) => f.name !== name)
-          : [...prev, { name, label: label || name }];
-        writeFavorites(username, next);
-        return next;
-      });
+      const exists = favorites.some((f) => f.name === name);
+      const next = exists
+        ? favorites.filter((f) => f.name !== name)
+        : [...favorites, { name, label: label || name }];
+      setFavorites(next);
+      writeFavorites(username, next);
+      syncToServer(next);
     },
-    [username]
+    [favorites, username, syncToServer]
   );
 
   const isFavorite = useCallback(

--- a/tools/app-shell/src/components/layout/SideMenu/SideMenu.jsx
+++ b/tools/app-shell/src/components/layout/SideMenu/SideMenu.jsx
@@ -466,8 +466,8 @@ export default function SideMenu({
                           )}
                         >
                           <span className={cn(
-                            'absolute left-[33px] top-0 bottom-0 w-0.5',
-                            isItemActive ? 'bg-white/40' : 'bg-border'
+                            'absolute left-[33px] top-0 bottom-0 w-px',
+                            isItemActive ? 'bg-white/40' : 'bg-[#E8EAEF]'
                           )} />
                           {isItemActive && (
                             <span className="absolute left-[33px] right-2 top-0 bottom-0 bg-accent-highlight" />
@@ -486,7 +486,7 @@ export default function SideMenu({
                                 to={`/${itemPath}`}
                                 className="relative flex w-full items-center pl-[52px] pr-4 py-1.5 text-sm text-text-primary hover:bg-muted/50 transition-colors"
                               >
-                                <span className="absolute left-[33px] top-0 bottom-0 w-0.5 bg-border" />
+                                <span className="absolute left-[33px] top-0 bottom-0 w-px bg-[#E8EAEF]" />
                                 <span className="relative z-10">{tMenu(item.label)}</span>
                               </NavLink>
                             );
@@ -497,7 +497,7 @@ export default function SideMenu({
                             onClick={() => setFavOverflowOpen(true)}
                             className="relative flex w-full items-center pl-[52px] pr-4 py-1.5 text-sm text-muted-foreground hover:bg-muted/50 transition-colors"
                           >
-                            <span className="absolute left-[33px] top-0 bottom-0 w-0.5 bg-border" />
+                            <span className="absolute left-[33px] top-0 bottom-0 w-px bg-[#E8EAEF]" />
                             <span className="flex-1 text-left">
                               {ui('andNMore', { n: g.items.length - FAVORITES_VISIBLE })}
                             </span>

--- a/tools/app-shell/src/components/layout/SideMenu/SideMenu.jsx
+++ b/tools/app-shell/src/components/layout/SideMenu/SideMenu.jsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import { useAuth } from '@/auth/AuthContext.jsx';
 import {
@@ -215,6 +215,11 @@ export default function SideMenu({
     if (activeGroup) initial[activeGroup.group] = true;
     return initial;
   });
+
+  useEffect(() => {
+    setOpenGroups(activeGroup ? { [activeGroup.group]: true } : {});
+  }, [location.pathname, location.search]);
+
   const [favOverflowOpen, setFavOverflowOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
 

--- a/tools/app-shell/src/pages/QuickPurchaseOrderPage.jsx
+++ b/tools/app-shell/src/pages/QuickPurchaseOrderPage.jsx
@@ -288,7 +288,7 @@ export default function QuickPurchaseOrderPage({ apiBaseUrl }) {
   useSetPageMeta({
     title: translatedTitle,
     breadcrumb,
-    onAddToFavorites: () => toggleFavorite(favKey, translatedTitle),
+    onAddToFavorites: () => toggleFavorite(favKey, 'Quick Purchase Order'),
     isFavorite: isFavorite(favKey),
   }, [isFavorite(favKey)]);
 

--- a/tools/app-shell/src/pages/QuickSalesOrderPage.jsx
+++ b/tools/app-shell/src/pages/QuickSalesOrderPage.jsx
@@ -302,7 +302,7 @@ export default function QuickSalesOrderPage({ apiBaseUrl }) {
   useSetPageMeta({
     title: translatedTitle,
     breadcrumb,
-    onAddToFavorites: () => toggleFavorite(favKey, translatedTitle),
+    onAddToFavorites: () => toggleFavorite(favKey, 'Quick Sales Order'),
     isFavorite: isFavorite(favKey),
   }, [isFavorite(favKey)]);
 

--- a/tools/app-shell/src/pages/ReportViewerPage.jsx
+++ b/tools/app-shell/src/pages/ReportViewerPage.jsx
@@ -1120,13 +1120,19 @@ function ReportViewer({ report, onBack, token, selectedOrgId, roleOrgIds, catego
     setResetKey(k => k + 1);
   };
 
+  const { toggleFavorite, isFavorite } = useFavorites();
   const title = report.title?.[locale] || report.title?.en_US || report.title?.es_ES || report.id;
   const categoryLabel = categoryFilter && CATEGORY_LABELS[categoryFilter]
     ? tMenu(CATEGORY_LABELS[categoryFilter].en)
     : null;
   const breadcrumb = [categoryLabel, tMenu('Reports'), title].filter(Boolean).join(' / ');
+  const favKey = categoryFilter
+    ? `report-viewer?category=${categoryFilter}&report=${report.id}`
+    : `report-viewer?report=${report.id}`;
+  const favActive = isFavorite(favKey);
 
-  useSetPageMeta({ title, breadcrumb, onBack });
+  const favLabel = report.title?.en_US || report.title?.en || report.id;
+  useSetPageMeta({ title, breadcrumb, onBack, onAddToFavorites: () => toggleFavorite(favKey, favLabel), isFavorite: favActive }, [favActive]);
 
   const DOWNLOAD_FORMATS = [
     { id: 'html', label: 'preview', icon: Eye },
@@ -1301,7 +1307,7 @@ function ReportList({ reports, loading, searchQuery, setSearchQuery, categoryFil
   useSetPageMeta({
     title: tMenu('Reports'),
     breadcrumb,
-    onAddToFavorites: () => toggleFavorite(favKey, tMenu('Reports')),
+    onAddToFavorites: () => toggleFavorite(favKey, 'Reports'),
     isFavorite: favActive,
   }, [favActive]);
 

--- a/tools/app-shell/src/pages/SmartScanPage.jsx
+++ b/tools/app-shell/src/pages/SmartScanPage.jsx
@@ -70,7 +70,7 @@ export default function SmartScanPage() {
   useSetPageMeta({
     title: translatedTitle,
     breadcrumb,
-    onAddToFavorites: () => toggleFavorite(favKey, translatedTitle),
+    onAddToFavorites: () => toggleFavorite(favKey, 'Smart Scan'),
     isFavorite: isFavorite(favKey),
   }, [isFavorite(favKey)]);
 


### PR DESCRIPTION
## ETP-3803 — Navigator UI fixes & persistent favorites

- Removed duplicate inline TopBar from report pages (ReportViewerPage, SmartScanPage, QuickSalesOrderPage, QuickPurchaseOrderPage) — these were rendering a second header with title, search bar and action icons inside the page content.
- Added "Add to Favorites" support to report pages (missing `onAddToFavorites` in `useSetPageMeta`).
- Fixed favorites bug: report categories were sharing the same `favKey`, causing false "already favorited" state and wrong navigation URL.
- Fixed gray vertical line position in SideMenu child items — aligned to the center of the group icon.
- Favorites overflow: shows first 2 items, rest under a collapsible "+N more" that disappears when expanded (Figma-faithful).
- Accordion behavior: opening a group collapses all others; active group stays highlighted even when collapsed.
- **Persistent favorites:** `FavoritesContext` now syncs favorites to the server on login (GET) and on every toggle (PUT fire-and-forget), with localStorage as fallback when the backend is unavailable.