### PR TITLE
Feature ETP-3585: Fix physical inventory selector context

### DIFF
--- a/artifacts/physical-inventory/contract.json
+++ b/artifacts/physical-inventory/contract.json
@@ -1,7 +1,7 @@
 {
   "version": "0.16.2",
-  "generatedAt": "2026-04-10T14:29:52.932Z",
-  "checksum": "caaafe7cc1438395",
+  "generatedAt": "2026-04-22T11:16:14.418Z",
+  "checksum": "93487654081e7e69",
   "frontendContract": {
     "window": {
       "id": "168",
@@ -37,7 +37,12 @@
             "required": true,
             "grid": true,
             "form": true,
-            "defaultValue": "@#Date@"
+            "defaultValue": "@#Date@",
+            "readOnlyLogic": {
+              "raw": "@Processed@='Y'",
+              "evaluable": true,
+              "js": "record['processed'] === true"
+            }
           },
           {
             "name": "name",
@@ -64,7 +69,12 @@
             "grid": true,
             "form": true,
             "reference": "Warehouse",
-            "inputMode": "search"
+            "inputMode": "search",
+            "readOnlyLogic": {
+              "raw": "@Processed@='Y'",
+              "evaluable": true,
+              "js": "record['processed'] === true"
+            }
           },
           {
             "name": "description",
@@ -222,7 +232,12 @@
             "required": false,
             "grid": true,
             "form": true,
-            "defaultValue": "@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM M_InventoryLine WHERE M_Inventory_ID=@M_Inventory_ID@"
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM M_InventoryLine WHERE M_Inventory_ID=@M_Inventory_ID@",
+            "readOnlyLogic": {
+              "raw": "@Processed@='Y'",
+              "evaluable": true,
+              "js": "record['processed'] === true"
+            }
           },
           {
             "name": "product",
@@ -240,6 +255,11 @@
             "lookup": true,
             "callout": {
               "className": "org.openbravo.erpCommon.ad_callouts.SL_Inventory_Product"
+            },
+            "readOnlyLogic": {
+              "raw": "@Processed@='Y'",
+              "evaluable": true,
+              "js": "record['processed'] === true"
             }
           },
           {
@@ -256,8 +276,20 @@
             "reference": "Locator",
             "inputMode": "search",
             "defaultValue": "@SQL=SELECT M_LOCATOR_ID AS DEFAULTVALUE FROM M_LOCATOR WHERE AD_ISORGINCLUDED(@AD_Org_ID@, M_LOCATOR.AD_Org_ID, @#AD_Client_ID@) <> -1 AND ISACTIVE='Y' AND M_WAREHOUSE_ID=@M_WAREHOUSE_ID@  ORDER BY M_LOCATOR.ISDEFAULT DESC",
+            "validationRule": {
+              "code": "M_Locator.M_Warehouse_ID=@M_Warehouse_ID@",
+              "contextParams": [],
+              "cascadeParams": [
+                "M_Warehouse_ID"
+              ]
+            },
             "callout": {
               "className": "org.openbravo.erpCommon.ad_callouts.SL_Inventory_Locator"
+            },
+            "readOnlyLogic": {
+              "raw": "@Processed@='Y'",
+              "evaluable": true,
+              "js": "record['processed'] === true"
             }
           },
           {
@@ -304,7 +336,12 @@
             "visibility": "editable",
             "required": true,
             "grid": true,
-            "form": true
+            "form": true,
+            "readOnlyLogic": {
+              "raw": "@Processed@='Y'",
+              "evaluable": true,
+              "js": "record['processed'] === true"
+            }
           },
           {
             "name": "uOM",
@@ -373,7 +410,8 @@
               "source": "0"
             }
           }
-        ]
+        ],
+        "javaQualifier": "inventoryLine"
       }
     }
   },
@@ -790,7 +828,8 @@
             "visibility": "system",
             "required": true
           }
-        ]
+        ],
+        "javaQualifier": "inventoryLine"
       }
     },
     "endpoints": [
@@ -978,6 +1017,9 @@
       },
       "filtering": "Use field name as query param: ?fieldName=value",
       "parentFilter": "parentId={id} for child entities"
