### PR TITLE
Feature ETP-3662: Hide Line Net Amount from invoice lines grid and form

### DIFF
--- a/artifacts/purchase-invoice/contract.json
+++ b/artifacts/purchase-invoice/contract.json
@@ -1,7 +1,7 @@
 {
   "version": "0.9.1",
-  "generatedAt": "2026-04-21T16:50:39.530Z",
-  "checksum": "2bff4813b9f76829",
+  "generatedAt": "2026-04-22T14:47:01.297Z",
+  "checksum": "2b9b9590ca75dc56",
   "frontendContract": {
     "window": {
       "id": "183",
@@ -802,27 +802,6 @@
               "raw": "@Processed@='Y'|@GROSSPRICE@='N'",
               "evaluable": true,
               "js": "record['processed'] === true || record['gROSSPRICE'] === 'N'"
-            }
-          },
-          {
-            "name": "lineNetAmount",
-            "apiKey": "lineNetAmount",
-            "column": "LineNetAmt",
-            "label": "Line Net Amount",
-            "type": "amount",
-            "tsType": "number",
-            "visibility": "readOnly",
-            "required": true,
-            "grid": true,
-            "form": true,
-            "section": "principal",
-            "callout": {
-              "className": "org.openbravo.erpCommon.ad_callouts.SL_Invoice_Amt"
-            },
-            "readOnlyLogic": {
-              "raw": "@Iseditlinenetamt@='N' | @Processed@='Y'",
-              "evaluable": true,
-              "js": "record['editLineAmount'] !== true || record['processed'] === true"
             }
           },
           {
@@ -4246,7 +4225,7 @@
             "apiKey": "lineNetAmount",
             "column": "LineNetAmt",
             "type": "amount",
-            "visibility": "readOnly",
+            "visibility": "system",
             "required": true
           },
           {
@@ -8487,20 +8466,12 @@
         "id": "t-97",
         "category": "field-presence",
         "entity": "lines",
-        "field": "lineNetAmount",
-        "runner": "node",
-        "description": "Field 'lineNetAmount' should be present in lines"
-      },
-      {
-        "id": "t-98",
-        "category": "field-presence",
-        "entity": "lines",
         "field": "grossAmount",
         "runner": "node",
         "description": "Field 'grossAmount' should be present in lines"
       },
       {
-        "id": "t-99",
+        "id": "t-98",
         "category": "field-presence",
         "entity": "lines",
         "field": "description",
@@ -8508,7 +8479,7 @@
         "description": "Field 'description' should be present in lines"
       },
       {
-        "id": "t-100",
+        "id": "t-99",
         "category": "field-presence",
         "entity": "lines",
         "field": "tax",
@@ -8516,7 +8487,7 @@
         "description": "Field 'tax' should be present in lines"
       },
       {
-        "id": "t-101",
+        "id": "t-100",
         "category": "field-presence",
         "entity": "lines",
         "field": "listPrice",
@@ -8524,7 +8495,7 @@
         "description": "Field 'listPrice' should be present in lines"
       },
       {
-        "id": "t-102",
+        "id": "t-101",
         "category": "field-presence",
         "entity": "lines",
         "field": "attributeSetValue",
@@ -8532,7 +8503,7 @@
         "description": "Field 'attributeSetValue' should be present in lines"
       },
       {
-        "id": "t-103",
+        "id": "t-102",
         "category": "field-presence",
         "entity": "lines",
         "field": "salesOrderLine",
@@ -8540,7 +8511,7 @@
         "description": "Field 'salesOrderLine' should be present in lines"
       },
       {
-        "id": "t-104",
+        "id": "t-103",
         "category": "field-presence",
         "entity": "lines",
         "field": "goodsShipmentLine",
@@ -8548,7 +8519,7 @@
         "description": "Field 'goodsShipmentLine' should be present in lines"
       },
       {
-        "id": "t-105",
+        "id": "t-104",
         "category": "field-presence",
         "entity": "lines",
         "field": "taxableAmount",
@@ -8556,7 +8527,7 @@
         "description": "Field 'taxableAmount' should be present in lines"
       },
       {
-        "id": "t-106",
+        "id": "t-105",
         "category": "field-presence",
         "entity": "lines",
         "field": "project",
@@ -8564,7 +8535,7 @@
         "description": "Field 'project' should be present in lines"
       },
       {
-        "id": "t-107",
+        "id": "t-106",
         "category": "field-presence",
         "entity": "lines",
         "field": "costcenter",
@@ -8572,7 +8543,7 @@
         "description": "Field 'costcenter' should be present in lines"
       },
       {
-        "id": "t-108",
+        "id": "t-107",
         "category": "field-presence",
         "entity": "lines",
         "field": "asset",
@@ -8580,7 +8551,7 @@
         "description": "Field 'asset' should be present in lines"
       },
       {
-        "id": "t-109",
+        "id": "t-108",
         "category": "field-presence",
         "entity": "lines",
         "field": "stDimension",
@@ -8588,7 +8559,7 @@
         "description": "Field 'stDimension' should be present in lines"
       },
       {
-        "id": "t-110",
+        "id": "t-109",
         "category": "field-presence",
         "entity": "lines",
         "field": "ndDimension",
@@ -8596,7 +8567,7 @@
         "description": "Field 'ndDimension' should be present in lines"
       },
       {
-        "id": "t-111",
+        "id": "t-110",
         "category": "field-type",
         "entity": "lines",
         "field": "product",
@@ -8604,7 +8575,7 @@
         "description": "Field 'product' should have type 'string' in lines"
       },
       {
-        "id": "t-112",
+        "id": "t-111",
         "category": "field-type",
         "entity": "lines",
         "field": "account",
@@ -8612,7 +8583,7 @@
         "description": "Field 'account' should have type 'string' in lines"
       },
       {
-        "id": "t-113",
+        "id": "t-112",
         "category": "field-type",
         "entity": "lines",
         "field": "operativeQuantity",
@@ -8620,7 +8591,7 @@
         "description": "Field 'operativeQuantity' should have type 'number' in lines"
       },
       {
-        "id": "t-114",
+        "id": "t-113",
         "category": "field-type",
         "entity": "lines",
         "field": "invoicedQuantity",
@@ -8628,7 +8599,7 @@
         "description": "Field 'invoicedQuantity' should have type 'number' in lines"
       },
       {
-        "id": "t-115",
+        "id": "t-114",
         "category": "field-type",
         "entity": "lines",
         "field": "unitPrice",
@@ -8636,7 +8607,7 @@
         "description": "Field 'unitPrice' should have type 'number' in lines"
       },
       {
-        "id": "t-116",
+        "id": "t-115",
         "category": "field-type",
         "entity": "lines",
         "field": "grossUnitPrice",
@@ -8644,15 +8615,7 @@
         "description": "Field 'grossUnitPrice' should have type 'number' in lines"
       },
       {
-        "id": "t-117",
-        "category": "field-type",
-        "entity": "lines",
-        "field": "lineNetAmount",
-        "runner": "node",
-        "description": "Field 'lineNetAmount' should have type 'number' in lines"
-      },
-      {
-        "id": "t-118",
+        "id": "t-116",
         "category": "field-type",
         "entity": "lines",
         "field": "grossAmount",
@@ -8660,7 +8623,7 @@
         "description": "Field 'grossAmount' should have type 'number' in lines"
       },
       {
-        "id": "t-119",
+        "id": "t-117",
         "category": "field-type",
         "entity": "lines",
         "field": "description",
@@ -8668,7 +8631,7 @@
         "description": "Field 'description' should have type 'string' in lines"
       },
       {
-        "id": "t-120",
+        "id": "t-118",
         "category": "field-type",
         "entity": "lines",
         "field": "tax",
@@ -8676,7 +8639,7 @@
         "description": "Field 'tax' should have type 'string' in lines"
       },
       {
-        "id": "t-121",
+        "id": "t-119",
         "category": "field-type",
         "entity": "lines",
         "field": "listPrice",
@@ -8684,7 +8647,7 @@
         "description": "Field 'listPrice' should have type 'number' in lines"
       },
       {
-        "id": "t-122",
+        "id": "t-120",
         "category": "field-type",
         "entity": "lines",
         "field": "attributeSetValue",
@@ -8692,7 +8655,7 @@
         "description": "Field 'attributeSetValue' should have type 'string' in lines"
       },
       {
-        "id": "t-123",
+        "id": "t-121",
         "category": "field-type",
         "entity": "lines",
         "field": "salesOrderLine",
@@ -8700,7 +8663,7 @@
         "description": "Field 'salesOrderLine' should have type 'string' in lines"
       },
       {
-        "id": "t-124",
+        "id": "t-122",
         "category": "field-type",
         "entity": "lines",
         "field": "goodsShipmentLine",
@@ -8708,7 +8671,7 @@
         "description": "Field 'goodsShipmentLine' should have type 'string' in lines"
       },
       {
-        "id": "t-125",
+        "id": "t-123",
         "category": "field-type",
         "entity": "lines",
         "field": "taxableAmount",
@@ -8716,7 +8679,7 @@
         "description": "Field 'taxableAmount' should have type 'number' in lines"
       },
       {
-        "id": "t-126",
+        "id": "t-124",
         "category": "field-type",
         "entity": "lines",
         "field": "project",
@@ -8724,7 +8687,7 @@
         "description": "Field 'project' should have type 'string' in lines"
       },
       {
-        "id": "t-127",
+        "id": "t-125",
         "category": "field-type",
         "entity": "lines",
         "field": "costcenter",
@@ -8732,7 +8695,7 @@
         "description": "Field 'costcenter' should have type 'string' in lines"
       },
       {
-        "id": "t-128",
+        "id": "t-126",
         "category": "field-type",
         "entity": "lines",
         "field": "asset",
@@ -8740,7 +8703,7 @@
         "description": "Field 'asset' should have type 'string' in lines"
       },
       {
-        "id": "t-129",
+        "id": "t-127",
         "category": "field-type",
         "entity": "lines",
         "field": "stDimension",
@@ -8748,7 +8711,7 @@
         "description": "Field 'stDimension' should have type 'string' in lines"
       },
       {
-        "id": "t-130",
+        "id": "t-128",
         "category": "field-type",
         "entity": "lines",
         "field": "ndDimension",
@@ -8756,14 +8719,14 @@
         "description": "Field 'ndDimension' should have type 'string' in lines"
       },
       {
-        "id": "t-131",
+        "id": "t-129",
         "category": "visibility",
         "entity": "lines",
         "runner": "node",
         "description": "Entity 'lines' should only expose visible fields in frontend"
       },
       {
-        "id": "t-132",
+        "id": "t-130",
         "category": "displaylogic-valid",
         "entity": "lines",
         "field": "grossUnitPrice",
@@ -8771,7 +8734,7 @@
         "description": "Display logic for 'grossUnitPrice' in lines should be valid JS"
       },
       {
-        "id": "t-133",
+        "id": "t-131",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "product",
@@ -8779,7 +8742,7 @@
         "description": "Read-only logic for 'product' in lines should be valid JS"
       },
       {
-        "id": "t-134",
+        "id": "t-132",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "account",
@@ -8787,7 +8750,7 @@
         "description": "Read-only logic for 'account' in lines should be valid JS"
       },
       {
-        "id": "t-135",
+        "id": "t-133",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "operativeQuantity",
@@ -8795,7 +8758,7 @@
         "description": "Read-only logic for 'operativeQuantity' in lines should be valid JS"
       },
       {
-        "id": "t-136",
+        "id": "t-134",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "invoicedQuantity",
@@ -8803,7 +8766,7 @@
         "description": "Read-only logic for 'invoicedQuantity' in lines should be valid JS"
       },
       {
-        "id": "t-137",
+        "id": "t-135",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "unitPrice",
@@ -8811,7 +8774,7 @@
         "description": "Read-only logic for 'unitPrice' in lines should be valid JS"
       },
       {
-        "id": "t-138",
+        "id": "t-136",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "grossUnitPrice",
@@ -8819,15 +8782,7 @@
         "description": "Read-only logic for 'grossUnitPrice' in lines should be valid JS"
       },
       {
-        "id": "t-139",
-        "category": "readonlylogic-valid",
-        "entity": "lines",
-        "field": "lineNetAmount",
-        "runner": "node",
-        "description": "Read-only logic for 'lineNetAmount' in lines should be valid JS"
-      },
-      {
-        "id": "t-140",
+        "id": "t-137",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "tax",
@@ -8835,7 +8790,7 @@
         "description": "Read-only logic for 'tax' in lines should be valid JS"
       },
       {
-        "id": "t-141",
+        "id": "t-138",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "listPrice",
@@ -8843,7 +8798,7 @@
         "description": "Read-only logic for 'listPrice' in lines should be valid JS"
       },
       {
-        "id": "t-142",
+        "id": "t-139",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "attributeSetValue",
@@ -8851,7 +8806,7 @@
         "description": "Read-only logic for 'attributeSetValue' in lines should be valid JS"
       },
       {
-        "id": "t-143",
+        "id": "t-140",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "taxableAmount",
@@ -8859,7 +8814,7 @@
         "description": "Read-only logic for 'taxableAmount' in lines should be valid JS"
       },
       {
-        "id": "t-144",
+        "id": "t-141",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "project",
@@ -8867,7 +8822,7 @@
         "description": "Read-only logic for 'project' in lines should be valid JS"
       },
       {
-        "id": "t-145",
+        "id": "t-142",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "costcenter",
@@ -8875,7 +8830,7 @@
         "description": "Read-only logic for 'costcenter' in lines should be valid JS"
       },
       {
-        "id": "t-146",
+        "id": "t-143",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "asset",
@@ -8883,7 +8838,7 @@
         "description": "Read-only logic for 'asset' in lines should be valid JS"
       },
       {
-        "id": "t-147",
+        "id": "t-144",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "stDimension",
@@ -8891,7 +8846,7 @@
         "description": "Read-only logic for 'stDimension' in lines should be valid JS"
       },
       {
-        "id": "t-148",
+        "id": "t-145",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "ndDimension",
@@ -8899,7 +8854,7 @@
         "description": "Read-only logic for 'ndDimension' in lines should be valid JS"
       },
       {
-        "id": "t-149",
+        "id": "t-146",
         "category": "displaylogic-evaluable",
         "entity": "lines",
         "field": "grossUnitPrice",
@@ -8907,7 +8862,7 @@
         "description": "Display logic for 'grossUnitPrice' in lines should have evaluable flag"
       },
       {
-        "id": "t-150",
+        "id": "t-147",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "product",
@@ -8915,7 +8870,7 @@
         "description": "Read-only logic for 'product' in lines should have evaluable flag"
       },
       {
-        "id": "t-151",
+        "id": "t-148",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "account",
@@ -8923,7 +8878,7 @@
         "description": "Read-only logic for 'account' in lines should have evaluable flag"
       },
       {
-        "id": "t-152",
+        "id": "t-149",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "operativeQuantity",
@@ -8931,7 +8886,7 @@
         "description": "Read-only logic for 'operativeQuantity' in lines should have evaluable flag"
       },
       {
-        "id": "t-153",
+        "id": "t-150",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "invoicedQuantity",
@@ -8939,7 +8894,7 @@
         "description": "Read-only logic for 'invoicedQuantity' in lines should have evaluable flag"
       },
       {
-        "id": "t-154",
+        "id": "t-151",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "unitPrice",
@@ -8947,7 +8902,7 @@
         "description": "Read-only logic for 'unitPrice' in lines should have evaluable flag"
       },
       {
-        "id": "t-155",
+        "id": "t-152",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "grossUnitPrice",
@@ -8955,15 +8910,7 @@
         "description": "Read-only logic for 'grossUnitPrice' in lines should have evaluable flag"
       },
       {
-        "id": "t-156",
-        "category": "readonlylogic-evaluable",
-        "entity": "lines",
-        "field": "lineNetAmount",
-        "runner": "node",
-        "description": "Read-only logic for 'lineNetAmount' in lines should have evaluable flag"
-      },
-      {
-        "id": "t-157",
+        "id": "t-153",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "tax",
@@ -8971,7 +8918,7 @@
         "description": "Read-only logic for 'tax' in lines should have evaluable flag"
       },
       {
-        "id": "t-158",
+        "id": "t-154",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "listPrice",
@@ -8979,7 +8926,7 @@
         "description": "Read-only logic for 'listPrice' in lines should have evaluable flag"
       },
       {
-        "id": "t-159",
+        "id": "t-155",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "attributeSetValue",
@@ -8987,7 +8934,7 @@
         "description": "Read-only logic for 'attributeSetValue' in lines should have evaluable flag"
       },
       {
-        "id": "t-160",
+        "id": "t-156",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "taxableAmount",
@@ -8995,7 +8942,7 @@
         "description": "Read-only logic for 'taxableAmount' in lines should have evaluable flag"
       },
       {
-        "id": "t-161",
+        "id": "t-157",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "project",
@@ -9003,7 +8950,7 @@
         "description": "Read-only logic for 'project' in lines should have evaluable flag"
       },
       {
-        "id": "t-162",
+        "id": "t-158",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "costcenter",
@@ -9011,7 +8958,7 @@
         "description": "Read-only logic for 'costcenter' in lines should have evaluable flag"
       },
       {
-        "id": "t-163",
+        "id": "t-159",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "asset",
@@ -9019,7 +8966,7 @@
         "description": "Read-only logic for 'asset' in lines should have evaluable flag"
       },
       {
-        "id": "t-164",
+        "id": "t-160",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "stDimension",
@@ -9027,7 +8974,7 @@
         "description": "Read-only logic for 'stDimension' in lines should have evaluable flag"
       },
       {
-        "id": "t-165",
+        "id": "t-161",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "ndDimension",
@@ -9035,7 +8982,7 @@
         "description": "Read-only logic for 'ndDimension' in lines should have evaluable flag"
       },
       {
-        "id": "t-166",
+        "id": "t-162",
         "category": "default-value-type",
         "entity": "lines",
         "field": "invoicedQuantity",
@@ -9043,7 +8990,7 @@
         "description": "Default value for 'invoicedQuantity' in lines should be a string"
       },
       {
-        "id": "t-167",
+        "id": "t-163",
         "category": "default-value-type",
         "entity": "lines",
         "field": "grossUnitPrice",
@@ -9051,7 +8998,7 @@
         "description": "Default value for 'grossUnitPrice' in lines should be a string"
       },
       {
-        "id": "t-168",
+        "id": "t-164",
         "category": "default-value-type",
         "entity": "lines",
         "field": "grossAmount",
@@ -9059,7 +9006,7 @@
         "description": "Default value for 'grossAmount' in lines should be a string"
       },
       {
-        "id": "t-169",
+        "id": "t-165",
         "category": "field-presence",
         "entity": "intrastat",
         "field": "invoiceLine",
@@ -9067,7 +9014,7 @@
         "description": "Field 'invoiceLine' should be present in intrastat"
       },
       {
-        "id": "t-170",
+        "id": "t-166",
         "category": "field-presence",
         "entity": "intrastat",
         "field": "product",
@@ -9075,7 +9022,7 @@
         "description": "Field 'product' should be present in intrastat"
       },
       {
-        "id": "t-171",
+        "id": "t-167",
         "category": "field-presence",
         "entity": "intrastat",
         "field": "incoterms",
@@ -9083,7 +9030,7 @@
         "description": "Field 'incoterms' should be present in intrastat"
       },
       {
-        "id": "t-172",
+        "id": "t-168",
         "category": "field-presence",
         "entity": "intrastat",
         "field": "transactionType",
@@ -9091,7 +9038,7 @@
         "description": "Field 'transactionType' should be present in intrastat"
       },
       {
-        "id": "t-173",
+        "id": "t-169",
         "category": "field-presence",
         "entity": "intrastat",
         "field": "transportationType",
@@ -9099,7 +9046,7 @@
         "description": "Field 'transportationType' should be present in intrastat"
       },
       {
-        "id": "t-174",
+        "id": "t-170",
         "category": "field-presence",
         "entity": "intrastat",
         "field": "portAirport",
@@ -9107,7 +9054,7 @@
         "description": "Field 'portAirport' should be present in intrastat"
       },
       {
-        "id": "t-175",
+        "id": "t-171",
         "category": "field-presence",
         "entity": "intrastat",
         "field": "statisticalRegime",
@@ -9115,7 +9062,7 @@
         "description": "Field 'statisticalRegime' should be present in intrastat"
       },
       {
-        "id": "t-176",
+        "id": "t-172",
         "category": "field-presence",
         "entity": "intrastat",
         "field": "origCountry",
@@ -9123,7 +9070,7 @@
         "description": "Field 'origCountry' should be present in intrastat"
       },
       {
-        "id": "t-177",
+        "id": "t-173",
         "category": "field-presence",
         "entity": "intrastat",
         "field": "nC8Code",
@@ -9131,7 +9078,7 @@
         "description": "Field 'nC8Code' should be present in intrastat"
       },
       {
-        "id": "t-178",
+        "id": "t-174",
         "category": "field-presence",
         "entity": "intrastat",
         "field": "netMassKg",
@@ -9139,7 +9086,7 @@
         "description": "Field 'netMassKg' should be present in intrastat"
       },
       {
-        "id": "t-179",
+        "id": "t-175",
         "category": "field-presence",
         "entity": "intrastat",
         "field": "hasSuplementaryUnit",
@@ -9147,7 +9094,7 @@
         "description": "Field 'hasSuplementaryUnit' should be present in intrastat"
       },
       {
-        "id": "t-180",
+        "id": "t-176",
         "category": "field-presence",
         "entity": "intrastat",
         "field": "conversionRate",
@@ -9155,7 +9102,7 @@
         "description": "Field 'conversionRate' should be present in intrastat"
       },
       {
-        "id": "t-181",
+        "id": "t-177",
         "category": "field-presence",
         "entity": "intrastat",
         "field": "staticalValue",
@@ -9163,7 +9110,7 @@
         "description": "Field 'staticalValue' should be present in intrastat"
       },
       {
-        "id": "t-182",
+        "id": "t-178",
         "category": "field-presence",
         "entity": "intrastat",
         "field": "supplementaryUOM",
@@ -9171,7 +9118,7 @@
         "description": "Field 'supplementaryUOM' should be present in intrastat"
       },
       {
-        "id": "t-183",
+        "id": "t-179",
         "category": "field-type",
         "entity": "intrastat",
         "field": "invoiceLine",
@@ -9179,7 +9126,7 @@
         "description": "Field 'invoiceLine' should have type 'string' in intrastat"
       },
       {
-        "id": "t-184",
+        "id": "t-180",
         "category": "field-type",
         "entity": "intrastat",
         "field": "product",
@@ -9187,7 +9134,7 @@
         "description": "Field 'product' should have type 'string' in intrastat"
       },
       {
-        "id": "t-185",
+        "id": "t-181",
         "category": "field-type",
         "entity": "intrastat",
         "field": "incoterms",
@@ -9195,7 +9142,7 @@
         "description": "Field 'incoterms' should have type 'string' in intrastat"
       },
       {
-        "id": "t-186",
+        "id": "t-182",
         "category": "field-type",
         "entity": "intrastat",
         "field": "transactionType",
@@ -9203,7 +9150,7 @@
         "description": "Field 'transactionType' should have type 'string' in intrastat"
       },
       {
-        "id": "t-187",
+        "id": "t-183",
         "category": "field-type",
         "entity": "intrastat",
         "field": "transportationType",
@@ -9211,7 +9158,7 @@
         "description": "Field 'transportationType' should have type 'string' in intrastat"
       },
       {
-        "id": "t-188",
+        "id": "t-184",
         "category": "field-type",
         "entity": "intrastat",
         "field": "portAirport",
@@ -9219,7 +9166,7 @@
         "description": "Field 'portAirport' should have type 'string' in intrastat"
       },
       {
-        "id": "t-189",
+        "id": "t-185",
         "category": "field-type",
         "entity": "intrastat",
         "field": "statisticalRegime",
@@ -9227,7 +9174,7 @@
         "description": "Field 'statisticalRegime' should have type 'string' in intrastat"
       },
       {
-        "id": "t-190",
+        "id": "t-186",
         "category": "field-type",
         "entity": "intrastat",
         "field": "origCountry",
@@ -9235,7 +9182,7 @@
         "description": "Field 'origCountry' should have type 'string' in intrastat"
       },
       {
-        "id": "t-191",
+        "id": "t-187",
         "category": "field-type",
         "entity": "intrastat",
         "field": "nC8Code",
@@ -9243,7 +9190,7 @@
         "description": "Field 'nC8Code' should have type 'string' in intrastat"
       },
       {
-        "id": "t-192",
+        "id": "t-188",
         "category": "field-type",
         "entity": "intrastat",
         "field": "netMassKg",
@@ -9251,7 +9198,7 @@
         "description": "Field 'netMassKg' should have type 'number' in intrastat"
       },
       {
-        "id": "t-193",
+        "id": "t-189",
         "category": "field-type",
         "entity": "intrastat",
         "field": "hasSuplementaryUnit",
@@ -9259,7 +9206,7 @@
         "description": "Field 'hasSuplementaryUnit' should have type 'boolean' in intrastat"
       },
       {
-        "id": "t-194",
+        "id": "t-190",
         "category": "field-type",
         "entity": "intrastat",
         "field": "conversionRate",
@@ -9267,7 +9214,7 @@
         "description": "Field 'conversionRate' should have type 'number' in intrastat"
       },
       {
-        "id": "t-195",
+        "id": "t-191",
         "category": "field-type",
         "entity": "intrastat",
         "field": "staticalValue",
@@ -9275,7 +9222,7 @@
         "description": "Field 'staticalValue' should have type 'number' in intrastat"
       },
       {
-        "id": "t-196",
+        "id": "t-192",
         "category": "field-type",
         "entity": "intrastat",
         "field": "supplementaryUOM",
@@ -9283,14 +9230,14 @@
         "description": "Field 'supplementaryUOM' should have type 'string' in intrastat"
       },
       {
-        "id": "t-197",
+        "id": "t-193",
         "category": "visibility",
         "entity": "intrastat",
         "runner": "node",
         "description": "Entity 'intrastat' should only expose visible fields in frontend"
       },
       {
-        "id": "t-198",
+        "id": "t-194",
         "category": "displaylogic-valid",
         "entity": "intrastat",
         "field": "portAirport",
@@ -9298,7 +9245,7 @@
         "description": "Display logic for 'portAirport' in intrastat should be valid JS"
       },
       {
-        "id": "t-199",
+        "id": "t-195",
         "category": "displaylogic-valid",
         "entity": "intrastat",
         "field": "conversionRate",
@@ -9306,7 +9253,7 @@
         "description": "Display logic for 'conversionRate' in intrastat should be valid JS"
       },
       {
-        "id": "t-200",
+        "id": "t-196",
         "category": "displaylogic-valid",
         "entity": "intrastat",
         "field": "supplementaryUOM",
@@ -9314,7 +9261,7 @@
         "description": "Display logic for 'supplementaryUOM' in intrastat should be valid JS"
       },
       {
-        "id": "t-201",
+        "id": "t-197",
         "category": "readonlylogic-valid",
         "entity": "intrastat",
         "field": "incoterms",
@@ -9322,7 +9269,7 @@
         "description": "Read-only logic for 'incoterms' in intrastat should be valid JS"
       },
       {
-        "id": "t-202",
+        "id": "t-198",
         "category": "readonlylogic-valid",
         "entity": "intrastat",
         "field": "transactionType",
@@ -9330,7 +9277,7 @@
         "description": "Read-only logic for 'transactionType' in intrastat should be valid JS"
       },
       {
-        "id": "t-203",
+        "id": "t-199",
         "category": "readonlylogic-valid",
         "entity": "intrastat",
         "field": "transportationType",
@@ -9338,7 +9285,7 @@
         "description": "Read-only logic for 'transportationType' in intrastat should be valid JS"
       },
       {
-        "id": "t-204",
+        "id": "t-200",
         "category": "readonlylogic-valid",
         "entity": "intrastat",
         "field": "portAirport",
@@ -9346,7 +9293,7 @@
         "description": "Read-only logic for 'portAirport' in intrastat should be valid JS"
       },
       {
-        "id": "t-205",
+        "id": "t-201",
         "category": "readonlylogic-valid",
         "entity": "intrastat",
         "field": "statisticalRegime",
@@ -9354,7 +9301,7 @@
         "description": "Read-only logic for 'statisticalRegime' in intrastat should be valid JS"
       },
       {
-        "id": "t-206",
+        "id": "t-202",
         "category": "readonlylogic-valid",
         "entity": "intrastat",
         "field": "origCountry",
@@ -9362,7 +9309,7 @@
         "description": "Read-only logic for 'origCountry' in intrastat should be valid JS"
       },
       {
-        "id": "t-207",
+        "id": "t-203",
         "category": "readonlylogic-valid",
         "entity": "intrastat",
         "field": "nC8Code",
@@ -9370,7 +9317,7 @@
         "description": "Read-only logic for 'nC8Code' in intrastat should be valid JS"
       },
       {
-        "id": "t-208",
+        "id": "t-204",
         "category": "readonlylogic-valid",
         "entity": "intrastat",
         "field": "netMassKg",
@@ -9378,7 +9325,7 @@
         "description": "Read-only logic for 'netMassKg' in intrastat should be valid JS"
       },
       {
-        "id": "t-209",
+        "id": "t-205",
         "category": "readonlylogic-valid",
         "entity": "intrastat",
         "field": "hasSuplementaryUnit",
@@ -9386,7 +9333,7 @@
         "description": "Read-only logic for 'hasSuplementaryUnit' in intrastat should be valid JS"
       },
       {
-        "id": "t-210",
+        "id": "t-206",
         "category": "readonlylogic-valid",
         "entity": "intrastat",
         "field": "conversionRate",
@@ -9394,7 +9341,7 @@
         "description": "Read-only logic for 'conversionRate' in intrastat should be valid JS"
       },
       {
-        "id": "t-211",
+        "id": "t-207",
         "category": "readonlylogic-valid",
         "entity": "intrastat",
         "field": "staticalValue",
@@ -9402,7 +9349,7 @@
         "description": "Read-only logic for 'staticalValue' in intrastat should be valid JS"
       },
       {
-        "id": "t-212",
+        "id": "t-208",
         "category": "readonlylogic-valid",
         "entity": "intrastat",
         "field": "supplementaryUOM",
@@ -9410,7 +9357,7 @@
         "description": "Read-only logic for 'supplementaryUOM' in intrastat should be valid JS"
       },
       {
-        "id": "t-213",
+        "id": "t-209",
         "category": "displaylogic-evaluable",
         "entity": "intrastat",
         "field": "portAirport",
@@ -9418,7 +9365,7 @@
         "description": "Display logic for 'portAirport' in intrastat should have evaluable flag"
       },
       {
-        "id": "t-214",
+        "id": "t-210",
         "category": "displaylogic-evaluable",
         "entity": "intrastat",
         "field": "conversionRate",
@@ -9426,7 +9373,7 @@
         "description": "Display logic for 'conversionRate' in intrastat should have evaluable flag"
       },
       {
-        "id": "t-215",
+        "id": "t-211",
         "category": "displaylogic-evaluable",
         "entity": "intrastat",
         "field": "supplementaryUOM",
@@ -9434,7 +9381,7 @@
         "description": "Display logic for 'supplementaryUOM' in intrastat should have evaluable flag"
       },
       {
-        "id": "t-216",
+        "id": "t-212",
         "category": "readonlylogic-evaluable",
         "entity": "intrastat",
         "field": "incoterms",
@@ -9442,7 +9389,7 @@
         "description": "Read-only logic for 'incoterms' in intrastat should have evaluable flag"
       },
       {
-        "id": "t-217",
+        "id": "t-213",
         "category": "readonlylogic-evaluable",
         "entity": "intrastat",
         "field": "transactionType",
@@ -9450,7 +9397,7 @@
         "description": "Read-only logic for 'transactionType' in intrastat should have evaluable flag"
       },
       {
-        "id": "t-218",
+        "id": "t-214",
         "category": "readonlylogic-evaluable",
         "entity": "intrastat",
         "field": "transportationType",
@@ -9458,7 +9405,7 @@
         "description": "Read-only logic for 'transportationType' in intrastat should have evaluable flag"
       },
       {
-        "id": "t-219",
+        "id": "t-215",
         "category": "readonlylogic-evaluable",
         "entity": "intrastat",
         "field": "portAirport",
@@ -9466,7 +9413,7 @@
         "description": "Read-only logic for 'portAirport' in intrastat should have evaluable flag"
       },
       {
-        "id": "t-220",
+        "id": "t-216",
         "category": "readonlylogic-evaluable",
         "entity": "intrastat",
         "field": "statisticalRegime",
@@ -9474,7 +9421,7 @@
         "description": "Read-only logic for 'statisticalRegime' in intrastat should have evaluable flag"
       },
       {
-        "id": "t-221",
+        "id": "t-217",
         "category": "readonlylogic-evaluable",
         "entity": "intrastat",
         "field": "origCountry",
@@ -9482,7 +9429,7 @@
         "description": "Read-only logic for 'origCountry' in intrastat should have evaluable flag"
       },
       {
-        "id": "t-222",
+        "id": "t-218",
         "category": "readonlylogic-evaluable",
         "entity": "intrastat",
         "field": "nC8Code",
@@ -9490,7 +9437,7 @@
         "description": "Read-only logic for 'nC8Code' in intrastat should have evaluable flag"
       },
       {
-        "id": "t-223",
+        "id": "t-219",
         "category": "readonlylogic-evaluable",
         "entity": "intrastat",
         "field": "netMassKg",
@@ -9498,7 +9445,7 @@
         "description": "Read-only logic for 'netMassKg' in intrastat should have evaluable flag"
       },
       {
-        "id": "t-224",
+        "id": "t-220",
         "category": "readonlylogic-evaluable",
         "entity": "intrastat",
         "field": "hasSuplementaryUnit",
@@ -9506,7 +9453,7 @@
         "description": "Read-only logic for 'hasSuplementaryUnit' in intrastat should have evaluable flag"
       },
       {
-        "id": "t-225",
+        "id": "t-221",
         "category": "readonlylogic-evaluable",
         "entity": "intrastat",
         "field": "conversionRate",
@@ -9514,7 +9461,7 @@
         "description": "Read-only logic for 'conversionRate' in intrastat should have evaluable flag"
       },
       {
-        "id": "t-226",
+        "id": "t-222",
         "category": "readonlylogic-evaluable",
         "entity": "intrastat",
         "field": "staticalValue",
@@ -9522,7 +9469,7 @@
         "description": "Read-only logic for 'staticalValue' in intrastat should have evaluable flag"
       },
       {
-        "id": "t-227",
+        "id": "t-223",
         "category": "readonlylogic-evaluable",
         "entity": "intrastat",
         "field": "supplementaryUOM",
@@ -9530,7 +9477,7 @@
         "description": "Read-only logic for 'supplementaryUOM' in intrastat should have evaluable flag"
       },
       {
-        "id": "t-228",
+        "id": "t-224",
         "category": "default-value-type",
         "entity": "intrastat",
         "field": "hasSuplementaryUnit",
@@ -9538,7 +9485,7 @@
         "description": "Default value for 'hasSuplementaryUnit' in intrastat should be a string"
       },
       {
-        "id": "t-229",
+        "id": "t-225",
         "category": "field-presence",
         "entity": "tax",
         "field": "lineNo",
@@ -9546,7 +9493,7 @@
         "description": "Field 'lineNo' should be present in tax"
       },
       {
-        "id": "t-230",
+        "id": "t-226",
         "category": "field-presence",
         "entity": "tax",
         "field": "tax",
@@ -9554,7 +9501,7 @@
         "description": "Field 'tax' should be present in tax"
       },
       {
-        "id": "t-231",
+        "id": "t-227",
         "category": "field-presence",
         "entity": "tax",
         "field": "taxAmount",
@@ -9562,7 +9509,7 @@
         "description": "Field 'taxAmount' should be present in tax"
       },
       {
-        "id": "t-232",
+        "id": "t-228",
         "category": "field-presence",
         "entity": "tax",
         "field": "taxableAmount",
@@ -9570,7 +9517,7 @@
         "description": "Field 'taxableAmount' should be present in tax"
       },
       {
-        "id": "t-233",
+        "id": "t-229",
         "category": "field-type",
         "entity": "tax",
         "field": "lineNo",
@@ -9578,7 +9525,7 @@
         "description": "Field 'lineNo' should have type 'number' in tax"
       },
       {
-        "id": "t-234",
+        "id": "t-230",
         "category": "field-type",
         "entity": "tax",
         "field": "tax",
@@ -9586,7 +9533,7 @@
         "description": "Field 'tax' should have type 'string' in tax"
       },
       {
-        "id": "t-235",
+        "id": "t-231",
         "category": "field-type",
         "entity": "tax",
         "field": "taxAmount",
@@ -9594,7 +9541,7 @@
         "description": "Field 'taxAmount' should have type 'number' in tax"
       },
       {
-        "id": "t-236",
+        "id": "t-232",
         "category": "field-type",
         "entity": "tax",
         "field": "taxableAmount",
@@ -9602,14 +9549,14 @@
         "description": "Field 'taxableAmount' should have type 'number' in tax"
       },
       {
-        "id": "t-237",
+        "id": "t-233",
         "category": "visibility",
         "entity": "tax",
         "runner": "node",
         "description": "Entity 'tax' should only expose visible fields in frontend"
       },
       {
-        "id": "t-238",
+        "id": "t-234",
         "category": "readonlylogic-valid",
         "entity": "tax",
         "field": "tax",
@@ -9617,7 +9564,7 @@
         "description": "Read-only logic for 'tax' in tax should be valid JS"
       },
       {
-        "id": "t-239",
+        "id": "t-235",
         "category": "readonlylogic-valid",
         "entity": "tax",
         "field": "taxAmount",
@@ -9625,7 +9572,7 @@
         "description": "Read-only logic for 'taxAmount' in tax should be valid JS"
       },
       {
-        "id": "t-240",
+        "id": "t-236",
         "category": "readonlylogic-valid",
         "entity": "tax",
         "field": "taxableAmount",
@@ -9633,7 +9580,7 @@
         "description": "Read-only logic for 'taxableAmount' in tax should be valid JS"
       },
       {
-        "id": "t-241",
+        "id": "t-237",
         "category": "readonlylogic-evaluable",
         "entity": "tax",
         "field": "tax",
@@ -9641,7 +9588,7 @@
         "description": "Read-only logic for 'tax' in tax should have evaluable flag"
       },
       {
-        "id": "t-242",
+        "id": "t-238",
         "category": "readonlylogic-evaluable",
         "entity": "tax",
         "field": "taxAmount",
@@ -9649,7 +9596,7 @@
         "description": "Read-only logic for 'taxAmount' in tax should have evaluable flag"
       },
       {
-        "id": "t-243",
+        "id": "t-239",
         "category": "readonlylogic-evaluable",
         "entity": "tax",
         "field": "taxableAmount",
@@ -9657,7 +9604,7 @@
         "description": "Read-only logic for 'taxableAmount' in tax should have evaluable flag"
       },
       {
-        "id": "t-244",
+        "id": "t-240",
         "category": "default-value-type",
         "entity": "tax",
         "field": "lineNo",
@@ -9665,7 +9612,7 @@
         "description": "Default value for 'lineNo' in tax should be a string"
       },
       {
-        "id": "t-245",
+        "id": "t-241",
         "category": "field-presence",
         "entity": "cashVat",
         "field": "paymentDate",
@@ -9673,7 +9620,7 @@
         "description": "Field 'paymentDate' should be present in cashVat"
       },
       {
-        "id": "t-246",
+        "id": "t-242",
         "category": "field-presence",
         "entity": "cashVat",
         "field": "percentage",
@@ -9681,7 +9628,7 @@
         "description": "Field 'percentage' should be present in cashVat"
       },
       {
-        "id": "t-247",
+        "id": "t-243",
         "category": "field-presence",
         "entity": "cashVat",
         "field": "taxAmount",
@@ -9689,7 +9636,7 @@
         "description": "Field 'taxAmount' should be present in cashVat"
       },
       {
-        "id": "t-248",
+        "id": "t-244",
         "category": "field-presence",
         "entity": "cashVat",
         "field": "taxableAmount",
@@ -9697,7 +9644,7 @@
         "description": "Field 'taxableAmount' should be present in cashVat"
       },
       {
-        "id": "t-249",
+        "id": "t-245",
         "category": "field-presence",
         "entity": "cashVat",
         "field": "canceled",
@@ -9705,7 +9652,7 @@
         "description": "Field 'canceled' should be present in cashVat"
       },
       {
-        "id": "t-250",
+        "id": "t-246",
         "category": "field-presence",
         "entity": "cashVat",
         "field": "payment",
@@ -9713,7 +9660,7 @@
         "description": "Field 'payment' should be present in cashVat"
       },
       {
-        "id": "t-251",
+        "id": "t-247",
         "category": "field-presence",
         "entity": "cashVat",
         "field": "status",
@@ -9721,7 +9668,7 @@
         "description": "Field 'status' should be present in cashVat"
       },
       {
-        "id": "t-252",
+        "id": "t-248",
         "category": "field-presence",
         "entity": "cashVat",
         "field": "isManualSettlement",
@@ -9729,7 +9676,7 @@
         "description": "Field 'isManualSettlement' should be present in cashVat"
       },
       {
-        "id": "t-253",
+        "id": "t-249",
         "category": "field-presence",
         "entity": "cashVat",
         "field": "accountingDate",
@@ -9737,7 +9684,7 @@
         "description": "Field 'accountingDate' should be present in cashVat"
       },
       {
-        "id": "t-254",
+        "id": "t-250",
         "category": "field-type",
         "entity": "cashVat",
         "field": "paymentDate",
@@ -9745,7 +9692,7 @@
         "description": "Field 'paymentDate' should have type 'string' in cashVat"
       },
       {
-        "id": "t-255",
+        "id": "t-251",
         "category": "field-type",
         "entity": "cashVat",
         "field": "percentage",
@@ -9753,7 +9700,7 @@
         "description": "Field 'percentage' should have type 'number' in cashVat"
       },
       {
-        "id": "t-256",
+        "id": "t-252",
         "category": "field-type",
         "entity": "cashVat",
         "field": "taxAmount",
@@ -9761,7 +9708,7 @@
         "description": "Field 'taxAmount' should have type 'number' in cashVat"
       },
       {
-        "id": "t-257",
+        "id": "t-253",
         "category": "field-type",
         "entity": "cashVat",
         "field": "taxableAmount",
@@ -9769,7 +9716,7 @@
         "description": "Field 'taxableAmount' should have type 'number' in cashVat"
       },
       {
-        "id": "t-258",
+        "id": "t-254",
         "category": "field-type",
         "entity": "cashVat",
         "field": "canceled",
@@ -9777,7 +9724,7 @@
         "description": "Field 'canceled' should have type 'boolean' in cashVat"
       },
       {
-        "id": "t-259",
+        "id": "t-255",
         "category": "field-type",
         "entity": "cashVat",
         "field": "payment",
@@ -9785,7 +9732,7 @@
         "description": "Field 'payment' should have type 'string' in cashVat"
       },
       {
-        "id": "t-260",
+        "id": "t-256",
         "category": "field-type",
         "entity": "cashVat",
         "field": "status",
@@ -9793,7 +9740,7 @@
         "description": "Field 'status' should have type 'string' in cashVat"
       },
       {
-        "id": "t-261",
+        "id": "t-257",
         "category": "field-type",
         "entity": "cashVat",
         "field": "isManualSettlement",
@@ -9801,7 +9748,7 @@
         "description": "Field 'isManualSettlement' should have type 'boolean' in cashVat"
       },
       {
-        "id": "t-262",
+        "id": "t-258",
         "category": "field-type",
         "entity": "cashVat",
         "field": "accountingDate",
@@ -9809,14 +9756,14 @@
         "description": "Field 'accountingDate' should have type 'string' in cashVat"
       },
       {
-        "id": "t-263",
+        "id": "t-259",
         "category": "visibility",
         "entity": "cashVat",
         "runner": "node",
         "description": "Entity 'cashVat' should only expose visible fields in frontend"
       },
       {
-        "id": "t-264",
+        "id": "t-260",
         "category": "default-value-type",
         "entity": "cashVat",
         "field": "accountingDate",
@@ -9824,7 +9771,7 @@
         "description": "Default value for 'accountingDate' in cashVat should be a string"
       },
       {
-        "id": "t-265",
+        "id": "t-261",
         "category": "field-presence",
         "entity": "basicDiscounts",
         "field": "lineNo",
@@ -9832,7 +9779,7 @@
         "description": "Field 'lineNo' should be present in basicDiscounts"
       },
       {
-        "id": "t-266",
+        "id": "t-262",
         "category": "field-presence",
         "entity": "basicDiscounts",
         "field": "discount",
@@ -9840,7 +9787,7 @@
         "description": "Field 'discount' should be present in basicDiscounts"
       },
       {
-        "id": "t-267",
+        "id": "t-263",
         "category": "field-presence",
         "entity": "basicDiscounts",
         "field": "cascade",
@@ -9848,7 +9795,7 @@
         "description": "Field 'cascade' should be present in basicDiscounts"
       },
       {
-        "id": "t-268",
+        "id": "t-264",
         "category": "field-type",
         "entity": "basicDiscounts",
         "field": "lineNo",
@@ -9856,7 +9803,7 @@
         "description": "Field 'lineNo' should have type 'number' in basicDiscounts"
       },
       {
-        "id": "t-269",
+        "id": "t-265",
         "category": "field-type",
         "entity": "basicDiscounts",
         "field": "discount",
@@ -9864,7 +9811,7 @@
         "description": "Field 'discount' should have type 'string' in basicDiscounts"
       },
       {
-        "id": "t-270",
+        "id": "t-266",
         "category": "field-type",
         "entity": "basicDiscounts",
         "field": "cascade",
@@ -9872,14 +9819,14 @@
         "description": "Field 'cascade' should have type 'boolean' in basicDiscounts"
       },
       {
-        "id": "t-271",
+        "id": "t-267",
         "category": "visibility",
         "entity": "basicDiscounts",
         "runner": "node",
         "description": "Entity 'basicDiscounts' should only expose visible fields in frontend"
       },
       {
-        "id": "t-272",
+        "id": "t-268",
         "category": "readonlylogic-valid",
         "entity": "basicDiscounts",
         "field": "lineNo",
@@ -9887,7 +9834,7 @@
         "description": "Read-only logic for 'lineNo' in basicDiscounts should be valid JS"
       },
       {
-        "id": "t-273",
+        "id": "t-269",
         "category": "readonlylogic-valid",
         "entity": "basicDiscounts",
         "field": "discount",
@@ -9895,7 +9842,7 @@
         "description": "Read-only logic for 'discount' in basicDiscounts should be valid JS"
       },
       {
-        "id": "t-274",
+        "id": "t-270",
         "category": "readonlylogic-evaluable",
         "entity": "basicDiscounts",
         "field": "lineNo",
@@ -9903,7 +9850,7 @@
         "description": "Read-only logic for 'lineNo' in basicDiscounts should have evaluable flag"
       },
       {
-        "id": "t-275",
+        "id": "t-271",
         "category": "readonlylogic-evaluable",
         "entity": "basicDiscounts",
         "field": "discount",
@@ -9911,7 +9858,7 @@
         "description": "Read-only logic for 'discount' in basicDiscounts should have evaluable flag"
       },
       {
-        "id": "t-276",
+        "id": "t-272",
         "category": "default-value-type",
         "entity": "basicDiscounts",
         "field": "lineNo",
@@ -9919,7 +9866,7 @@
         "description": "Default value for 'lineNo' in basicDiscounts should be a string"
       },
       {
-        "id": "t-277",
+        "id": "t-273",
         "category": "default-value-type",
         "entity": "basicDiscounts",
         "field": "cascade",
@@ -9927,7 +9874,7 @@
         "description": "Default value for 'cascade' in basicDiscounts should be a string"
       },
       {
-        "id": "t-278",
+        "id": "t-274",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "dueDate",
@@ -9935,7 +9882,7 @@
         "description": "Field 'dueDate' should be present in paymentPlan"
       },
       {
-        "id": "t-279",
+        "id": "t-275",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "expectedDate",
@@ -9943,7 +9890,7 @@
         "description": "Field 'expectedDate' should be present in paymentPlan"
       },
       {
-        "id": "t-280",
+        "id": "t-276",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "paymentMethod",
@@ -9951,7 +9898,7 @@
         "description": "Field 'paymentMethod' should be present in paymentPlan"
       },
       {
-        "id": "t-281",
+        "id": "t-277",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "amount",
@@ -9959,7 +9906,7 @@
         "description": "Field 'amount' should be present in paymentPlan"
       },
       {
-        "id": "t-282",
+        "id": "t-278",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "paidAmount",
@@ -9967,7 +9914,7 @@
         "description": "Field 'paidAmount' should be present in paymentPlan"
       },
       {
-        "id": "t-283",
+        "id": "t-279",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "outstandingAmount",
@@ -9975,7 +9922,7 @@
         "description": "Field 'outstandingAmount' should be present in paymentPlan"
       },
       {
-        "id": "t-284",
+        "id": "t-280",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "currency",
@@ -9983,7 +9930,7 @@
         "description": "Field 'currency' should be present in paymentPlan"
       },
       {
-        "id": "t-285",
+        "id": "t-281",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "lastPaymentDate",
@@ -9991,7 +9938,7 @@
         "description": "Field 'lastPaymentDate' should be present in paymentPlan"
       },
       {
-        "id": "t-286",
+        "id": "t-282",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "daysOverdue",
@@ -9999,7 +9946,7 @@
         "description": "Field 'daysOverdue' should be present in paymentPlan"
       },
       {
-        "id": "t-287",
+        "id": "t-283",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "numberOfPayments",
@@ -10007,7 +9954,7 @@
         "description": "Field 'numberOfPayments' should be present in paymentPlan"
       },
       {
-        "id": "t-288",
+        "id": "t-284",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "description",
@@ -10015,7 +9962,7 @@
         "description": "Field 'description' should be present in paymentPlan"
       },
       {
-        "id": "t-289",
+        "id": "t-285",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "dueDate",
@@ -10023,7 +9970,7 @@
         "description": "Field 'dueDate' should have type 'string' in paymentPlan"
       },
       {
-        "id": "t-290",
+        "id": "t-286",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "expectedDate",
@@ -10031,7 +9978,7 @@
         "description": "Field 'expectedDate' should have type 'string' in paymentPlan"
       },
       {
-        "id": "t-291",
+        "id": "t-287",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "paymentMethod",
@@ -10039,7 +9986,7 @@
         "description": "Field 'paymentMethod' should have type 'string' in paymentPlan"
       },
       {
-        "id": "t-292",
+        "id": "t-288",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "amount",
@@ -10047,7 +9994,7 @@
         "description": "Field 'amount' should have type 'number' in paymentPlan"
       },
       {
-        "id": "t-293",
+        "id": "t-289",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "paidAmount",
@@ -10055,7 +10002,7 @@
         "description": "Field 'paidAmount' should have type 'number' in paymentPlan"
       },
       {
-        "id": "t-294",
+        "id": "t-290",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "outstandingAmount",
@@ -10063,7 +10010,7 @@
         "description": "Field 'outstandingAmount' should have type 'number' in paymentPlan"
       },
       {
-        "id": "t-295",
+        "id": "t-291",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "currency",
@@ -10071,7 +10018,7 @@
         "description": "Field 'currency' should have type 'string' in paymentPlan"
       },
       {
-        "id": "t-296",
+        "id": "t-292",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "lastPaymentDate",
@@ -10079,7 +10026,7 @@
         "description": "Field 'lastPaymentDate' should have type 'string' in paymentPlan"
       },
       {
-        "id": "t-297",
+        "id": "t-293",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "daysOverdue",
@@ -10087,7 +10034,7 @@
         "description": "Field 'daysOverdue' should have type 'number' in paymentPlan"
       },
       {
-        "id": "t-298",
+        "id": "t-294",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "numberOfPayments",
@@ -10095,7 +10042,7 @@
         "description": "Field 'numberOfPayments' should have type 'number' in paymentPlan"
       },
       {
-        "id": "t-299",
+        "id": "t-295",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "description",
@@ -10103,14 +10050,14 @@
         "description": "Field 'description' should have type 'string' in paymentPlan"
       },
       {
-        "id": "t-300",
+        "id": "t-296",
         "category": "visibility",
         "entity": "paymentPlan",
         "runner": "node",
         "description": "Entity 'paymentPlan' should only expose visible fields in frontend"
       },
       {
-        "id": "t-301",
+        "id": "t-297",
         "category": "default-value-type",
         "entity": "paymentPlan",
         "field": "amount",
@@ -10118,7 +10065,7 @@
         "description": "Default value for 'amount' in paymentPlan should be a string"
       },
       {
-        "id": "t-302",
+        "id": "t-298",
         "category": "default-value-type",
         "entity": "paymentPlan",
         "field": "paidAmount",
@@ -10126,7 +10073,7 @@
         "description": "Default value for 'paidAmount' in paymentPlan should be a string"
       },
       {
-        "id": "t-303",
+        "id": "t-299",
         "category": "default-value-type",
         "entity": "paymentPlan",
         "field": "outstandingAmount",
@@ -10134,7 +10081,7 @@
         "description": "Default value for 'outstandingAmount' in paymentPlan should be a string"
       },
       {
-        "id": "t-304",
+        "id": "t-300",
         "category": "field-presence",
         "entity": "paymentDetails",
         "field": "amount",
@@ -10142,7 +10089,7 @@
         "description": "Field 'amount' should be present in paymentDetails"
       },
       {
-        "id": "t-305",
+        "id": "t-301",
         "category": "field-presence",
         "entity": "paymentDetails",
         "field": "writeoffAmount",
@@ -10150,7 +10097,7 @@
         "description": "Field 'writeoffAmount' should be present in paymentDetails"
       },
       {
-        "id": "t-306",
+        "id": "t-302",
         "category": "field-presence",
         "entity": "paymentDetails",
         "field": "amount2",
@@ -10158,7 +10105,7 @@
         "description": "Field 'amount2' should be present in paymentDetails"
       },
       {
-        "id": "t-307",
+        "id": "t-303",
         "category": "field-presence",
         "entity": "paymentDetails",
         "field": "canceled",
@@ -10166,7 +10113,7 @@
         "description": "Field 'canceled' should be present in paymentDetails"
       },
       {
-        "id": "t-308",
+        "id": "t-304",
         "category": "field-presence",
         "entity": "paymentDetails",
         "field": "finPaymentID",
@@ -10174,7 +10121,7 @@
         "description": "Field 'finPaymentID' should be present in paymentDetails"
       },
       {
-        "id": "t-309",
+        "id": "t-305",
         "category": "field-presence",
         "entity": "paymentDetails",
         "field": "invoicePaid",
@@ -10182,7 +10129,7 @@
         "description": "Field 'invoicePaid' should be present in paymentDetails"
       },
       {
-        "id": "t-310",
+        "id": "t-306",
         "category": "field-type",
         "entity": "paymentDetails",
         "field": "amount",
@@ -10190,7 +10137,7 @@
         "description": "Field 'amount' should have type 'number' in paymentDetails"
       },
       {
-        "id": "t-311",
+        "id": "t-307",
         "category": "field-type",
         "entity": "paymentDetails",
         "field": "writeoffAmount",
@@ -10198,7 +10145,7 @@
         "description": "Field 'writeoffAmount' should have type 'number' in paymentDetails"
       },
       {
-        "id": "t-312",
+        "id": "t-308",
         "category": "field-type",
         "entity": "paymentDetails",
         "field": "amount2",
@@ -10206,7 +10153,7 @@
         "description": "Field 'amount2' should have type 'number' in paymentDetails"
       },
       {
-        "id": "t-313",
+        "id": "t-309",
         "category": "field-type",
         "entity": "paymentDetails",
         "field": "canceled",
@@ -10214,7 +10161,7 @@
         "description": "Field 'canceled' should have type 'boolean' in paymentDetails"
       },
       {
-        "id": "t-314",
+        "id": "t-310",
         "category": "field-type",
         "entity": "paymentDetails",
         "field": "finPaymentID",
@@ -10222,7 +10169,7 @@
         "description": "Field 'finPaymentID' should have type 'string' in paymentDetails"
       },
       {
-        "id": "t-315",
+        "id": "t-311",
         "category": "field-type",
         "entity": "paymentDetails",
         "field": "invoicePaid",
@@ -10230,14 +10177,14 @@
         "description": "Field 'invoicePaid' should have type 'boolean' in paymentDetails"
       },
       {
-        "id": "t-316",
+        "id": "t-312",
         "category": "visibility",
         "entity": "paymentDetails",
         "runner": "node",
         "description": "Entity 'paymentDetails' should only expose visible fields in frontend"
       },
       {
-        "id": "t-317",
+        "id": "t-313",
         "category": "displaylogic-valid",
         "entity": "paymentDetails",
         "field": "invoicePaid",
@@ -10245,7 +10192,7 @@
         "description": "Display logic for 'invoicePaid' in paymentDetails should be valid JS"
       },
       {
-        "id": "t-318",
+        "id": "t-314",
         "category": "displaylogic-evaluable",
         "entity": "paymentDetails",
         "field": "invoicePaid",
@@ -10253,7 +10200,7 @@
         "description": "Display logic for 'invoicePaid' in paymentDetails should have evaluable flag"
       },
       {
-        "id": "t-319",
+        "id": "t-315",
         "category": "default-value-type",
         "entity": "paymentDetails",
         "field": "amount",
@@ -10261,7 +10208,7 @@
         "description": "Default value for 'amount' in paymentDetails should be a string"
       },
       {
-        "id": "t-320",
+        "id": "t-316",
         "category": "default-value-type",
         "entity": "paymentDetails",
         "field": "writeoffAmount",
@@ -10269,7 +10216,7 @@
         "description": "Default value for 'writeoffAmount' in paymentDetails should be a string"
       },
       {
-        "id": "t-321",
+        "id": "t-317",
         "category": "default-value-type",
         "entity": "paymentDetails",
         "field": "amount2",
@@ -10277,7 +10224,7 @@
         "description": "Default value for 'amount2' in paymentDetails should be a string"
       },
       {
-        "id": "t-322",
+        "id": "t-318",
         "category": "default-value-type",
         "entity": "paymentDetails",
         "field": "canceled",
@@ -10285,7 +10232,7 @@
         "description": "Default value for 'canceled' in paymentDetails should be a string"
       },
       {
-        "id": "t-323",
+        "id": "t-319",
         "category": "default-value-type",
         "entity": "paymentDetails",
         "field": "invoicePaid",
@@ -10293,7 +10240,7 @@
         "description": "Default value for 'invoicePaid' in paymentDetails should be a string"
       },
       {
-        "id": "t-324",
+        "id": "t-320",
         "category": "field-presence",
         "entity": "reversedInvoices",
         "field": "reversedInvoice",
@@ -10301,7 +10248,7 @@
         "description": "Field 'reversedInvoice' should be present in reversedInvoices"
       },
       {
-        "id": "t-325",
+        "id": "t-321",
         "category": "field-type",
         "entity": "reversedInvoices",
         "field": "reversedInvoice",
@@ -10309,14 +10256,14 @@
         "description": "Field 'reversedInvoice' should have type 'string' in reversedInvoices"
       },
       {
-        "id": "t-326",
+        "id": "t-322",
         "category": "visibility",
         "entity": "reversedInvoices",
         "runner": "node",
         "description": "Entity 'reversedInvoices' should only expose visible fields in frontend"
       },
       {
-        "id": "t-327",
+        "id": "t-323",
         "category": "readonlylogic-valid",
         "entity": "reversedInvoices",
         "field": "reversedInvoice",
@@ -10324,7 +10271,7 @@
         "description": "Read-only logic for 'reversedInvoice' in reversedInvoices should be valid JS"
       },
       {
-        "id": "t-328",
+        "id": "t-324",
         "category": "readonlylogic-evaluable",
         "entity": "reversedInvoices",
         "field": "reversedInvoice",
@@ -10332,7 +10279,7 @@
         "description": "Read-only logic for 'reversedInvoice' in reversedInvoices should have evaluable flag"
       },
       {
-        "id": "t-329",
+        "id": "t-325",
         "category": "field-presence",
         "entity": "accounting",
         "field": "accountingSchema",
@@ -10340,7 +10287,7 @@
         "description": "Field 'accountingSchema' should be present in accounting"
       },
       {
-        "id": "t-330",
+        "id": "t-326",
         "category": "field-presence",
         "entity": "accounting",
         "field": "currency",
@@ -10348,7 +10295,7 @@
         "description": "Field 'currency' should be present in accounting"
       },
       {
-        "id": "t-331",
+        "id": "t-327",
         "category": "field-presence",
         "entity": "accounting",
         "field": "period",
@@ -10356,7 +10303,7 @@
         "description": "Field 'period' should be present in accounting"
       },
       {
-        "id": "t-332",
+        "id": "t-328",
         "category": "field-presence",
         "entity": "accounting",
         "field": "accountingDate",
@@ -10364,7 +10311,7 @@
         "description": "Field 'accountingDate' should be present in accounting"
       },
       {
-        "id": "t-333",
+        "id": "t-329",
         "category": "field-presence",
         "entity": "accounting",
         "field": "account",
@@ -10372,7 +10319,7 @@
         "description": "Field 'account' should be present in accounting"
       },
       {
-        "id": "t-334",
+        "id": "t-330",
         "category": "field-presence",
         "entity": "accounting",
         "field": "debit",
@@ -10380,7 +10327,7 @@
         "description": "Field 'debit' should be present in accounting"
       },
       {
-        "id": "t-335",
+        "id": "t-331",
         "category": "field-presence",
         "entity": "accounting",
         "field": "credit",
@@ -10388,7 +10335,7 @@
         "description": "Field 'credit' should be present in accounting"
       },
       {
-        "id": "t-336",
+        "id": "t-332",
         "category": "field-presence",
         "entity": "accounting",
         "field": "description",
@@ -10396,7 +10343,7 @@
         "description": "Field 'description' should be present in accounting"
       },
       {
-        "id": "t-337",
+        "id": "t-333",
         "category": "field-presence",
         "entity": "accounting",
         "field": "businessPartner",
@@ -10404,7 +10351,7 @@
         "description": "Field 'businessPartner' should be present in accounting"
       },
       {
-        "id": "t-338",
+        "id": "t-334",
         "category": "field-presence",
         "entity": "accounting",
         "field": "product",
@@ -10412,7 +10359,7 @@
         "description": "Field 'product' should be present in accounting"
       },
       {
-        "id": "t-339",
+        "id": "t-335",
         "category": "field-presence",
         "entity": "accounting",
         "field": "project",
@@ -10420,7 +10367,7 @@
         "description": "Field 'project' should be present in accounting"
       },
       {
-        "id": "t-340",
+        "id": "t-336",
         "category": "field-presence",
         "entity": "accounting",
         "field": "costcenter",
@@ -10428,7 +10375,7 @@
         "description": "Field 'costcenter' should be present in accounting"
       },
       {
-        "id": "t-341",
+        "id": "t-337",
         "category": "field-presence",
         "entity": "accounting",
         "field": "asset",
@@ -10436,7 +10383,7 @@
         "description": "Field 'asset' should be present in accounting"
       },
       {
-        "id": "t-342",
+        "id": "t-338",
         "category": "field-presence",
         "entity": "accounting",
         "field": "stDimension",
@@ -10444,7 +10391,7 @@
         "description": "Field 'stDimension' should be present in accounting"
       },
       {
-        "id": "t-343",
+        "id": "t-339",
         "category": "field-presence",
         "entity": "accounting",
         "field": "ndDimension",
@@ -10452,7 +10399,7 @@
         "description": "Field 'ndDimension' should be present in accounting"
       },
       {
-        "id": "t-344",
+        "id": "t-340",
         "category": "field-presence",
         "entity": "accounting",
         "field": "postingType",
@@ -10460,7 +10407,7 @@
         "description": "Field 'postingType' should be present in accounting"
       },
       {
-        "id": "t-345",
+        "id": "t-341",
         "category": "field-type",
         "entity": "accounting",
         "field": "accountingSchema",
@@ -10468,7 +10415,7 @@
         "description": "Field 'accountingSchema' should have type 'string' in accounting"
       },
       {
-        "id": "t-346",
+        "id": "t-342",
         "category": "field-type",
         "entity": "accounting",
         "field": "currency",
@@ -10476,7 +10423,7 @@
         "description": "Field 'currency' should have type 'string' in accounting"
       },
       {
-        "id": "t-347",
+        "id": "t-343",
         "category": "field-type",
         "entity": "accounting",
         "field": "period",
@@ -10484,7 +10431,7 @@
         "description": "Field 'period' should have type 'string' in accounting"
       },
       {
-        "id": "t-348",
+        "id": "t-344",
         "category": "field-type",
         "entity": "accounting",
         "field": "accountingDate",
@@ -10492,7 +10439,7 @@
         "description": "Field 'accountingDate' should have type 'string' in accounting"
       },
       {
-        "id": "t-349",
+        "id": "t-345",
         "category": "field-type",
         "entity": "accounting",
         "field": "account",
@@ -10500,7 +10447,7 @@
         "description": "Field 'account' should have type 'string' in accounting"
       },
       {
-        "id": "t-350",
+        "id": "t-346",
         "category": "field-type",
         "entity": "accounting",
         "field": "debit",
@@ -10508,7 +10455,7 @@
         "description": "Field 'debit' should have type 'number' in accounting"
       },
       {
-        "id": "t-351",
+        "id": "t-347",
         "category": "field-type",
         "entity": "accounting",
         "field": "credit",
@@ -10516,7 +10463,7 @@
         "description": "Field 'credit' should have type 'number' in accounting"
       },
       {
-        "id": "t-352",
+        "id": "t-348",
         "category": "field-type",
         "entity": "accounting",
         "field": "description",
@@ -10524,7 +10471,7 @@
         "description": "Field 'description' should have type 'string' in accounting"
       },
       {
-        "id": "t-353",
+        "id": "t-349",
         "category": "field-type",
         "entity": "accounting",
         "field": "businessPartner",
@@ -10532,7 +10479,7 @@
         "description": "Field 'businessPartner' should have type 'string' in accounting"
       },
       {
-        "id": "t-354",
+        "id": "t-350",
         "category": "field-type",
         "entity": "accounting",
         "field": "product",
@@ -10540,7 +10487,7 @@
         "description": "Field 'product' should have type 'string' in accounting"
       },
       {
-        "id": "t-355",
+        "id": "t-351",
         "category": "field-type",
         "entity": "accounting",
         "field": "project",
@@ -10548,7 +10495,7 @@
         "description": "Field 'project' should have type 'string' in accounting"
       },
       {
-        "id": "t-356",
+        "id": "t-352",
         "category": "field-type",
         "entity": "accounting",
         "field": "costcenter",
@@ -10556,7 +10503,7 @@
         "description": "Field 'costcenter' should have type 'string' in accounting"
       },
       {
-        "id": "t-357",
+        "id": "t-353",
         "category": "field-type",
         "entity": "accounting",
         "field": "asset",
@@ -10564,7 +10511,7 @@
         "description": "Field 'asset' should have type 'string' in accounting"
       },
       {
-        "id": "t-358",
+        "id": "t-354",
         "category": "field-type",
         "entity": "accounting",
         "field": "stDimension",
@@ -10572,7 +10519,7 @@
         "description": "Field 'stDimension' should have type 'string' in accounting"
       },
       {
-        "id": "t-359",
+        "id": "t-355",
         "category": "field-type",
         "entity": "accounting",
         "field": "ndDimension",
@@ -10580,7 +10527,7 @@
         "description": "Field 'ndDimension' should have type 'string' in accounting"
       },
       {
-        "id": "t-360",
+        "id": "t-356",
         "category": "field-type",
         "entity": "accounting",
         "field": "postingType",
@@ -10588,14 +10535,14 @@
         "description": "Field 'postingType' should have type 'string' in accounting"
       },
       {
-        "id": "t-361",
+        "id": "t-357",
         "category": "visibility",
         "entity": "accounting",
         "runner": "node",
         "description": "Entity 'accounting' should only expose visible fields in frontend"
       },
       {
-        "id": "t-362",
+        "id": "t-358",
         "category": "field-presence",
         "entity": "siiData",
         "field": "conexinSII",
@@ -10603,7 +10550,7 @@
         "description": "Field 'conexinSII' should be present in siiData"
       },
       {
-        "id": "t-363",
+        "id": "t-359",
         "category": "field-presence",
         "entity": "siiData",
         "field": "cdigoCSV",
@@ -10611,7 +10558,7 @@
         "description": "Field 'cdigoCSV' should be present in siiData"
       },
       {
-        "id": "t-364",
+        "id": "t-360",
         "category": "field-presence",
         "entity": "siiData",
         "field": "estadoRegistro",
@@ -10619,7 +10566,7 @@
         "description": "Field 'estadoRegistro' should be present in siiData"
       },
       {
-        "id": "t-365",
+        "id": "t-361",
         "category": "field-presence",
         "entity": "siiData",
         "field": "comunicacion",
@@ -10627,7 +10574,7 @@
         "description": "Field 'comunicacion' should be present in siiData"
       },
       {
-        "id": "t-366",
+        "id": "t-362",
         "category": "field-presence",
         "entity": "siiData",
         "field": "motivo",
@@ -10635,7 +10582,7 @@
         "description": "Field 'motivo' should be present in siiData"
       },
       {
-        "id": "t-367",
+        "id": "t-363",
         "category": "field-presence",
         "entity": "siiData",
         "field": "estadoCuadre",
@@ -10643,7 +10590,7 @@
         "description": "Field 'estadoCuadre' should be present in siiData"
       },
       {
-        "id": "t-368",
+        "id": "t-364",
         "category": "field-presence",
         "entity": "siiData",
         "field": "fechaCuadre",
@@ -10651,7 +10598,7 @@
         "description": "Field 'fechaCuadre' should be present in siiData"
       },
       {
-        "id": "t-369",
+        "id": "t-365",
         "category": "field-presence",
         "entity": "siiData",
         "field": "fechaltimaModificacinSII",
@@ -10659,7 +10606,7 @@
         "description": "Field 'fechaltimaModificacinSII' should be present in siiData"
       },
       {
-        "id": "t-370",
+        "id": "t-366",
         "category": "field-type",
         "entity": "siiData",
         "field": "conexinSII",
@@ -10667,7 +10614,7 @@
         "description": "Field 'conexinSII' should have type 'string' in siiData"
       },
       {
-        "id": "t-371",
+        "id": "t-367",
         "category": "field-type",
         "entity": "siiData",
         "field": "cdigoCSV",
@@ -10675,7 +10622,7 @@
         "description": "Field 'cdigoCSV' should have type 'string' in siiData"
       },
       {
-        "id": "t-372",
+        "id": "t-368",
         "category": "field-type",
         "entity": "siiData",
         "field": "estadoRegistro",
@@ -10683,7 +10630,7 @@
         "description": "Field 'estadoRegistro' should have type 'string' in siiData"
       },
       {
-        "id": "t-373",
+        "id": "t-369",
         "category": "field-type",
         "entity": "siiData",
         "field": "comunicacion",
@@ -10691,7 +10638,7 @@
         "description": "Field 'comunicacion' should have type 'string' in siiData"
       },
       {
-        "id": "t-374",
+        "id": "t-370",
         "category": "field-type",
         "entity": "siiData",
         "field": "motivo",
@@ -10699,7 +10646,7 @@
         "description": "Field 'motivo' should have type 'string' in siiData"
       },
       {
-        "id": "t-375",
+        "id": "t-371",
         "category": "field-type",
         "entity": "siiData",
         "field": "estadoCuadre",
@@ -10707,7 +10654,7 @@
         "description": "Field 'estadoCuadre' should have type 'string' in siiData"
       },
       {
-        "id": "t-376",
+        "id": "t-372",
         "category": "field-type",
         "entity": "siiData",
         "field": "fechaCuadre",
@@ -10715,7 +10662,7 @@
         "description": "Field 'fechaCuadre' should have type 'string' in siiData"
       },
       {
-        "id": "t-377",
+        "id": "t-373",
         "category": "field-type",
         "entity": "siiData",
         "field": "fechaltimaModificacinSII",
@@ -10723,14 +10670,14 @@
         "description": "Field 'fechaltimaModificacinSII' should have type 'string' in siiData"
       },
       {
-        "id": "t-378",
+        "id": "t-374",
         "category": "visibility",
         "entity": "siiData",
         "runner": "node",
         "description": "Entity 'siiData' should only expose visible fields in frontend"
       },
       {
-        "id": "t-379",
+        "id": "t-375",
         "category": "field-presence",
         "entity": "batuz",
         "field": "active",
@@ -10738,7 +10685,7 @@
         "description": "Field 'active' should be present in batuz"
       },
       {
-        "id": "t-380",
+        "id": "t-376",
         "category": "field-presence",
         "entity": "batuz",
         "field": "estado",
@@ -10746,7 +10693,7 @@
         "description": "Field 'estado' should be present in batuz"
       },
       {
-        "id": "t-381",
+        "id": "t-377",
         "category": "field-presence",
         "entity": "batuz",
         "field": "descripcion",
@@ -10754,7 +10701,7 @@
         "description": "Field 'descripcion' should be present in batuz"
       },
       {
-        "id": "t-382",
+        "id": "t-378",
         "category": "field-presence",
         "entity": "batuz",
         "field": "invoice",
@@ -10762,7 +10709,7 @@
         "description": "Field 'invoice' should be present in batuz"
       },
       {
-        "id": "t-383",
+        "id": "t-379",
         "category": "field-type",
         "entity": "batuz",
         "field": "active",
@@ -10770,7 +10717,7 @@
         "description": "Field 'active' should have type 'boolean' in batuz"
       },
       {
-        "id": "t-384",
+        "id": "t-380",
         "category": "field-type",
         "entity": "batuz",
         "field": "estado",
@@ -10778,7 +10725,7 @@
         "description": "Field 'estado' should have type 'string' in batuz"
       },
       {
-        "id": "t-385",
+        "id": "t-381",
         "category": "field-type",
         "entity": "batuz",
         "field": "descripcion",
@@ -10786,7 +10733,7 @@
         "description": "Field 'descripcion' should have type 'string' in batuz"
       },
       {
-        "id": "t-386",
+        "id": "t-382",
         "category": "field-type",
         "entity": "batuz",
         "field": "invoice",
@@ -10794,14 +10741,14 @@
         "description": "Field 'invoice' should have type 'string' in batuz"
       },
       {
-        "id": "t-387",
+        "id": "t-383",
         "category": "visibility",
         "entity": "batuz",
         "runner": "node",
         "description": "Entity 'batuz' should only expose visible fields in frontend"
       },
       {
-        "id": "t-388",
+        "id": "t-384",
         "category": "default-value-type",
         "entity": "batuz",
         "field": "active",
@@ -10809,7 +10756,7 @@
         "description": "Default value for 'active' in batuz should be a string"
       },
       {
-        "id": "t-389",
+        "id": "t-385",
         "category": "system-field",
         "entity": "header",
         "field": "organization",
@@ -10817,7 +10764,7 @@
         "description": "System field 'organization' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-390",
+        "id": "t-386",
         "category": "system-field",
         "entity": "header",
         "field": "orderReference",
@@ -10825,7 +10772,7 @@
         "description": "System field 'orderReference' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-391",
+        "id": "t-387",
         "category": "system-field",
         "entity": "header",
         "field": "lastCalculatedOnDate",
@@ -10833,7 +10780,7 @@
         "description": "System field 'lastCalculatedOnDate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-392",
+        "id": "t-388",
         "category": "system-field",
         "entity": "header",
         "field": "taxDate",
@@ -10841,7 +10788,7 @@
         "description": "System field 'taxDate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-393",
+        "id": "t-389",
         "category": "system-field",
         "entity": "header",
         "field": "orderDate",
@@ -10849,7 +10796,7 @@
         "description": "System field 'orderDate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-394",
+        "id": "t-390",
         "category": "system-field",
         "entity": "header",
         "field": "daysTillDue",
@@ -10857,7 +10804,7 @@
         "description": "System field 'daysTillDue' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-395",
+        "id": "t-391",
         "category": "system-field",
         "entity": "header",
         "field": "printDiscount",
@@ -10865,7 +10812,7 @@
         "description": "System field 'printDiscount' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-396",
+        "id": "t-392",
         "category": "system-field",
         "entity": "header",
         "field": "documentType",
@@ -10873,7 +10820,7 @@
         "description": "System field 'documentType' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-397",
+        "id": "t-393",
         "category": "system-field",
         "entity": "header",
         "field": "withholdingAmount",
@@ -10881,7 +10828,7 @@
         "description": "System field 'withholdingAmount' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-398",
+        "id": "t-394",
         "category": "system-field",
         "entity": "header",
         "field": "withholding",
@@ -10889,7 +10836,7 @@
         "description": "System field 'withholding' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-399",
+        "id": "t-395",
         "category": "system-field",
         "entity": "header",
         "field": "percentageOverdue",
@@ -10897,7 +10844,7 @@
         "description": "System field 'percentageOverdue' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-400",
+        "id": "t-396",
         "category": "system-field",
         "entity": "header",
         "field": "activity",
@@ -10905,7 +10852,7 @@
         "description": "System field 'activity' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-401",
+        "id": "t-397",
         "category": "system-field",
         "entity": "header",
         "field": "finalSettlementDate",
@@ -10913,7 +10860,7 @@
         "description": "System field 'finalSettlementDate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-402",
+        "id": "t-398",
         "category": "system-field",
         "entity": "header",
         "field": "daysSalesOutstanding",
@@ -10921,7 +10868,7 @@
         "description": "System field 'daysSalesOutstanding' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-403",
+        "id": "t-399",
         "category": "system-field",
         "entity": "header",
         "field": "active",
@@ -10929,7 +10876,7 @@
         "description": "System field 'active' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-404",
+        "id": "t-400",
         "category": "system-field",
         "entity": "header",
         "field": "generateTo",
@@ -10937,7 +10884,7 @@
         "description": "System field 'generateTo' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-405",
+        "id": "t-401",
         "category": "system-field",
         "entity": "header",
         "field": "trxOrganization",
@@ -10945,7 +10892,7 @@
         "description": "System field 'trxOrganization' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-406",
+        "id": "t-402",
         "category": "system-field",
         "entity": "header",
         "field": "aPRMAddpayment",
@@ -10953,7 +10900,7 @@
         "description": "System field 'aPRMAddpayment' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-407",
+        "id": "t-403",
         "category": "system-field",
         "entity": "header",
         "field": "posted",
@@ -10961,7 +10908,7 @@
         "description": "System field 'posted' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-408",
+        "id": "t-404",
         "category": "system-field",
         "entity": "header",
         "field": "aPRMProcessinvoice",
@@ -10969,7 +10916,7 @@
         "description": "System field 'aPRMProcessinvoice' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-409",
+        "id": "t-405",
         "category": "system-field",
         "entity": "header",
         "field": "documentAction",
@@ -10977,7 +10924,7 @@
         "description": "System field 'documentAction' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-410",
+        "id": "t-406",
         "category": "system-field",
         "entity": "header",
         "field": "createLinesFromOrder",
@@ -10985,7 +10932,7 @@
         "description": "System field 'createLinesFromOrder' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-411",
+        "id": "t-407",
         "category": "system-field",
         "entity": "header",
         "field": "createLinesFromShipment",
@@ -10993,7 +10940,7 @@
         "description": "System field 'createLinesFromShipment' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-412",
+        "id": "t-408",
         "category": "system-field",
         "entity": "header",
         "field": "copyFrom",
@@ -11001,7 +10948,7 @@
         "description": "System field 'copyFrom' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-413",
+        "id": "t-409",
         "category": "system-field",
         "entity": "header",
         "field": "calculatePromotions",
@@ -11009,7 +10956,7 @@
         "description": "System field 'calculatePromotions' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-414",
+        "id": "t-410",
         "category": "system-field",
         "entity": "header",
         "field": "cashVAT",
@@ -11017,7 +10964,7 @@
         "description": "System field 'cashVAT' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-415",
+        "id": "t-411",
         "category": "system-field",
         "entity": "header",
         "field": "costcenter",
@@ -11025,7 +10972,7 @@
         "description": "System field 'costcenter' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-416",
+        "id": "t-412",
         "category": "system-field",
         "entity": "header",
         "field": "asset",
@@ -11033,7 +10980,7 @@
         "description": "System field 'asset' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-417",
+        "id": "t-413",
         "category": "system-field",
         "entity": "header",
         "field": "salesCampaign",
@@ -11041,7 +10988,7 @@
         "description": "System field 'salesCampaign' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-418",
+        "id": "t-414",
         "category": "system-field",
         "entity": "header",
         "field": "stDimension",
@@ -11049,7 +10996,7 @@
         "description": "System field 'stDimension' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-419",
+        "id": "t-415",
         "category": "system-field",
         "entity": "header",
         "field": "ndDimension",
@@ -11057,7 +11004,7 @@
         "description": "System field 'ndDimension' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-420",
+        "id": "t-416",
         "category": "system-field",
         "entity": "header",
         "field": "etcopagCopilotFeedback",
@@ -11065,7 +11012,7 @@
         "description": "System field 'etcopagCopilotFeedback' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-421",
+        "id": "t-417",
         "category": "system-field",
         "entity": "header",
         "field": "etsgDateOperation",
@@ -11073,7 +11020,7 @@
         "description": "System field 'etsgDateOperation' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-422",
+        "id": "t-418",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiSend",
@@ -11081,7 +11028,7 @@
         "description": "System field 'aeatsiiSend' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-423",
+        "id": "t-419",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiModif",
@@ -11089,7 +11036,7 @@
         "description": "System field 'aeatsiiModif' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-424",
+        "id": "t-420",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiIssent",
@@ -11097,7 +11044,7 @@
         "description": "System field 'aeatsiiIssent' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-425",
+        "id": "t-421",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiModified",
@@ -11105,7 +11052,7 @@
         "description": "System field 'aeatsiiModified' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-426",
+        "id": "t-422",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiFechaRegCont",
@@ -11113,7 +11060,7 @@
         "description": "System field 'aeatsiiFechaRegCont' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-427",
+        "id": "t-423",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiClaveTipoFc",
@@ -11121,7 +11068,7 @@
         "description": "System field 'aeatsiiClaveTipoFc' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-428",
+        "id": "t-424",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiPurDescription",
@@ -11129,7 +11076,7 @@
         "description": "System field 'aeatsiiPurDescription' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-429",
+        "id": "t-425",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiDescripcionSii",
@@ -11137,7 +11084,7 @@
         "description": "System field 'aeatsiiDescripcionSii' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-430",
+        "id": "t-426",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiEstado",
@@ -11145,7 +11092,7 @@
         "description": "System field 'aeatsiiEstado' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-431",
+        "id": "t-427",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiErrorRegistral",
@@ -11153,7 +11100,7 @@
         "description": "System field 'aeatsiiErrorRegistral' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-432",
+        "id": "t-428",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiAutofactura",
@@ -11161,7 +11108,7 @@
         "description": "System field 'aeatsiiAutofactura' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-433",
+        "id": "t-429",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiEjercicio",
@@ -11169,7 +11116,7 @@
         "description": "System field 'aeatsiiEjercicio' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-434",
+        "id": "t-430",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiPeriodo",
@@ -11177,7 +11124,7 @@
         "description": "System field 'aeatsiiPeriodo' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-435",
+        "id": "t-431",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiIsauthorization",
@@ -11185,7 +11132,7 @@
         "description": "System field 'aeatsiiIsauthorization' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-436",
+        "id": "t-432",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiAuthorizationno",
@@ -11193,7 +11140,7 @@
         "description": "System field 'aeatsiiAuthorizationno' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-437",
+        "id": "t-433",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiDua",
@@ -11201,7 +11148,7 @@
         "description": "System field 'aeatsiiDua' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-438",
+        "id": "t-434",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiFechaDua",
@@ -11209,7 +11156,7 @@
         "description": "System field 'aeatsiiFechaDua' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-439",
+        "id": "t-435",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiMultiDua",
@@ -11217,7 +11164,7 @@
         "description": "System field 'aeatsiiMultiDua' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-440",
+        "id": "t-436",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiXmlgenerator",
@@ -11225,7 +11172,7 @@
         "description": "System field 'tbaiXmlgenerator' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-441",
+        "id": "t-437",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiIssent",
@@ -11233,7 +11180,7 @@
         "description": "System field 'tbaiIssent' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-442",
+        "id": "t-438",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiIssueDate",
@@ -11241,7 +11188,7 @@
         "description": "System field 'tbaiIssueDate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-443",
+        "id": "t-439",
         "category": "system-field",
         "entity": "header",
         "field": "processNow",
@@ -11249,7 +11196,7 @@
         "description": "System field 'processNow' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-444",
+        "id": "t-440",
         "category": "system-field",
         "entity": "header",
         "field": "processed",
@@ -11257,7 +11204,7 @@
         "description": "System field 'processed' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-445",
+        "id": "t-441",
         "category": "system-field",
         "entity": "header",
         "field": "salesTransaction",
@@ -11265,7 +11212,7 @@
         "description": "System field 'salesTransaction' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-446",
+        "id": "t-442",
         "category": "system-field",
         "entity": "header",
         "field": "priceIncludesTax",
@@ -11273,7 +11220,7 @@
         "description": "System field 'priceIncludesTax' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-447",
+        "id": "t-443",
         "category": "system-field",
         "entity": "header",
         "field": "id",
@@ -11281,7 +11228,7 @@
         "description": "System field 'id' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-448",
+        "id": "t-444",
         "category": "system-field",
         "entity": "header",
         "field": "selfService",
@@ -11289,7 +11236,7 @@
         "description": "System field 'selfService' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-449",
+        "id": "t-445",
         "category": "system-field",
         "entity": "header",
         "field": "datePrinted",
@@ -11297,7 +11244,7 @@
         "description": "System field 'datePrinted' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-450",
+        "id": "t-446",
         "category": "system-field",
         "entity": "header",
         "field": "creationDate",
@@ -11305,7 +11252,7 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-451",
+        "id": "t-447",
         "category": "system-field",
         "entity": "header",
         "field": "client",
@@ -11313,7 +11260,7 @@
         "description": "System field 'client' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-452",
+        "id": "t-448",
         "category": "system-field",
         "entity": "header",
         "field": "print",
@@ -11321,7 +11268,7 @@
         "description": "System field 'print' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-453",
+        "id": "t-449",
         "category": "system-field",
         "entity": "header",
         "field": "externalBusinessPartnerReference",
@@ -11329,7 +11276,7 @@
         "description": "System field 'externalBusinessPartnerReference' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-454",
+        "id": "t-450",
         "category": "system-field",
         "entity": "header",
         "field": "createdBy",
@@ -11337,7 +11284,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-455",
+        "id": "t-451",
         "category": "system-field",
         "entity": "header",
         "field": "createLinesFrom",
@@ -11345,7 +11292,7 @@
         "description": "System field 'createLinesFrom' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-456",
+        "id": "t-452",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiCauseExemption",
@@ -11353,7 +11300,7 @@
         "description": "System field 'aeatsiiCauseExemption' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-457",
+        "id": "t-453",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiClaveTipo",
@@ -11361,7 +11308,7 @@
         "description": "System field 'aeatsiiClaveTipo' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-458",
+        "id": "t-454",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiDateIssue",
@@ -11369,7 +11316,7 @@
         "description": "System field 'aeatsiiDateIssue' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-459",
+        "id": "t-455",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiDescription",
@@ -11377,7 +11324,7 @@
         "description": "System field 'aeatsiiDescription' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-460",
+        "id": "t-456",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiDup",
@@ -11385,7 +11332,7 @@
         "description": "System field 'aeatsiiDup' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-461",
+        "id": "t-457",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiErrorCode",
@@ -11393,7 +11340,7 @@
         "description": "System field 'aeatsiiErrorCode' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-462",
+        "id": "t-458",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiErrorMsg",
@@ -11401,7 +11348,7 @@
         "description": "System field 'aeatsiiErrorMsg' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-463",
+        "id": "t-459",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiFechaOperacion",
@@ -11409,7 +11356,7 @@
         "description": "System field 'aeatsiiFechaOperacion' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-464",
+        "id": "t-460",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiHash",
@@ -11417,7 +11364,7 @@
         "description": "System field 'aeatsiiHash' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-465",
+        "id": "t-461",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiInsiidate",
@@ -11425,7 +11372,7 @@
         "description": "System field 'aeatsiiInsiidate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-466",
+        "id": "t-462",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiInvoice",
@@ -11433,7 +11380,7 @@
         "description": "System field 'aeatsiiInvoice' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-467",
+        "id": "t-463",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiMotivoRectif",
@@ -11441,7 +11388,7 @@
         "description": "System field 'aeatsiiMotivoRectif' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-468",
+        "id": "t-464",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiTipoRectif",
@@ -11449,7 +11396,7 @@
         "description": "System field 'aeatsiiTipoRectif' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-469",
+        "id": "t-465",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiUnsubscribe",
@@ -11457,7 +11404,7 @@
         "description": "System field 'aeatsiiUnsubscribe' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-470",
+        "id": "t-466",
         "category": "system-field",
         "entity": "header",
         "field": "etsgIsF3",
@@ -11465,7 +11412,7 @@
         "description": "System field 'etsgIsF3' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-471",
+        "id": "t-467",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacAddress1Copy",
@@ -11473,7 +11420,7 @@
         "description": "System field 'etvfacAddress1Copy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-472",
+        "id": "t-468",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacBpNameCopy",
@@ -11481,7 +11428,7 @@
         "description": "System field 'etvfacBpNameCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-473",
+        "id": "t-469",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacBpTaxidCopy",
@@ -11489,7 +11436,7 @@
         "description": "System field 'etvfacBpTaxidCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-474",
+        "id": "t-470",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacCityCopy",
@@ -11497,7 +11444,7 @@
         "description": "System field 'etvfacCityCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-475",
+        "id": "t-471",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacContactNameCopy",
@@ -11505,7 +11452,7 @@
         "description": "System field 'etvfacContactNameCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-476",
+        "id": "t-472",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacCorrectedInv",
@@ -11513,7 +11460,7 @@
         "description": "System field 'etvfacCorrectedInv' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-477",
+        "id": "t-473",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacCountryCopy",
@@ -11521,7 +11468,7 @@
         "description": "System field 'etvfacCountryCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-478",
+        "id": "t-474",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacDateIssue",
@@ -11529,7 +11476,7 @@
         "description": "System field 'etvfacDateIssue' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-479",
+        "id": "t-475",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacDateOperation",
@@ -11537,7 +11484,7 @@
         "description": "System field 'etvfacDateOperation' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-480",
+        "id": "t-476",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacExternalRef",
@@ -11545,7 +11492,7 @@
         "description": "System field 'etvfacExternalRef' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-481",
+        "id": "t-477",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacFaxCopy",
@@ -11553,7 +11500,7 @@
         "description": "System field 'etvfacFaxCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-482",
+        "id": "t-478",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacHash",
@@ -11561,7 +11508,7 @@
         "description": "System field 'etvfacHash' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-483",
+        "id": "t-479",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacInvType",
@@ -11569,7 +11516,7 @@
         "description": "System field 'etvfacInvType' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-484",
+        "id": "t-480",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacInvNoIDArt61d",
@@ -11577,7 +11524,7 @@
         "description": "System field 'etvfacInvNoIDArt61d' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-485",
+        "id": "t-481",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacInvoiceStatus",
@@ -11585,7 +11532,7 @@
         "description": "System field 'etvfacInvoiceStatus' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-486",
+        "id": "t-482",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacIsGenManual",
@@ -11593,7 +11540,7 @@
         "description": "System field 'etvfacIsGenManual' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-487",
+        "id": "t-483",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacIsSubsanation",
@@ -11601,7 +11548,7 @@
         "description": "System field 'etvfacIsSubsanation' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-488",
+        "id": "t-484",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacIssue",
@@ -11609,7 +11556,7 @@
         "description": "System field 'etvfacIssue' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-489",
+        "id": "t-485",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacIssueDescription",
@@ -11617,7 +11564,7 @@
         "description": "System field 'etvfacIssueDescription' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-490",
+        "id": "t-486",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacIssuedExternally",
@@ -11625,7 +11572,7 @@
         "description": "System field 'etvfacIssuedExternally' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-491",
+        "id": "t-487",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacOrgLocationCopy",
@@ -11633,7 +11580,7 @@
         "description": "System field 'etvfacOrgLocationCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-492",
+        "id": "t-488",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacOrgNameCopy",
@@ -11641,7 +11588,7 @@
         "description": "System field 'etvfacOrgNameCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-493",
+        "id": "t-489",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacOrgTaxidCopy",
@@ -11649,7 +11596,7 @@
         "description": "System field 'etvfacOrgTaxidCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-494",
+        "id": "t-490",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacPhoneCopy",
@@ -11657,7 +11604,7 @@
         "description": "System field 'etvfacPhoneCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-495",
+        "id": "t-491",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacPostalCopy",
@@ -11665,7 +11612,7 @@
         "description": "System field 'etvfacPostalCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-496",
+        "id": "t-492",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacQRURL",
@@ -11673,7 +11620,7 @@
         "description": "System field 'etvfacQRURL' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-497",
+        "id": "t-493",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacRectCreate",
@@ -11681,7 +11628,7 @@
         "description": "System field 'etvfacRectCreate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-498",
+        "id": "t-494",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacRegionCopy",
@@ -11689,7 +11636,7 @@
         "description": "System field 'etvfacRegionCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-499",
+        "id": "t-495",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacReverseinvtype",
@@ -11697,7 +11644,7 @@
         "description": "System field 'etvfacReverseinvtype' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-500",
+        "id": "t-496",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacSentToVerifac",
@@ -11705,7 +11652,7 @@
         "description": "System field 'etvfacSentToVerifac' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-501",
+        "id": "t-497",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacSimpinvart7273",
@@ -11713,7 +11660,7 @@
         "description": "System field 'etvfacSimpinvart7273' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-502",
+        "id": "t-498",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacVerifacDesc",
@@ -11721,7 +11668,7 @@
         "description": "System field 'etvfacVerifacDesc' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-503",
+        "id": "t-499",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacVoid",
@@ -11729,7 +11676,7 @@
         "description": "System field 'etvfacVoid' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-504",
+        "id": "t-500",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiDateOperation",
@@ -11737,7 +11684,7 @@
         "description": "System field 'tbaiDateOperation' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-505",
+        "id": "t-501",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiIdtbai",
@@ -11745,7 +11692,7 @@
         "description": "System field 'tbaiIdtbai' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-506",
+        "id": "t-502",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiInvoicenum",
@@ -11753,7 +11700,7 @@
         "description": "System field 'tbaiInvoicenum' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-507",
+        "id": "t-503",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiInvoiceseq",
@@ -11761,7 +11708,7 @@
         "description": "System field 'tbaiInvoiceseq' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-508",
+        "id": "t-504",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiIsreverseinvoice",
@@ -11769,7 +11716,7 @@
         "description": "System field 'tbaiIsreverseinvoice' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-509",
+        "id": "t-505",
         "category": "system-field",
         "entity": "header",
         "field": "tBAIQRcode",
@@ -11777,7 +11724,7 @@
         "description": "System field 'tBAIQRcode' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-510",
+        "id": "t-506",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiReverseinvoicecode",
@@ -11785,7 +11732,7 @@
         "description": "System field 'tbaiReverseinvoicecode' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-511",
+        "id": "t-507",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiReverseinvoicetype",
@@ -11793,7 +11740,7 @@
         "description": "System field 'tbaiReverseinvoicetype' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-512",
+        "id": "t-508",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiSequence",
@@ -11801,7 +11748,7 @@
         "description": "System field 'tbaiSequence' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-513",
+        "id": "t-509",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiSignaturevalue",
@@ -11809,7 +11756,7 @@
         "description": "System field 'tbaiSignaturevalue' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-514",
+        "id": "t-510",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiUrl",
@@ -11817,7 +11764,7 @@
         "description": "System field 'tbaiUrl' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-515",
+        "id": "t-511",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiVoidxmlgenerator",
@@ -11825,7 +11772,7 @@
         "description": "System field 'tbaiVoidxmlgenerator' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-516",
+        "id": "t-512",
         "category": "system-field",
         "entity": "header",
         "field": "fINPaymentPriorityID",
@@ -11833,7 +11780,7 @@
         "description": "System field 'fINPaymentPriorityID' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-517",
+        "id": "t-513",
         "category": "system-field",
         "entity": "header",
         "field": "paidAmountAtInvoicing",
@@ -11841,7 +11788,7 @@
         "description": "System field 'paidAmountAtInvoicing' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-518",
+        "id": "t-514",
         "category": "system-field",
         "entity": "header",
         "field": "updated",
@@ -11849,7 +11796,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-519",
+        "id": "t-515",
         "category": "system-field",
         "entity": "header",
         "field": "updatedBy",
@@ -11857,7 +11804,7 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-520",
+        "id": "t-516",
         "category": "system-field",
         "entity": "lines",
         "field": "lineNo",
@@ -11865,7 +11812,7 @@
         "description": "System field 'lineNo' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-521",
+        "id": "t-517",
         "category": "system-field",
         "entity": "lines",
         "field": "financialInvoiceLine",
@@ -11873,7 +11820,7 @@
         "description": "System field 'financialInvoiceLine' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-522",
+        "id": "t-518",
         "category": "system-field",
         "entity": "lines",
         "field": "operativeUOM",
@@ -11881,7 +11828,7 @@
         "description": "System field 'operativeUOM' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-523",
+        "id": "t-519",
         "category": "system-field",
         "entity": "lines",
         "field": "uOM",
@@ -11889,7 +11836,15 @@
         "description": "System field 'uOM' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-524",
+        "id": "t-520",
+        "category": "system-field",
+        "entity": "lines",
+        "field": "lineNetAmount",
+        "runner": "node",
+        "description": "System field 'lineNetAmount' should exist in backend but not frontend for lines"
+      },
+      {
+        "id": "t-521",
         "category": "system-field",
         "entity": "lines",
         "field": "grossListPrice",
@@ -11897,7 +11852,7 @@
         "description": "System field 'grossListPrice' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-525",
+        "id": "t-522",
         "category": "system-field",
         "entity": "lines",
         "field": "deferred",
@@ -11905,7 +11860,7 @@
         "description": "System field 'deferred' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-526",
+        "id": "t-523",
         "category": "system-field",
         "entity": "lines",
         "field": "excludeforwithholding",
@@ -11913,7 +11868,7 @@
         "description": "System field 'excludeforwithholding' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-527",
+        "id": "t-524",
         "category": "system-field",
         "entity": "lines",
         "field": "charge",
@@ -11921,7 +11876,7 @@
         "description": "System field 'charge' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-528",
+        "id": "t-525",
         "category": "system-field",
         "entity": "lines",
         "field": "editLineAmount",
@@ -11929,7 +11884,7 @@
         "description": "System field 'editLineAmount' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-529",
+        "id": "t-526",
         "category": "system-field",
         "entity": "lines",
         "field": "orderQuantity",
@@ -11937,7 +11892,7 @@
         "description": "System field 'orderQuantity' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-530",
+        "id": "t-527",
         "category": "system-field",
         "entity": "lines",
         "field": "orderUOM",
@@ -11945,7 +11900,7 @@
         "description": "System field 'orderUOM' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-531",
+        "id": "t-528",
         "category": "system-field",
         "entity": "lines",
         "field": "baseGrossUnitPrice",
@@ -11953,7 +11908,7 @@
         "description": "System field 'baseGrossUnitPrice' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-532",
+        "id": "t-529",
         "category": "system-field",
         "entity": "lines",
         "field": "standardPrice",
@@ -11961,7 +11916,7 @@
         "description": "System field 'standardPrice' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-533",
+        "id": "t-530",
         "category": "system-field",
         "entity": "lines",
         "field": "deferredPlanType",
@@ -11969,7 +11924,7 @@
         "description": "System field 'deferredPlanType' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-534",
+        "id": "t-531",
         "category": "system-field",
         "entity": "lines",
         "field": "periodNumber",
@@ -11977,7 +11932,7 @@
         "description": "System field 'periodNumber' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-535",
+        "id": "t-532",
         "category": "system-field",
         "entity": "lines",
         "field": "period",
@@ -11985,7 +11940,7 @@
         "description": "System field 'period' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-536",
+        "id": "t-533",
         "category": "system-field",
         "entity": "lines",
         "field": "organization",
@@ -11993,7 +11948,7 @@
         "description": "System field 'organization' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-537",
+        "id": "t-534",
         "category": "system-field",
         "entity": "lines",
         "field": "businessPartner",
@@ -12001,7 +11956,7 @@
         "description": "System field 'businessPartner' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-538",
+        "id": "t-535",
         "category": "system-field",
         "entity": "lines",
         "field": "explode",
@@ -12009,7 +11964,7 @@
         "description": "System field 'explode' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-539",
+        "id": "t-536",
         "category": "system-field",
         "entity": "lines",
         "field": "bOMParentID",
@@ -12017,7 +11972,7 @@
         "description": "System field 'bOMParentID' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-540",
+        "id": "t-537",
         "category": "system-field",
         "entity": "lines",
         "field": "matchLCCosts",
@@ -12025,7 +11980,7 @@
         "description": "System field 'matchLCCosts' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-541",
+        "id": "t-538",
         "category": "system-field",
         "entity": "lines",
         "field": "id",
@@ -12033,7 +11988,7 @@
         "description": "System field 'id' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-542",
+        "id": "t-539",
         "category": "system-field",
         "entity": "lines",
         "field": "client",
@@ -12041,7 +11996,7 @@
         "description": "System field 'client' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-543",
+        "id": "t-540",
         "category": "system-field",
         "entity": "lines",
         "field": "invoice",
@@ -12049,7 +12004,7 @@
         "description": "System field 'invoice' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-544",
+        "id": "t-541",
         "category": "system-field",
         "entity": "lines",
         "field": "active",
@@ -12057,7 +12012,7 @@
         "description": "System field 'active' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-545",
+        "id": "t-542",
         "category": "system-field",
         "entity": "lines",
         "field": "chargeAmount",
@@ -12065,7 +12020,7 @@
         "description": "System field 'chargeAmount' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-546",
+        "id": "t-543",
         "category": "system-field",
         "entity": "lines",
         "field": "priceLimit",
@@ -12073,7 +12028,7 @@
         "description": "System field 'priceLimit' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-547",
+        "id": "t-544",
         "category": "system-field",
         "entity": "lines",
         "field": "resourceAssignment",
@@ -12081,7 +12036,7 @@
         "description": "System field 'resourceAssignment' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-548",
+        "id": "t-545",
         "category": "system-field",
         "entity": "lines",
         "field": "descriptionOnly",
@@ -12089,7 +12044,7 @@
         "description": "System field 'descriptionOnly' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-549",
+        "id": "t-546",
         "category": "system-field",
         "entity": "lines",
         "field": "invoiceDiscount",
@@ -12097,7 +12052,7 @@
         "description": "System field 'invoiceDiscount' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-550",
+        "id": "t-547",
         "category": "system-field",
         "entity": "lines",
         "field": "projectLine",
@@ -12105,7 +12060,7 @@
         "description": "System field 'projectLine' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-551",
+        "id": "t-548",
         "category": "system-field",
         "entity": "lines",
         "field": "priceAdjustment",
@@ -12113,7 +12068,7 @@
         "description": "System field 'priceAdjustment' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-552",
+        "id": "t-549",
         "category": "system-field",
         "entity": "lines",
         "field": "creationDate",
@@ -12121,7 +12076,7 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-553",
+        "id": "t-550",
         "category": "system-field",
         "entity": "lines",
         "field": "cancelPriceAdjustment",
@@ -12129,7 +12084,7 @@
         "description": "System field 'cancelPriceAdjustment' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-554",
+        "id": "t-551",
         "category": "system-field",
         "entity": "lines",
         "field": "createdBy",
@@ -12137,7 +12092,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-555",
+        "id": "t-552",
         "category": "system-field",
         "entity": "lines",
         "field": "updated",
@@ -12145,7 +12100,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-556",
+        "id": "t-553",
         "category": "system-field",
         "entity": "lines",
         "field": "updatedBy",
@@ -12153,7 +12108,7 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-557",
+        "id": "t-554",
         "category": "system-field",
         "entity": "intrastat",
         "field": "client",
@@ -12161,7 +12116,7 @@
         "description": "System field 'client' should exist in backend but not frontend for intrastat"
       },
       {
-        "id": "t-558",
+        "id": "t-555",
         "category": "system-field",
         "entity": "intrastat",
         "field": "organization",
@@ -12169,7 +12124,7 @@
         "description": "System field 'organization' should exist in backend but not frontend for intrastat"
       },
       {
-        "id": "t-559",
+        "id": "t-556",
         "category": "system-field",
         "entity": "intrastat",
         "field": "active",
@@ -12177,7 +12132,7 @@
         "description": "System field 'active' should exist in backend but not frontend for intrastat"
       },
       {
-        "id": "t-560",
+        "id": "t-557",
         "category": "system-field",
         "entity": "intrastat",
         "field": "intrCInvoiceline",
@@ -12185,7 +12140,7 @@
         "description": "System field 'intrCInvoiceline' should exist in backend but not frontend for intrastat"
       },
       {
-        "id": "t-561",
+        "id": "t-558",
         "category": "system-field",
         "entity": "intrastat",
         "field": "creationDate",
@@ -12193,7 +12148,7 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for intrastat"
       },
       {
-        "id": "t-562",
+        "id": "t-559",
         "category": "system-field",
         "entity": "intrastat",
         "field": "createdBy",
@@ -12201,7 +12156,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for intrastat"
       },
       {
-        "id": "t-563",
+        "id": "t-560",
         "category": "system-field",
         "entity": "intrastat",
         "field": "updated",
@@ -12209,7 +12164,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for intrastat"
       },
       {
-        "id": "t-564",
+        "id": "t-561",
         "category": "system-field",
         "entity": "intrastat",
         "field": "updatedBy",
@@ -12217,7 +12172,7 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for intrastat"
       },
       {
-        "id": "t-565",
+        "id": "t-562",
         "category": "system-field",
         "entity": "tax",
         "field": "recalculate",
@@ -12225,7 +12180,7 @@
         "description": "System field 'recalculate' should exist in backend but not frontend for tax"
       },
       {
-        "id": "t-566",
+        "id": "t-563",
         "category": "system-field",
         "entity": "tax",
         "field": "aeatsiiDua",
@@ -12233,7 +12188,7 @@
         "description": "System field 'aeatsiiDua' should exist in backend but not frontend for tax"
       },
       {
-        "id": "t-567",
+        "id": "t-564",
         "category": "system-field",
         "entity": "tax",
         "field": "aeatsiiFechaDua",
@@ -12241,7 +12196,7 @@
         "description": "System field 'aeatsiiFechaDua' should exist in backend but not frontend for tax"
       },
       {
-        "id": "t-568",
+        "id": "t-565",
         "category": "system-field",
         "entity": "tax",
         "field": "client",
@@ -12249,7 +12204,7 @@
         "description": "System field 'client' should exist in backend but not frontend for tax"
       },
       {
-        "id": "t-569",
+        "id": "t-566",
         "category": "system-field",
         "entity": "tax",
         "field": "organization",
@@ -12257,7 +12212,7 @@
         "description": "System field 'organization' should exist in backend but not frontend for tax"
       },
       {
-        "id": "t-570",
+        "id": "t-567",
         "category": "system-field",
         "entity": "tax",
         "field": "active",
@@ -12265,7 +12220,7 @@
         "description": "System field 'active' should exist in backend but not frontend for tax"
       },
       {
-        "id": "t-571",
+        "id": "t-568",
         "category": "system-field",
         "entity": "tax",
         "field": "invoice",
@@ -12273,7 +12228,7 @@
         "description": "System field 'invoice' should exist in backend but not frontend for tax"
       },
       {
-        "id": "t-572",
+        "id": "t-569",
         "category": "system-field",
         "entity": "tax",
         "field": "id",
@@ -12281,7 +12236,7 @@
         "description": "System field 'id' should exist in backend but not frontend for tax"
       },
       {
-        "id": "t-573",
+        "id": "t-570",
         "category": "system-field",
         "entity": "tax",
         "field": "creationDate",
@@ -12289,7 +12244,7 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for tax"
       },
       {
-        "id": "t-574",
+        "id": "t-571",
         "category": "system-field",
         "entity": "tax",
         "field": "createdBy",
@@ -12297,7 +12252,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for tax"
       },
       {
-        "id": "t-575",
+        "id": "t-572",
         "category": "system-field",
         "entity": "tax",
         "field": "obirbOperationCode",
@@ -12305,7 +12260,7 @@
         "description": "System field 'obirbOperationCode' should exist in backend but not frontend for tax"
       },
       {
-        "id": "t-576",
+        "id": "t-573",
         "category": "system-field",
         "entity": "tax",
         "field": "updated",
@@ -12313,7 +12268,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for tax"
       },
       {
-        "id": "t-577",
+        "id": "t-574",
         "category": "system-field",
         "entity": "tax",
         "field": "updatedBy",
@@ -12321,7 +12276,7 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for tax"
       },
       {
-        "id": "t-578",
+        "id": "t-575",
         "category": "system-field",
         "entity": "cashVat",
         "field": "organization",
@@ -12329,7 +12284,7 @@
         "description": "System field 'organization' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-579",
+        "id": "t-576",
         "category": "system-field",
         "entity": "cashVat",
         "field": "active",
@@ -12337,7 +12292,7 @@
         "description": "System field 'active' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-580",
+        "id": "t-577",
         "category": "system-field",
         "entity": "cashVat",
         "field": "paymentDetails",
@@ -12345,7 +12300,7 @@
         "description": "System field 'paymentDetails' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-581",
+        "id": "t-578",
         "category": "system-field",
         "entity": "cashVat",
         "field": "receipt",
@@ -12353,7 +12308,7 @@
         "description": "System field 'receipt' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-582",
+        "id": "t-579",
         "category": "system-field",
         "entity": "cashVat",
         "field": "businessPartner",
@@ -12361,7 +12316,7 @@
         "description": "System field 'businessPartner' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-583",
+        "id": "t-580",
         "category": "system-field",
         "entity": "cashVat",
         "field": "paymentMethod",
@@ -12369,7 +12324,7 @@
         "description": "System field 'paymentMethod' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-584",
+        "id": "t-581",
         "category": "system-field",
         "entity": "cashVat",
         "field": "amount",
@@ -12377,7 +12332,7 @@
         "description": "System field 'amount' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-585",
+        "id": "t-582",
         "category": "system-field",
         "entity": "cashVat",
         "field": "currency",
@@ -12385,7 +12340,7 @@
         "description": "System field 'currency' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-586",
+        "id": "t-583",
         "category": "system-field",
         "entity": "cashVat",
         "field": "oBCVATMANUALSETTLEMENTLINE",
@@ -12393,7 +12348,7 @@
         "description": "System field 'oBCVATMANUALSETTLEMENTLINE' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-587",
+        "id": "t-584",
         "category": "system-field",
         "entity": "cashVat",
         "field": "client",
@@ -12401,7 +12356,7 @@
         "description": "System field 'client' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-588",
+        "id": "t-585",
         "category": "system-field",
         "entity": "cashVat",
         "field": "cInvoicetaxCashvatVID",
@@ -12409,7 +12364,7 @@
         "description": "System field 'cInvoicetaxCashvatVID' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-589",
+        "id": "t-586",
         "category": "system-field",
         "entity": "cashVat",
         "field": "invoice",
@@ -12417,7 +12372,7 @@
         "description": "System field 'invoice' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-590",
+        "id": "t-587",
         "category": "system-field",
         "entity": "cashVat",
         "field": "cInvoiceTaxID",
@@ -12425,7 +12380,7 @@
         "description": "System field 'cInvoiceTaxID' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-591",
+        "id": "t-588",
         "category": "system-field",
         "entity": "cashVat",
         "field": "tax",
@@ -12433,7 +12388,7 @@
         "description": "System field 'tax' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-592",
+        "id": "t-589",
         "category": "system-field",
         "entity": "cashVat",
         "field": "creationDate",
@@ -12441,7 +12396,7 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-593",
+        "id": "t-590",
         "category": "system-field",
         "entity": "cashVat",
         "field": "createdBy",
@@ -12449,7 +12404,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-594",
+        "id": "t-591",
         "category": "system-field",
         "entity": "cashVat",
         "field": "isPaidAtInvoicing",
@@ -12457,7 +12412,7 @@
         "description": "System field 'isPaidAtInvoicing' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-595",
+        "id": "t-592",
         "category": "system-field",
         "entity": "cashVat",
         "field": "isPrepayment",
@@ -12465,7 +12420,7 @@
         "description": "System field 'isPrepayment' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-596",
+        "id": "t-593",
         "category": "system-field",
         "entity": "cashVat",
         "field": "updated",
@@ -12473,7 +12428,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-597",
+        "id": "t-594",
         "category": "system-field",
         "entity": "cashVat",
         "field": "updatedBy",
@@ -12481,7 +12436,7 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for cashVat"
       },
       {
-        "id": "t-598",
+        "id": "t-595",
         "category": "system-field",
         "entity": "basicDiscounts",
         "field": "active",
@@ -12489,7 +12444,7 @@
         "description": "System field 'active' should exist in backend but not frontend for basicDiscounts"
       },
       {
-        "id": "t-599",
+        "id": "t-596",
         "category": "system-field",
         "entity": "basicDiscounts",
         "field": "client",
@@ -12497,7 +12452,7 @@
         "description": "System field 'client' should exist in backend but not frontend for basicDiscounts"
       },
       {
-        "id": "t-600",
+        "id": "t-597",
         "category": "system-field",
         "entity": "basicDiscounts",
         "field": "id",
@@ -12505,7 +12460,7 @@
         "description": "System field 'id' should exist in backend but not frontend for basicDiscounts"
       },
       {
-        "id": "t-601",
+        "id": "t-598",
         "category": "system-field",
         "entity": "basicDiscounts",
         "field": "invoice",
@@ -12513,7 +12468,7 @@
         "description": "System field 'invoice' should exist in backend but not frontend for basicDiscounts"
       },
       {
-        "id": "t-602",
+        "id": "t-599",
         "category": "system-field",
         "entity": "basicDiscounts",
         "field": "organization",
@@ -12521,7 +12476,7 @@
         "description": "System field 'organization' should exist in backend but not frontend for basicDiscounts"
       },
       {
-        "id": "t-603",
+        "id": "t-600",
         "category": "system-field",
         "entity": "basicDiscounts",
         "field": "creationDate",
@@ -12529,7 +12484,7 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for basicDiscounts"
       },
       {
-        "id": "t-604",
+        "id": "t-601",
         "category": "system-field",
         "entity": "basicDiscounts",
         "field": "createdBy",
@@ -12537,7 +12492,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for basicDiscounts"
       },
       {
-        "id": "t-605",
+        "id": "t-602",
         "category": "system-field",
         "entity": "basicDiscounts",
         "field": "updated",
@@ -12545,7 +12500,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for basicDiscounts"
       },
       {
-        "id": "t-606",
+        "id": "t-603",
         "category": "system-field",
         "entity": "basicDiscounts",
         "field": "updatedBy",
@@ -12553,7 +12508,7 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for basicDiscounts"
       },
       {
-        "id": "t-607",
+        "id": "t-604",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "organization",
@@ -12561,7 +12516,7 @@
         "description": "System field 'organization' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-608",
+        "id": "t-605",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "invoice",
@@ -12569,7 +12524,7 @@
         "description": "System field 'invoice' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-609",
+        "id": "t-606",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "origDueDate",
@@ -12577,7 +12532,7 @@
         "description": "System field 'origDueDate' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-610",
+        "id": "t-607",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "updatePaymentPlan",
@@ -12585,7 +12540,7 @@
         "description": "System field 'updatePaymentPlan' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-611",
+        "id": "t-608",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "active",
@@ -12593,7 +12548,7 @@
         "description": "System field 'active' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-612",
+        "id": "t-609",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "aprmModifPaymentOUTPlan",
@@ -12601,7 +12556,7 @@
         "description": "System field 'aprmModifPaymentOUTPlan' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-613",
+        "id": "t-610",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "finPaymentScheduleID",
@@ -12609,7 +12564,7 @@
         "description": "System field 'finPaymentScheduleID' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-614",
+        "id": "t-611",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "client",
@@ -12617,7 +12572,7 @@
         "description": "System field 'client' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-615",
+        "id": "t-612",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "order",
@@ -12625,7 +12580,7 @@
         "description": "System field 'order' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-616",
+        "id": "t-613",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "creationDate",
@@ -12633,7 +12588,7 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-617",
+        "id": "t-614",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "createdBy",
@@ -12641,7 +12596,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-618",
+        "id": "t-615",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "aprmModifPaymentINPlan",
@@ -12649,7 +12604,7 @@
         "description": "System field 'aprmModifPaymentINPlan' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-619",
+        "id": "t-616",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "fINPaymentPriorityID",
@@ -12657,7 +12612,7 @@
         "description": "System field 'fINPaymentPriorityID' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-620",
+        "id": "t-617",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "totalDebtAmount",
@@ -12665,7 +12620,7 @@
         "description": "System field 'totalDebtAmount' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-621",
+        "id": "t-618",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "updated",
@@ -12673,7 +12628,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-622",
+        "id": "t-619",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "updatedBy",
@@ -12681,7 +12636,7 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-623",
+        "id": "t-620",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "organization",
@@ -12689,7 +12644,7 @@
         "description": "System field 'organization' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-624",
+        "id": "t-621",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "paymentDetails",
@@ -12697,7 +12652,7 @@
         "description": "System field 'paymentDetails' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-625",
+        "id": "t-622",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "orderPaymentSchedule",
@@ -12705,7 +12660,7 @@
         "description": "System field 'orderPaymentSchedule' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-626",
+        "id": "t-623",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "invoicePaymentSchedule",
@@ -12713,7 +12668,7 @@
         "description": "System field 'invoicePaymentSchedule' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-627",
+        "id": "t-624",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "active",
@@ -12721,7 +12676,7 @@
         "description": "System field 'active' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-628",
+        "id": "t-625",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "businessPartner",
@@ -12729,7 +12684,7 @@
         "description": "System field 'businessPartner' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-629",
+        "id": "t-626",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "activity",
@@ -12737,7 +12692,7 @@
         "description": "System field 'activity' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-630",
+        "id": "t-627",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "product",
@@ -12745,7 +12700,7 @@
         "description": "System field 'product' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-631",
+        "id": "t-628",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "salesCampaign",
@@ -12753,7 +12708,7 @@
         "description": "System field 'salesCampaign' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-632",
+        "id": "t-629",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "project",
@@ -12761,7 +12716,7 @@
         "description": "System field 'project' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-633",
+        "id": "t-630",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "salesRegion",
@@ -12769,7 +12724,7 @@
         "description": "System field 'salesRegion' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-634",
+        "id": "t-631",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "paymentDate",
@@ -12777,7 +12732,7 @@
         "description": "System field 'paymentDate' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-635",
+        "id": "t-632",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "documentNo",
@@ -12785,7 +12740,7 @@
         "description": "System field 'documentNo' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-636",
+        "id": "t-633",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "paymentMethod",
@@ -12793,7 +12748,7 @@
         "description": "System field 'paymentMethod' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-637",
+        "id": "t-634",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "account",
@@ -12801,7 +12756,7 @@
         "description": "System field 'account' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-638",
+        "id": "t-635",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "status",
@@ -12809,7 +12764,7 @@
         "description": "System field 'status' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-639",
+        "id": "t-636",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "client",
@@ -12817,7 +12772,7 @@
         "description": "System field 'client' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-640",
+        "id": "t-637",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "fINPaymentScheduledetailID",
@@ -12825,7 +12780,7 @@
         "description": "System field 'fINPaymentScheduledetailID' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-641",
+        "id": "t-638",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "costCenter",
@@ -12833,7 +12788,7 @@
         "description": "System field 'costCenter' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-642",
+        "id": "t-639",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "creationDate",
@@ -12841,7 +12796,7 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-643",
+        "id": "t-640",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "createdBy",
@@ -12849,7 +12804,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-644",
+        "id": "t-641",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "doubtfulDebtAmount",
@@ -12857,7 +12812,7 @@
         "description": "System field 'doubtfulDebtAmount' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-645",
+        "id": "t-642",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "dueDate",
@@ -12865,7 +12820,7 @@
         "description": "System field 'dueDate' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-646",
+        "id": "t-643",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "aPRMFinancialAccount",
@@ -12873,7 +12828,7 @@
         "description": "System field 'aPRMFinancialAccount' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-647",
+        "id": "t-644",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "aPRMPaymentMethod",
@@ -12881,7 +12836,7 @@
         "description": "System field 'aPRMPaymentMethod' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-648",
+        "id": "t-645",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "etvfacPaymentZero",
@@ -12889,7 +12844,7 @@
         "description": "System field 'etvfacPaymentZero' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-649",
+        "id": "t-646",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "expected",
@@ -12897,7 +12852,7 @@
         "description": "System field 'expected' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-650",
+        "id": "t-647",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "invoiceAmount",
@@ -12905,7 +12860,7 @@
         "description": "System field 'invoiceAmount' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-651",
+        "id": "t-648",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "updated",
@@ -12913,7 +12868,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-652",
+        "id": "t-649",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "updatedBy",
@@ -12921,7 +12876,7 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-653",
+        "id": "t-650",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "stDimension",
@@ -12929,7 +12884,7 @@
         "description": "System field 'stDimension' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-654",
+        "id": "t-651",
         "category": "system-field",
         "entity": "paymentDetails",
         "field": "ndDimension",
@@ -12937,7 +12892,7 @@
         "description": "System field 'ndDimension' should exist in backend but not frontend for paymentDetails"
       },
       {
-        "id": "t-655",
+        "id": "t-652",
         "category": "system-field",
         "entity": "reversedInvoices",
         "field": "aEAT349IsCorrective",
@@ -12945,7 +12900,7 @@
         "description": "System field 'aEAT349IsCorrective' should exist in backend but not frontend for reversedInvoices"
       },
       {
-        "id": "t-656",
+        "id": "t-653",
         "category": "system-field",
         "entity": "reversedInvoices",
         "field": "aEAT349CYear",
@@ -12953,7 +12908,7 @@
         "description": "System field 'aEAT349CYear' should exist in backend but not frontend for reversedInvoices"
       },
       {
-        "id": "t-657",
+        "id": "t-654",
         "category": "system-field",
         "entity": "reversedInvoices",
         "field": "aEAT349Period",
@@ -12961,7 +12916,7 @@
         "description": "System field 'aEAT349Period' should exist in backend but not frontend for reversedInvoices"
       },
       {
-        "id": "t-658",
+        "id": "t-655",
         "category": "system-field",
         "entity": "reversedInvoices",
         "field": "aEAT349BPBaseAmount",
@@ -12969,7 +12924,7 @@
         "description": "System field 'aEAT349BPBaseAmount' should exist in backend but not frontend for reversedInvoices"
       },
       {
-        "id": "t-659",
+        "id": "t-656",
         "category": "system-field",
         "entity": "reversedInvoices",
         "field": "aEAT349CBpartner",
@@ -12977,7 +12932,7 @@
         "description": "System field 'aEAT349CBpartner' should exist in backend but not frontend for reversedInvoices"
       },
       {
-        "id": "t-660",
+        "id": "t-657",
         "category": "system-field",
         "entity": "reversedInvoices",
         "field": "aEAT349BPBaseAmountS",
@@ -12985,7 +12940,7 @@
         "description": "System field 'aEAT349BPBaseAmountS' should exist in backend but not frontend for reversedInvoices"
       },
       {
-        "id": "t-661",
+        "id": "t-658",
         "category": "system-field",
         "entity": "reversedInvoices",
         "field": "invoice",
@@ -12993,7 +12948,7 @@
         "description": "System field 'invoice' should exist in backend but not frontend for reversedInvoices"
       },
       {
-        "id": "t-662",
+        "id": "t-659",
         "category": "system-field",
         "entity": "reversedInvoices",
         "field": "client",
@@ -13001,7 +12956,7 @@
         "description": "System field 'client' should exist in backend but not frontend for reversedInvoices"
       },
       {
-        "id": "t-663",
+        "id": "t-660",
         "category": "system-field",
         "entity": "reversedInvoices",
         "field": "id",
@@ -13009,7 +12964,7 @@
         "description": "System field 'id' should exist in backend but not frontend for reversedInvoices"
       },
       {
-        "id": "t-664",
+        "id": "t-661",
         "category": "system-field",
         "entity": "reversedInvoices",
         "field": "active",
@@ -13017,7 +12972,7 @@
         "description": "System field 'active' should exist in backend but not frontend for reversedInvoices"
       },
       {
-        "id": "t-665",
+        "id": "t-662",
         "category": "system-field",
         "entity": "reversedInvoices",
         "field": "organization",
@@ -13025,7 +12980,7 @@
         "description": "System field 'organization' should exist in backend but not frontend for reversedInvoices"
       },
       {
-        "id": "t-666",
+        "id": "t-663",
         "category": "system-field",
         "entity": "reversedInvoices",
         "field": "creationDate",
@@ -13033,7 +12988,7 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for reversedInvoices"
       },
       {
-        "id": "t-667",
+        "id": "t-664",
         "category": "system-field",
         "entity": "reversedInvoices",
         "field": "createdBy",
@@ -13041,7 +12996,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for reversedInvoices"
       },
       {
-        "id": "t-668",
+        "id": "t-665",
         "category": "system-field",
         "entity": "reversedInvoices",
         "field": "updated",
@@ -13049,7 +13004,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for reversedInvoices"
       },
       {
-        "id": "t-669",
+        "id": "t-666",
         "category": "system-field",
         "entity": "reversedInvoices",
         "field": "updatedBy",
@@ -13057,7 +13012,7 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for reversedInvoices"
       },
       {
-        "id": "t-670",
+        "id": "t-667",
         "category": "system-field",
         "entity": "accounting",
         "field": "client",
@@ -13065,7 +13020,7 @@
         "description": "System field 'client' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-671",
+        "id": "t-668",
         "category": "system-field",
         "entity": "accounting",
         "field": "organization",
@@ -13073,7 +13028,7 @@
         "description": "System field 'organization' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-672",
+        "id": "t-669",
         "category": "system-field",
         "entity": "accounting",
         "field": "active",
@@ -13081,7 +13036,7 @@
         "description": "System field 'active' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-673",
+        "id": "t-670",
         "category": "system-field",
         "entity": "accounting",
         "field": "recordID",
@@ -13089,7 +13044,7 @@
         "description": "System field 'recordID' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-674",
+        "id": "t-671",
         "category": "system-field",
         "entity": "accounting",
         "field": "sequenceNumber",
@@ -13097,7 +13052,7 @@
         "description": "System field 'sequenceNumber' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-675",
+        "id": "t-672",
         "category": "system-field",
         "entity": "accounting",
         "field": "value",
@@ -13105,7 +13060,7 @@
         "description": "System field 'value' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-676",
+        "id": "t-673",
         "category": "system-field",
         "entity": "accounting",
         "field": "accountingEntryDescription",
@@ -13113,7 +13068,7 @@
         "description": "System field 'accountingEntryDescription' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-677",
+        "id": "t-674",
         "category": "system-field",
         "entity": "accounting",
         "field": "id",
@@ -13121,7 +13076,7 @@
         "description": "System field 'id' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-678",
+        "id": "t-675",
         "category": "system-field",
         "entity": "accounting",
         "field": "lineID",
@@ -13129,7 +13084,7 @@
         "description": "System field 'lineID' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-679",
+        "id": "t-676",
         "category": "system-field",
         "entity": "accounting",
         "field": "uOM",
@@ -13137,7 +13092,7 @@
         "description": "System field 'uOM' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-680",
+        "id": "t-677",
         "category": "system-field",
         "entity": "accounting",
         "field": "withholding",
@@ -13145,7 +13100,7 @@
         "description": "System field 'withholding' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-681",
+        "id": "t-678",
         "category": "system-field",
         "entity": "accounting",
         "field": "tax",
@@ -13153,7 +13108,7 @@
         "description": "System field 'tax' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-682",
+        "id": "t-679",
         "category": "system-field",
         "entity": "accounting",
         "field": "salesCampaign",
@@ -13161,7 +13116,7 @@
         "description": "System field 'salesCampaign' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-683",
+        "id": "t-680",
         "category": "system-field",
         "entity": "accounting",
         "field": "foreignCurrencyDebit",
@@ -13169,7 +13124,7 @@
         "description": "System field 'foreignCurrencyDebit' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-684",
+        "id": "t-681",
         "category": "system-field",
         "entity": "accounting",
         "field": "salesRegion",
@@ -13177,7 +13132,7 @@
         "description": "System field 'salesRegion' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-685",
+        "id": "t-682",
         "category": "system-field",
         "entity": "accounting",
         "field": "type",
@@ -13185,7 +13140,7 @@
         "description": "System field 'type' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-686",
+        "id": "t-683",
         "category": "system-field",
         "entity": "accounting",
         "field": "recordID2",
@@ -13193,7 +13148,7 @@
         "description": "System field 'recordID2' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-687",
+        "id": "t-684",
         "category": "system-field",
         "entity": "accounting",
         "field": "activity",
@@ -13201,7 +13156,7 @@
         "description": "System field 'activity' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-688",
+        "id": "t-685",
         "category": "system-field",
         "entity": "accounting",
         "field": "quantity",
@@ -13209,7 +13164,7 @@
         "description": "System field 'quantity' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-689",
+        "id": "t-686",
         "category": "system-field",
         "entity": "accounting",
         "field": "documentType",
@@ -13217,7 +13172,7 @@
         "description": "System field 'documentType' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-690",
+        "id": "t-687",
         "category": "system-field",
         "entity": "accounting",
         "field": "foreignCurrencyCredit",
@@ -13225,7 +13180,7 @@
         "description": "System field 'foreignCurrencyCredit' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-691",
+        "id": "t-688",
         "category": "system-field",
         "entity": "accounting",
         "field": "locationToAddress",
@@ -13233,7 +13188,7 @@
         "description": "System field 'locationToAddress' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-692",
+        "id": "t-689",
         "category": "system-field",
         "entity": "accounting",
         "field": "groupID",
@@ -13241,7 +13196,7 @@
         "description": "System field 'groupID' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-693",
+        "id": "t-690",
         "category": "system-field",
         "entity": "accounting",
         "field": "adTable",
@@ -13249,7 +13204,7 @@
         "description": "System field 'adTable' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-694",
+        "id": "t-691",
         "category": "system-field",
         "entity": "accounting",
         "field": "trxOrganization",
@@ -13257,7 +13212,7 @@
         "description": "System field 'trxOrganization' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-695",
+        "id": "t-692",
         "category": "system-field",
         "entity": "accounting",
         "field": "gLCategory",
@@ -13265,7 +13220,7 @@
         "description": "System field 'gLCategory' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-696",
+        "id": "t-693",
         "category": "system-field",
         "entity": "accounting",
         "field": "documentCategory",
@@ -13273,7 +13228,7 @@
         "description": "System field 'documentCategory' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-697",
+        "id": "t-694",
         "category": "system-field",
         "entity": "accounting",
         "field": "transactionDate",
@@ -13281,7 +13236,7 @@
         "description": "System field 'transactionDate' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-698",
+        "id": "t-695",
         "category": "system-field",
         "entity": "accounting",
         "field": "locationFromAddress",
@@ -13289,7 +13244,7 @@
         "description": "System field 'locationFromAddress' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-699",
+        "id": "t-696",
         "category": "system-field",
         "entity": "accounting",
         "field": "storageBin",
@@ -13297,7 +13252,7 @@
         "description": "System field 'storageBin' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-700",
+        "id": "t-697",
         "category": "system-field",
         "entity": "accounting",
         "field": "creationDate",
@@ -13305,7 +13260,7 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-701",
+        "id": "t-698",
         "category": "system-field",
         "entity": "accounting",
         "field": "createdBy",
@@ -13313,7 +13268,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-702",
+        "id": "t-699",
         "category": "system-field",
         "entity": "accounting",
         "field": "dateBalanced",
@@ -13321,7 +13276,7 @@
         "description": "System field 'dateBalanced' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-703",
+        "id": "t-700",
         "category": "system-field",
         "entity": "accounting",
         "field": "modify",
@@ -13329,7 +13284,7 @@
         "description": "System field 'modify' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-704",
+        "id": "t-701",
         "category": "system-field",
         "entity": "accounting",
         "field": "updated",
@@ -13337,7 +13292,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-705",
+        "id": "t-702",
         "category": "system-field",
         "entity": "accounting",
         "field": "updatedBy",
@@ -13345,7 +13300,7 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for accounting"
       },
       {
-        "id": "t-706",
+        "id": "t-703",
         "category": "system-field",
         "entity": "siiData",
         "field": "organization",
@@ -13353,7 +13308,7 @@
         "description": "System field 'organization' should exist in backend but not frontend for siiData"
       },
       {
-        "id": "t-707",
+        "id": "t-704",
         "category": "system-field",
         "entity": "siiData",
         "field": "active",
@@ -13361,7 +13316,7 @@
         "description": "System field 'active' should exist in backend but not frontend for siiData"
       },
       {
-        "id": "t-708",
+        "id": "t-705",
         "category": "system-field",
         "entity": "siiData",
         "field": "invoice",
@@ -13369,7 +13324,7 @@
         "description": "System field 'invoice' should exist in backend but not frontend for siiData"
       },
       {
-        "id": "t-709",
+        "id": "t-706",
         "category": "system-field",
         "entity": "siiData",
         "field": "creationDate",
@@ -13377,7 +13332,7 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for siiData"
       },
       {
-        "id": "t-710",
+        "id": "t-707",
         "category": "system-field",
         "entity": "siiData",
         "field": "factura",
@@ -13385,7 +13340,7 @@
         "description": "System field 'factura' should exist in backend but not frontend for siiData"
       },
       {
-        "id": "t-711",
+        "id": "t-708",
         "category": "system-field",
         "entity": "siiData",
         "field": "client",
@@ -13393,7 +13348,7 @@
         "description": "System field 'client' should exist in backend but not frontend for siiData"
       },
       {
-        "id": "t-712",
+        "id": "t-709",
         "category": "system-field",
         "entity": "siiData",
         "field": "createdBy",
@@ -13401,7 +13356,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for siiData"
       },
       {
-        "id": "t-713",
+        "id": "t-710",
         "category": "system-field",
         "entity": "siiData",
         "field": "updated",
@@ -13409,7 +13364,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for siiData"
       },
       {
-        "id": "t-714",
+        "id": "t-711",
         "category": "system-field",
         "entity": "siiData",
         "field": "updatedBy",
@@ -13417,7 +13372,7 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for siiData"
       },
       {
-        "id": "t-715",
+        "id": "t-712",
         "category": "system-field",
         "entity": "batuz",
         "field": "organization",
@@ -13425,7 +13380,7 @@
         "description": "System field 'organization' should exist in backend but not frontend for batuz"
       },
       {
-        "id": "t-716",
+        "id": "t-713",
         "category": "system-field",
         "entity": "batuz",
         "field": "tbaiSyncinvoiceID",
@@ -13433,7 +13388,7 @@
         "description": "System field 'tbaiSyncinvoiceID' should exist in backend but not frontend for batuz"
       },
       {
-        "id": "t-717",
+        "id": "t-714",
         "category": "system-field",
         "entity": "batuz",
         "field": "client",
@@ -13441,7 +13396,7 @@
         "description": "System field 'client' should exist in backend but not frontend for batuz"
       },
       {
-        "id": "t-718",
+        "id": "t-715",
         "category": "system-field",
         "entity": "batuz",
         "field": "creationDate",
@@ -13449,7 +13404,7 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for batuz"
       },
       {
-        "id": "t-719",
+        "id": "t-716",
         "category": "system-field",
         "entity": "batuz",
         "field": "createdBy",
@@ -13457,7 +13412,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for batuz"
       },
       {
-        "id": "t-720",
+        "id": "t-717",
         "category": "system-field",
         "entity": "batuz",
         "field": "updated",
@@ -13465,7 +13420,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for batuz"
       },
       {
-        "id": "t-721",
+        "id": "t-718",
         "category": "system-field",
         "entity": "batuz",
         "field": "updatedBy",
@@ -13473,238 +13428,238 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for batuz"
       },
       {
-        "id": "t-722",
+        "id": "t-719",
         "category": "rule-declared",
         "rule": "SE_Invoice_BPartner",
         "runner": "node",
         "description": "Rule 'SE_Invoice_BPartner' (undefined) should be declared"
       },
       {
-        "id": "t-723",
+        "id": "t-720",
         "category": "rule-declared",
         "rule": "SE_Invoice_BPartnerLocation",
         "runner": "node",
         "description": "Rule 'SE_Invoice_BPartnerLocation' (undefined) should be declared"
       },
       {
-        "id": "t-724",
+        "id": "t-721",
         "category": "rule-declared",
         "rule": "SL_Invoice_DocType",
         "runner": "node",
         "description": "Rule 'SL_Invoice_DocType' (undefined) should be declared"
       },
       {
-        "id": "t-725",
+        "id": "t-722",
         "category": "rule-declared",
         "rule": "SE_Invoice_AccountingDate",
         "runner": "node",
         "description": "Rule 'SE_Invoice_AccountingDate' (undefined) should be declared"
       },
       {
-        "id": "t-726",
+        "id": "t-723",
         "category": "rule-declared",
         "rule": "SL_Invoice_PriceList",
         "runner": "node",
         "description": "Rule 'SL_Invoice_PriceList' (undefined) should be declared"
       },
       {
-        "id": "t-727",
+        "id": "t-724",
         "category": "rule-declared",
         "rule": "SL_Invoice_Product",
         "runner": "node",
         "description": "Rule 'SL_Invoice_Product' (undefined) should be declared"
       },
       {
-        "id": "t-728",
+        "id": "t-725",
         "category": "rule-declared",
         "rule": "SL_Invoice_Amt",
         "runner": "node",
         "description": "Rule 'SL_Invoice_Amt' (undefined) should be declared"
       },
       {
-        "id": "t-729",
+        "id": "t-726",
         "category": "rule-declared",
         "rule": "SL_Invoice_Conversion",
         "runner": "node",
         "description": "Rule 'SL_Invoice_Conversion' (undefined) should be declared"
       },
       {
-        "id": "t-730",
+        "id": "t-727",
         "category": "rule-declared",
         "rule": "OperativeQuantity_To_BaseQuantity",
         "runner": "node",
         "description": "Rule 'OperativeQuantity_To_BaseQuantity' (undefined) should be declared"
       },
       {
-        "id": "t-731",
+        "id": "t-728",
         "category": "rule-declared",
         "rule": "VAL_BPartnerLocation_BillTo",
         "runner": "node",
         "description": "Rule 'VAL_BPartnerLocation_BillTo' (validation) should be declared"
       },
       {
-        "id": "t-732",
+        "id": "t-729",
         "category": "rule-declared",
         "rule": "VAL_DocType_APInvoice",
         "runner": "node",
         "description": "Rule 'VAL_DocType_APInvoice' (validation) should be declared"
       },
       {
-        "id": "t-733",
+        "id": "t-730",
         "category": "rule-declared",
         "rule": "VAL_User_BPartnerContact",
         "runner": "node",
         "description": "Rule 'VAL_User_BPartnerContact' (validation) should be declared"
       },
       {
-        "id": "t-734",
+        "id": "t-731",
         "category": "rule-declared",
         "rule": "VAL_User_OrgTree",
         "runner": "node",
         "description": "Rule 'VAL_User_OrgTree' (validation) should be declared"
       },
       {
-        "id": "t-735",
+        "id": "t-732",
         "category": "rule-declared",
         "rule": "VAL_Project_StatusAndBPartner",
         "runner": "node",
         "description": "Rule 'VAL_Project_StatusAndBPartner' (validation) should be declared"
       },
       {
-        "id": "t-736",
+        "id": "t-733",
         "category": "rule-declared",
         "rule": "VAL_PriceList_IsSOTrx",
         "runner": "node",
         "description": "Rule 'VAL_PriceList_IsSOTrx' (validation) should be declared"
       },
       {
-        "id": "t-737",
+        "id": "t-734",
         "category": "rule-declared",
         "rule": "VAL_PaymentMethod_Account",
         "runner": "node",
         "description": "Rule 'VAL_PaymentMethod_Account' (validation) should be declared"
       },
       {
-        "id": "t-738",
+        "id": "t-735",
         "category": "rule-declared",
         "rule": "VAL_Tax_IsSOTrx_Date",
         "runner": "node",
         "description": "Rule 'VAL_Tax_IsSOTrx_Date' (validation) should be declared"
       },
       {
-        "id": "t-739",
+        "id": "t-736",
         "category": "rule-declared",
         "rule": "READONLY_Processed_Header",
         "runner": "node",
         "description": "Rule 'READONLY_Processed_Header' (readOnlyLogic) should be declared"
       },
       {
-        "id": "t-740",
+        "id": "t-737",
         "category": "rule-declared",
         "rule": "READONLY_Processed_Lines",
         "runner": "node",
         "description": "Rule 'READONLY_Processed_Lines' (readOnlyLogic) should be declared"
       },
       {
-        "id": "t-741",
+        "id": "t-738",
         "category": "rule-declared",
         "rule": "READONLY_ReversedInvoice_Processed",
         "runner": "node",
         "description": "Rule 'READONLY_ReversedInvoice_Processed' (readOnlyLogic) should be declared"
       },
       {
-        "id": "t-742",
+        "id": "t-739",
         "category": "rule-declared",
         "rule": "DISPLAY_OperativeQty_WhenApplicable",
         "runner": "node",
         "description": "Rule 'DISPLAY_OperativeQty_WhenApplicable' (displayLogic) should be declared"
       },
       {
-        "id": "t-743",
+        "id": "t-740",
         "category": "crud-flags",
         "entity": "header",
         "runner": "node",
         "description": "CRUD flags for 'header' should all be booleans"
       },
       {
-        "id": "t-744",
+        "id": "t-741",
         "category": "crud-flags",
         "entity": "lines",
         "runner": "node",
         "description": "CRUD flags for 'lines' should all be booleans"
       },
       {
-        "id": "t-745",
+        "id": "t-742",
         "category": "crud-flags",
         "entity": "intrastat",
         "runner": "node",
         "description": "CRUD flags for 'intrastat' should all be booleans"
       },
       {
-        "id": "t-746",
+        "id": "t-743",
         "category": "crud-flags",
         "entity": "tax",
         "runner": "node",
         "description": "CRUD flags for 'tax' should all be booleans"
       },
       {
-        "id": "t-747",
+        "id": "t-744",
         "category": "crud-flags",
         "entity": "cashVat",
         "runner": "node",
         "description": "CRUD flags for 'cashVat' should all be booleans"
       },
       {
-        "id": "t-748",
+        "id": "t-745",
         "category": "crud-flags",
         "entity": "basicDiscounts",
         "runner": "node",
         "description": "CRUD flags for 'basicDiscounts' should all be booleans"
       },
       {
-        "id": "t-749",
+        "id": "t-746",
         "category": "crud-flags",
         "entity": "paymentPlan",
         "runner": "node",
         "description": "CRUD flags for 'paymentPlan' should all be booleans"
       },
       {
-        "id": "t-750",
+        "id": "t-747",
         "category": "crud-flags",
         "entity": "paymentDetails",
         "runner": "node",
         "description": "CRUD flags for 'paymentDetails' should all be booleans"
       },
       {
-        "id": "t-751",
+        "id": "t-748",
         "category": "crud-flags",
         "entity": "reversedInvoices",
         "runner": "node",
         "description": "CRUD flags for 'reversedInvoices' should all be booleans"
       },
       {
-        "id": "t-752",
+        "id": "t-749",
         "category": "crud-flags",
         "entity": "accounting",
         "runner": "node",
         "description": "CRUD flags for 'accounting' should all be booleans"
       },
       {
-        "id": "t-753",
+        "id": "t-750",
         "category": "crud-flags",
         "entity": "siiData",
         "runner": "node",
         "description": "CRUD flags for 'siiData' should all be booleans"
       },
       {
-        "id": "t-754",
+        "id": "t-751",
         "category": "crud-flags",
         "entity": "batuz",
         "runner": "node",
         "description": "CRUD flags for 'batuz' should all be booleans"
       },
       {
-        "id": "t-755",
+        "id": "t-752",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "transactionDocument",
@@ -13712,7 +13667,7 @@
         "description": "Selector endpoint for 'transactionDocument' in header should exist"
       },
       {
-        "id": "t-756",
+        "id": "t-753",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "businessPartner",
@@ -13720,7 +13675,7 @@
         "description": "Selector endpoint for 'businessPartner' in header should exist"
       },
       {
-        "id": "t-757",
+        "id": "t-754",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "partnerAddress",
@@ -13728,7 +13683,7 @@
         "description": "Selector endpoint for 'partnerAddress' in header should exist"
       },
       {
-        "id": "t-758",
+        "id": "t-755",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "priceList",
@@ -13736,7 +13691,7 @@
         "description": "Selector endpoint for 'priceList' in header should exist"
       },
       {
-        "id": "t-759",
+        "id": "t-756",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "paymentTerms",
@@ -13744,7 +13699,7 @@
         "description": "Selector endpoint for 'paymentTerms' in header should exist"
       },
       {
-        "id": "t-760",
+        "id": "t-757",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "paymentMethod",
@@ -13752,7 +13707,7 @@
         "description": "Selector endpoint for 'paymentMethod' in header should exist"
       },
       {
-        "id": "t-761",
+        "id": "t-758",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "salesOrder",
@@ -13760,7 +13715,7 @@
         "description": "Selector endpoint for 'salesOrder' in header should exist"
       },
       {
-        "id": "t-762",
+        "id": "t-759",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "currency",
@@ -13768,7 +13723,7 @@
         "description": "Selector endpoint for 'currency' in header should exist"
       },
       {
-        "id": "t-763",
+        "id": "t-760",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "userContact",
@@ -13776,7 +13731,7 @@
         "description": "Selector endpoint for 'userContact' in header should exist"
       },
       {
-        "id": "t-764",
+        "id": "t-761",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "salesRepresentative",
@@ -13784,7 +13739,7 @@
         "description": "Selector endpoint for 'salesRepresentative' in header should exist"
       },
       {
-        "id": "t-765",
+        "id": "t-762",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "charge",
@@ -13792,7 +13747,7 @@
         "description": "Selector endpoint for 'charge' in header should exist"
       },
       {
-        "id": "t-766",
+        "id": "t-763",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "project",
@@ -13800,7 +13755,7 @@
         "description": "Selector endpoint for 'project' in header should exist"
       },
       {
-        "id": "t-767",
+        "id": "t-764",
         "category": "selector-endpoint",
         "entity": "lines",
         "field": "product",
@@ -13808,7 +13763,7 @@
         "description": "Selector endpoint for 'product' in lines should exist"
       },
       {
-        "id": "t-768",
+        "id": "t-765",
         "category": "selector-endpoint",
         "entity": "lines",
         "field": "account",
@@ -13816,7 +13771,7 @@
         "description": "Selector endpoint for 'account' in lines should exist"
       },
       {
-        "id": "t-769",
+        "id": "t-766",
         "category": "selector-endpoint",
         "entity": "lines",
         "field": "tax",
@@ -13824,7 +13779,7 @@
         "description": "Selector endpoint for 'tax' in lines should exist"
       },
       {
-        "id": "t-770",
+        "id": "t-767",
         "category": "selector-endpoint",
         "entity": "lines",
         "field": "salesOrderLine",
@@ -13832,7 +13787,7 @@
         "description": "Selector endpoint for 'salesOrderLine' in lines should exist"
       },
       {
-        "id": "t-771",
+        "id": "t-768",
         "category": "selector-endpoint",
         "entity": "lines",
         "field": "goodsShipmentLine",
@@ -13840,7 +13795,7 @@
         "description": "Selector endpoint for 'goodsShipmentLine' in lines should exist"
       },
       {
-        "id": "t-772",
+        "id": "t-769",
         "category": "selector-endpoint",
         "entity": "lines",
         "field": "project",
@@ -13848,7 +13803,7 @@
         "description": "Selector endpoint for 'project' in lines should exist"
       },
       {
-        "id": "t-773",
+        "id": "t-770",
         "category": "selector-endpoint",
         "entity": "lines",
         "field": "costcenter",
@@ -13856,7 +13811,7 @@
         "description": "Selector endpoint for 'costcenter' in lines should exist"
       },
       {
-        "id": "t-774",
+        "id": "t-771",
         "category": "selector-endpoint",
         "entity": "lines",
         "field": "asset",
@@ -13864,7 +13819,7 @@
         "description": "Selector endpoint for 'asset' in lines should exist"
       },
       {
-        "id": "t-775",
+        "id": "t-772",
         "category": "selector-endpoint",
         "entity": "lines",
         "field": "stDimension",
@@ -13872,7 +13827,7 @@
         "description": "Selector endpoint for 'stDimension' in lines should exist"
       },
       {
-        "id": "t-776",
+        "id": "t-773",
         "category": "selector-endpoint",
         "entity": "lines",
         "field": "ndDimension",
@@ -13880,7 +13835,7 @@
         "description": "Selector endpoint for 'ndDimension' in lines should exist"
       },
       {
-        "id": "t-777",
+        "id": "t-774",
         "category": "selector-endpoint",
         "entity": "intrastat",
         "field": "invoiceLine",
@@ -13888,7 +13843,7 @@
         "description": "Selector endpoint for 'invoiceLine' in intrastat should exist"
       },
       {
-        "id": "t-778",
+        "id": "t-775",
         "category": "selector-endpoint",
         "entity": "intrastat",
         "field": "product",
@@ -13896,7 +13851,7 @@
         "description": "Selector endpoint for 'product' in intrastat should exist"
       },
       {
-        "id": "t-779",
+        "id": "t-776",
         "category": "selector-endpoint",
         "entity": "intrastat",
         "field": "incoterms",
@@ -13904,7 +13859,7 @@
         "description": "Selector endpoint for 'incoterms' in intrastat should exist"
       },
       {
-        "id": "t-780",
+        "id": "t-777",
         "category": "selector-endpoint",
         "entity": "intrastat",
         "field": "origCountry",
@@ -13912,7 +13867,7 @@
         "description": "Selector endpoint for 'origCountry' in intrastat should exist"
       },
       {
-        "id": "t-781",
+        "id": "t-778",
         "category": "selector-endpoint",
         "entity": "intrastat",
         "field": "supplementaryUOM",
@@ -13920,7 +13875,7 @@
         "description": "Selector endpoint for 'supplementaryUOM' in intrastat should exist"
       },
       {
-        "id": "t-782",
+        "id": "t-779",
         "category": "selector-endpoint",
         "entity": "tax",
         "field": "tax",
@@ -13928,7 +13883,7 @@
         "description": "Selector endpoint for 'tax' in tax should exist"
       },
       {
-        "id": "t-783",
+        "id": "t-780",
         "category": "selector-endpoint",
         "entity": "cashVat",
         "field": "payment",
@@ -13936,7 +13891,7 @@
         "description": "Selector endpoint for 'payment' in cashVat should exist"
       },
       {
-        "id": "t-784",
+        "id": "t-781",
         "category": "selector-endpoint",
         "entity": "basicDiscounts",
         "field": "discount",
@@ -13944,7 +13899,7 @@
         "description": "Selector endpoint for 'discount' in basicDiscounts should exist"
       },
       {
-        "id": "t-785",
+        "id": "t-782",
         "category": "selector-endpoint",
         "entity": "paymentPlan",
         "field": "paymentMethod",
@@ -13952,7 +13907,7 @@
         "description": "Selector endpoint for 'paymentMethod' in paymentPlan should exist"
       },
       {
-        "id": "t-786",
+        "id": "t-783",
         "category": "selector-endpoint",
         "entity": "paymentPlan",
         "field": "currency",
@@ -13960,7 +13915,7 @@
         "description": "Selector endpoint for 'currency' in paymentPlan should exist"
       },
       {
-        "id": "t-787",
+        "id": "t-784",
         "category": "selector-endpoint",
         "entity": "paymentDetails",
         "field": "finPaymentID",
@@ -13968,7 +13923,7 @@
         "description": "Selector endpoint for 'finPaymentID' in paymentDetails should exist"
       },
       {
-        "id": "t-788",
+        "id": "t-785",
         "category": "selector-endpoint",
         "entity": "reversedInvoices",
         "field": "reversedInvoice",
@@ -13976,7 +13931,7 @@
         "description": "Selector endpoint for 'reversedInvoice' in reversedInvoices should exist"
       },
       {
-        "id": "t-789",
+        "id": "t-786",
         "category": "selector-endpoint",
         "entity": "accounting",
         "field": "accountingSchema",
@@ -13984,7 +13939,7 @@
         "description": "Selector endpoint for 'accountingSchema' in accounting should exist"
       },
       {
-        "id": "t-790",
+        "id": "t-787",
         "category": "selector-endpoint",
         "entity": "accounting",
         "field": "currency",
@@ -13992,7 +13947,7 @@
         "description": "Selector endpoint for 'currency' in accounting should exist"
       },
       {
-        "id": "t-791",
+        "id": "t-788",
         "category": "selector-endpoint",
         "entity": "accounting",
         "field": "period",
@@ -14000,7 +13955,7 @@
         "description": "Selector endpoint for 'period' in accounting should exist"
       },
       {
-        "id": "t-792",
+        "id": "t-789",
         "category": "selector-endpoint",
         "entity": "accounting",
         "field": "account",
@@ -14008,7 +13963,7 @@
         "description": "Selector endpoint for 'account' in accounting should exist"
       },
       {
-        "id": "t-793",
+        "id": "t-790",
         "category": "selector-endpoint",
         "entity": "accounting",
         "field": "businessPartner",
@@ -14016,7 +13971,7 @@
         "description": "Selector endpoint for 'businessPartner' in accounting should exist"
       },
       {
-        "id": "t-794",
+        "id": "t-791",
         "category": "selector-endpoint",
         "entity": "accounting",
         "field": "product",
@@ -14024,7 +13979,7 @@
         "description": "Selector endpoint for 'product' in accounting should exist"
       },
       {
-        "id": "t-795",
+        "id": "t-792",
         "category": "selector-endpoint",
         "entity": "accounting",
         "field": "project",
@@ -14032,7 +13987,7 @@
         "description": "Selector endpoint for 'project' in accounting should exist"
       },
       {
-        "id": "t-796",
+        "id": "t-793",
         "category": "selector-endpoint",
         "entity": "accounting",
         "field": "costcenter",
@@ -14040,7 +13995,7 @@
         "description": "Selector endpoint for 'costcenter' in accounting should exist"
       },
       {
-        "id": "t-797",
+        "id": "t-794",
         "category": "selector-endpoint",
         "entity": "accounting",
         "field": "asset",
@@ -14048,7 +14003,7 @@
         "description": "Selector endpoint for 'asset' in accounting should exist"
       },
       {
-        "id": "t-798",
+        "id": "t-795",
         "category": "selector-endpoint",
         "entity": "accounting",
         "field": "stDimension",
@@ -14056,7 +14011,7 @@
         "description": "Selector endpoint for 'stDimension' in accounting should exist"
       },
       {
-        "id": "t-799",
+        "id": "t-796",
         "category": "selector-endpoint",
         "entity": "accounting",
         "field": "ndDimension",
@@ -14064,7 +14019,7 @@
         "description": "Selector endpoint for 'ndDimension' in accounting should exist"
       },
       {
-        "id": "t-800",
+        "id": "t-797",
         "category": "selector-endpoint",
         "entity": "siiData",
         "field": "conexinSII",
@@ -14072,7 +14027,7 @@
         "description": "Selector endpoint for 'conexinSII' in siiData should exist"
       },
       {
-        "id": "t-801",
+        "id": "t-798",
         "category": "selector-endpoint",
         "entity": "batuz",
         "field": "invoice",
@@ -14080,7 +14035,7 @@
         "description": "Selector endpoint for 'invoice' in batuz should exist"
       },
       {
-        "id": "t-802",
+        "id": "t-799",
         "category": "action-endpoint",
         "entity": "header",
         "field": "generateTo",
@@ -14088,7 +14043,7 @@
         "description": "Action endpoint for 'generateTo' in header should exist"
       },
       {
-        "id": "t-803",
+        "id": "t-800",
         "category": "action-endpoint",
         "entity": "header",
         "field": "aPRMAddpayment",
@@ -14096,7 +14051,7 @@
         "description": "Action endpoint for 'aPRMAddpayment' in header should exist"
       },
       {
-        "id": "t-804",
+        "id": "t-801",
         "category": "action-endpoint",
         "entity": "header",
         "field": "posted",
@@ -14104,7 +14059,7 @@
         "description": "Action endpoint for 'posted' in header should exist"
       },
       {
-        "id": "t-805",
+        "id": "t-802",
         "category": "action-endpoint",
         "entity": "header",
         "field": "aPRMProcessinvoice",
@@ -14112,7 +14067,7 @@
         "description": "Action endpoint for 'aPRMProcessinvoice' in header should exist"
       },
       {
-        "id": "t-806",
+        "id": "t-803",
         "category": "action-endpoint",
         "entity": "header",
         "field": "documentAction",
@@ -14120,7 +14075,7 @@
         "description": "Action endpoint for 'documentAction' in header should exist"
       },
       {
-        "id": "t-807",
+        "id": "t-804",
         "category": "action-endpoint",
         "entity": "header",
         "field": "createLinesFromOrder",
@@ -14128,7 +14083,7 @@
         "description": "Action endpoint for 'createLinesFromOrder' in header should exist"
       },
       {
-        "id": "t-808",
+        "id": "t-805",
         "category": "action-endpoint",
         "entity": "header",
         "field": "createLinesFromShipment",
@@ -14136,7 +14091,7 @@
         "description": "Action endpoint for 'createLinesFromShipment' in header should exist"
       },
       {
-        "id": "t-809",
+        "id": "t-806",
         "category": "action-endpoint",
         "entity": "header",
         "field": "copyFrom",
@@ -14144,7 +14099,7 @@
         "description": "Action endpoint for 'copyFrom' in header should exist"
       },
       {
-        "id": "t-810",
+        "id": "t-807",
         "category": "action-endpoint",
         "entity": "header",
         "field": "calculatePromotions",
@@ -14152,7 +14107,7 @@
         "description": "Action endpoint for 'calculatePromotions' in header should exist"
       },
       {
-        "id": "t-811",
+        "id": "t-808",
         "category": "action-endpoint",
         "entity": "header",
         "field": "aeatsiiSend",
@@ -14160,7 +14115,7 @@
         "description": "Action endpoint for 'aeatsiiSend' in header should exist"
       },
       {
-        "id": "t-812",
+        "id": "t-809",
         "category": "action-endpoint",
         "entity": "header",
         "field": "aeatsiiModif",
@@ -14168,7 +14123,7 @@
         "description": "Action endpoint for 'aeatsiiModif' in header should exist"
       },
       {
-        "id": "t-813",
+        "id": "t-810",
         "category": "action-endpoint",
         "entity": "header",
         "field": "tbaiXmlgenerator",
@@ -14176,7 +14131,7 @@
         "description": "Action endpoint for 'tbaiXmlgenerator' in header should exist"
       },
       {
-        "id": "t-814",
+        "id": "t-811",
         "category": "action-endpoint",
         "entity": "header",
         "field": "processNow",
@@ -14184,7 +14139,7 @@
         "description": "Action endpoint for 'processNow' in header should exist"
       },
       {
-        "id": "t-815",
+        "id": "t-812",
         "category": "action-endpoint",
         "entity": "header",
         "field": "createLinesFrom",
@@ -14192,7 +14147,7 @@
         "description": "Action endpoint for 'createLinesFrom' in header should exist"
       },
       {
-        "id": "t-816",
+        "id": "t-813",
         "category": "action-endpoint",
         "entity": "header",
         "field": "aeatsiiDup",
@@ -14200,7 +14155,7 @@
         "description": "Action endpoint for 'aeatsiiDup' in header should exist"
       },
       {
-        "id": "t-817",
+        "id": "t-814",
         "category": "action-endpoint",
         "entity": "header",
         "field": "aeatsiiUnsubscribe",
@@ -14208,7 +14163,7 @@
         "description": "Action endpoint for 'aeatsiiUnsubscribe' in header should exist"
       },
       {
-        "id": "t-818",
+        "id": "t-815",
         "category": "action-endpoint",
         "entity": "header",
         "field": "etvfacRectCreate",
@@ -14216,7 +14171,7 @@
         "description": "Action endpoint for 'etvfacRectCreate' in header should exist"
       },
       {
-        "id": "t-819",
+        "id": "t-816",
         "category": "action-endpoint",
         "entity": "header",
         "field": "tBAIQRcode",
@@ -14224,7 +14179,7 @@
         "description": "Action endpoint for 'tBAIQRcode' in header should exist"
       },
       {
-        "id": "t-820",
+        "id": "t-817",
         "category": "action-endpoint",
         "entity": "header",
         "field": "tbaiVoidxmlgenerator",
@@ -14232,7 +14187,7 @@
         "description": "Action endpoint for 'tbaiVoidxmlgenerator' in header should exist"
       },
       {
-        "id": "t-821",
+        "id": "t-818",
         "category": "action-endpoint",
         "entity": "lines",
         "field": "explode",
@@ -14240,7 +14195,7 @@
         "description": "Action endpoint for 'explode' in lines should exist"
       },
       {
-        "id": "t-822",
+        "id": "t-819",
         "category": "action-endpoint",
         "entity": "lines",
         "field": "matchLCCosts",
@@ -14248,7 +14203,7 @@
         "description": "Action endpoint for 'matchLCCosts' in lines should exist"
       },
       {
-        "id": "t-823",
+        "id": "t-820",
         "category": "action-endpoint",
         "entity": "paymentPlan",
         "field": "updatePaymentPlan",
@@ -14256,7 +14211,7 @@
         "description": "Action endpoint for 'updatePaymentPlan' in paymentPlan should exist"
       },
       {
-        "id": "t-824",
+        "id": "t-821",
         "category": "action-endpoint",
         "entity": "paymentPlan",
         "field": "aprmModifPaymentOUTPlan",
@@ -14264,7 +14219,7 @@
         "description": "Action endpoint for 'aprmModifPaymentOUTPlan' in paymentPlan should exist"
       },
       {
-        "id": "t-825",
+        "id": "t-822",
         "category": "action-endpoint",
         "entity": "paymentPlan",
         "field": "aprmModifPaymentINPlan",
@@ -14273,25 +14228,25 @@
       }
     ],
     "summary": {
-      "total": 825,
+      "total": 822,
       "byCategory": {
-        "field-presence": 121,
-        "field-type": 121,
+        "field-presence": 120,
+        "field-type": 120,
         "searchable-filters": 4,
         "visibility": 12,
-        "readonlylogic-valid": 47,
-        "readonlylogic-evaluable": 47,
+        "readonlylogic-valid": 46,
+        "readonlylogic-evaluable": 46,
         "default-value-type": 26,
         "displaylogic-valid": 5,
         "displaylogic-evaluable": 5,
-        "system-field": 333,
+        "system-field": 334,
         "rule-declared": 21,
         "crud-flags": 12,
         "selector-endpoint": 47,
         "action-endpoint": 24
       },
       "byRunner": {
-        "node": 825,
+        "node": 822,
         "junit": 0
       }
     }

