### PR TITLE
Feature ETP-3803: Add favname field and fix favorites i18n

### DIFF
--- a/tools/app-shell/src/auth/api.js
+++ b/tools/app-shell/src/auth/api.js
@@ -1,4 +1,4 @@
-function detectBaseUrl() {
+export function detectBaseUrl() {
   const path = window.location.pathname;
   const webIdx = path.indexOf('/web/');
   if (webIdx !== -1) return path.substring(0, webIdx);

--- a/tools/app-shell/src/components/layout/FavoritesContext.jsx
+++ b/tools/app-shell/src/components/layout/FavoritesContext.jsx
@@ -8,12 +8,12 @@ import {
   useState,
 } from 'react';
 import { useAuth } from '@/auth/AuthContext.jsx';
-import { buildHeaders } from '@/auth/api.js';
+import { buildHeaders, detectBaseUrl } from '@/auth/api.js';
 
 const FavoritesContext = createContext(null);
 
 const STORAGE_PREFIX = 'sf_favorites_';
-const FAVORITES_ENDPOINT = '/sws/neo/favorites';
+const FAVORITES_ENDPOINT = `${detectBaseUrl()}/sws/neo/favorites`;
 
 function storageKey(username) {
   return `${STORAGE_PREFIX}${username || 'anonymous'}`;
@@ -86,10 +86,11 @@ export function FavoritesProvider({ children }) {
   );
 
   const addFavorite = useCallback(
-    (name, label) => {
+    (name, label, labels) => {
       if (!name) return;
       if (favorites.some((f) => f.name === name)) return;
-      const next = [...favorites, { name, label: label || name }];
+      const entry = labels ? { name, label: label || name, labels } : { name, label: label || name };
+      const next = [...favorites, entry];
       setFavorites(next);
       writeFavorites(username, next);
       syncToServer(next);
@@ -109,12 +110,13 @@ export function FavoritesProvider({ children }) {
   );
 
   const toggleFavorite = useCallback(
-    (name, label) => {
+    (name, label, labels) => {
       if (!name) return;
       const exists = favorites.some((f) => f.name === name);
+      const entry = labels ? { name, label: label || name, labels } : { name, label: label || name };
       const next = exists
         ? favorites.filter((f) => f.name !== name)
-        : [...favorites, { name, label: label || name }];
+        : [...favorites, entry];
       setFavorites(next);
       writeFavorites(username, next);
       syncToServer(next);

--- a/tools/app-shell/src/components/layout/SideMenu/SideMenu.jsx
+++ b/tools/app-shell/src/components/layout/SideMenu/SideMenu.jsx
@@ -61,6 +61,7 @@ import {
 import { cn } from '@/lib/utils.js';
 import { useMenuLabel, useUI, useLocaleSwitch } from '@/i18n';
 import { useFavorites } from '@/components/layout/FavoritesContext';
+import menuConfig from '@/menu.json';
 
 const ICON_MAP = {
   ClipboardCheck,
@@ -203,14 +204,14 @@ export default function SideMenu({
 
   const favNameMap = useMemo(() => {
     const map = {};
-    for (const g of menuGroups) {
+    for (const g of menuConfig.menu) {
       if (g.group === 'Favorites') continue;
       for (const item of g.items || []) {
         map[item.path || item.name] = item.favname || item.label;
       }
     }
     return map;
-  }, [menuGroups]);
+  }, []);
 
   const resolvedMenuGroups = menuGroups.map((g) => {
     if (g.group !== 'Favorites') return g;

--- a/tools/app-shell/src/components/layout/SideMenu/SideMenu.jsx
+++ b/tools/app-shell/src/components/layout/SideMenu/SideMenu.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { NavLink, useLocation } from 'react-router-dom';
 import { useAuth } from '@/auth/AuthContext.jsx';
 import {
@@ -59,7 +59,7 @@ import {
   FileCode,
 } from '@phosphor-icons/react';
 import { cn } from '@/lib/utils.js';
-import { useMenuLabel, useUI } from '@/i18n';
+import { useMenuLabel, useUI, useLocaleSwitch } from '@/i18n';
 import { useFavorites } from '@/components/layout/FavoritesContext';
 
 const ICON_MAP = {
@@ -201,6 +201,17 @@ export default function SideMenu({
   const currentPath = location.pathname.replace(/^\//, '');
   const { favorites } = useFavorites();
 
+  const favNameMap = useMemo(() => {
+    const map = {};
+    for (const g of menuGroups) {
+      if (g.group === 'Favorites') continue;
+      for (const item of g.items || []) {
+        map[item.path || item.name] = item.favname || item.label;
+      }
+    }
+    return map;
+  }, [menuGroups]);
+
   const resolvedMenuGroups = menuGroups.map((g) => {
     if (g.group !== 'Favorites') return g;
     return { ...g, items: favorites };
@@ -209,6 +220,7 @@ export default function SideMenu({
   const activeGroup = findActiveGroup(resolvedMenuGroups, location.pathname, location.search);
   const tMenu = useMenuLabel();
   const ui = useUI();
+  const { locale } = useLocaleSwitch();
 
   const [openGroups, setOpenGroups] = useState(() => {
     const initial = {};
@@ -477,7 +489,7 @@ export default function SideMenu({
                           {isItemActive && (
                             <span className="absolute left-[33px] right-2 top-0 bottom-0 bg-accent-highlight" />
                           )}
-                          <span className="relative z-10">{tMenu(item.label)}</span>
+                          <span className="relative z-10">{g.group === 'Favorites' ? (item.labels?.[locale] || tMenu(favNameMap[item.path || item.name] || item.label)) : tMenu(item.label)}</span>
                         </NavLink>
                       );
                     })}
@@ -492,7 +504,7 @@ export default function SideMenu({
                                 className="relative flex w-full items-center pl-[52px] pr-4 py-1.5 text-sm text-text-primary hover:bg-muted/50 transition-colors"
                               >
                                 <span className="absolute left-[33px] top-0 bottom-0 w-px bg-[#E8EAEF]" />
-                                <span className="relative z-10">{tMenu(item.label)}</span>
+                                <span className="relative z-10">{item.labels?.[locale] || tMenu(favNameMap[itemPath] || item.label)}</span>
                               </NavLink>
                             );
                           })

--- a/tools/app-shell/src/locales/en_US.json
+++ b/tools/app-shell/src/locales/en_US.json
@@ -16159,9 +16159,6 @@
     "Goods Receipt": {
       "label": "Goods Receipt"
     },
-    "HR": {
-      "label": "HR"
-    },
     "Home": {
       "label": "Home"
     },
@@ -18512,6 +18509,15 @@
     "Reports": {
       "label": "Reports"
     },
+    "Purchases Reports": {
+      "label": "Purchases Reports"
+    },
+    "Inventory Reports": {
+      "label": "Inventory Reports"
+    },
+    "Finance Reports": {
+      "label": "Finance Reports"
+    },
     "Production Management": {
       "label": "Production Management"
     },
@@ -18685,6 +18691,30 @@
     },
     "Intrastat File Configuration": {
       "label": "Intrastat File Configuration"
+    },
+    "Order": {
+      "label": "Order"
+    },
+    "Invoice": {
+      "label": "Invoice"
+    },
+    "Quotation": {
+      "label": "Quotation"
+    },
+    "Shipment": {
+      "label": "Shipment"
+    },
+    "Receipt": {
+      "label": "Receipt"
+    },
+    "Return": {
+      "label": "Return"
+    },
+    "Return Receipt": {
+      "label": "Return Receipt"
+    },
+    "Return Shipment": {
+      "label": "Return Shipment"
     }
   },
   "statuses": {

--- a/tools/app-shell/src/locales/es_ES.json
+++ b/tools/app-shell/src/locales/es_ES.json
@@ -16330,9 +16330,6 @@
     "Leads": {
       "label": "Leads"
     },
-    "HR": {
-      "label": "RRHH"
-    },
     "Employees": {
       "label": "Empleados"
     },
@@ -18115,6 +18112,15 @@
     "Reports": {
       "label": "Informes"
     },
+    "Purchases Reports": {
+      "label": "Informes de Compras"
+    },
+    "Inventory Reports": {
+      "label": "Informes de Inventario"
+    },
+    "Finance Reports": {
+      "label": "Informes de Finanzas"
+    },
     "Payment Tracker": {
       "label": "Seguimiento cobros-pagos"
     },
@@ -18377,7 +18383,7 @@
       "label": "Terceros"
     },
     "Return Material Receipt": {
-      "label": "Recibo devolución de material"
+      "label": "Recibo de Devolución"
     },
     "General Ledger Configuration": {
       "label": "Esquema contable"
@@ -18422,7 +18428,7 @@
       "label": "Transportista"
     },
     "Sales Order": {
-      "label": "Pedido de venta"
+      "label": "Pedido de Venta"
     },
     "Product Category": {
       "label": "Categoría del producto"
@@ -18458,7 +18464,7 @@
       "label": "Informes y procesos"
     },
     "Sales Invoice": {
-      "label": "Factura (Cliente)"
+      "label": "Factura de Venta"
     },
     "Physical Inventory": {
       "label": "Inventario físico"
@@ -18467,7 +18473,7 @@
       "label": "Ajuste de Costes"
     },
     "Goods Shipment": {
-      "label": "Albarán (Cliente)"
+      "label": "Albarán de Venta"
     },
     "Goods Movements": {
       "label": "Movimiento entre almacenes"
@@ -18479,13 +18485,13 @@
       "label": "Entradas de Datos Importados"
     },
     "Purchase Order": {
-      "label": "Pedido de compra"
+      "label": "Pedido de Compra"
     },
     "Purchase Invoice": {
-      "label": "Factura (Proveedor)"
+      "label": "Factura de Compra"
     },
     "Goods Receipt": {
-      "label": "Albarán (Proveedor)"
+      "label": "Albarán de Compra"
     },
     "Form": {
       "label": "Formulario"
@@ -18557,7 +18563,7 @@
       "label": "Rol permisos"
     },
     "Return to Vendor Shipment": {
-      "label": "Devolución a albarán de proveedor"
+      "label": "Albarán de Devolución a Proveedor"
     },
     "Alert": {
       "label": "Alertas"
@@ -18602,7 +18608,7 @@
       "label": "Inventario Referenciado"
     },
     "Sales Quotation": {
-      "label": "Presupuesto de ventas"
+      "label": "Presupuesto de Venta"
     },
     "Costing Algorithm": {
       "label": "Algoritmo de cálculo de costes"
@@ -18812,7 +18818,7 @@
       "label": "Método de Adjuntos"
     },
     "Return to Vendor": {
-      "label": "Devolución a proveedor"
+      "label": "Devolución a Proveedor"
     },
     "Process Group": {
       "label": "Grupo de Procesos"
@@ -18851,7 +18857,7 @@
       "label": "Histórico de auditoría"
     },
     "Return from Customer": {
-      "label": "Devolución de cliente"
+      "label": "Devolución de Cliente"
     },
     "Production Run": {
       "label": "Parte de Fabricación"
@@ -18942,6 +18948,30 @@
     },
     "Depreciation Setup": {
       "label": "Configuración de depreciación"
+    },
+    "Order": {
+      "label": "Pedido"
+    },
+    "Invoice": {
+      "label": "Factura"
+    },
+    "Quotation": {
+      "label": "Presupuesto"
+    },
+    "Shipment": {
+      "label": "Albarán"
+    },
+    "Receipt": {
+      "label": "Albarán"
+    },
+    "Return": {
+      "label": "Devolución"
+    },
+    "Return Receipt": {
+      "label": "Recibo de Devolución"
+    },
+    "Return Shipment": {
+      "label": "Albarán de Devolución"
     }
   },
   "statuses": {

--- a/tools/app-shell/src/locales/es_ES.json
+++ b/tools/app-shell/src/locales/es_ES.json
@@ -16142,7 +16142,7 @@
       "label": "Albarán de devolución"
     },
     "Purchase Invoice": {
-      "label": "Factura"
+      "label": "Factura de Compra"
     },
     "Warehouses": {
       "label": "Almacenes"
@@ -16232,7 +16232,7 @@
       "label": "General"
     },
     "Goods Receipt": {
-      "label": "Albarán"
+      "label": "Albarán de Compra"
     },
     "Return Shipments": {
       "label": "Envíos de devolución"
@@ -16253,31 +16253,31 @@
       "label": "Facturas recurrentes"
     },
     "Sales Quotation": {
-      "label": "Presupuesto"
+      "label": "Presupuesto de Venta"
     },
     "Sales Order": {
-      "label": "Pedido"
+      "label": "Pedido de Venta"
     },
     "Goods Shipment": {
-      "label": "Albarán"
+      "label": "Albarán de Venta"
     },
     "Sales Invoice": {
-      "label": "Factura"
+      "label": "Factura de Venta"
     },
     "Return from Customer": {
-      "label": "Devolución"
+      "label": "Devolución de Cliente"
     },
     "Return Material Receipt": {
-      "label": "Albarán de devolución"
+      "label": "Recibo de Devolución"
     },
     "Purchase Order": {
-      "label": "Pedido"
+      "label": "Pedido de Compra"
     },
     "Return to Vendor": {
-      "label": "Devolución"
+      "label": "Devolución a Proveedor"
     },
     "Return to Vendor Shipment": {
-      "label": "Albarán de devolución"
+      "label": "Albarán de Devolución a Proveedor"
     },
     "Quotation": {
       "label": "Presupuesto"

--- a/tools/app-shell/src/menu.json
+++ b/tools/app-shell/src/menu.json
@@ -5,7 +5,11 @@
       "icon": "Home",
       "section": "General",
       "items": [
-        { "name": "dashboard", "label": "Home" }
+        {
+          "name": "dashboard",
+          "label": "Home",
+          "favname": "Home"
+        }
       ]
     },
     {
@@ -19,14 +23,53 @@
       "icon": "Contact2",
       "section": "Commercial",
       "items": [
-        { "name": "contacts", "label": "Contacts" },
-        { "name": "business-partner", "label": "Business Partner", "hidden": true },
-        { "name": "deal", "label": "Deal", "hidden": true },
-        { "name": "activity", "label": "Activity", "hidden": true },
-        { "name": "lead", "label": "Lead", "hidden": true },
-        { "name": "hr", "label": "HR", "hidden": true },
-        { "name": "employee", "label": "Employee", "hidden": true },
-        { "name": "absence", "label": "Absence", "hidden": true }
+        {
+          "name": "contacts",
+          "label": "Contacts",
+          "favname": "Contacts"
+        },
+        {
+          "name": "business-partner",
+          "label": "Business Partner",
+          "favname": "Business Partner",
+          "hidden": true
+        },
+        {
+          "name": "deal",
+          "label": "Deal",
+          "favname": "Deal",
+          "hidden": true
+        },
+        {
+          "name": "activity",
+          "label": "Activity",
+          "favname": "Activity",
+          "hidden": true
+        },
+        {
+          "name": "lead",
+          "label": "Lead",
+          "favname": "Lead",
+          "hidden": true
+        },
+        {
+          "name": "hr",
+          "label": "HR",
+          "favname": "HR",
+          "hidden": true
+        },
+        {
+          "name": "employee",
+          "label": "Employee",
+          "favname": "Employee",
+          "hidden": true
+        },
+        {
+          "name": "absence",
+          "label": "Absence",
+          "favname": "Absence",
+          "hidden": true
+        }
       ]
     },
     {
@@ -34,12 +77,36 @@
       "icon": "TrendingUp",
       "section": "Commercial",
       "items": [
-        { "name": "sales-quotation", "label": "Sales Quotation" },
-        { "name": "sales-order", "label": "Sales Order" },
-        { "name": "goods-shipment", "label": "Goods Shipment" },
-        { "name": "sales-invoice", "label": "Sales Invoice" },
-        { "name": "return-from-customer", "label": "Return from Customer" },
-        { "name": "return-material-receipt", "label": "Return Material Receipt" }
+        {
+          "name": "sales-quotation",
+          "label": "Quotation",
+          "favname": "Sales Quotation"
+        },
+        {
+          "name": "sales-order",
+          "label": "Order",
+          "favname": "Sales Order"
+        },
+        {
+          "name": "goods-shipment",
+          "label": "Shipment",
+          "favname": "Goods Shipment"
+        },
+        {
+          "name": "sales-invoice",
+          "label": "Invoice",
+          "favname": "Sales Invoice"
+        },
+        {
+          "name": "return-from-customer",
+          "label": "Return",
+          "favname": "Return from Customer"
+        },
+        {
+          "name": "return-material-receipt",
+          "label": "Return Receipt",
+          "favname": "Return Material Receipt"
+        }
       ]
     },
     {
@@ -47,12 +114,37 @@
       "icon": "Receipt",
       "section": "Operations",
       "items": [
-        { "name": "purchase-order", "label": "Purchase Order" },
-        { "name": "goods-receipt", "label": "Goods Receipt" },
-        { "name": "purchase-invoice", "label": "Purchase Invoice" },
-        { "name": "return-to-vendor", "label": "Return to Vendor" },
-        { "name": "return-to-vendor-shipment", "label": "Return to Vendor Shipment" },
-        { "name": "report-viewer-purchases", "label": "Reports", "path": "report-viewer?category=purchases" }
+        {
+          "name": "purchase-order",
+          "label": "Order",
+          "favname": "Purchase Order"
+        },
+        {
+          "name": "goods-receipt",
+          "label": "Receipt",
+          "favname": "Goods Receipt"
+        },
+        {
+          "name": "purchase-invoice",
+          "label": "Invoice",
+          "favname": "Purchase Invoice"
+        },
+        {
+          "name": "return-to-vendor",
+          "label": "Return",
+          "favname": "Return to Vendor"
+        },
+        {
+          "name": "return-to-vendor-shipment",
+          "label": "Return Shipment",
+          "favname": "Return to Vendor Shipment"
+        },
+        {
+          "name": "report-viewer-purchases",
+          "label": "Reports",
+          "favname": "Purchases Reports",
+          "path": "report-viewer?category=purchases"
+        }
       ]
     },
     {
@@ -60,14 +152,48 @@
       "icon": "Package",
       "section": "Operations",
       "items": [
-        { "name": "product", "label": "Product" },
-        { "name": "product-category", "label": "Product Category" },
-        { "name": "physical-inventory", "label": "Physical Inventory" },
-        { "name": "goods-movements", "label": "Goods Movement" },
-        { "name": "internal-consumption", "label": "Internal Consumption" },
-        { "name": "warehouse", "label": "Warehouse" },
-        { "name": "report-viewer-inventory", "label": "Reports", "path": "report-viewer?category=inventory" },
-        { "name": "warehouse-storage-bins", "label": "Storage Bin", "hidden": true }
+        {
+          "name": "product",
+          "label": "Product",
+          "favname": "Product"
+        },
+        {
+          "name": "product-category",
+          "label": "Product Category",
+          "favname": "Product Category"
+        },
+        {
+          "name": "physical-inventory",
+          "label": "Physical Inventory",
+          "favname": "Physical Inventory"
+        },
+        {
+          "name": "goods-movements",
+          "label": "Goods Movement",
+          "favname": "Goods Movement"
+        },
+        {
+          "name": "internal-consumption",
+          "label": "Internal Consumption",
+          "favname": "Internal Consumption"
+        },
+        {
+          "name": "warehouse",
+          "label": "Warehouse",
+          "favname": "Warehouse"
+        },
+        {
+          "name": "report-viewer-inventory",
+          "label": "Reports",
+          "favname": "Inventory Reports",
+          "path": "report-viewer?category=inventory"
+        },
+        {
+          "name": "warehouse-storage-bins",
+          "label": "Storage Bin",
+          "favname": "Storage Bin",
+          "hidden": true
+        }
       ]
     },
     {
@@ -76,9 +202,21 @@
       "section": "Operations",
       "hidden": true,
       "items": [
-        { "name": "project", "label": "Project" },
-        { "name": "time-tracking", "label": "Time Tracking" },
-        { "name": "document", "label": "Document" }
+        {
+          "name": "project",
+          "label": "Project",
+          "favname": "Project"
+        },
+        {
+          "name": "time-tracking",
+          "label": "Time Tracking",
+          "favname": "Time Tracking"
+        },
+        {
+          "name": "document",
+          "label": "Document",
+          "favname": "Document"
+        }
       ]
     },
     {
@@ -86,13 +224,43 @@
       "icon": "Building2",
       "section": "Finance",
       "items": [
-        { "name": "payment-in", "label": "Payment In" },
-        { "name": "payment-out", "label": "Payment Out" },
-        { "name": "bank-reconciliation", "label": "Bank Reconciliation" },
-        { "name": "chart-of-accounts", "label": "Chart of Accounts" },
-        { "name": "assets", "label": "Assets" },
-        { "name": "recurring-invoice", "label": "Recurring Invoice", "hidden": true },
-        { "name": "report-viewer-finance", "label": "Reports", "path": "report-viewer?category=finance" }
+        {
+          "name": "payment-in",
+          "label": "Payment In",
+          "favname": "Payment In"
+        },
+        {
+          "name": "payment-out",
+          "label": "Payment Out",
+          "favname": "Payment Out"
+        },
+        {
+          "name": "bank-reconciliation",
+          "label": "Bank Reconciliation",
+          "favname": "Bank Reconciliation"
+        },
+        {
+          "name": "chart-of-accounts",
+          "label": "Chart of Accounts",
+          "favname": "Chart of Accounts"
+        },
+        {
+          "name": "assets",
+          "label": "Assets",
+          "favname": "Assets"
+        },
+        {
+          "name": "recurring-invoice",
+          "label": "Recurring Invoice",
+          "favname": "Recurring Invoice",
+          "hidden": true
+        },
+        {
+          "name": "report-viewer-finance",
+          "label": "Reports",
+          "favname": "Finance Reports",
+          "path": "report-viewer?category=finance"
+        }
       ]
     },
     {
@@ -100,7 +268,11 @@
       "icon": "Plug",
       "section": "System",
       "items": [
-        { "name": "authorize", "label": "Connect with Claude" }
+        {
+          "name": "authorize",
+          "label": "Connect with Claude",
+          "favname": "Connect with Claude"
+        }
       ]
     },
     {
@@ -108,14 +280,47 @@
       "icon": "Settings",
       "section": "System",
       "items": [
-        { "name": "price-list", "label": "Price List" },
-        { "name": "payment-term", "label": "Payment Term" },
-        { "name": "payment-method", "label": "Payment Method" },
-        { "name": "tax", "label": "Tax" },
-        { "name": "unit-of-measure", "label": "Unit of Measure" },
-        { "name": "user", "label": "User" },
-        { "name": "smart-scan", "label": "Smart Scan" },
-        { "name": "oauth2-clients", "label": "OAuth2 Clients", "icon": "Shield" }
+        {
+          "name": "price-list",
+          "label": "Price List",
+          "favname": "Price List"
+        },
+        {
+          "name": "payment-term",
+          "label": "Payment Term",
+          "favname": "Payment Term"
+        },
+        {
+          "name": "payment-method",
+          "label": "Payment Method",
+          "favname": "Payment Method"
+        },
+        {
+          "name": "tax",
+          "label": "Tax",
+          "favname": "Tax"
+        },
+        {
+          "name": "unit-of-measure",
+          "label": "Unit of Measure",
+          "favname": "Unit of Measure"
+        },
+        {
+          "name": "user",
+          "label": "User",
+          "favname": "User"
+        },
+        {
+          "name": "smart-scan",
+          "label": "Smart Scan",
+          "favname": "Smart Scan"
+        },
+        {
+          "name": "oauth2-clients",
+          "label": "OAuth2 Clients",
+          "favname": "OAuth2 Clients",
+          "icon": "Shield"
+        }
       ]
     },
     {
@@ -123,8 +328,16 @@
       "icon": "FlaskConical",
       "section": "System",
       "items": [
-        { "name": "quick-sales-order", "label": "Quick Sales Order" },
-        { "name": "quick-purchase-order", "label": "Quick Purchase Order" }
+        {
+          "name": "quick-sales-order",
+          "label": "Quick Sales Order",
+          "favname": "Quick Sales Order"
+        },
+        {
+          "name": "quick-purchase-order",
+          "label": "Quick Purchase Order",
+          "favname": "Quick Purchase Order"
+        }
       ]
     }
   ]

--- a/tools/app-shell/src/pages/ReportViewerPage.jsx
+++ b/tools/app-shell/src/pages/ReportViewerPage.jsx
@@ -1132,7 +1132,8 @@ function ReportViewer({ report, onBack, token, selectedOrgId, roleOrgIds, catego
   const favActive = isFavorite(favKey);
 
   const favLabel = report.title?.en_US || report.title?.en || report.id;
-  useSetPageMeta({ title, breadcrumb, onBack, onAddToFavorites: () => toggleFavorite(favKey, favLabel), isFavorite: favActive }, [favActive]);
+  const favLabels = report.title && typeof report.title === 'object' ? report.title : undefined;
+  useSetPageMeta({ title, breadcrumb, onBack, onAddToFavorites: () => toggleFavorite(favKey, favLabel, favLabels), isFavorite: favActive }, [favActive]);
 
   const DOWNLOAD_FORMATS = [
     { id: 'html', label: 'preview', icon: Eye },


### PR DESCRIPTION
- Add favname to all menu items: sidebar uses short label (group provides context), favorites uses full name (Sales Order, Purchase Order, etc.)
- Shorten Sales/Purchases group labels: Order, Invoice, Quotation, Shipment, Receipt, Return
- Fix favorites endpoint URL missing Etendo context path in production environments
- Translate specific report favorites using stored labels map (report.title per locale)
- Update es_ES favname translations: Factura de Venta, Pedido de Compra, etc.