+    },
+    "window": {
+      "category": "inventory"
     }
   },
   "testManifest": {
@@ -1161,12 +1203,28 @@
         "id": "t-23",
         "category": "readonlylogic-valid",
         "entity": "inventory",
+        "field": "movementDate",
+        "runner": "node",
+        "description": "Read-only logic for 'movementDate' in inventory should be valid JS"
+      },
+      {
+        "id": "t-24",
+        "category": "readonlylogic-valid",
+        "entity": "inventory",
+        "field": "warehouse",
+        "runner": "node",
+        "description": "Read-only logic for 'warehouse' in inventory should be valid JS"
+      },
+      {
+        "id": "t-25",
+        "category": "readonlylogic-valid",
+        "entity": "inventory",
         "field": "project",
         "runner": "node",
         "description": "Read-only logic for 'project' in inventory should be valid JS"
       },
       {
-        "id": "t-24",
+        "id": "t-26",
         "category": "displaylogic-evaluable",
         "entity": "inventory",
         "field": "processNow",
@@ -1174,7 +1232,7 @@
         "description": "Display logic for 'processNow' in inventory should have evaluable flag"
       },
       {
-        "id": "t-25",
+        "id": "t-27",
         "category": "displaylogic-evaluable",
         "entity": "inventory",
         "field": "project",
@@ -1182,7 +1240,23 @@
         "description": "Display logic for 'project' in inventory should have evaluable flag"
       },
       {
-        "id": "t-26",
+        "id": "t-28",
+        "category": "readonlylogic-evaluable",
+        "entity": "inventory",
+        "field": "movementDate",
+        "runner": "node",
+        "description": "Read-only logic for 'movementDate' in inventory should have evaluable flag"
+      },
+      {
+        "id": "t-29",
+        "category": "readonlylogic-evaluable",
+        "entity": "inventory",
+        "field": "warehouse",
+        "runner": "node",
+        "description": "Read-only logic for 'warehouse' in inventory should have evaluable flag"
+      },
+      {
+        "id": "t-30",
         "category": "readonlylogic-evaluable",
         "entity": "inventory",
         "field": "project",
@@ -1190,7 +1264,7 @@
         "description": "Read-only logic for 'project' in inventory should have evaluable flag"
       },
       {
-        "id": "t-27",
+        "id": "t-31",
         "category": "default-value-type",
         "entity": "inventory",
         "field": "movementDate",
@@ -1198,7 +1272,7 @@
         "description": "Default value for 'movementDate' in inventory should be a string"
       },
       {
-        "id": "t-28",
+        "id": "t-32",
         "category": "default-value-type",
         "entity": "inventory",
         "field": "name",
@@ -1206,7 +1280,7 @@
         "description": "Default value for 'name' in inventory should be a string"
       },
       {
-        "id": "t-29",
+        "id": "t-33",
         "category": "default-value-type",
         "entity": "inventory",
         "field": "inventoryType",
@@ -1214,7 +1288,7 @@
         "description": "Default value for 'inventoryType' in inventory should be a string"
       },
       {
-        "id": "t-30",
+        "id": "t-34",
         "category": "field-presence",
         "entity": "inventoryLine",
         "field": "lineNo",
@@ -1222,7 +1296,7 @@
         "description": "Field 'lineNo' should be present in inventoryLine"
       },
       {
-        "id": "t-31",
+        "id": "t-35",
         "category": "field-presence",
         "entity": "inventoryLine",
         "field": "product",
@@ -1230,7 +1304,7 @@
         "description": "Field 'product' should be present in inventoryLine"
       },
       {
-        "id": "t-32",
+        "id": "t-36",
         "category": "field-presence",
         "entity": "inventoryLine",
         "field": "storageBin",
@@ -1238,7 +1312,7 @@
         "description": "Field 'storageBin' should be present in inventoryLine"
       },
       {
-        "id": "t-33",
+        "id": "t-37",
         "category": "field-presence",
         "entity": "inventoryLine",
         "field": "description",
@@ -1246,7 +1320,7 @@
         "description": "Field 'description' should be present in inventoryLine"
       },
       {
-        "id": "t-34",
+        "id": "t-38",
         "category": "field-presence",
         "entity": "inventoryLine",
         "field": "quantityOrderBook",
@@ -1254,7 +1328,7 @@
         "description": "Field 'quantityOrderBook' should be present in inventoryLine"
       },
       {
-        "id": "t-35",
+        "id": "t-39",
         "category": "field-presence",
         "entity": "inventoryLine",
         "field": "quantityCount",
@@ -1262,7 +1336,7 @@
         "description": "Field 'quantityCount' should be present in inventoryLine"
       },
       {
-        "id": "t-36",
+        "id": "t-40",
         "category": "field-presence",
         "entity": "inventoryLine",
         "field": "uOM",
@@ -1270,7 +1344,7 @@
         "description": "Field 'uOM' should be present in inventoryLine"
       },
       {
-        "id": "t-37",
+        "id": "t-41",
         "category": "field-presence",
         "entity": "inventoryLine",
         "field": "bookQuantity",
@@ -1278,7 +1352,7 @@
         "description": "Field 'bookQuantity' should be present in inventoryLine"
       },
       {
-        "id": "t-38",
+        "id": "t-42",
         "category": "field-presence",
         "entity": "inventoryLine",
         "field": "cost",
@@ -1286,7 +1360,7 @@
         "description": "Field 'cost' should be present in inventoryLine"
       },
       {
-        "id": "t-39",
+        "id": "t-43",
         "category": "field-type",
         "entity": "inventoryLine",
         "field": "lineNo",
@@ -1294,7 +1368,7 @@
         "description": "Field 'lineNo' should have type 'number' in inventoryLine"
       },
       {
-        "id": "t-40",
+        "id": "t-44",
         "category": "field-type",
         "entity": "inventoryLine",
         "field": "product",
@@ -1302,7 +1376,7 @@
         "description": "Field 'product' should have type 'string' in inventoryLine"
       },
       {
-        "id": "t-41",
+        "id": "t-45",
         "category": "field-type",
         "entity": "inventoryLine",
         "field": "storageBin",
@@ -1310,7 +1384,7 @@
         "description": "Field 'storageBin' should have type 'string' in inventoryLine"
       },
       {
-        "id": "t-42",
+        "id": "t-46",
         "category": "field-type",
         "entity": "inventoryLine",
         "field": "description",
@@ -1318,7 +1392,7 @@
         "description": "Field 'description' should have type 'string' in inventoryLine"
       },
       {
-        "id": "t-43",
+        "id": "t-47",
         "category": "field-type",
         "entity": "inventoryLine",
         "field": "quantityOrderBook",
@@ -1326,7 +1400,7 @@
         "description": "Field 'quantityOrderBook' should have type 'number' in inventoryLine"
       },
       {
-        "id": "t-44",
+        "id": "t-48",
         "category": "field-type",
         "entity": "inventoryLine",
         "field": "quantityCount",
@@ -1334,7 +1408,7 @@
         "description": "Field 'quantityCount' should have type 'number' in inventoryLine"
       },
       {
-        "id": "t-45",
+        "id": "t-49",
         "category": "field-type",
         "entity": "inventoryLine",
         "field": "uOM",
@@ -1342,7 +1416,7 @@
         "description": "Field 'uOM' should have type 'string' in inventoryLine"
       },
       {
-        "id": "t-46",
+        "id": "t-50",
         "category": "field-type",
         "entity": "inventoryLine",
         "field": "bookQuantity",
@@ -1350,7 +1424,7 @@
         "description": "Field 'bookQuantity' should have type 'number' in inventoryLine"
       },
       {
-        "id": "t-47",
+        "id": "t-51",
         "category": "field-type",
         "entity": "inventoryLine",
         "field": "cost",
@@ -1358,14 +1432,14 @@
         "description": "Field 'cost' should have type 'number' in inventoryLine"
       },
       {
-        "id": "t-48",
+        "id": "t-52",
         "category": "visibility",
         "entity": "inventoryLine",
         "runner": "node",
         "description": "Entity 'inventoryLine' should only expose visible fields in frontend"
       },
       {
-        "id": "t-49",
+        "id": "t-53",
         "category": "displaylogic-valid",
         "entity": "inventoryLine",
         "field": "quantityOrderBook",
@@ -1373,7 +1447,31 @@
         "description": "Display logic for 'quantityOrderBook' in inventoryLine should be valid JS"
       },
       {
-        "id": "t-50",
+        "id": "t-54",
+        "category": "readonlylogic-valid",
+        "entity": "inventoryLine",
+        "field": "lineNo",
+        "runner": "node",
+        "description": "Read-only logic for 'lineNo' in inventoryLine should be valid JS"
+      },
+      {
+        "id": "t-55",
+        "category": "readonlylogic-valid",
+        "entity": "inventoryLine",
+        "field": "product",
+        "runner": "node",
+        "description": "Read-only logic for 'product' in inventoryLine should be valid JS"
+      },
+      {
+        "id": "t-56",
+        "category": "readonlylogic-valid",
+        "entity": "inventoryLine",
+        "field": "storageBin",
+        "runner": "node",
+        "description": "Read-only logic for 'storageBin' in inventoryLine should be valid JS"
+      },
+      {
+        "id": "t-57",
         "category": "readonlylogic-valid",
         "entity": "inventoryLine",
         "field": "description",
@@ -1381,7 +1479,15 @@
         "description": "Read-only logic for 'description' in inventoryLine should be valid JS"
       },
       {
-        "id": "t-51",
+        "id": "t-58",
+        "category": "readonlylogic-valid",
+        "entity": "inventoryLine",
+        "field": "quantityCount",
+        "runner": "node",
+        "description": "Read-only logic for 'quantityCount' in inventoryLine should be valid JS"
+      },
+      {
+        "id": "t-59",
         "category": "readonlylogic-valid",
         "entity": "inventoryLine",
         "field": "cost",
@@ -1389,7 +1495,7 @@
         "description": "Read-only logic for 'cost' in inventoryLine should be valid JS"
       },
       {
-        "id": "t-52",
+        "id": "t-60",
         "category": "displaylogic-evaluable",
         "entity": "inventoryLine",
         "field": "quantityOrderBook",
@@ -1397,7 +1503,31 @@
         "description": "Display logic for 'quantityOrderBook' in inventoryLine should have evaluable flag"
       },
       {
-        "id": "t-53",
+        "id": "t-61",
+        "category": "readonlylogic-evaluable",
+        "entity": "inventoryLine",
+        "field": "lineNo",
+        "runner": "node",
+        "description": "Read-only logic for 'lineNo' in inventoryLine should have evaluable flag"
+      },
+      {
+        "id": "t-62",
+        "category": "readonlylogic-evaluable",
+        "entity": "inventoryLine",
+        "field": "product",
+        "runner": "node",
+        "description": "Read-only logic for 'product' in inventoryLine should have evaluable flag"
+      },
+      {
+        "id": "t-63",
+        "category": "readonlylogic-evaluable",
+        "entity": "inventoryLine",
+        "field": "storageBin",
+        "runner": "node",
+        "description": "Read-only logic for 'storageBin' in inventoryLine should have evaluable flag"
+      },
+      {
+        "id": "t-64",
         "category": "readonlylogic-evaluable",
         "entity": "inventoryLine",
         "field": "description",
@@ -1405,7 +1535,15 @@
         "description": "Read-only logic for 'description' in inventoryLine should have evaluable flag"
       },
       {
-        "id": "t-54",
+        "id": "t-65",
+        "category": "readonlylogic-evaluable",
+        "entity": "inventoryLine",
+        "field": "quantityCount",
+        "runner": "node",
+        "description": "Read-only logic for 'quantityCount' in inventoryLine should have evaluable flag"
+      },
+      {
+        "id": "t-66",
         "category": "readonlylogic-evaluable",
         "entity": "inventoryLine",
         "field": "cost",
@@ -1413,7 +1551,7 @@
         "description": "Read-only logic for 'cost' in inventoryLine should have evaluable flag"
       },
       {
-        "id": "t-55",
+        "id": "t-67",
         "category": "default-value-type",
         "entity": "inventoryLine",
         "field": "lineNo",
@@ -1421,7 +1559,7 @@
         "description": "Default value for 'lineNo' in inventoryLine should be a string"
       },
       {
-        "id": "t-56",
+        "id": "t-68",
         "category": "default-value-type",
         "entity": "inventoryLine",
         "field": "storageBin",
@@ -1429,7 +1567,7 @@
         "description": "Default value for 'storageBin' in inventoryLine should be a string"
       },
       {
-        "id": "t-57",
+        "id": "t-69",
         "category": "default-value-type",
         "entity": "inventoryLine",
         "field": "quantityOrderBook",
@@ -1437,7 +1575,7 @@
         "description": "Default value for 'quantityOrderBook' in inventoryLine should be a string"
       },
       {
-        "id": "t-58",
+        "id": "t-70",
         "category": "system-field",
         "entity": "inventory",
         "field": "organization",
@@ -1445,7 +1583,7 @@
         "description": "System field 'organization' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-59",
+        "id": "t-71",
         "category": "system-field",
         "entity": "inventory",
         "field": "generateList",
@@ -1453,7 +1591,7 @@
         "description": "System field 'generateList' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-60",
+        "id": "t-72",
         "category": "system-field",
         "entity": "inventory",
         "field": "updateQuantities",
@@ -1461,7 +1599,7 @@
         "description": "System field 'updateQuantities' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-61",
+        "id": "t-73",
         "category": "system-field",
         "entity": "inventory",
         "field": "posted",
@@ -1469,7 +1607,7 @@
         "description": "System field 'posted' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-62",
+        "id": "t-74",
         "category": "system-field",
         "entity": "inventory",
         "field": "costCenter",
@@ -1477,7 +1615,7 @@
         "description": "System field 'costCenter' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-63",
+        "id": "t-75",
         "category": "system-field",
         "entity": "inventory",
         "field": "asset",
@@ -1485,7 +1623,7 @@
         "description": "System field 'asset' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-64",
+        "id": "t-76",
         "category": "system-field",
         "entity": "inventory",
         "field": "activity",
@@ -1493,7 +1631,7 @@
         "description": "System field 'activity' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-65",
+        "id": "t-77",
         "category": "system-field",
         "entity": "inventory",
         "field": "salesCampaign",
@@ -1501,7 +1639,7 @@
         "description": "System field 'salesCampaign' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-66",
+        "id": "t-78",
         "category": "system-field",
         "entity": "inventory",
         "field": "stDimension",
@@ -1509,7 +1647,7 @@
         "description": "System field 'stDimension' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-67",
+        "id": "t-79",
         "category": "system-field",
         "entity": "inventory",
         "field": "ndDimension",
@@ -1517,7 +1655,7 @@
         "description": "System field 'ndDimension' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-68",
+        "id": "t-80",
         "category": "system-field",
         "entity": "inventory",
         "field": "trxOrganization",
@@ -1525,7 +1663,7 @@
         "description": "System field 'trxOrganization' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-69",
+        "id": "t-81",
         "category": "system-field",
         "entity": "inventory",
         "field": "id",
@@ -1533,7 +1671,7 @@
         "description": "System field 'id' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-70",
+        "id": "t-82",
         "category": "system-field",
         "entity": "inventory",
         "field": "active",
@@ -1541,7 +1679,7 @@
         "description": "System field 'active' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-71",
+        "id": "t-83",
         "category": "system-field",
         "entity": "inventory",
         "field": "client",
@@ -1549,7 +1687,7 @@
         "description": "System field 'client' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-72",
+        "id": "t-84",
         "category": "system-field",
         "entity": "inventory",
         "field": "creationDate",
@@ -1557,7 +1695,7 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-73",
+        "id": "t-85",
         "category": "system-field",
         "entity": "inventory",
         "field": "createdBy",
@@ -1565,7 +1703,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-74",
+        "id": "t-86",
         "category": "system-field",
         "entity": "inventory",
         "field": "updated",
@@ -1573,7 +1711,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-75",
+        "id": "t-87",
         "category": "system-field",
         "entity": "inventory",
         "field": "updatedBy",
@@ -1581,7 +1719,7 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for inventory"
       },
       {
-        "id": "t-76",
+        "id": "t-88",
         "category": "system-field",
         "entity": "inventoryLine",
         "field": "attributeSetValue",
@@ -1589,7 +1727,7 @@
         "description": "System field 'attributeSetValue' should exist in backend but not frontend for inventoryLine"
       },
       {
-        "id": "t-77",
+        "id": "t-89",
         "category": "system-field",
         "entity": "inventoryLine",
         "field": "orderQuantity",
@@ -1597,7 +1735,7 @@
         "description": "System field 'orderQuantity' should exist in backend but not frontend for inventoryLine"
       },
       {
-        "id": "t-78",
+        "id": "t-90",
         "category": "system-field",
         "entity": "inventoryLine",
         "field": "orderUOM",
@@ -1605,7 +1743,7 @@
         "description": "System field 'orderUOM' should exist in backend but not frontend for inventoryLine"
       },
       {
-        "id": "t-79",
+        "id": "t-91",
         "category": "system-field",
         "entity": "inventoryLine",
         "field": "relatedInventory",
@@ -1613,7 +1751,7 @@
         "description": "System field 'relatedInventory' should exist in backend but not frontend for inventoryLine"
       },
       {
-        "id": "t-80",
+        "id": "t-92",
         "category": "system-field",
         "entity": "inventoryLine",
         "field": "organization",
@@ -1621,7 +1759,7 @@
         "description": "System field 'organization' should exist in backend but not frontend for inventoryLine"
       },
       {
-        "id": "t-81",
+        "id": "t-93",
         "category": "system-field",
         "entity": "inventoryLine",
         "field": "active",
@@ -1629,7 +1767,7 @@
         "description": "System field 'active' should exist in backend but not frontend for inventoryLine"
       },
       {
-        "id": "t-82",
+        "id": "t-94",
         "category": "system-field",
         "entity": "inventoryLine",
         "field": "physInventory",
@@ -1637,7 +1775,7 @@
         "description": "System field 'physInventory' should exist in backend but not frontend for inventoryLine"
       },
       {
-        "id": "t-83",
+        "id": "t-95",
         "category": "system-field",
         "entity": "inventoryLine",
         "field": "id",
@@ -1645,7 +1783,7 @@
         "description": "System field 'id' should exist in backend but not frontend for inventoryLine"
       },
       {
-        "id": "t-84",
+        "id": "t-96",
         "category": "system-field",
         "entity": "inventoryLine",
         "field": "client",
@@ -1653,7 +1791,7 @@
         "description": "System field 'client' should exist in backend but not frontend for inventoryLine"
       },
       {
-        "id": "t-85",
+        "id": "t-97",
         "category": "system-field",
         "entity": "inventoryLine",
         "field": "creationDate",
@@ -1661,7 +1799,7 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for inventoryLine"
       },
       {
-        "id": "t-86",
+        "id": "t-98",
         "category": "system-field",
         "entity": "inventoryLine",
         "field": "createdBy",
@@ -1669,7 +1807,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for inventoryLine"
       },
       {
-        "id": "t-87",
+        "id": "t-99",
         "category": "system-field",
         "entity": "inventoryLine",
         "field": "updated",
@@ -1677,7 +1815,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for inventoryLine"
       },
       {
-        "id": "t-88",
+        "id": "t-100",
         "category": "system-field",
         "entity": "inventoryLine",
         "field": "updatedBy",
@@ -1685,98 +1823,98 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for inventoryLine"
       },
       {
-        "id": "t-89",
+        "id": "t-101",
         "category": "rule-declared",
         "rule": "SL_Inventory_Conversion",
         "runner": "node",
         "description": "Rule 'SL_Inventory_Conversion' (undefined) should be declared"
       },
       {
-        "id": "t-90",
+        "id": "t-102",
         "category": "rule-declared",
         "rule": "SL_Inventory_Product",
         "runner": "node",
         "description": "Rule 'SL_Inventory_Product' (undefined) should be declared"
       },
       {
-        "id": "t-91",
+        "id": "t-103",
         "category": "rule-declared",
         "rule": "SL_Inventory_Locator",
         "runner": "node",
         "description": "Rule 'SL_Inventory_Locator' (undefined) should be declared"
       },
       {
-        "id": "t-92",
+        "id": "t-104",
         "category": "rule-declared",
         "rule": "AD_Org show child organizations",
         "runner": "node",
         "description": "Rule 'AD_Org show child organizations' (validation) should be declared"
       },
       {
-        "id": "t-93",
+        "id": "t-105",
         "category": "rule-declared",
         "rule": "M_Locator of Warehouse",
         "runner": "node",
         "description": "Rule 'M_Locator of Warehouse' (validation) should be declared"
       },
       {
-        "id": "t-94",
+        "id": "t-106",
         "category": "rule-declared",
         "rule": "READONLY_Processed_Header",
         "runner": "node",
         "description": "Rule 'READONLY_Processed_Header' (readOnlyLogic) should be declared"
       },
       {
-        "id": "t-95",
+        "id": "t-107",
         "category": "rule-declared",
         "rule": "READONLY_Processed_Lines",
         "runner": "node",
         "description": "Rule 'READONLY_Processed_Lines' (readOnlyLogic) should be declared"
       },
       {
-        "id": "t-96",
+        "id": "t-108",
         "category": "rule-declared",
         "rule": "PROCESS_ProcessInventoryCount",
         "runner": "node",
         "description": "Rule 'PROCESS_ProcessInventoryCount' (process) should be declared"
       },
       {
-        "id": "t-97",
+        "id": "t-109",
         "category": "rule-declared",
         "rule": "PROCESS_CreateInventoryCountList",
         "runner": "node",
         "description": "Rule 'PROCESS_CreateInventoryCountList' (process) should be declared"
       },
       {
-        "id": "t-98",
+        "id": "t-110",
         "category": "rule-declared",
         "rule": "PROCESS_UpdateQuantity",
         "runner": "node",
         "description": "Rule 'PROCESS_UpdateQuantity' (process) should be declared"
       },
       {
-        "id": "t-99",
+        "id": "t-111",
         "category": "rule-declared",
         "rule": "PROCESS_Posted",
         "runner": "node",
         "description": "Rule 'PROCESS_Posted' (process) should be declared"
       },
       {
-        "id": "t-100",
+        "id": "t-112",
         "category": "crud-flags",
         "entity": "inventory",
         "runner": "node",
         "description": "CRUD flags for 'inventory' should all be booleans"
       },
       {
-        "id": "t-101",
+        "id": "t-113",
         "category": "crud-flags",
         "entity": "inventoryLine",
         "runner": "node",
         "description": "CRUD flags for 'inventoryLine' should all be booleans"
       },
       {
-        "id": "t-102",
+        "id": "t-114",
         "category": "selector-endpoint",
         "entity": "inventory",
         "field": "warehouse",
@@ -1784,7 +1922,7 @@
         "description": "Selector endpoint for 'warehouse' in inventory should exist"
       },
       {
-        "id": "t-103",
+        "id": "t-115",
         "category": "selector-endpoint",
         "entity": "inventory",
         "field": "project",
@@ -1792,7 +1930,7 @@
         "description": "Selector endpoint for 'project' in inventory should exist"
       },
       {
-        "id": "t-104",
+        "id": "t-116",
         "category": "selector-endpoint",
         "entity": "inventoryLine",
         "field": "product",
@@ -1800,7 +1938,7 @@
         "description": "Selector endpoint for 'product' in inventoryLine should exist"
       },
       {
-        "id": "t-105",
+        "id": "t-117",
         "category": "selector-endpoint",
         "entity": "inventoryLine",
         "field": "storageBin",
@@ -1808,7 +1946,7 @@
         "description": "Selector endpoint for 'storageBin' in inventoryLine should exist"
       },
       {
-        "id": "t-106",
+        "id": "t-118",
         "category": "selector-endpoint",
         "entity": "inventoryLine",
         "field": "uOM",
@@ -1816,7 +1954,7 @@
         "description": "Selector endpoint for 'uOM' in inventoryLine should exist"
       },
       {
-        "id": "t-107",
+        "id": "t-119",
         "category": "action-endpoint",
         "entity": "inventory",
         "field": "generateList",
@@ -1824,7 +1962,7 @@
         "description": "Action endpoint for 'generateList' in inventory should exist"
       },
       {
-        "id": "t-108",
+        "id": "t-120",
         "category": "action-endpoint",
         "entity": "inventory",
         "field": "updateQuantities",
@@ -1832,7 +1970,7 @@
         "description": "Action endpoint for 'updateQuantities' in inventory should exist"
       },
       {
-        "id": "t-109",
+        "id": "t-121",
         "category": "action-endpoint",
         "entity": "inventory",
         "field": "processNow",
@@ -1840,7 +1978,7 @@
         "description": "Action endpoint for 'processNow' in inventory should exist"
       },
       {
-        "id": "t-110",
+        "id": "t-122",
         "category": "action-endpoint",
         "entity": "inventory",
         "field": "posted",
@@ -1849,16 +1987,16 @@
       }
     ],
     "summary": {
-      "total": 110,
+      "total": 122,
       "byCategory": {
         "field-presence": 17,
         "field-type": 17,
         "searchable-filters": 3,
         "visibility": 2,
         "displaylogic-valid": 3,
-        "readonlylogic-valid": 3,
+        "readonlylogic-valid": 9,
         "displaylogic-evaluable": 3,
-        "readonlylogic-evaluable": 3,
+        "readonlylogic-evaluable": 9,
         "default-value-type": 6,
         "system-field": 31,
         "rule-declared": 11,
@@ -1867,7 +2005,7 @@
         "action-endpoint": 4
       },
       "byRunner": {
-        "node": 110,
+        "node": 122,
         "junit": 0
       }
     }