--- a/artifacts/purchase-invoice/decisions.json
+++ b/artifacts/purchase-invoice/decisions.json
@@ -331,8 +331,8 @@
           "displayLogic": null
         },
         "lineNetAmount": {
-          "visibility": "readOnly",
-          "grid": true,
+          "visibility": "system",
+          "grid": false,
           "section": "principal",
           "readOnlyLogic": null
         },

--- a/artifacts/purchase-invoice/generated/web/purchase-invoice/LinesForm.jsx
+++ b/artifacts/purchase-invoice/generated/web/purchase-invoice/LinesForm.jsx
@@ -5,7 +5,6 @@ const fields = [
   { key: 'product', column: 'M_Product_ID', type: 'search', label: 'Product', section: 'principal', reference: 'Product', inputMode: 'search', readOnlyLogic: (record) => record['processed'] === true },
   { key: 'invoicedQuantity', column: 'QtyInvoiced', type: 'number', label: 'Invoiced Quantity', required: true, section: 'principal', defaultValue: '1', readOnlyLogic: (record) => record['processed'] === true || (record['uomManagement'] === 'Y' && record['financialInvoiceLine'] !== true) },
   { key: 'unitPrice', column: 'PriceActual', type: 'number', label: 'Net Unit Price', required: true, section: 'principal', readOnlyLogic: (record) => record['processed'] === true || record['gROSSPRICE'] === 'Y' },
-  { key: 'lineNetAmount', column: 'LineNetAmt', type: 'number', label: 'Line Net Amount', required: true, readOnly: true, section: 'principal', readOnlyLogic: (record) => record['editLineAmount'] !== true || record['processed'] === true },
   { key: 'grossAmount', column: 'Line_Gross_Amount', type: 'number', label: 'Line Gross Amount', readOnly: true, section: 'principal', defaultValue: '0' },
   { key: 'description', column: 'Description', type: 'textarea', label: 'Description', section: 'principal' },
   { key: 'tax', column: 'C_Tax_ID', type: 'search', label: 'Tax', section: 'principal', reference: 'Tax', inputMode: 'search', readOnlyLogic: (record) => record['processed'] === true },

--- a/artifacts/purchase-invoice/generated/web/purchase-invoice/LinesTable.jsx
+++ b/artifacts/purchase-invoice/generated/web/purchase-invoice/LinesTable.jsx
@@ -5,7 +5,6 @@ const columns = [
   { key: 'product', column: 'M_Product_ID', type: 'string', label: 'Product' },
   { key: 'invoicedQuantity', column: 'QtyInvoiced', type: 'number', label: 'Invoiced Quantity' },
   { key: 'unitPrice', column: 'PriceActual', type: 'number', label: 'Net Unit Price' },
-  { key: 'lineNetAmount', column: 'LineNetAmt', type: 'amount', label: 'Line Net Amount' },
   { key: 'tax', column: 'C_Tax_ID', type: 'string', label: 'Tax' },
   { key: 'grossAmount', column: 'Line_Gross_Amount', type: 'amount', label: 'Line Gross Amount' },
 ];

--- a/artifacts/sales-invoice/contract.json
+++ b/artifacts/sales-invoice/contract.json
@@ -1,7 +1,7 @@
 {
   "version": "0.11.1",
-  "generatedAt": "2026-04-21T16:50:39.402Z",
-  "checksum": "27d7f0cded05077f",
+  "generatedAt": "2026-04-22T14:47:01.187Z",
+  "checksum": "42980a7a334ff3f9",
   "frontendContract": {
     "window": {
       "id": "167",
@@ -567,27 +567,6 @@
               "raw": "@Processed@='Y'|@GROSSPRICE@='N'",
               "evaluable": true,
               "js": "record['processed'] === true || record['gROSSPRICE'] === 'N'"
-            }
-          },
-          {
-            "name": "lineNetAmount",
-            "apiKey": "lineNetAmount",
-            "column": "LineNetAmt",
-            "label": "Line Net Amount",
-            "type": "amount",
-            "tsType": "number",
-            "visibility": "readOnly",
-            "required": true,
-            "grid": true,
-            "form": true,
-            "section": "principal",
-            "callout": {
-              "className": "org.openbravo.erpCommon.ad_callouts.SL_Invoice_Amt"
-            },
-            "readOnlyLogic": {
-              "raw": "@Iseditlinenetamt@='N' | @Processed@='Y'",
-              "evaluable": true,
-              "js": "record['editLineAmount'] !== true || record['processed'] === true"
             }
           },
           {
@@ -2246,7 +2225,7 @@
             "apiKey": "lineNetAmount",
             "column": "LineNetAmt",
             "type": "amount",
-            "visibility": "readOnly",
+            "visibility": "system",
             "required": true
           },
           {
@@ -3835,20 +3814,12 @@
         "id": "t-68",
         "category": "field-presence",
         "entity": "lines",
-        "field": "lineNetAmount",
-        "runner": "node",
-        "description": "Field 'lineNetAmount' should be present in lines"
-      },
-      {
-        "id": "t-69",
-        "category": "field-presence",
-        "entity": "lines",
         "field": "grossAmount",
         "runner": "node",
         "description": "Field 'grossAmount' should be present in lines"
       },
       {
-        "id": "t-70",
+        "id": "t-69",
         "category": "field-presence",
         "entity": "lines",
         "field": "tax",
@@ -3856,7 +3827,7 @@
         "description": "Field 'tax' should be present in lines"
       },
       {
-        "id": "t-71",
+        "id": "t-70",
         "category": "field-presence",
         "entity": "lines",
         "field": "description",
@@ -3864,7 +3835,7 @@
         "description": "Field 'description' should be present in lines"
       },
       {
-        "id": "t-72",
+        "id": "t-71",
         "category": "field-type",
         "entity": "lines",
         "field": "product",
@@ -3872,7 +3843,7 @@
         "description": "Field 'product' should have type 'string' in lines"
       },
       {
-        "id": "t-73",
+        "id": "t-72",
         "category": "field-type",
         "entity": "lines",
         "field": "invoicedQuantity",
@@ -3880,7 +3851,7 @@
         "description": "Field 'invoicedQuantity' should have type 'number' in lines"
       },
       {
-        "id": "t-74",
+        "id": "t-73",
         "category": "field-type",
         "entity": "lines",
         "field": "unitPrice",
@@ -3888,7 +3859,7 @@
         "description": "Field 'unitPrice' should have type 'number' in lines"
       },
       {
-        "id": "t-75",
+        "id": "t-74",
         "category": "field-type",
         "entity": "lines",
         "field": "grossUnitPrice",
@@ -3896,15 +3867,7 @@
         "description": "Field 'grossUnitPrice' should have type 'number' in lines"
       },
       {
-        "id": "t-76",
-        "category": "field-type",
-        "entity": "lines",
-        "field": "lineNetAmount",
-        "runner": "node",
-        "description": "Field 'lineNetAmount' should have type 'number' in lines"
-      },
-      {
-        "id": "t-77",
+        "id": "t-75",
         "category": "field-type",
         "entity": "lines",
         "field": "grossAmount",
@@ -3912,7 +3875,7 @@
         "description": "Field 'grossAmount' should have type 'number' in lines"
       },
       {
-        "id": "t-78",
+        "id": "t-76",
         "category": "field-type",
         "entity": "lines",
         "field": "tax",
@@ -3920,7 +3883,7 @@
         "description": "Field 'tax' should have type 'string' in lines"
       },
       {
-        "id": "t-79",
+        "id": "t-77",
         "category": "field-type",
         "entity": "lines",
         "field": "description",
@@ -3928,7 +3891,7 @@
         "description": "Field 'description' should have type 'string' in lines"
       },
       {
-        "id": "t-80",
+        "id": "t-78",
         "category": "searchable-filters",
         "entity": "lines",
         "field": "product",
@@ -3936,14 +3899,14 @@
         "description": "Field 'product' should be a supported filter for lines"
       },
       {
-        "id": "t-81",
+        "id": "t-79",
         "category": "visibility",
         "entity": "lines",
         "runner": "node",
         "description": "Entity 'lines' should only expose visible fields in frontend"
       },
       {
-        "id": "t-82",
+        "id": "t-80",
         "category": "displaylogic-valid",
         "entity": "lines",
         "field": "grossUnitPrice",
@@ -3951,7 +3914,7 @@
         "description": "Display logic for 'grossUnitPrice' in lines should be valid JS"
       },
       {
-        "id": "t-83",
+        "id": "t-81",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "product",
@@ -3959,7 +3922,7 @@
         "description": "Read-only logic for 'product' in lines should be valid JS"
       },
       {
-        "id": "t-84",
+        "id": "t-82",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "invoicedQuantity",
@@ -3967,7 +3930,7 @@
         "description": "Read-only logic for 'invoicedQuantity' in lines should be valid JS"
       },
       {
-        "id": "t-85",
+        "id": "t-83",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "unitPrice",
@@ -3975,7 +3938,7 @@
         "description": "Read-only logic for 'unitPrice' in lines should be valid JS"
       },
       {
-        "id": "t-86",
+        "id": "t-84",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "grossUnitPrice",
@@ -3983,15 +3946,7 @@
         "description": "Read-only logic for 'grossUnitPrice' in lines should be valid JS"
       },
       {
-        "id": "t-87",
-        "category": "readonlylogic-valid",
-        "entity": "lines",
-        "field": "lineNetAmount",
-        "runner": "node",
-        "description": "Read-only logic for 'lineNetAmount' in lines should be valid JS"
-      },
-      {
-        "id": "t-88",
+        "id": "t-85",
         "category": "readonlylogic-valid",
         "entity": "lines",
         "field": "tax",
@@ -3999,7 +3954,7 @@
         "description": "Read-only logic for 'tax' in lines should be valid JS"
       },
       {
-        "id": "t-89",
+        "id": "t-86",
         "category": "displaylogic-evaluable",
         "entity": "lines",
         "field": "grossUnitPrice",
@@ -4007,7 +3962,7 @@
         "description": "Display logic for 'grossUnitPrice' in lines should have evaluable flag"
       },
       {
-        "id": "t-90",
+        "id": "t-87",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "product",
@@ -4015,7 +3970,7 @@
         "description": "Read-only logic for 'product' in lines should have evaluable flag"
       },
       {
-        "id": "t-91",
+        "id": "t-88",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "invoicedQuantity",
@@ -4023,7 +3978,7 @@
         "description": "Read-only logic for 'invoicedQuantity' in lines should have evaluable flag"
       },
       {
-        "id": "t-92",
+        "id": "t-89",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "unitPrice",
@@ -4031,7 +3986,7 @@
         "description": "Read-only logic for 'unitPrice' in lines should have evaluable flag"
       },
       {
-        "id": "t-93",
+        "id": "t-90",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "grossUnitPrice",
@@ -4039,15 +3994,7 @@
         "description": "Read-only logic for 'grossUnitPrice' in lines should have evaluable flag"
       },
       {
-        "id": "t-94",
-        "category": "readonlylogic-evaluable",
-        "entity": "lines",
-        "field": "lineNetAmount",
-        "runner": "node",
-        "description": "Read-only logic for 'lineNetAmount' in lines should have evaluable flag"
-      },
-      {
-        "id": "t-95",
+        "id": "t-91",
         "category": "readonlylogic-evaluable",
         "entity": "lines",
         "field": "tax",
@@ -4055,7 +4002,7 @@
         "description": "Read-only logic for 'tax' in lines should have evaluable flag"
       },
       {
-        "id": "t-96",
+        "id": "t-92",
         "category": "default-value-type",
         "entity": "lines",
         "field": "invoicedQuantity",
@@ -4063,7 +4010,7 @@
         "description": "Default value for 'invoicedQuantity' in lines should be a string"
       },
       {
-        "id": "t-97",
+        "id": "t-93",
         "category": "default-value-type",
         "entity": "lines",
         "field": "grossUnitPrice",
@@ -4071,7 +4018,7 @@
         "description": "Default value for 'grossUnitPrice' in lines should be a string"
       },
       {
-        "id": "t-98",
+        "id": "t-94",
         "category": "default-value-type",
         "entity": "lines",
         "field": "grossAmount",
@@ -4079,7 +4026,7 @@
         "description": "Default value for 'grossAmount' in lines should be a string"
       },
       {
-        "id": "t-99",
+        "id": "t-95",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "dueDate",
@@ -4087,7 +4034,7 @@
         "description": "Field 'dueDate' should be present in paymentPlan"
       },
       {
-        "id": "t-100",
+        "id": "t-96",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "expectedDate",
@@ -4095,7 +4042,7 @@
         "description": "Field 'expectedDate' should be present in paymentPlan"
       },
       {
-        "id": "t-101",
+        "id": "t-97",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "finPaymentmethodID",
@@ -4103,7 +4050,7 @@
         "description": "Field 'finPaymentmethodID' should be present in paymentPlan"
       },
       {
-        "id": "t-102",
+        "id": "t-98",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "amount",
@@ -4111,7 +4058,7 @@
         "description": "Field 'amount' should be present in paymentPlan"
       },
       {
-        "id": "t-103",
+        "id": "t-99",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "paidAmount",
@@ -4119,7 +4066,7 @@
         "description": "Field 'paidAmount' should be present in paymentPlan"
       },
       {
-        "id": "t-104",
+        "id": "t-100",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "outstandingAmount",
@@ -4127,7 +4074,7 @@
         "description": "Field 'outstandingAmount' should be present in paymentPlan"
       },
       {
-        "id": "t-105",
+        "id": "t-101",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "currency",
@@ -4135,7 +4082,7 @@
         "description": "Field 'currency' should be present in paymentPlan"
       },
       {
-        "id": "t-106",
+        "id": "t-102",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "lastPaymentDate",
@@ -4143,7 +4090,7 @@
         "description": "Field 'lastPaymentDate' should be present in paymentPlan"
       },
       {
-        "id": "t-107",
+        "id": "t-103",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "daysOverdue",
@@ -4151,7 +4098,7 @@
         "description": "Field 'daysOverdue' should be present in paymentPlan"
       },
       {
-        "id": "t-108",
+        "id": "t-104",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "numberOfPayments",
@@ -4159,7 +4106,7 @@
         "description": "Field 'numberOfPayments' should be present in paymentPlan"
       },
       {
-        "id": "t-109",
+        "id": "t-105",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "description",
@@ -4167,7 +4114,7 @@
         "description": "Field 'description' should be present in paymentPlan"
       },
       {
-        "id": "t-110",
+        "id": "t-106",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "totalDebtAmount",
@@ -4175,7 +4122,7 @@
         "description": "Field 'totalDebtAmount' should be present in paymentPlan"
       },
       {
-        "id": "t-111",
+        "id": "t-107",
         "category": "field-presence",
         "entity": "paymentPlan",
         "field": "finPaymentScheduleID",
@@ -4183,7 +4130,7 @@
         "description": "Field 'finPaymentScheduleID' should be present in paymentPlan"
       },
       {
-        "id": "t-112",
+        "id": "t-108",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "dueDate",
@@ -4191,7 +4138,7 @@
         "description": "Field 'dueDate' should have type 'string' in paymentPlan"
       },
       {
-        "id": "t-113",
+        "id": "t-109",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "expectedDate",
@@ -4199,7 +4146,7 @@
         "description": "Field 'expectedDate' should have type 'string' in paymentPlan"
       },
       {
-        "id": "t-114",
+        "id": "t-110",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "finPaymentmethodID",
@@ -4207,7 +4154,7 @@
         "description": "Field 'finPaymentmethodID' should have type 'string' in paymentPlan"
       },
       {
-        "id": "t-115",
+        "id": "t-111",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "amount",
@@ -4215,7 +4162,7 @@
         "description": "Field 'amount' should have type 'number' in paymentPlan"
       },
       {
-        "id": "t-116",
+        "id": "t-112",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "paidAmount",
@@ -4223,7 +4170,7 @@
         "description": "Field 'paidAmount' should have type 'number' in paymentPlan"
       },
       {
-        "id": "t-117",
+        "id": "t-113",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "outstandingAmount",
@@ -4231,7 +4178,7 @@
         "description": "Field 'outstandingAmount' should have type 'number' in paymentPlan"
       },
       {
-        "id": "t-118",
+        "id": "t-114",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "currency",
@@ -4239,7 +4186,7 @@
         "description": "Field 'currency' should have type 'string' in paymentPlan"
       },
       {
-        "id": "t-119",
+        "id": "t-115",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "lastPaymentDate",
@@ -4247,7 +4194,7 @@
         "description": "Field 'lastPaymentDate' should have type 'string' in paymentPlan"
       },
       {
-        "id": "t-120",
+        "id": "t-116",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "daysOverdue",
@@ -4255,7 +4202,7 @@
         "description": "Field 'daysOverdue' should have type 'number' in paymentPlan"
       },
       {
-        "id": "t-121",
+        "id": "t-117",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "numberOfPayments",
@@ -4263,7 +4210,7 @@
         "description": "Field 'numberOfPayments' should have type 'number' in paymentPlan"
       },
       {
-        "id": "t-122",
+        "id": "t-118",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "description",
@@ -4271,7 +4218,7 @@
         "description": "Field 'description' should have type 'string' in paymentPlan"
       },
       {
-        "id": "t-123",
+        "id": "t-119",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "totalDebtAmount",
@@ -4279,7 +4226,7 @@
         "description": "Field 'totalDebtAmount' should have type 'number' in paymentPlan"
       },
       {
-        "id": "t-124",
+        "id": "t-120",
         "category": "field-type",
         "entity": "paymentPlan",
         "field": "finPaymentScheduleID",
@@ -4287,14 +4234,14 @@
         "description": "Field 'finPaymentScheduleID' should have type 'string' in paymentPlan"
       },
       {
-        "id": "t-125",
+        "id": "t-121",
         "category": "visibility",
         "entity": "paymentPlan",
         "runner": "node",
         "description": "Entity 'paymentPlan' should only expose visible fields in frontend"
       },
       {
-        "id": "t-126",
+        "id": "t-122",
         "category": "default-value-type",
         "entity": "paymentPlan",
         "field": "amount",
@@ -4302,7 +4249,7 @@
         "description": "Default value for 'amount' in paymentPlan should be a string"
       },
       {
-        "id": "t-127",
+        "id": "t-123",
         "category": "default-value-type",
         "entity": "paymentPlan",
         "field": "paidAmount",
@@ -4310,7 +4257,7 @@
         "description": "Default value for 'paidAmount' in paymentPlan should be a string"
       },
       {
-        "id": "t-128",
+        "id": "t-124",
         "category": "default-value-type",
         "entity": "paymentPlan",
         "field": "outstandingAmount",
@@ -4318,7 +4265,7 @@
         "description": "Default value for 'outstandingAmount' in paymentPlan should be a string"
       },
       {
-        "id": "t-129",
+        "id": "t-125",
         "category": "default-value-type",
         "entity": "paymentPlan",
         "field": "totalDebtAmount",
@@ -4326,7 +4273,7 @@
         "description": "Default value for 'totalDebtAmount' in paymentPlan should be a string"
       },
       {
-        "id": "t-130",
+        "id": "t-126",
         "category": "system-field",
         "entity": "header",
         "field": "adOrgId",
@@ -4334,7 +4281,7 @@
         "description": "System field 'adOrgId' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-131",
+        "id": "t-127",
         "category": "system-field",
         "entity": "header",
         "field": "cDocTypeTargetId",
@@ -4342,7 +4289,7 @@
         "description": "System field 'cDocTypeTargetId' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-132",
+        "id": "t-128",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiIsreverseinvoice",
@@ -4350,7 +4297,7 @@
         "description": "System field 'tbaiIsreverseinvoice' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-133",
+        "id": "t-129",
         "category": "system-field",
         "entity": "header",
         "field": "userContact",
@@ -4358,7 +4305,7 @@
         "description": "System field 'userContact' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-134",
+        "id": "t-130",
         "category": "system-field",
         "entity": "header",
         "field": "totalPaid",
@@ -4366,7 +4313,7 @@
         "description": "System field 'totalPaid' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-135",
+        "id": "t-131",
         "category": "system-field",
         "entity": "header",
         "field": "aPRMAddpayment",
@@ -4374,7 +4321,7 @@
         "description": "System field 'aPRMAddpayment' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-136",
+        "id": "t-132",
         "category": "system-field",
         "entity": "header",
         "field": "aPRMProcessinvoice",
@@ -4382,7 +4329,7 @@
         "description": "System field 'aPRMProcessinvoice' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-137",
+        "id": "t-133",
         "category": "system-field",
         "entity": "header",
         "field": "documentAction",
@@ -4390,7 +4337,7 @@
         "description": "System field 'documentAction' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-138",
+        "id": "t-134",
         "category": "system-field",
         "entity": "header",
         "field": "createLinesFromOrder",
@@ -4398,7 +4345,7 @@
         "description": "System field 'createLinesFromOrder' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-139",
+        "id": "t-135",
         "category": "system-field",
         "entity": "header",
         "field": "createLinesFromShipment",
@@ -4406,7 +4353,7 @@
         "description": "System field 'createLinesFromShipment' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-140",
+        "id": "t-136",
         "category": "system-field",
         "entity": "header",
         "field": "copyFrom",
@@ -4414,7 +4361,7 @@
         "description": "System field 'copyFrom' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-141",
+        "id": "t-137",
         "category": "system-field",
         "entity": "header",
         "field": "dueAmount",
@@ -4422,7 +4369,7 @@
         "description": "System field 'dueAmount' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-142",
+        "id": "t-138",
         "category": "system-field",
         "entity": "header",
         "field": "daysTillDue",
@@ -4430,7 +4377,7 @@
         "description": "System field 'daysTillDue' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-143",
+        "id": "t-139",
         "category": "system-field",
         "entity": "header",
         "field": "percentageOverdue",
@@ -4438,7 +4385,7 @@
         "description": "System field 'percentageOverdue' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-144",
+        "id": "t-140",
         "category": "system-field",
         "entity": "header",
         "field": "trxOrganization",
@@ -4446,7 +4393,7 @@
         "description": "System field 'trxOrganization' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-145",
+        "id": "t-141",
         "category": "system-field",
         "entity": "header",
         "field": "finalSettlementDate",
@@ -4454,7 +4401,7 @@
         "description": "System field 'finalSettlementDate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-146",
+        "id": "t-142",
         "category": "system-field",
         "entity": "header",
         "field": "daysSalesOutstanding",
@@ -4462,7 +4409,7 @@
         "description": "System field 'daysSalesOutstanding' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-147",
+        "id": "t-143",
         "category": "system-field",
         "entity": "header",
         "field": "salesRepresentative",
@@ -4470,7 +4417,7 @@
         "description": "System field 'salesRepresentative' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-148",
+        "id": "t-144",
         "category": "system-field",
         "entity": "header",
         "field": "salesOrder",
@@ -4478,7 +4425,7 @@
         "description": "System field 'salesOrder' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-149",
+        "id": "t-145",
         "category": "system-field",
         "entity": "header",
         "field": "orderReference",
@@ -4486,7 +4433,7 @@
         "description": "System field 'orderReference' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-150",
+        "id": "t-146",
         "category": "system-field",
         "entity": "header",
         "field": "accountingDate",
@@ -4494,7 +4441,7 @@
         "description": "System field 'accountingDate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-151",
+        "id": "t-147",
         "category": "system-field",
         "entity": "header",
         "field": "taxDate",
@@ -4502,7 +4449,7 @@
         "description": "System field 'taxDate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-152",
+        "id": "t-148",
         "category": "system-field",
         "entity": "header",
         "field": "activity",
@@ -4510,7 +4457,7 @@
         "description": "System field 'activity' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-153",
+        "id": "t-149",
         "category": "system-field",
         "entity": "header",
         "field": "charge",
@@ -4518,7 +4465,7 @@
         "description": "System field 'charge' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-154",
+        "id": "t-150",
         "category": "system-field",
         "entity": "header",
         "field": "chargeAmount",
@@ -4526,7 +4473,7 @@
         "description": "System field 'chargeAmount' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-155",
+        "id": "t-151",
         "category": "system-field",
         "entity": "header",
         "field": "orderDate",
@@ -4534,7 +4481,7 @@
         "description": "System field 'orderDate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-156",
+        "id": "t-152",
         "category": "system-field",
         "entity": "header",
         "field": "cDocTypeId",
@@ -4542,7 +4489,7 @@
         "description": "System field 'cDocTypeId' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-157",
+        "id": "t-153",
         "category": "system-field",
         "entity": "header",
         "field": "calculatePromotions",
@@ -4550,7 +4497,7 @@
         "description": "System field 'calculatePromotions' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-158",
+        "id": "t-154",
         "category": "system-field",
         "entity": "header",
         "field": "externalBusinessPartnerReference",
@@ -4558,7 +4505,7 @@
         "description": "System field 'externalBusinessPartnerReference' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-159",
+        "id": "t-155",
         "category": "system-field",
         "entity": "header",
         "field": "cashVAT",
@@ -4566,7 +4513,7 @@
         "description": "System field 'cashVAT' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-160",
+        "id": "t-156",
         "category": "system-field",
         "entity": "header",
         "field": "project",
@@ -4574,7 +4521,7 @@
         "description": "System field 'project' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-161",
+        "id": "t-157",
         "category": "system-field",
         "entity": "header",
         "field": "costcenter",
@@ -4582,7 +4529,7 @@
         "description": "System field 'costcenter' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-162",
+        "id": "t-158",
         "category": "system-field",
         "entity": "header",
         "field": "asset",
@@ -4590,7 +4537,7 @@
         "description": "System field 'asset' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-163",
+        "id": "t-159",
         "category": "system-field",
         "entity": "header",
         "field": "salesCampaign",
@@ -4598,7 +4545,7 @@
         "description": "System field 'salesCampaign' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-164",
+        "id": "t-160",
         "category": "system-field",
         "entity": "header",
         "field": "stDimension",
@@ -4606,7 +4553,7 @@
         "description": "System field 'stDimension' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-165",
+        "id": "t-161",
         "category": "system-field",
         "entity": "header",
         "field": "ndDimension",
@@ -4614,7 +4561,7 @@
         "description": "System field 'ndDimension' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-166",
+        "id": "t-162",
         "category": "system-field",
         "entity": "header",
         "field": "prepaymentamt",
@@ -4622,7 +4569,7 @@
         "description": "System field 'prepaymentamt' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-167",
+        "id": "t-163",
         "category": "system-field",
         "entity": "header",
         "field": "paidAmountAtInvoicing",
@@ -4630,7 +4577,7 @@
         "description": "System field 'paidAmountAtInvoicing' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-168",
+        "id": "t-164",
         "category": "system-field",
         "entity": "header",
         "field": "etsgDateOperation",
@@ -4638,7 +4585,7 @@
         "description": "System field 'etsgDateOperation' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-169",
+        "id": "t-165",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacInvoiceStatus",
@@ -4646,7 +4593,7 @@
         "description": "System field 'etvfacInvoiceStatus' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-170",
+        "id": "t-166",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacInvType",
@@ -4654,7 +4601,7 @@
         "description": "System field 'etvfacInvType' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-171",
+        "id": "t-167",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacVerifacDesc",
@@ -4662,7 +4609,7 @@
         "description": "System field 'etvfacVerifacDesc' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-172",
+        "id": "t-168",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacIsSubsanation",
@@ -4670,7 +4617,7 @@
         "description": "System field 'etvfacIsSubsanation' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-173",
+        "id": "t-169",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacReverseinvtype",
@@ -4678,7 +4625,7 @@
         "description": "System field 'etvfacReverseinvtype' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-174",
+        "id": "t-170",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacExternalRef",
@@ -4686,7 +4633,7 @@
         "description": "System field 'etvfacExternalRef' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-175",
+        "id": "t-171",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacSimpinvart7273",
@@ -4694,7 +4641,7 @@
         "description": "System field 'etvfacSimpinvart7273' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-176",
+        "id": "t-172",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacInvNoIDArt61d",
@@ -4702,7 +4649,7 @@
         "description": "System field 'etvfacInvNoIDArt61d' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-177",
+        "id": "t-173",
         "category": "system-field",
         "entity": "header",
         "field": "tBAIQRcode",
@@ -4710,7 +4657,7 @@
         "description": "System field 'tBAIQRcode' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-178",
+        "id": "t-174",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacIssue",
@@ -4718,7 +4665,7 @@
         "description": "System field 'etvfacIssue' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-179",
+        "id": "t-175",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacQRURL",
@@ -4726,7 +4673,7 @@
         "description": "System field 'etvfacQRURL' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-180",
+        "id": "t-176",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacCorrectedInv",
@@ -4734,7 +4681,7 @@
         "description": "System field 'etvfacCorrectedInv' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-181",
+        "id": "t-177",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacDateIssue",
@@ -4742,7 +4689,7 @@
         "description": "System field 'etvfacDateIssue' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-182",
+        "id": "t-178",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacIssueDescription",
@@ -4750,7 +4697,7 @@
         "description": "System field 'etvfacIssueDescription' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-183",
+        "id": "t-179",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacVoid",
@@ -4758,7 +4705,7 @@
         "description": "System field 'etvfacVoid' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-184",
+        "id": "t-180",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacIssuedExternally",
@@ -4766,7 +4713,7 @@
         "description": "System field 'etvfacIssuedExternally' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-185",
+        "id": "t-181",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacRectCreate",
@@ -4774,7 +4721,7 @@
         "description": "System field 'etvfacRectCreate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-186",
+        "id": "t-182",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiXmlgenerator",
@@ -4782,7 +4729,7 @@
         "description": "System field 'tbaiXmlgenerator' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-187",
+        "id": "t-183",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacSentToVerifac",
@@ -4790,7 +4737,7 @@
         "description": "System field 'etvfacSentToVerifac' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-188",
+        "id": "t-184",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiSequence",
@@ -4798,7 +4745,7 @@
         "description": "System field 'tbaiSequence' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-189",
+        "id": "t-185",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiInvoicenum",
@@ -4806,7 +4753,7 @@
         "description": "System field 'tbaiInvoicenum' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-190",
+        "id": "t-186",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiInvoiceseq",
@@ -4814,7 +4761,7 @@
         "description": "System field 'tbaiInvoiceseq' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-191",
+        "id": "t-187",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacIsGenManual",
@@ -4822,7 +4769,7 @@
         "description": "System field 'etvfacIsGenManual' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-192",
+        "id": "t-188",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiReverseinvoicecode",
@@ -4830,7 +4777,7 @@
         "description": "System field 'tbaiReverseinvoicecode' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-193",
+        "id": "t-189",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiReverseinvoicetype",
@@ -4838,7 +4785,7 @@
         "description": "System field 'tbaiReverseinvoicetype' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-194",
+        "id": "t-190",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiIssent",
@@ -4846,7 +4793,7 @@
         "description": "System field 'tbaiIssent' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-195",
+        "id": "t-191",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiVoidxmlgenerator",
@@ -4854,7 +4801,7 @@
         "description": "System field 'tbaiVoidxmlgenerator' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-196",
+        "id": "t-192",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiSend",
@@ -4862,7 +4809,7 @@
         "description": "System field 'aeatsiiSend' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-197",
+        "id": "t-193",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiModif",
@@ -4870,7 +4817,7 @@
         "description": "System field 'aeatsiiModif' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-198",
+        "id": "t-194",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiIssent",
@@ -4878,7 +4825,7 @@
         "description": "System field 'aeatsiiIssent' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-199",
+        "id": "t-195",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiModified",
@@ -4886,7 +4833,7 @@
         "description": "System field 'aeatsiiModified' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-200",
+        "id": "t-196",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiClaveTipo",
@@ -4894,7 +4841,7 @@
         "description": "System field 'aeatsiiClaveTipo' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-201",
+        "id": "t-197",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiTipoRectif",
@@ -4902,7 +4849,7 @@
         "description": "System field 'aeatsiiTipoRectif' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-202",
+        "id": "t-198",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiMotivoRectif",
@@ -4910,7 +4857,7 @@
         "description": "System field 'aeatsiiMotivoRectif' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-203",
+        "id": "t-199",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiDescription",
@@ -4918,7 +4865,7 @@
         "description": "System field 'aeatsiiDescription' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-204",
+        "id": "t-200",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiDescripcionSii",
@@ -4926,7 +4873,7 @@
         "description": "System field 'aeatsiiDescripcionSii' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-205",
+        "id": "t-201",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiEstado",
@@ -4934,7 +4881,7 @@
         "description": "System field 'aeatsiiEstado' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-206",
+        "id": "t-202",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiErrorRegistral",
@@ -4942,7 +4889,7 @@
         "description": "System field 'aeatsiiErrorRegistral' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-207",
+        "id": "t-203",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiEjercicio",
@@ -4950,7 +4897,7 @@
         "description": "System field 'aeatsiiEjercicio' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-208",
+        "id": "t-204",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiPeriodo",
@@ -4958,7 +4905,7 @@
         "description": "System field 'aeatsiiPeriodo' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-209",
+        "id": "t-205",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiCauseExemption",
@@ -4966,7 +4913,7 @@
         "description": "System field 'aeatsiiCauseExemption' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-210",
+        "id": "t-206",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiIsauthorization",
@@ -4974,7 +4921,7 @@
         "description": "System field 'aeatsiiIsauthorization' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-211",
+        "id": "t-207",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiAuthorizationno",
@@ -4982,7 +4929,7 @@
         "description": "System field 'aeatsiiAuthorizationno' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-212",
+        "id": "t-208",
         "category": "system-field",
         "entity": "header",
         "field": "id",
@@ -4990,7 +4937,7 @@
         "description": "System field 'id' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-213",
+        "id": "t-209",
         "category": "system-field",
         "entity": "header",
         "field": "withholding",
@@ -4998,7 +4945,7 @@
         "description": "System field 'withholding' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-214",
+        "id": "t-210",
         "category": "system-field",
         "entity": "header",
         "field": "withholdingamount",
@@ -5006,7 +4953,7 @@
         "description": "System field 'withholdingamount' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-215",
+        "id": "t-211",
         "category": "system-field",
         "entity": "header",
         "field": "isActive",
@@ -5014,7 +4961,7 @@
         "description": "System field 'isActive' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-216",
+        "id": "t-212",
         "category": "system-field",
         "entity": "header",
         "field": "adClientId",
@@ -5022,7 +4969,7 @@
         "description": "System field 'adClientId' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-217",
+        "id": "t-213",
         "category": "system-field",
         "entity": "header",
         "field": "lastCalculatedOnDate",
@@ -5030,7 +4977,7 @@
         "description": "System field 'lastCalculatedOnDate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-218",
+        "id": "t-214",
         "category": "system-field",
         "entity": "header",
         "field": "printDiscount",
@@ -5038,7 +4985,7 @@
         "description": "System field 'printDiscount' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-219",
+        "id": "t-215",
         "category": "system-field",
         "entity": "header",
         "field": "created",
@@ -5046,7 +4993,7 @@
         "description": "System field 'created' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-220",
+        "id": "t-216",
         "category": "system-field",
         "entity": "header",
         "field": "selfService",
@@ -5054,7 +5001,7 @@
         "description": "System field 'selfService' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-221",
+        "id": "t-217",
         "category": "system-field",
         "entity": "header",
         "field": "generateTo",
@@ -5062,7 +5009,7 @@
         "description": "System field 'generateTo' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-222",
+        "id": "t-218",
         "category": "system-field",
         "entity": "header",
         "field": "isSotrx",
@@ -5070,7 +5017,7 @@
         "description": "System field 'isSotrx' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-223",
+        "id": "t-219",
         "category": "system-field",
         "entity": "header",
         "field": "datePrinted",
@@ -5078,7 +5025,7 @@
         "description": "System field 'datePrinted' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-224",
+        "id": "t-220",
         "category": "system-field",
         "entity": "header",
         "field": "priceIncludesTax",
@@ -5086,7 +5033,7 @@
         "description": "System field 'priceIncludesTax' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-225",
+        "id": "t-221",
         "category": "system-field",
         "entity": "header",
         "field": "print",
@@ -5094,7 +5041,7 @@
         "description": "System field 'print' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-226",
+        "id": "t-222",
         "category": "system-field",
         "entity": "header",
         "field": "processNow",
@@ -5102,7 +5049,7 @@
         "description": "System field 'processNow' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-227",
+        "id": "t-223",
         "category": "system-field",
         "entity": "header",
         "field": "createdBy",
@@ -5110,7 +5057,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-228",
+        "id": "t-224",
         "category": "system-field",
         "entity": "header",
         "field": "createLinesFrom",
@@ -5118,7 +5065,7 @@
         "description": "System field 'createLinesFrom' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-229",
+        "id": "t-225",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiAutofactura",
@@ -5126,7 +5073,7 @@
         "description": "System field 'aeatsiiAutofactura' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-230",
+        "id": "t-226",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiClaveTipoFc",
@@ -5134,7 +5081,7 @@
         "description": "System field 'aeatsiiClaveTipoFc' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-231",
+        "id": "t-227",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiDateIssue",
@@ -5142,7 +5089,7 @@
         "description": "System field 'aeatsiiDateIssue' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-232",
+        "id": "t-228",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiDua",
@@ -5150,7 +5097,7 @@
         "description": "System field 'aeatsiiDua' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-233",
+        "id": "t-229",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiDup",
@@ -5158,7 +5105,7 @@
         "description": "System field 'aeatsiiDup' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-234",
+        "id": "t-230",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiErrorCode",
@@ -5166,7 +5113,7 @@
         "description": "System field 'aeatsiiErrorCode' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-235",
+        "id": "t-231",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiErrorMsg",
@@ -5174,7 +5121,7 @@
         "description": "System field 'aeatsiiErrorMsg' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-236",
+        "id": "t-232",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiFechaDua",
@@ -5182,7 +5129,7 @@
         "description": "System field 'aeatsiiFechaDua' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-237",
+        "id": "t-233",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiFechaOperacion",
@@ -5190,7 +5137,7 @@
         "description": "System field 'aeatsiiFechaOperacion' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-238",
+        "id": "t-234",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiFechaRegCont",
@@ -5198,7 +5145,7 @@
         "description": "System field 'aeatsiiFechaRegCont' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-239",
+        "id": "t-235",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiHash",
@@ -5206,7 +5153,7 @@
         "description": "System field 'aeatsiiHash' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-240",
+        "id": "t-236",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiInsiidate",
@@ -5214,7 +5161,7 @@
         "description": "System field 'aeatsiiInsiidate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-241",
+        "id": "t-237",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiInvoice",
@@ -5222,7 +5169,7 @@
         "description": "System field 'aeatsiiInvoice' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-242",
+        "id": "t-238",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiMultiDua",
@@ -5230,7 +5177,7 @@
         "description": "System field 'aeatsiiMultiDua' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-243",
+        "id": "t-239",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiPurDescription",
@@ -5238,7 +5185,7 @@
         "description": "System field 'aeatsiiPurDescription' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-244",
+        "id": "t-240",
         "category": "system-field",
         "entity": "header",
         "field": "aeatsiiUnsubscribe",
@@ -5246,7 +5193,7 @@
         "description": "System field 'aeatsiiUnsubscribe' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-245",
+        "id": "t-241",
         "category": "system-field",
         "entity": "header",
         "field": "etcopagCopilotFeedback",
@@ -5254,7 +5201,7 @@
         "description": "System field 'etcopagCopilotFeedback' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-246",
+        "id": "t-242",
         "category": "system-field",
         "entity": "header",
         "field": "etsgIsF3",
@@ -5262,7 +5209,7 @@
         "description": "System field 'etsgIsF3' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-247",
+        "id": "t-243",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacAddress1Copy",
@@ -5270,7 +5217,7 @@
         "description": "System field 'etvfacAddress1Copy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-248",
+        "id": "t-244",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacBpNameCopy",
@@ -5278,7 +5225,7 @@
         "description": "System field 'etvfacBpNameCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-249",
+        "id": "t-245",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacBpTaxidCopy",
@@ -5286,7 +5233,7 @@
         "description": "System field 'etvfacBpTaxidCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-250",
+        "id": "t-246",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacCityCopy",
@@ -5294,7 +5241,7 @@
         "description": "System field 'etvfacCityCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-251",
+        "id": "t-247",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacContactNameCopy",
@@ -5302,7 +5249,7 @@
         "description": "System field 'etvfacContactNameCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-252",
+        "id": "t-248",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacCountryCopy",
@@ -5310,7 +5257,7 @@
         "description": "System field 'etvfacCountryCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-253",
+        "id": "t-249",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacDateOperation",
@@ -5318,7 +5265,7 @@
         "description": "System field 'etvfacDateOperation' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-254",
+        "id": "t-250",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacFaxCopy",
@@ -5326,7 +5273,7 @@
         "description": "System field 'etvfacFaxCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-255",
+        "id": "t-251",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacHash",
@@ -5334,7 +5281,7 @@
         "description": "System field 'etvfacHash' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-256",
+        "id": "t-252",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacOrgLocationCopy",
@@ -5342,7 +5289,7 @@
         "description": "System field 'etvfacOrgLocationCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-257",
+        "id": "t-253",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacOrgNameCopy",
@@ -5350,7 +5297,7 @@
         "description": "System field 'etvfacOrgNameCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-258",
+        "id": "t-254",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacOrgTaxidCopy",
@@ -5358,7 +5305,7 @@
         "description": "System field 'etvfacOrgTaxidCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-259",
+        "id": "t-255",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacPhoneCopy",
@@ -5366,7 +5313,7 @@
         "description": "System field 'etvfacPhoneCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-260",
+        "id": "t-256",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacPostalCopy",
@@ -5374,7 +5321,7 @@
         "description": "System field 'etvfacPostalCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-261",
+        "id": "t-257",
         "category": "system-field",
         "entity": "header",
         "field": "etvfacRegionCopy",
@@ -5382,7 +5329,7 @@
         "description": "System field 'etvfacRegionCopy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-262",
+        "id": "t-258",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiDateOperation",
@@ -5390,7 +5337,7 @@
         "description": "System field 'tbaiDateOperation' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-263",
+        "id": "t-259",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiIdtbai",
@@ -5398,7 +5345,7 @@
         "description": "System field 'tbaiIdtbai' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-264",
+        "id": "t-260",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiIssueDate",
@@ -5406,7 +5353,7 @@
         "description": "System field 'tbaiIssueDate' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-265",
+        "id": "t-261",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiSignaturevalue",
@@ -5414,7 +5361,7 @@
         "description": "System field 'tbaiSignaturevalue' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-266",
+        "id": "t-262",
         "category": "system-field",
         "entity": "header",
         "field": "tbaiUrl",
@@ -5422,7 +5369,7 @@
         "description": "System field 'tbaiUrl' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-267",
+        "id": "t-263",
         "category": "system-field",
         "entity": "header",
         "field": "fINPaymentPriorityID",
@@ -5430,7 +5377,7 @@
         "description": "System field 'fINPaymentPriorityID' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-268",
+        "id": "t-264",
         "category": "system-field",
         "entity": "header",
         "field": "updated",
@@ -5438,7 +5385,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-269",
+        "id": "t-265",
         "category": "system-field",
         "entity": "header",
         "field": "updatedBy",
@@ -5446,7 +5393,7 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for header"
       },
       {
-        "id": "t-270",
+        "id": "t-266",
         "category": "system-field",
         "entity": "lines",
         "field": "lineNo",
@@ -5454,7 +5401,7 @@
         "description": "System field 'lineNo' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-271",
+        "id": "t-267",
         "category": "system-field",
         "entity": "lines",
         "field": "operativeQuantity",
@@ -5462,7 +5409,7 @@
         "description": "System field 'operativeQuantity' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-272",
+        "id": "t-268",
         "category": "system-field",
         "entity": "lines",
         "field": "operativeUOM",
@@ -5470,7 +5417,7 @@
         "description": "System field 'operativeUOM' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-273",
+        "id": "t-269",
         "category": "system-field",
         "entity": "lines",
         "field": "uOM",
@@ -5478,7 +5425,15 @@
         "description": "System field 'uOM' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-274",
+        "id": "t-270",
+        "category": "system-field",
+        "entity": "lines",
+        "field": "lineNetAmount",
+        "runner": "node",
+        "description": "System field 'lineNetAmount' should exist in backend but not frontend for lines"
+      },
+      {
+        "id": "t-271",
         "category": "system-field",
         "entity": "lines",
         "field": "listPrice",
@@ -5486,7 +5441,7 @@
         "description": "System field 'listPrice' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-275",
+        "id": "t-272",
         "category": "system-field",
         "entity": "lines",
         "field": "grossListPrice",
@@ -5494,7 +5449,7 @@
         "description": "System field 'grossListPrice' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-276",
+        "id": "t-273",
         "category": "system-field",
         "entity": "lines",
         "field": "financialInvoiceLine",
@@ -5502,7 +5457,7 @@
         "description": "System field 'financialInvoiceLine' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-277",
+        "id": "t-274",
         "category": "system-field",
         "entity": "lines",
         "field": "account",
@@ -5510,7 +5465,7 @@
         "description": "System field 'account' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-278",
+        "id": "t-275",
         "category": "system-field",
         "entity": "lines",
         "field": "attributeSetValue",
@@ -5518,7 +5473,7 @@
         "description": "System field 'attributeSetValue' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-279",
+        "id": "t-276",
         "category": "system-field",
         "entity": "lines",
         "field": "cOrderlineId",
@@ -5526,7 +5481,7 @@
         "description": "System field 'cOrderlineId' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-280",
+        "id": "t-277",
         "category": "system-field",
         "entity": "lines",
         "field": "mInoutlineId",
@@ -5534,7 +5489,7 @@
         "description": "System field 'mInoutlineId' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-281",
+        "id": "t-278",
         "category": "system-field",
         "entity": "lines",
         "field": "editLineAmount",
@@ -5542,7 +5497,7 @@
         "description": "System field 'editLineAmount' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-282",
+        "id": "t-279",
         "category": "system-field",
         "entity": "lines",
         "field": "taxableAmount",
@@ -5550,7 +5505,7 @@
         "description": "System field 'taxableAmount' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-283",
+        "id": "t-280",
         "category": "system-field",
         "entity": "lines",
         "field": "excludeforwithholding",
@@ -5558,7 +5513,7 @@
         "description": "System field 'excludeforwithholding' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-284",
+        "id": "t-281",
         "category": "system-field",
         "entity": "lines",
         "field": "orderUOM",
@@ -5566,7 +5521,7 @@
         "description": "System field 'orderUOM' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-285",
+        "id": "t-282",
         "category": "system-field",
         "entity": "lines",
         "field": "deferred",
@@ -5574,7 +5529,7 @@
         "description": "System field 'deferred' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-286",
+        "id": "t-283",
         "category": "system-field",
         "entity": "lines",
         "field": "orderQuantity",
@@ -5582,7 +5537,7 @@
         "description": "System field 'orderQuantity' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-287",
+        "id": "t-284",
         "category": "system-field",
         "entity": "lines",
         "field": "cancelPriceAdjustment",
@@ -5590,7 +5545,7 @@
         "description": "System field 'cancelPriceAdjustment' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-288",
+        "id": "t-285",
         "category": "system-field",
         "entity": "lines",
         "field": "baseGrossUnitPrice",
@@ -5598,7 +5553,7 @@
         "description": "System field 'baseGrossUnitPrice' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-289",
+        "id": "t-286",
         "category": "system-field",
         "entity": "lines",
         "field": "standardPrice",
@@ -5606,7 +5561,7 @@
         "description": "System field 'standardPrice' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-290",
+        "id": "t-287",
         "category": "system-field",
         "entity": "lines",
         "field": "deferredPlanType",
@@ -5614,7 +5569,7 @@
         "description": "System field 'deferredPlanType' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-291",
+        "id": "t-288",
         "category": "system-field",
         "entity": "lines",
         "field": "periodNumber",
@@ -5622,7 +5577,7 @@
         "description": "System field 'periodNumber' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-292",
+        "id": "t-289",
         "category": "system-field",
         "entity": "lines",
         "field": "period",
@@ -5630,7 +5585,7 @@
         "description": "System field 'period' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-293",
+        "id": "t-290",
         "category": "system-field",
         "entity": "lines",
         "field": "adOrgId",
@@ -5638,7 +5593,7 @@
         "description": "System field 'adOrgId' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-294",
+        "id": "t-291",
         "category": "system-field",
         "entity": "lines",
         "field": "project",
@@ -5646,7 +5601,7 @@
         "description": "System field 'project' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-295",
+        "id": "t-292",
         "category": "system-field",
         "entity": "lines",
         "field": "costcenter",
@@ -5654,7 +5609,7 @@
         "description": "System field 'costcenter' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-296",
+        "id": "t-293",
         "category": "system-field",
         "entity": "lines",
         "field": "asset",
@@ -5662,7 +5617,7 @@
         "description": "System field 'asset' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-297",
+        "id": "t-294",
         "category": "system-field",
         "entity": "lines",
         "field": "stDimension",
@@ -5670,7 +5625,7 @@
         "description": "System field 'stDimension' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-298",
+        "id": "t-295",
         "category": "system-field",
         "entity": "lines",
         "field": "ndDimension",
@@ -5678,7 +5633,7 @@
         "description": "System field 'ndDimension' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-299",
+        "id": "t-296",
         "category": "system-field",
         "entity": "lines",
         "field": "explode",
@@ -5686,7 +5641,7 @@
         "description": "System field 'explode' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-300",
+        "id": "t-297",
         "category": "system-field",
         "entity": "lines",
         "field": "bOMParentID",
@@ -5694,7 +5649,7 @@
         "description": "System field 'bOMParentID' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-301",
+        "id": "t-298",
         "category": "system-field",
         "entity": "lines",
         "field": "priceAdjustment",
@@ -5702,7 +5657,7 @@
         "description": "System field 'priceAdjustment' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-302",
+        "id": "t-299",
         "category": "system-field",
         "entity": "lines",
         "field": "charge",
@@ -5710,7 +5665,7 @@
         "description": "System field 'charge' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-303",
+        "id": "t-300",
         "category": "system-field",
         "entity": "lines",
         "field": "projectLine",
@@ -5718,7 +5673,7 @@
         "description": "System field 'projectLine' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-304",
+        "id": "t-301",
         "category": "system-field",
         "entity": "lines",
         "field": "invoiceDiscount",
@@ -5726,7 +5681,7 @@
         "description": "System field 'invoiceDiscount' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-305",
+        "id": "t-302",
         "category": "system-field",
         "entity": "lines",
         "field": "businessPartner",
@@ -5734,7 +5689,7 @@
         "description": "System field 'businessPartner' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-306",
+        "id": "t-303",
         "category": "system-field",
         "entity": "lines",
         "field": "creationDate",
@@ -5742,7 +5697,7 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-307",
+        "id": "t-304",
         "category": "system-field",
         "entity": "lines",
         "field": "active",
@@ -5750,7 +5705,7 @@
         "description": "System field 'active' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-308",
+        "id": "t-305",
         "category": "system-field",
         "entity": "lines",
         "field": "chargeAmount",
@@ -5758,7 +5713,7 @@
         "description": "System field 'chargeAmount' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-309",
+        "id": "t-306",
         "category": "system-field",
         "entity": "lines",
         "field": "priceLimit",
@@ -5766,7 +5721,7 @@
         "description": "System field 'priceLimit' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-310",
+        "id": "t-307",
         "category": "system-field",
         "entity": "lines",
         "field": "resourceAssignment",
@@ -5774,7 +5729,7 @@
         "description": "System field 'resourceAssignment' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-311",
+        "id": "t-308",
         "category": "system-field",
         "entity": "lines",
         "field": "adClientId",
@@ -5782,7 +5737,7 @@
         "description": "System field 'adClientId' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-312",
+        "id": "t-309",
         "category": "system-field",
         "entity": "lines",
         "field": "cInvoiceId",
@@ -5790,7 +5745,7 @@
         "description": "System field 'cInvoiceId' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-313",
+        "id": "t-310",
         "category": "system-field",
         "entity": "lines",
         "field": "id",
@@ -5798,7 +5753,7 @@
         "description": "System field 'id' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-314",
+        "id": "t-311",
         "category": "system-field",
         "entity": "lines",
         "field": "descriptionOnly",
@@ -5806,7 +5761,7 @@
         "description": "System field 'descriptionOnly' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-315",
+        "id": "t-312",
         "category": "system-field",
         "entity": "lines",
         "field": "createdBy",
@@ -5814,7 +5769,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-316",
+        "id": "t-313",
         "category": "system-field",
         "entity": "lines",
         "field": "matchLCCosts",
@@ -5822,7 +5777,7 @@
         "description": "System field 'matchLCCosts' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-317",
+        "id": "t-314",
         "category": "system-field",
         "entity": "lines",
         "field": "updated",
@@ -5830,7 +5785,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-318",
+        "id": "t-315",
         "category": "system-field",
         "entity": "lines",
         "field": "updatedBy",
@@ -5838,7 +5793,7 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for lines"
       },
       {
-        "id": "t-319",
+        "id": "t-316",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "organization",
@@ -5846,7 +5801,7 @@
         "description": "System field 'organization' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-320",
+        "id": "t-317",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "invoice",
@@ -5854,7 +5809,7 @@
         "description": "System field 'invoice' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-321",
+        "id": "t-318",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "origDueDate",
@@ -5862,7 +5817,7 @@
         "description": "System field 'origDueDate' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-322",
+        "id": "t-319",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "updatePaymentPlan",
@@ -5870,7 +5825,7 @@
         "description": "System field 'updatePaymentPlan' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-323",
+        "id": "t-320",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "active",
@@ -5878,7 +5833,7 @@
         "description": "System field 'active' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-324",
+        "id": "t-321",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "aprmModifPaymentINPlan",
@@ -5886,7 +5841,7 @@
         "description": "System field 'aprmModifPaymentINPlan' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-325",
+        "id": "t-322",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "client",
@@ -5894,7 +5849,7 @@
         "description": "System field 'client' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-326",
+        "id": "t-323",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "order",
@@ -5902,7 +5857,7 @@
         "description": "System field 'order' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-327",
+        "id": "t-324",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "creationDate",
@@ -5910,7 +5865,7 @@
         "description": "System field 'creationDate' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-328",
+        "id": "t-325",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "createdBy",
@@ -5918,7 +5873,7 @@
         "description": "System field 'createdBy' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-329",
+        "id": "t-326",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "aprmModifPaymentOUTPlan",
@@ -5926,7 +5881,7 @@
         "description": "System field 'aprmModifPaymentOUTPlan' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-330",
+        "id": "t-327",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "fINPaymentPriorityID",
@@ -5934,7 +5889,7 @@
         "description": "System field 'fINPaymentPriorityID' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-331",
+        "id": "t-328",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "updated",
@@ -5942,7 +5897,7 @@
         "description": "System field 'updated' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-332",
+        "id": "t-329",
         "category": "system-field",
         "entity": "paymentPlan",
         "field": "updatedBy",
@@ -5950,84 +5905,84 @@
         "description": "System field 'updatedBy' should exist in backend but not frontend for paymentPlan"
       },
       {
-        "id": "t-333",
+        "id": "t-330",
         "category": "rule-declared",
         "rule": "BP_AutoFill_Address",
         "runner": "node",
         "description": "Rule 'BP_AutoFill_Address' (callout) should be declared"
       },
       {
-        "id": "t-334",
+        "id": "t-331",
         "category": "rule-declared",
         "rule": "Line_Recalc_Totals",
         "runner": "node",
         "description": "Rule 'Line_Recalc_Totals' (eventHandler) should be declared"
       },
       {
-        "id": "t-335",
+        "id": "t-332",
         "category": "rule-declared",
         "rule": "Product_AutoFill_Price",
         "runner": "node",
         "description": "Rule 'Product_AutoFill_Price' (callout) should be declared"
       },
       {
-        "id": "t-336",
+        "id": "t-333",
         "category": "rule-declared",
         "rule": "Line_Calc_NetAmount",
         "runner": "node",
         "description": "Rule 'Line_Calc_NetAmount' (callout) should be declared"
       },
       {
-        "id": "t-337",
+        "id": "t-334",
         "category": "rule-declared",
         "rule": "ReadOnly_When_Processed",
         "runner": "node",
         "description": "Rule 'ReadOnly_When_Processed' (displayLogic) should be declared"
       },
       {
-        "id": "t-338",
+        "id": "t-335",
         "category": "rule-declared",
         "rule": "Match_SO_Shipment",
         "runner": "node",
         "description": "Rule 'Match_SO_Shipment' (eventHandler) should be declared"
       },
       {
-        "id": "t-339",
+        "id": "t-336",
         "category": "rule-declared",
         "rule": "DateAcct_Default",
         "runner": "node",
         "description": "Rule 'DateAcct_Default' (callout) should be declared"
       },
       {
-        "id": "t-340",
+        "id": "t-337",
         "category": "rule-declared",
         "rule": "Currency_From_PriceList",
         "runner": "node",
         "description": "Rule 'Currency_From_PriceList' (callout) should be declared"
       },
       {
-        "id": "t-341",
+        "id": "t-338",
         "category": "crud-flags",
         "entity": "header",
         "runner": "node",
         "description": "CRUD flags for 'header' should all be booleans"
       },
       {
-        "id": "t-342",
+        "id": "t-339",
         "category": "crud-flags",
         "entity": "lines",
         "runner": "node",
         "description": "CRUD flags for 'lines' should all be booleans"
       },
       {
-        "id": "t-343",
+        "id": "t-340",
         "category": "crud-flags",
         "entity": "paymentPlan",
         "runner": "node",
         "description": "CRUD flags for 'paymentPlan' should all be booleans"
       },
       {
-        "id": "t-344",
+        "id": "t-341",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "businessPartner",
@@ -6035,7 +5990,7 @@
         "description": "Selector endpoint for 'businessPartner' in header should exist"
       },
       {
-        "id": "t-345",
+        "id": "t-342",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "partnerAddress",
@@ -6043,7 +5998,7 @@
         "description": "Selector endpoint for 'partnerAddress' in header should exist"
       },
       {
-        "id": "t-346",
+        "id": "t-343",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "paymentTerms",
@@ -6051,7 +6006,7 @@
         "description": "Selector endpoint for 'paymentTerms' in header should exist"
       },
       {
-        "id": "t-347",
+        "id": "t-344",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "paymentMethod",
@@ -6059,7 +6014,7 @@
         "description": "Selector endpoint for 'paymentMethod' in header should exist"
       },
       {
-        "id": "t-348",
+        "id": "t-345",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "currency",
@@ -6067,7 +6022,7 @@
         "description": "Selector endpoint for 'currency' in header should exist"
       },
       {
-        "id": "t-349",
+        "id": "t-346",
         "category": "selector-endpoint",
         "entity": "header",
         "field": "priceList",
@@ -6075,7 +6030,7 @@
         "description": "Selector endpoint for 'priceList' in header should exist"
       },
       {
-        "id": "t-350",
+        "id": "t-347",
         "category": "selector-endpoint",
         "entity": "lines",
         "field": "product",
@@ -6083,7 +6038,7 @@
         "description": "Selector endpoint for 'product' in lines should exist"
       },
       {
-        "id": "t-351",
+        "id": "t-348",
         "category": "selector-endpoint",
         "entity": "lines",
         "field": "tax",
@@ -6091,7 +6046,7 @@
         "description": "Selector endpoint for 'tax' in lines should exist"
       },
       {
-        "id": "t-352",
+        "id": "t-349",
         "category": "selector-endpoint",
         "entity": "paymentPlan",
         "field": "finPaymentmethodID",
@@ -6099,7 +6054,7 @@
         "description": "Selector endpoint for 'finPaymentmethodID' in paymentPlan should exist"
       },
       {
-        "id": "t-353",
+        "id": "t-350",
         "category": "selector-endpoint",
         "entity": "paymentPlan",
         "field": "currency",
@@ -6107,7 +6062,7 @@
         "description": "Selector endpoint for 'currency' in paymentPlan should exist"
       },
       {
-        "id": "t-354",
+        "id": "t-351",
         "category": "action-endpoint",
         "entity": "header",
         "field": "aPRMAddpayment",
@@ -6115,7 +6070,7 @@
         "description": "Action endpoint for 'aPRMAddpayment' in header should exist"
       },
       {
-        "id": "t-355",
+        "id": "t-352",
         "category": "action-endpoint",
         "entity": "header",
         "field": "posted",
@@ -6123,7 +6078,7 @@
         "description": "Action endpoint for 'posted' in header should exist"
       },
       {
-        "id": "t-356",
+        "id": "t-353",
         "category": "action-endpoint",
         "entity": "header",
         "field": "aPRMProcessinvoice",
@@ -6131,7 +6086,7 @@
         "description": "Action endpoint for 'aPRMProcessinvoice' in header should exist"
       },
       {
-        "id": "t-357",
+        "id": "t-354",
         "category": "action-endpoint",
         "entity": "header",
         "field": "documentAction",
@@ -6139,7 +6094,7 @@
         "description": "Action endpoint for 'documentAction' in header should exist"
       },
       {
-        "id": "t-358",
+        "id": "t-355",
         "category": "action-endpoint",
         "entity": "header",
         "field": "createLinesFromOrder",
@@ -6147,7 +6102,7 @@
         "description": "Action endpoint for 'createLinesFromOrder' in header should exist"
       },
       {
-        "id": "t-359",
+        "id": "t-356",
         "category": "action-endpoint",
         "entity": "header",
         "field": "createLinesFromShipment",
@@ -6155,7 +6110,7 @@
         "description": "Action endpoint for 'createLinesFromShipment' in header should exist"
       },
       {
-        "id": "t-360",
+        "id": "t-357",
         "category": "action-endpoint",
         "entity": "header",
         "field": "copyFrom",
@@ -6163,7 +6118,7 @@
         "description": "Action endpoint for 'copyFrom' in header should exist"
       },
       {
-        "id": "t-361",
+        "id": "t-358",
         "category": "action-endpoint",
         "entity": "header",
         "field": "calculatePromotions",
@@ -6171,7 +6126,7 @@
         "description": "Action endpoint for 'calculatePromotions' in header should exist"
       },
       {
-        "id": "t-362",
+        "id": "t-359",
         "category": "action-endpoint",
         "entity": "header",
         "field": "tBAIQRcode",
@@ -6179,7 +6134,7 @@
         "description": "Action endpoint for 'tBAIQRcode' in header should exist"
       },
       {
-        "id": "t-363",
+        "id": "t-360",
         "category": "action-endpoint",
         "entity": "header",
         "field": "etvfacRectCreate",
@@ -6187,7 +6142,7 @@
         "description": "Action endpoint for 'etvfacRectCreate' in header should exist"
       },
       {
-        "id": "t-364",
+        "id": "t-361",
         "category": "action-endpoint",
         "entity": "header",
         "field": "tbaiXmlgenerator",
@@ -6195,7 +6150,7 @@
         "description": "Action endpoint for 'tbaiXmlgenerator' in header should exist"
       },
       {
-        "id": "t-365",
+        "id": "t-362",
         "category": "action-endpoint",
         "entity": "header",
         "field": "tbaiVoidxmlgenerator",
@@ -6203,7 +6158,7 @@
         "description": "Action endpoint for 'tbaiVoidxmlgenerator' in header should exist"
       },
       {
-        "id": "t-366",
+        "id": "t-363",
         "category": "action-endpoint",
         "entity": "header",
         "field": "aeatsiiSend",
@@ -6211,7 +6166,7 @@
         "description": "Action endpoint for 'aeatsiiSend' in header should exist"
       },
       {
-        "id": "t-367",
+        "id": "t-364",
         "category": "action-endpoint",
         "entity": "header",
         "field": "aeatsiiModif",
@@ -6219,7 +6174,7 @@
         "description": "Action endpoint for 'aeatsiiModif' in header should exist"
       },
       {
-        "id": "t-368",
+        "id": "t-365",
         "category": "action-endpoint",
         "entity": "header",
         "field": "generateTo",
@@ -6227,7 +6182,7 @@
         "description": "Action endpoint for 'generateTo' in header should exist"
       },
       {
-        "id": "t-369",
+        "id": "t-366",
         "category": "action-endpoint",
         "entity": "header",
         "field": "processNow",
@@ -6235,7 +6190,7 @@
         "description": "Action endpoint for 'processNow' in header should exist"
       },
       {
-        "id": "t-370",
+        "id": "t-367",
         "category": "action-endpoint",
         "entity": "header",
         "field": "createLinesFrom",
@@ -6243,7 +6198,7 @@
         "description": "Action endpoint for 'createLinesFrom' in header should exist"
       },
       {
-        "id": "t-371",
+        "id": "t-368",
         "category": "action-endpoint",
         "entity": "header",
         "field": "aeatsiiDup",
@@ -6251,7 +6206,7 @@
         "description": "Action endpoint for 'aeatsiiDup' in header should exist"
       },
       {
-        "id": "t-372",
+        "id": "t-369",
         "category": "action-endpoint",
         "entity": "header",
         "field": "aeatsiiUnsubscribe",
@@ -6259,7 +6214,7 @@
         "description": "Action endpoint for 'aeatsiiUnsubscribe' in header should exist"
       },
       {
-        "id": "t-373",
+        "id": "t-370",
         "category": "action-endpoint",
         "entity": "lines",
         "field": "explode",
@@ -6267,7 +6222,7 @@
         "description": "Action endpoint for 'explode' in lines should exist"
       },
       {
-        "id": "t-374",
+        "id": "t-371",
         "category": "action-endpoint",
         "entity": "lines",
         "field": "matchLCCosts",
@@ -6275,7 +6230,7 @@
         "description": "Action endpoint for 'matchLCCosts' in lines should exist"
       },
       {
-        "id": "t-375",
+        "id": "t-372",
         "category": "action-endpoint",
         "entity": "paymentPlan",
         "field": "updatePaymentPlan",
@@ -6283,7 +6238,7 @@
         "description": "Action endpoint for 'updatePaymentPlan' in paymentPlan should exist"
       },
       {
-        "id": "t-376",
+        "id": "t-373",
         "category": "action-endpoint",
         "entity": "paymentPlan",
         "field": "aprmModifPaymentINPlan",
@@ -6291,7 +6246,7 @@
         "description": "Action endpoint for 'aprmModifPaymentINPlan' in paymentPlan should exist"
       },
       {
-        "id": "t-377",
+        "id": "t-374",
         "category": "action-endpoint",
         "entity": "paymentPlan",
         "field": "aprmModifPaymentOUTPlan",
@@ -6300,25 +6255,25 @@
       }
     ],
     "summary": {
-      "total": 377,
+      "total": 374,
       "byCategory": {
-        "field-presence": 37,
-        "field-type": 37,
+        "field-presence": 36,
+        "field-type": 36,
         "searchable-filters": 5,
         "visibility": 3,
         "displaylogic-valid": 4,
-        "readonlylogic-valid": 13,
+        "readonlylogic-valid": 12,
         "displaylogic-evaluable": 4,
-        "readonlylogic-evaluable": 13,
+        "readonlylogic-evaluable": 12,
         "default-value-type": 13,
-        "system-field": 203,
+        "system-field": 204,
         "rule-declared": 8,
         "crud-flags": 3,
         "selector-endpoint": 10,
         "action-endpoint": 24
       },
       "byRunner": {
-        "node": 377,
+        "node": 374,
         "junit": 0
       }
     }

--- a/artifacts/sales-invoice/decisions.json
+++ b/artifacts/sales-invoice/decisions.json
@@ -279,8 +279,8 @@
           "inputMode": "search"
         },
         "lineNetAmount": {
-          "visibility": "readOnly",
-          "grid": true,
+          "visibility": "system",
+          "grid": false,
           "section": "principal"
         },
         "discount": {
@@ -454,7 +454,7 @@
     "ticketbai": {
       "exclude": true
     },
-    "resultadoValidación": {
+    "resultadoValidaci\u00f3n": {
       "exclude": true
     },
     "cashVat": {

--- a/artifacts/sales-invoice/generated/web/sales-invoice/LinesForm.jsx
+++ b/artifacts/sales-invoice/generated/web/sales-invoice/LinesForm.jsx
@@ -5,7 +5,6 @@ const fields = [
   { key: 'product', column: 'M_Product_ID', type: 'search', label: 'Product', section: 'principal', reference: 'Product', inputMode: 'search', readOnlyLogic: (record) => record['processed'] === true },
   { key: 'invoicedQuantity', column: 'QtyInvoiced', type: 'number', label: 'Invoiced Quantity', required: true, section: 'principal', defaultValue: '1', readOnlyLogic: (record) => record['processed'] === true || (record['uomManagement'] === 'Y' && record['financialInvoiceLine'] !== true) },
   { key: 'unitPrice', column: 'PriceActual', type: 'number', label: 'Net Unit Price', required: true, section: 'principal', readOnlyLogic: (record) => record['processed'] === true || record['gROSSPRICE'] === 'Y' },
-  { key: 'lineNetAmount', column: 'LineNetAmt', type: 'number', label: 'Line Net Amount', required: true, readOnly: true, section: 'principal', readOnlyLogic: (record) => record['editLineAmount'] !== true || record['processed'] === true },
   { key: 'grossAmount', column: 'Line_Gross_Amount', type: 'number', label: 'Line Gross Amount', readOnly: true, section: 'principal', defaultValue: '0' },
   { key: 'tax', column: 'C_Tax_ID', type: 'search', label: 'Tax', section: 'principal', reference: 'Tax', inputMode: 'search', readOnlyLogic: (record) => record['processed'] === true },
   { key: 'description', column: 'Description', type: 'textarea', label: 'Description', section: 'principal' },

--- a/artifacts/sales-invoice/generated/web/sales-invoice/LinesTable.jsx
+++ b/artifacts/sales-invoice/generated/web/sales-invoice/LinesTable.jsx
@@ -5,7 +5,6 @@ const columns = [
   { key: 'product', column: 'M_Product_ID', type: 'string', label: 'Product' },
   { key: 'invoicedQuantity', column: 'QtyInvoiced', type: 'number', label: 'Invoiced Quantity' },
   { key: 'unitPrice', column: 'PriceActual', type: 'number', label: 'Net Unit Price' },
-  { key: 'lineNetAmount', column: 'LineNetAmt', type: 'amount', label: 'Line Net Amount' },
   { key: 'tax', column: 'C_Tax_ID', type: 'string', label: 'Tax' },
   { key: 'grossAmount', column: 'Line_Gross_Amount', type: 'amount', label: 'Line Gross Amount' },
 ];

--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -475,10 +475,11 @@ function InlineAddRow({ columns, fields, onAdd, onCancel, data, catalogs, onFiel
           // Prefer $_identifier (human-readable) over raw ID for FK fields.
           const rawVal = values[col.key];
           const identVal = values[col.key + '$_identifier'];
+          const isNumericDerived = NUMERIC_FIELD_TYPES.has(col.type);
           const displayVal = identVal || rawVal;
           return (
-            <TableCell key={col.key} className="text-muted-foreground text-sm">
-              {displayVal != null && displayVal !== '' ? displayVal : '\u2014'}
+            <TableCell key={col.key} className={`text-muted-foreground text-sm${isNumericDerived ? ' text-right tabular-nums' : ''}`}>
+              {displayVal != null && displayVal !== '' ? displayVal : '—'}
             </TableCell>
           );
         }

--- a/tools/app-shell/src/windows/custom/purchase-invoice/InvoiceLineTableCustom.jsx
+++ b/tools/app-shell/src/windows/custom/purchase-invoice/InvoiceLineTableCustom.jsx
@@ -4,7 +4,6 @@ const columns = [
   { key: 'product',          column: 'M_Product_ID',       type: 'string', label: 'Product' },
   { key: 'invoicedQuantity', column: 'QtyInvoiced',         type: 'number', label: 'Invoiced Quantity' },
   { key: 'unitPrice',        column: 'PriceActual',         type: 'number', label: 'Net Unit Price' },
-  { key: 'lineNetAmount',    column: 'LineNetAmt',          type: 'amount', label: 'Line Net Amount' },
   { key: 'tax',              column: 'C_Tax_ID',            type: 'string', label: 'Tax' },
   { key: 'grossAmount',      column: 'Line_Gross_Amount',   type: 'amount', label: 'Line Gross Amount' },
 ];


### PR DESCRIPTION
- Set lineNetAmount visibility to system in decisions.json for both sales-invoice and purchase-invoice (field stays in API contract)
- Remove lineNetAmount column from InvoiceLineTableCustom.jsx
- Fix numeric derived cells in InlineAddRow to right-align amounts