--- a/artifacts/physical-inventory/decisions.json
+++ b/artifacts/physical-inventory/decisions.json
@@ -68,6 +68,7 @@
     },
     "lines": {
       "name": "inventoryLine",
+      "javaQualifier": "inventoryLine",
       "fields": {
         "storageBin": {
           "form": false,

--- a/artifacts/physical-inventory/generated/web/physical-inventory/InventoryForm.jsx
+++ b/artifacts/physical-inventory/generated/web/physical-inventory/InventoryForm.jsx
@@ -2,9 +2,9 @@ import { EntityForm } from '@/components/contract-ui';
 
 // @sf-generated-start fields:inventory
 const fields = [
-  { key: 'movementDate', column: 'MovementDate', type: 'date', label: 'Movement Date', required: true, section: 'principal', defaultValue: '@#Date@' },
+  { key: 'movementDate', column: 'MovementDate', type: 'date', label: 'Movement Date', required: true, section: 'principal', defaultValue: '@#Date@', readOnlyLogic: (record) => record['processed'] === true },
   { key: 'name', column: 'Name', type: 'text', label: 'Name', required: true, section: 'principal', defaultValue: '@#Date@' },
-  { key: 'warehouse', column: 'M_Warehouse_ID', type: 'search', label: 'Warehouse', required: true, section: 'principal', reference: 'Warehouse', inputMode: 'search' },
+  { key: 'warehouse', column: 'M_Warehouse_ID', type: 'search', label: 'Warehouse', required: true, section: 'principal', reference: 'Warehouse', inputMode: 'search', readOnlyLogic: (record) => record['processed'] === true },
   { key: 'description', column: 'Description', type: 'textarea', label: 'Description', section: 'other' },
   { key: 'inventoryType', column: 'Inventory_Type', type: 'select', label: 'Inventory Type', required: true, readOnly: true, section: 'other', options: [{ value: 'C', label: 'Closing Inventory' }, { value: 'N', label: 'Normal' }, { value: 'O', label: 'Opening Inventory' }], defaultValue: 'N' },
   { key: 'project', column: 'C_Project_ID', type: 'search', label: 'Project', section: 'other', reference: 'Project', inputMode: 'search', visible: null, visibilitySource: 'server', displayLogicReason: 'server-macro', readOnlyLogic: (record) => record['posted'] === 'Y' },

--- a/artifacts/physical-inventory/generated/web/physical-inventory/InventoryLineForm.jsx
+++ b/artifacts/physical-inventory/generated/web/physical-inventory/InventoryLineForm.jsx
@@ -2,11 +2,11 @@ import { EntityForm } from '@/components/contract-ui';
 
 // @sf-generated-start fields:inventoryLine
 const fields = [
-  { key: 'lineNo', column: 'Line', type: 'number', label: 'Line No.', section: 'principal', defaultValue: '@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM M_InventoryLine WHERE M_Inventory_ID=@M_Inventory_ID@' },
-  { key: 'product', column: 'M_Product_ID', type: 'search', label: 'Product', required: true, lookup: true, section: 'principal', reference: 'Product', inputMode: 'search' },
+  { key: 'lineNo', column: 'Line', type: 'number', label: 'Line No.', section: 'principal', defaultValue: '@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM M_InventoryLine WHERE M_Inventory_ID=@M_Inventory_ID@', readOnlyLogic: (record) => record['processed'] === true },
+  { key: 'product', column: 'M_Product_ID', type: 'search', label: 'Product', required: true, lookup: true, section: 'principal', reference: 'Product', inputMode: 'search', readOnlyLogic: (record) => record['processed'] === true },
   { key: 'description', column: 'Description', type: 'textarea', label: 'Description', section: 'principal', readOnlyLogic: (record) => record['processed'] === true },
   { key: 'quantityOrderBook', column: 'QuantityOrderBook', type: 'number', label: 'Quantity order book', readOnly: true, section: 'other', defaultValue: '0' },
-  { key: 'quantityCount', column: 'QtyCount', type: 'number', label: 'User Count', required: true, section: 'principal' },
+  { key: 'quantityCount', column: 'QtyCount', type: 'number', label: 'User Count', required: true, section: 'principal', readOnlyLogic: (record) => record['processed'] === true },
   { key: 'uOM', column: 'C_UOM_ID', type: 'selector', label: 'UOM', required: true, readOnly: true, section: 'other', reference: 'UOM', inputMode: 'selector' },
   { key: 'bookQuantity', column: 'QtyBook', type: 'number', label: 'System Count', required: true, readOnly: true, section: 'other' },
   { key: 'cost', column: 'Cost', type: 'number', label: 'Cost', section: 'other', readOnlyLogic: (record) => record['processed'] === true },

--- a/artifacts/physical-inventory/generated/web/physical-inventory/InventoryPage.jsx
+++ b/artifacts/physical-inventory/generated/web/physical-inventory/InventoryPage.jsx
@@ -37,7 +37,7 @@ const draftMode = null;
 // @sf-generated-start addLineFields:inventoryLine
 const addLineFields = {
   entry: [
-    { key: 'lineNo', column: 'Line', type: 'number', label: 'Line No.' },
+    { key: 'lineNo', column: 'Line', type: 'number', label: 'Line No.', defaultValue: '@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM M_InventoryLine WHERE M_Inventory_ID=@M_Inventory_ID@' },
     { key: 'product', column: 'M_Product_ID', type: 'search', required: true, lookup: true, label: 'Product', reference: 'Product', inputMode: 'search' },
     { key: 'description', column: 'Description', type: 'textarea', label: 'Description' },
     { key: 'quantityCount', column: 'QtyCount', type: 'number', required: true, label: 'User Count' },
@@ -46,7 +46,7 @@ const addLineFields = {
     { key: 'cost', column: 'Cost', type: 'number', label: 'Cost' },
   ],
   hidden: [
-    { key: 'storageBin', value: '@SQL=SELECT M_LOCATOR_ID AS DEFAULTVALUE FROM M_LOCATOR WHERE AD_ISORGINCLUDED(@AD_Org_ID@, M_LOCATOR.AD_Org_ID, @#AD_Client_ID@) <> -1 AND ISACTIVE=\'Y\' AND M_WAREHOUSE_ID=@M_WAREHOUSE_ID@  ORDER BY M_LOCATOR.ISDEFAULT DESC' },
+
   ],
 };
 // @sf-generated-end addLineFields:inventoryLine
@@ -168,12 +168,14 @@ const api = {
     },
     "filtering": "Use field name as query param: ?fieldName=value",
     "parentFilter": "parentId={id} for child entities"
+  },
+  "window": {
+    "category": "inventory"
   }
 };
 
 // @sf-generated-start component:InventoryPage
 export default function InventoryPage({ windowName, recordId, ...props }) {
-  
   if (recordId) {
     return (
       <DetailView

--- a/artifacts/physical-inventory/generated/web/physical-inventory/index.jsx
+++ b/artifacts/physical-inventory/generated/web/physical-inventory/index.jsx
@@ -119,6 +119,9 @@ const api = {
     },
     "filtering": "Use field name as query param: ?fieldName=value",
     "parentFilter": "parentId={id} for child entities"
+  },
+  "window": {
+    "category": "inventory"
   }
 };
 

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -563,7 +563,9 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
     return `    { key: '${f.name}', column: '${f.column}', type: '${type}'${labelPart}${referencePart}${inputModePart} },`;
   }).join('\n');
 
-  const hiddenDefaultsArray = hiddenDefaultFields.map(f => {
+  const hiddenDefaultsArray = hiddenDefaultFields
+    .filter(f => !String(f.defaultValue).startsWith('@SQL='))
+    .map(f => {
     const rawDefault = String(f.defaultValue);
     const parentColMatch = rawDefault.match(/^@(\w+)@$/);
     if (parentColMatch) {


### PR DESCRIPTION
## Summary
- update the physical-inventory frontend flow so line creation uses the inventory header context instead of leaking SQL defaults into hidden fields
- wire the generated line form and callout handling to support the current inventory selector behavior for warehouse-scoped stock values
- document the remaining overwrite caveat and the proposed scoped `forceCalloutFields` follow-up

## Why
Physical Inventory lines were using the wrong context when selecting a product, which caused inconsistent stock-derived values in the UI. This change aligns the frontend/generator side with the warehouse-scoped selector flow and leaves the overwrite behavior documented for a separate follow-up.