### PR TITLE
Feature ETP-3828: Add Schema Forge quality gate

### DIFF
--- a/.github/workflows/quality-gate.yml
+++ b/.github/workflows/quality-gate.yml
@@ -1,0 +1,86 @@
+name: Schema Forge Quality Gate
+
+on:
+  pull_request:
+    branches: [develop, epic/ETP-3504]
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  sfqg:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - uses: actions/cache@v4
+        with:
+          path: .quality-gate-cache
+          key: sfqg-baseline-${{ github.base_ref }}-${{ hashFiles('quality-gate.config.json') }}
+
+      - name: Run quality gate
+        run: >-
+          node cli/src/quality-gate.js
+          --pr-affected
+          --baseline-ref origin/${{ github.base_ref }}
+          --format md
+          --output qg-report.md
+          --json qg-report.json
+
+      - name: Post PR comment
+        uses: actions/github-script@v7
+        env:
+          REPORT_PATH: qg-report.md
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- sfqg-report -->';
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.issue.number;
+            const body = fs.readFileSync(process.env.REPORT_PATH, 'utf8');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+
+            const existingComment = comments.find((comment) =>
+              comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existingComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: sfqg-report
+          path: qg-report.json

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ artifacts/test-report.html
 .mcp.json
 .playwright-mcp/
 .worktrees/
+.quality-gate-cache/
 window-locks.json
 tools/app-shell/dist/
 tools/app-shell/.env.local

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-frontend test-e2e test-e2e-headless test-e2e-debug test-e2e-ui test-e2e-report test-e2e-record generate dev build install install-e2e deploy clean help report-serve report-serve-detach report-stop report-preview
+.PHONY: test test-frontend test-e2e test-e2e-headless test-e2e-debug test-e2e-ui test-e2e-report test-e2e-record generate dev build install install-e2e deploy clean help report-serve report-serve-detach report-stop report-preview quality-gate
 
 # --- Testing ---
 
@@ -8,6 +8,9 @@ test: ## Run all CLI tests
 test-frontend: ## Run only frontend generator tests
 	cd cli && node --test 'test/generate-frontend.test.js'
 
+
+quality-gate: ## Run Schema Forge quality gate for PR-affected windows
+	node cli/src/quality-gate.js --pr-affected --baseline-ref origin/main --format md
 # --- E2E Testing (Playwright) ---
 
 test-e2e: ## Run E2E tests with visible browser

--- a/cli/package.json
+++ b/cli/package.json
@@ -25,9 +25,11 @@
     "sf-lock": "./src/lock-window.js",
     "sf-report-contract": "./src/report-contract.js",
     "sf-report-serve": "./src/report-serve.js",
-    "sf-report-preview": "./src/report-preview.js"
+    "sf-report-preview": "./src/report-preview.js",
+    "sf-quality-gate": "./src/quality-gate.js"
   },
   "devDependencies": {
+    "@babel/parser": "^7.29.2",
     "ajv": "^8.17.0"
   }
 }

--- a/cli/src/generate-contract.js
+++ b/cli/src/generate-contract.js
@@ -147,6 +147,8 @@ export function generateFrontendContract(schema, rules = []) {
         grid: f.grid,
         form: f.form,
       };
+      if (f.sourceRequired === true) mapped.sourceRequired = true;
+      if (f.derivation) mapped.derivation = f.derivation;
       if (f.columnType) mapped.columnType = f.columnType;
       if (f.reference) mapped.reference = f.reference;
       if (f.enumValues) mapped.enumValues = f.enumValues;
@@ -156,7 +158,7 @@ export function generateFrontendContract(schema, rules = []) {
       if (f.popup) mapped.popup = true;
 
       // UI hints
-      if (f.defaultValue) mapped.defaultValue = f.defaultValue;
+      if (f.defaultValue !== undefined) mapped.defaultValue = f.defaultValue;
       if (f.isIdentifier) mapped.isIdentifier = true;
       if (f.help) mapped.help = f.help;
       if (f.fieldGroup) mapped.fieldGroup = f.fieldGroup;

--- a/cli/src/quality-gate.js
+++ b/cli/src/quality-gate.js
@@ -1,0 +1,238 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { resolveBaseline } from './quality-gate/baseline.js';
+import { loadQualityGateConfig, QualityGateConfigError } from './quality-gate/config.js';
+import { collectDecisionWindows, detectAffectedWindows, getChangedFiles, resolveGitRef } from './quality-gate/detect.js';
+import { runQualityGate } from './quality-gate/runner.js';
+import { buildQualityGateAnalysisBundle, buildQualityGateReport } from './quality-gate/report.js';
+import { QUALITY_GATE_CHECKS } from './quality-gate/checks/index.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = join(__dirname, '..', '..');
+
+function collectRuntimeFiles(dir) {
+  if (!existsSync(dir)) {
+    return [];
+  }
+  const files = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectRuntimeFiles(fullPath));
+      continue;
+    }
+    if (fullPath.endsWith('.js') || fullPath.endsWith('.json')) {
+      files.push(fullPath);
+    }
+  }
+  return files.sort((left, right) => left.localeCompare(right));
+}
+
+function hashCacheInputs(rootDir, config) {
+  const hash = createHash('sha1');
+  hash.update(JSON.stringify(config));
+  for (const filePath of [
+    ...collectRuntimeFiles(join(rootDir, 'cli', 'src', 'quality-gate')),
+    join(rootDir, 'cli', 'src', 'quality-gate.js'),
+    join(rootDir, 'schemas', 'contract.schema.json'),
+    join(rootDir, 'schemas', 'quality-gate-config.schema.json'),
+  ]) {
+    if (!existsSync(filePath)) {
+      continue;
+    }
+    hash.update(filePath);
+    hash.update(readFileSync(filePath, 'utf8'));
+  }
+  return hash.digest('hex').slice(0, 12);
+}
+
+function writeTextFile(path, content) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content);
+}
+
+function computeBaselineWithWorktree({ rootDir, baselineRef, baselineSha, windowNames, config, runner }) {
+  const worktreePath = join(rootDir, '.quality-gate-cache', 'worktree', baselineSha.slice(0, 12));
+  mkdirSync(dirname(worktreePath), { recursive: true });
+
+  try {
+    execFileSync('git', ['worktree', 'add', '--detach', '--force', worktreePath, baselineRef], {
+      cwd: rootDir,
+      encoding: 'utf8',
+    });
+
+    return runner({
+      windowNames,
+      rootDir: worktreePath,
+      config,
+      checkers: QUALITY_GATE_CHECKS,
+    });
+  } finally {
+    try {
+      execFileSync('git', ['worktree', 'remove', '--force', worktreePath], {
+        cwd: rootDir,
+        encoding: 'utf8',
+      });
+    } catch {
+      // Best effort cleanup; missing baseline should degrade to head-only enforcement.
+    }
+  }
+}
+
+export function parseQualityGateArgs(argv) {
+  const options = {
+    mode: 'pr-affected',
+    windowName: null,
+    baselineRef: null,
+    format: 'md',
+    outputPath: null,
+    jsonPath: null,
+    analysisDir: null,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--window' && argv[index + 1]) {
+      options.mode = 'window';
+      options.windowName = argv[index + 1];
+      index += 1;
+    } else if (arg === '--all') {
+      options.mode = 'all';
+    } else if (arg === '--pr-affected') {
+      options.mode = 'pr-affected';
+    } else if (arg === '--baseline-ref' && argv[index + 1]) {
+      options.baselineRef = argv[index + 1];
+      index += 1;
+    } else if (arg === '--format' && argv[index + 1]) {
+      options.format = argv[index + 1];
+      index += 1;
+    } else if (arg === '--output' && argv[index + 1]) {
+      options.outputPath = argv[index + 1];
+      index += 1;
+    } else if (arg === '--json' && argv[index + 1]) {
+      options.jsonPath = argv[index + 1];
+      index += 1;
+    } else if (arg === '--analysis-dir' && argv[index + 1]) {
+      options.analysisDir = argv[index + 1];
+      index += 1;
+    }
+  }
+
+  if (options.mode === 'window' && !options.windowName) {
+    throw new Error('Usage: quality-gate.js --window <name> | --all | --pr-affected [--baseline-ref <ref>] [--format md|json] [--output <path>] [--json <path>] [--analysis-dir <dir>]');
+  }
+
+  return options;
+}
+
+export async function runQualityGateCli({ args = process.argv.slice(2), rootDir = ROOT, deps = {} } = {}) {
+  const options = parseQualityGateArgs(args);
+  const loadConfig = deps.loadConfig ?? loadQualityGateConfig;
+  const collectWindows = deps.collectDecisionWindows ?? collectDecisionWindows;
+  const detectWindows = deps.detectAffectedWindows ?? detectAffectedWindows;
+  const changedFilesForPr = deps.getChangedFiles ?? getChangedFiles;
+  const qualityRunner = deps.runQualityGate ?? ((params) => runQualityGate({ ...params, checkers: QUALITY_GATE_CHECKS }));
+  const config = await loadConfig(rootDir);
+  const baselineRef = options.baselineRef ?? config.gate?.baselineRef ?? 'origin/main';
+
+  const availableWindows = options.mode === 'window'
+    ? [options.windowName]
+    : collectWindows(rootDir);
+
+  const windowNames = options.mode === 'window'
+    ? [options.windowName]
+    : options.mode === 'all'
+      ? availableWindows
+      : detectWindows({
+          changedFiles: await changedFilesForPr({ rootDir, baselineRef, headRef: 'HEAD' }),
+          blastRadius: config.blastRadius ?? [],
+          availableWindows,
+        });
+
+  if (windowNames.length === 0) {
+    return {
+      exitCode: 0,
+      stdout: 'No windows affected; gate skipped\n',
+      summary: null,
+      report: null,
+    };
+  }
+
+  const baselineResult = await (deps.resolveBaseline ?? ((params) => resolveBaseline(params)))({
+    baselineRef,
+    cacheDir: join(rootDir, '.quality-gate-cache'),
+    configHash: hashCacheInputs(rootDir, config),
+    resolveRefSha: async (ref) => resolveGitRef(rootDir, ref),
+    computeBaseline: async ({ baselineRef: ref, baselineSha }) => computeBaselineWithWorktree({
+      rootDir,
+      baselineRef: ref,
+      baselineSha,
+      windowNames,
+      config,
+      runner: qualityRunner,
+    }),
+  });
+
+  const headResult = await qualityRunner({
+    windowNames,
+    rootDir,
+    config,
+    checkers: QUALITY_GATE_CHECKS,
+  });
+
+  const report = buildQualityGateReport({
+    baselineRef,
+    baselineSha: baselineResult?.baselineSha ?? null,
+    headResult,
+    baselineResult: baselineResult?.data ?? null,
+    baselineWarning: baselineResult?.warning ?? null,
+  });
+
+  const analysisDir = options.analysisDir ?? (options.mode === 'all'
+    ? join(rootDir, '.quality-gate-cache', 'analysis', 'quality-gate-all')
+    : null);
+
+  if (options.outputPath) {
+    writeTextFile(options.outputPath, report.markdown);
+  }
+  if (options.jsonPath) {
+    writeTextFile(options.jsonPath, `${JSON.stringify(report.json, null, 2)}\n`);
+  }
+  if (analysisDir) {
+    const bundle = buildQualityGateAnalysisBundle(report);
+    writeTextFile(join(analysisDir, 'report.json'), bundle.reportJson);
+    writeTextFile(join(analysisDir, 'summary.csv'), bundle.summaryCsv);
+    writeTextFile(join(analysisDir, 'checks.csv'), bundle.checksCsv);
+    writeTextFile(join(analysisDir, 'checks.jsonl'), bundle.checksJsonl);
+  }
+
+  return {
+    exitCode: report.summary.gateVerdict === 'FAIL' ? 1 : 0,
+    stdout: options.format === 'json' ? `${JSON.stringify(report.json, null, 2)}\n` : report.markdown,
+    summary: report.summary,
+    report,
+    analysisDir,
+  };
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMain) {
+  try {
+    const result = await runQualityGateCli();
+    process.stdout.write(result.stdout);
+    process.exit(result.exitCode);
+  } catch (error) {
+    if (error instanceof QualityGateConfigError) {
+      console.error(error.message);
+      process.exit(error.exitCode);
+    }
+    console.error(error.message || String(error));
+    process.exit(1);
+  }
+}

--- a/cli/src/quality-gate/baseline.js
+++ b/cli/src/quality-gate/baseline.js
@@ -1,0 +1,35 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export async function resolveBaseline({ baselineRef, cacheDir, configHash, resolveRefSha, computeBaseline }) {
+  try {
+    const baselineSha = await resolveRefSha(baselineRef);
+    const cachePath = join(cacheDir, `${baselineSha}-${configHash}.json`);
+
+    if (existsSync(cachePath)) {
+      return {
+        source: 'cache',
+        baselineSha,
+        cachePath,
+        data: JSON.parse(readFileSync(cachePath, 'utf8')),
+      };
+    }
+
+    mkdirSync(cacheDir, { recursive: true });
+    const data = await computeBaseline({ baselineRef, baselineSha, cachePath });
+    writeFileSync(cachePath, `${JSON.stringify(data, null, 2)}\n`);
+
+    return {
+      source: 'computed',
+      baselineSha,
+      cachePath,
+      data,
+    };
+  } catch (error) {
+    return {
+      source: 'unavailable',
+      data: null,
+      warning: `Unable to compute baseline from ${baselineRef}: ${error?.message || String(error)}`,
+    };
+  }
+}

--- a/cli/src/quality-gate/checks/contract.js
+++ b/cli/src/quality-gate/checks/contract.js
@@ -1,0 +1,32 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import Ajv from 'ajv';
+import { readJson } from './shared.js';
+
+export async function runContractCheck(_windowName, { rootDir, windowDir }) {
+  const schemaPath = join(rootDir, 'schemas', 'contract.schema.json');
+  const contractPath = join(windowDir, 'contract.json');
+
+  if (!existsSync(contractPath)) {
+    return { status: 'skip', detail: 'contract.json is missing.' };
+  }
+  if (!existsSync(schemaPath)) {
+    return { status: 'skip', detail: 'schemas/contract.schema.json is missing.' };
+  }
+
+  const ajv = new Ajv({ allErrors: true, validateSchema: false });
+  const validate = ajv.compile(readJson(schemaPath));
+  const valid = validate(readJson(contractPath));
+
+  if (!valid) {
+    return {
+      status: 'fail',
+      detail: ajv.errorsText(validate.errors, { separator: '; ' }),
+    };
+  }
+
+  return {
+    status: 'pass',
+    detail: 'contract.json matches schemas/contract.schema.json.',
+  };
+}

--- a/cli/src/quality-gate/checks/i18n.js
+++ b/cli/src/quality-gate/checks/i18n.js
@@ -1,0 +1,123 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { collectSourceFiles, isJavaScriptModule, parseModuleSource, readJson, repoRelative, walkAst } from './shared.js';
+
+const IGNORED_VISIBILITIES = new Set(['discarded', 'system']);
+const SCANNED_ATTRIBUTES = new Set(['title', 'placeholder', 'aria-label']);
+const TRANSLATOR_HOOKS = new Set(['useUI', 'useLabel', 'useMenuLabel']);
+
+function collectAllowlist(source) {
+  const match = source.match(/i18n-allowlist:\s*(\[[^\]]*\])/);
+  if (!match) {
+    return new Set();
+  }
+
+  try {
+    const values = JSON.parse(match[1]);
+    return new Set(Array.isArray(values) ? values : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function significantText(value) {
+  const normalized = value.replace(/\s+/g, ' ').trim();
+  return normalized.length > 2 ? normalized : null;
+}
+
+function collectTranslatorAliases(ast) {
+  const aliases = new Set(['t']);
+  walkAst(ast, (node) => {
+    if (
+      node.type === 'VariableDeclarator'
+      && node.id?.type === 'Identifier'
+      && node.init?.type === 'CallExpression'
+      && node.init.callee?.type === 'Identifier'
+      && TRANSLATOR_HOOKS.has(node.init.callee.name)
+    ) {
+      aliases.add(node.id.name);
+    }
+  });
+  return aliases;
+}
+
+function collectCustomFiles(rootDir, windowDir, windowName) {
+  return [
+    ...collectSourceFiles(join(windowDir, 'custom'), isJavaScriptModule),
+    ...collectSourceFiles(join(rootDir, 'tools', 'app-shell', 'src', 'windows', 'custom', windowName), isJavaScriptModule),
+  ].sort((left, right) => left.localeCompare(right));
+}
+
+function collectStringViolations(ast, source, rootDir, filePath) {
+  const violations = [];
+  const allowlist = collectAllowlist(source);
+  const translatorAliases = collectTranslatorAliases(ast);
+
+  walkAst(ast, (node) => {
+    if (node.type === 'JSXText') {
+      const text = significantText(node.value || '');
+      if (text && !allowlist.has(text)) {
+        violations.push(`${repoRelative(rootDir, filePath)}:${node.loc?.start?.line ?? 1} — hardcoded JSX text '${text}'.`);
+      }
+      return;
+    }
+
+    if (
+      node.type === 'JSXAttribute'
+      && node.name?.type === 'JSXIdentifier'
+      && SCANNED_ATTRIBUTES.has(node.name.name)
+      && node.value?.type === 'StringLiteral'
+    ) {
+      const text = significantText(node.value.value || '');
+      if (text && !allowlist.has(text)) {
+        violations.push(`${repoRelative(rootDir, filePath)}:${node.loc?.start?.line ?? 1} — hardcoded ${node.name.name} '${text}'.`);
+      }
+      return;
+    }
+
+    if (
+      node.type === 'CallExpression'
+      && node.callee?.type === 'Identifier'
+      && translatorAliases.has(node.callee.name)
+      && node.arguments?.[0]?.type === 'StringLiteral'
+    ) {
+      allowlist.add(node.arguments[0].value);
+    }
+  });
+
+  return violations;
+}
+
+export async function runI18nCheck(windowName, { rootDir, windowDir }) {
+  const contractPath = join(windowDir, 'contract.json');
+  if (!existsSync(contractPath)) {
+    return { status: 'skip', detail: 'contract.json is missing.' };
+  }
+
+  const contract = readJson(contractPath);
+  const violations = [];
+
+  for (const [entityName, entity] of Object.entries(contract.frontendContract?.entities ?? {})) {
+    for (const field of entity.fields ?? []) {
+      if (!field.form || IGNORED_VISIBILITIES.has(field.visibility)) {
+        continue;
+      }
+      if (typeof field.column !== 'string' || field.column.trim().length === 0) {
+        violations.push(`${entityName}.${field.name} is missing a non-empty column key for i18n lookup.`);
+      }
+    }
+  }
+
+  const customFiles = collectCustomFiles(rootDir, windowDir, windowName);
+  for (const filePath of customFiles) {
+    const source = readFileSync(filePath, 'utf8');
+    const ast = parseModuleSource(source, filePath);
+    violations.push(...collectStringViolations(ast, source, rootDir, filePath));
+  }
+
+  if (violations.length > 0) {
+    return { status: 'fail', detail: violations.join(' ') };
+  }
+
+  return { status: 'pass', detail: 'i18n coverage and custom code checks passed.' };
+}

--- a/cli/src/quality-gate/checks/imports.js
+++ b/cli/src/quality-gate/checks/imports.js
@@ -1,0 +1,68 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { collectSourceFiles, isJavaScriptModule, parseModuleSource, repoRelative, walkAst } from './shared.js';
+
+function isRelativeSpecifier(specifier) {
+  return specifier.startsWith('./') || specifier.startsWith('../');
+}
+
+function resolveRelativeImport(importerPath, specifier) {
+  const base = join(dirname(importerPath), specifier);
+  const candidates = [
+    base,
+    `${base}.js`,
+    `${base}.jsx`,
+    join(base, 'index.js'),
+    join(base, 'index.jsx'),
+  ];
+  return candidates.find((candidate) => existsSync(candidate)) ?? null;
+}
+
+function collectRelativeImports(ast) {
+  const imports = [];
+  walkAst(ast, (node) => {
+    if (node.type === 'ImportDeclaration' && typeof node.source?.value === 'string' && isRelativeSpecifier(node.source.value)) {
+      imports.push({ specifier: node.source.value, line: node.loc?.start?.line ?? 1 });
+      return;
+    }
+    if (
+      node.type === 'CallExpression'
+      && node.callee?.type === 'Identifier'
+      && node.callee.name === 'require'
+      && node.arguments?.[0]?.type === 'StringLiteral'
+      && isRelativeSpecifier(node.arguments[0].value)
+    ) {
+      imports.push({ specifier: node.arguments[0].value, line: node.loc?.start?.line ?? 1 });
+    }
+  });
+  return imports;
+}
+
+export async function runImportsCheck(_windowName, { rootDir, windowDir }) {
+  const files = collectSourceFiles(join(windowDir, 'generated'), isJavaScriptModule);
+  if (files.length === 0) {
+    return { status: 'skip', detail: 'No generated .js or .jsx files found.' };
+  }
+
+  let resolvedCount = 0;
+  for (const filePath of files) {
+    const source = readFileSync(filePath, 'utf8');
+    const ast = parseModuleSource(source, filePath);
+    const imports = collectRelativeImports(ast);
+
+    for (const entry of imports) {
+      if (!resolveRelativeImport(filePath, entry.specifier)) {
+        return {
+          status: 'fail',
+          detail: `${repoRelative(rootDir, filePath)}:${entry.line} — unresolved relative import '${entry.specifier}'.`,
+        };
+      }
+      resolvedCount += 1;
+    }
+  }
+
+  return {
+    status: 'pass',
+    detail: `Resolved ${resolvedCount} relative import(s).`,
+  };
+}

--- a/cli/src/quality-gate/checks/index.js
+++ b/cli/src/quality-gate/checks/index.js
@@ -1,0 +1,13 @@
+import { runParseCheck } from './parse.js';
+import { runImportsCheck } from './imports.js';
+import { runContractCheck } from './contract.js';
+import { runInvariantsCheck } from './invariants.js';
+import { runI18nCheck } from './i18n.js';
+
+export const QUALITY_GATE_CHECKS = {
+  parse: runParseCheck,
+  imports: runImportsCheck,
+  contract: runContractCheck,
+  invariants: runInvariantsCheck,
+  i18n: runI18nCheck,
+};

--- a/cli/src/quality-gate/checks/invariants.js
+++ b/cli/src/quality-gate/checks/invariants.js
@@ -1,0 +1,112 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { readJson } from './shared.js';
+
+const NON_EDITABLE_VISIBILITIES = new Set(['discarded', 'system', 'readOnly']);
+const SERVER_DEFAULT_DERIVATIONS = new Set(['sequence', 'fromParent', 'fromConfig']);
+
+function readContract(windowDir) {
+  const contractPath = join(windowDir, 'contract.json');
+  return existsSync(contractPath) ? readJson(contractPath) : null;
+}
+
+
+function getAddLineFieldsSource(pageSource) {
+  const match = pageSource.match(/const addLineFields = \{([\s\S]*?)\n\};/);
+  return match ? match[0] : null;
+}
+
+function hasServerDefault(field) {
+  if (field.callout) {
+    return true;
+  }
+  return SERVER_DEFAULT_DERIVATIONS.has(field.derivation?.type);
+}
+
+function findCustomFormDeclarations(windowConfig) {
+  const declarations = [];
+  if (windowConfig?.headerExtra?.customForm) {
+    declarations.push({ location: 'window.headerExtra.customForm', component: windowConfig.headerExtra.customForm });
+  }
+  for (const [key, value] of Object.entries(windowConfig?.secondaryTabs ?? {})) {
+    if (value?.customForm) {
+      declarations.push({ location: `window.secondaryTabs.${key}.customForm`, component: value.customForm });
+    }
+  }
+  return declarations;
+}
+
+function customFormExists(rootDir, windowName, component) {
+  return existsSync(join(rootDir, 'artifacts', windowName, 'custom', `${component}.jsx`))
+    || existsSync(join(rootDir, 'tools', 'app-shell', 'src', 'windows', 'custom', windowName, `${component}.jsx`));
+}
+
+export async function runInvariantsCheck(windowName, { rootDir, windowDir, config }) {
+  const contract = readContract(windowDir);
+  if (!contract?.frontendContract) {
+    return { status: 'skip', detail: 'contract.json is missing frontendContract.' };
+  }
+
+  const violations = [];
+  const entities = contract.frontendContract.entities ?? {};
+  const primaryEntity = contract.frontendContract.window?.primaryEntity ?? Object.keys(entities)[0] ?? null;
+  const headerEntity = primaryEntity ? entities[primaryEntity] : null;
+  const anyDraftMode = Object.values(entities).some((entity) => entity?.draftMode?.enabled === true);
+
+  if (config?.invariants?.draftModeReadOnlyLogic && anyDraftMode && headerEntity?.fields) {
+    for (const field of headerEntity.fields) {
+      if (!field.form || NON_EDITABLE_VISIBILITIES.has(field.visibility)) {
+        continue;
+      }
+      if (!field.readOnlyLogic) {
+        violations.push(`${primaryEntity}.${field.name} missing readOnlyLogic while draftMode is enabled.`);
+      }
+    }
+  }
+
+  if (config?.invariants?.notNullRequiresRequired) {
+    for (const [entityName, entity] of Object.entries(entities)) {
+      for (const field of entity.fields ?? []) {
+        if (field.sourceRequired === true && field.required !== true && !hasServerDefault(field)) {
+          violations.push(`${entityName}.${field.name} must remain required because the source column is NOT NULL.`);
+        }
+      }
+    }
+  }
+
+  const generatedPagePath = join(windowDir, 'generated', 'web', windowName, `${windowName.split('-').map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join('')}Page.jsx`);
+  if (config?.invariants?.addLineFields && existsSync(generatedPagePath)) {
+    const addLineFieldsSource = getAddLineFieldsSource(readFileSync(generatedPagePath, 'utf8'));
+    if (addLineFieldsSource) {
+      if (config.invariants.addLineFields.requiredProductLookup && !/key:\s*'product'[\s\S]*?lookup:\s*true/.test(addLineFieldsSource)) {
+        violations.push('lines.addLineFields.product must declare lookup: true.');
+      }
+      if (config.invariants.addLineFields.quantityDefaultOne && !/key:\s*'quantity'[\s\S]*?defaultValue:\s*1/.test(addLineFieldsSource)) {
+        violations.push('lines.addLineFields.quantity must declare defaultValue: 1.');
+      }
+      if (config.invariants.addLineFields.hiddenContainsGrossUnitPriceAndPriceList) {
+        if (!/hidden:\s*\[[\s\S]*'grossUnitPrice'/.test(addLineFieldsSource)) {
+          violations.push("lines.addLineFields.hidden must include 'grossUnitPrice'.");
+        }
+        if (!/hidden:\s*\[[\s\S]*'priceList'/.test(addLineFieldsSource)) {
+          violations.push("lines.addLineFields.hidden must include 'priceList'.");
+        }
+      }
+    }
+  }
+
+  for (const declaration of findCustomFormDeclarations(contract.frontendContract.window)) {
+    if (!customFormExists(rootDir, windowName, declaration.component)) {
+      violations.push(`${declaration.location} references '${declaration.component}', but no local custom form exists for ${windowName}.`);
+    }
+  }
+
+  if (violations.length > 0) {
+    return {
+      status: 'fail',
+      detail: violations.join(' '),
+    };
+  }
+
+  return { status: 'pass', detail: 'All invariants satisfied.' };
+}

--- a/cli/src/quality-gate/checks/parse.js
+++ b/cli/src/quality-gate/checks/parse.js
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { collectSourceFiles, isJavaScriptModule, parseModuleSource, repoRelative } from './shared.js';
+
+export async function runParseCheck(_windowName, { rootDir, windowDir }) {
+  const generatedDir = join(windowDir, 'generated');
+  const files = collectSourceFiles(generatedDir, isJavaScriptModule);
+
+  if (files.length === 0) {
+    return { status: 'skip', detail: 'No generated .js or .jsx files found.' };
+  }
+
+  for (const filePath of files) {
+    try {
+      parseModuleSource(readFileSync(filePath, 'utf8'), filePath);
+    } catch (error) {
+      return {
+        status: 'fail',
+        detail: `${repoRelative(rootDir, filePath)} — ${error.message}`,
+      };
+    }
+  }
+
+  return {
+    status: 'pass',
+    detail: `Parsed ${files.length} generated source file(s).`,
+  };
+}

--- a/cli/src/quality-gate/checks/shared.js
+++ b/cli/src/quality-gate/checks/shared.js
@@ -1,0 +1,65 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { parse } from '@babel/parser';
+
+export function collectSourceFiles(dir, predicate = () => true) {
+  if (!existsSync(dir)) {
+    return [];
+  }
+
+  const files = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(fullPath, predicate));
+      continue;
+    }
+    if (predicate(fullPath)) {
+      files.push(fullPath);
+    }
+  }
+  return files.sort((left, right) => left.localeCompare(right));
+}
+
+export function isJavaScriptModule(filePath) {
+  return filePath.endsWith('.js') || filePath.endsWith('.jsx');
+}
+
+export function parseModuleSource(source, filename) {
+  return parse(source, {
+    sourceType: 'module',
+    plugins: ['jsx'],
+    errorRecovery: false,
+    sourceFilename: filename,
+  });
+}
+
+export function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+export function repoRelative(rootDir, filePath) {
+  return relative(rootDir, filePath).replaceAll('\\', '/');
+}
+
+export function walkAst(node, visit) {
+  if (!node || typeof node !== 'object') {
+    return;
+  }
+
+  if (Array.isArray(node)) {
+    node.forEach((child) => walkAst(child, visit));
+    return;
+  }
+
+  if (typeof node.type === 'string') {
+    visit(node);
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'loc' || key === 'start' || key === 'end') {
+      continue;
+    }
+    walkAst(value, visit);
+  }
+}

--- a/cli/src/quality-gate/config.js
+++ b/cli/src/quality-gate/config.js
@@ -1,0 +1,52 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import Ajv from 'ajv';
+
+export class QualityGateConfigError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'QualityGateConfigError';
+    this.exitCode = 2;
+  }
+}
+
+function loadJson(path) {
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch (error) {
+    throw new QualityGateConfigError(`Unable to read ${path}: ${error.message}`);
+  }
+}
+
+function validateGracePeriods(config) {
+  const today = new Date().toISOString().slice(0, 10);
+  for (const entry of config.gracePeriod ?? []) {
+    if (entry.until && entry.until < today) {
+      throw new QualityGateConfigError(`Expired quality gate grace period: ${JSON.stringify(entry)}`);
+    }
+  }
+}
+
+export function loadQualityGateConfig(rootDir) {
+  const configPath = join(rootDir, 'quality-gate.config.json');
+  const schemaPath = join(rootDir, 'schemas', 'quality-gate-config.schema.json');
+
+  if (!existsSync(configPath)) {
+    throw new QualityGateConfigError('quality-gate.config.json is missing.');
+  }
+  if (!existsSync(schemaPath)) {
+    throw new QualityGateConfigError('schemas/quality-gate-config.schema.json is missing.');
+  }
+
+  const config = loadJson(configPath);
+  const schema = loadJson(schemaPath);
+  const ajv = new Ajv({ allErrors: true, validateSchema: false });
+  const validate = ajv.compile(schema);
+
+  if (!validate(config)) {
+    throw new QualityGateConfigError(ajv.errorsText(validate.errors, { separator: '; ' }));
+  }
+
+  validateGracePeriods(config);
+  return config;
+}

--- a/cli/src/quality-gate/detect.js
+++ b/cli/src/quality-gate/detect.js
@@ -1,0 +1,93 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+function escapeRegex(text) {
+  return text.replace(/[|\\{}()[\]^$+?.]/g, '\\$&');
+}
+
+function globToRegExp(pattern) {
+  const placeholder = '__DOUBLE_STAR__';
+  const escaped = escapeRegex(pattern)
+    .replace(/\*\*/g, placeholder)
+    .replace(/\*/g, '[^/]*')
+    .replaceAll(placeholder, '.*');
+  return new RegExp(`^${escaped}$`);
+}
+
+function resolveTouchedWindows(filePath, availableWindows) {
+  const artifactMatch = filePath.match(/^artifacts\/([^/]+)\//);
+  if (artifactMatch) {
+    return [artifactMatch[1]];
+  }
+
+  const appShellMatch = filePath.match(/^tools\/app-shell\/src\/windows\/custom\/([^/]+)\//);
+  if (!appShellMatch) {
+    return [];
+  }
+
+  const customDir = appShellMatch[1];
+  if (availableWindows.includes(customDir)) {
+    return [customDir];
+  }
+  if (customDir === 'businessPartner' && availableWindows.includes('contacts')) {
+    return ['contacts'];
+  }
+  if (customDir === 'shared') {
+    return [...availableWindows];
+  }
+  return [];
+}
+
+function runGit(rootDir, args) {
+  return execFileSync('git', args, { cwd: rootDir, encoding: 'utf8' }).trim();
+}
+
+export function collectDecisionWindows(rootDir) {
+  const artifactsDir = join(rootDir, 'artifacts');
+  if (!existsSync(artifactsDir)) {
+    return [];
+  }
+
+  return readdirSync(artifactsDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((windowName) => existsSync(join(artifactsDir, windowName, 'decisions.json')))
+    .sort((left, right) => left.localeCompare(right));
+}
+
+export function detectAffectedWindows({ changedFiles, blastRadius, availableWindows }) {
+  const affected = new Set();
+  const allWindows = [...availableWindows].sort((left, right) => left.localeCompare(right));
+
+  for (const changedFile of changedFiles) {
+    for (const rule of blastRadius) {
+      if (!globToRegExp(rule.pattern).test(changedFile)) {
+        continue;
+      }
+
+      if (rule.scope === 'all-windows') {
+        allWindows.forEach((windowName) => affected.add(windowName));
+        continue;
+      }
+
+      if (rule.scope === 'touched-window') {
+        for (const windowName of resolveTouchedWindows(changedFile, allWindows)) {
+          affected.add(windowName);
+        }
+      }
+    }
+  }
+
+  return [...affected].sort((left, right) => left.localeCompare(right));
+}
+
+export function resolveGitRef(rootDir, ref) {
+  return runGit(rootDir, ['rev-parse', ref]);
+}
+
+export function getChangedFiles({ rootDir, baselineRef, headRef = 'HEAD' }) {
+  const compareBase = runGit(rootDir, ['merge-base', baselineRef, headRef]);
+  const output = runGit(rootDir, ['diff', '--name-only', compareBase, headRef]);
+  return output.split('\n').map((line) => line.trim()).filter(Boolean);
+}

--- a/cli/src/quality-gate/report.js
+++ b/cli/src/quality-gate/report.js
@@ -1,0 +1,175 @@
+function scoreText(score) {
+  return `${score.passed}/${score.total}`;
+}
+
+function baselineScoreMap(baselineResult) {
+  const map = new Map();
+  for (const window of baselineResult?.windows ?? []) {
+    map.set(window.window, window.score ?? null);
+  }
+  return map;
+}
+
+function renderFailures(window) {
+  const failingChecks = window.checks.filter((check) => check.status === 'fail' || check.status === 'error');
+  if (failingChecks.length === 0) {
+    return '';
+  }
+
+  return failingChecks.map((check) => {
+    return [
+      `### ${window.window} — ${check.check}`,
+      '',
+      `**${check.check}** (${check.severity})`,
+      `- ${check.detail}`,
+      '',
+    ].join('\n');
+  }).join('\n');
+}
+
+export function buildQualityGateReport({ baselineRef, baselineSha, headResult, baselineResult, baselineWarning = null }) {
+  const baselineByWindow = baselineScoreMap(baselineResult);
+  const windows = headResult.windows.map((window) => {
+    const baseline = baselineByWindow.get(window.window) ?? null;
+    const delta = baseline ? window.score.passed - baseline.passed : 0;
+    return {
+      ...window,
+      baseline,
+      delta,
+    };
+  });
+
+  const regressionWindows = windows.filter((window) => window.baseline && window.delta < 0 && window.verdict !== 'NO-OP');
+  const gateVerdict = headResult.summary.gateVerdict === 'FAIL' || regressionWindows.length > 0 ? 'FAIL' : 'PASS';
+
+  const summary = {
+    gateVerdict,
+    baselineRef,
+    baselineSha,
+    affectedWindows: headResult.summary.affectedWindows,
+    regressionFailures: regressionWindows.map((window) => window.window),
+    windows: windows.map((window) => ({
+      window: window.window,
+      verdict: window.verdict,
+      score: window.score,
+      baseline: window.baseline,
+      delta: window.delta,
+      blockerFailures: window.blockerFailures,
+    })),
+  };
+
+  const lines = [
+    '<!-- sfqg-report -->',
+    '## Schema Forge Quality Gate',
+    '',
+    `Baseline: ${baselineRef}${baselineSha ? ` @ ${baselineSha}` : ''}`,
+    `Affected windows: ${summary.affectedWindows}`,
+    `Gate verdict: ${summary.gateVerdict}`,
+  ];
+
+  if (baselineWarning) {
+    lines.push('', `Warning: ${baselineWarning}`);
+  }
+  if (summary.regressionFailures.length > 0) {
+    lines.push('', `Regression failures: ${summary.regressionFailures.join(', ')}`);
+  }
+
+  lines.push(
+    '',
+    '| Window | Score | Baseline | Delta | Blockers failed |',
+    '|---|---:|---:|---:|---|',
+    ...windows.map((window) => {
+      const baseline = window.baseline ? scoreText(window.baseline) : '—';
+      const blockerFailures = window.blockerFailures.length > 0 ? window.blockerFailures.join(', ') : '—';
+      return `| ${window.window} | ${scoreText(window.score)} | ${baseline} | ${window.delta} | ${blockerFailures} |`;
+    }),
+    '',
+  );
+
+  const failureSections = windows.map(renderFailures).filter(Boolean);
+  if (failureSections.length > 0) {
+    lines.push(...failureSections);
+  }
+
+  return {
+    summary,
+    markdown: lines.join('\n').trimEnd() + '\n',
+    json: {
+      summary,
+      windows,
+      baselineWarning,
+    },
+  };
+}
+
+function csvCell(value) {
+  const normalized = value == null ? '' : String(value);
+  if (/[",\n]/.test(normalized)) {
+    return `"${normalized.replaceAll('"', '""')}"`;
+  }
+  return normalized;
+}
+
+function toCsv(columns, rows) {
+  const lines = [columns.join(',')];
+  for (const row of rows) {
+    lines.push(columns.map((column) => csvCell(row[column])).join(','));
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+export function buildQualityGateAnalysisBundle(report) {
+  const windows = report.json.windows ?? [];
+  const summaryRows = windows.map((window) => ({
+    window: window.window,
+    verdict: window.verdict,
+    score_passed: window.score?.passed ?? 0,
+    score_total: window.score?.total ?? 0,
+    baseline_passed: window.baseline?.passed ?? '',
+    baseline_total: window.baseline?.total ?? '',
+    delta: window.delta ?? 0,
+    blocker_failures: (window.blockerFailures ?? []).join('|'),
+  }));
+
+  const checkRows = windows.flatMap((window) => (window.checks ?? []).map((check) => ({
+    window: window.window,
+    verdict: window.verdict,
+    check: check.check,
+    severity: check.severity,
+    status: check.status,
+    detail: check.detail,
+    score_passed: window.score?.passed ?? 0,
+    score_total: window.score?.total ?? 0,
+    baseline_passed: window.baseline?.passed ?? '',
+    baseline_total: window.baseline?.total ?? '',
+    delta: window.delta ?? 0,
+  })));
+
+  return {
+    summaryCsv: toCsv([
+      'window',
+      'verdict',
+      'score_passed',
+      'score_total',
+      'baseline_passed',
+      'baseline_total',
+      'delta',
+      'blocker_failures',
+    ], summaryRows),
+    checksCsv: toCsv([
+      'window',
+      'check',
+      'severity',
+      'status',
+      'detail',
+      'verdict',
+      'score_passed',
+      'score_total',
+      'baseline_passed',
+      'baseline_total',
+      'delta',
+    ], checkRows),
+    checksJsonl: checkRows.map((row) => JSON.stringify(row)).join('\n') + (checkRows.length > 0 ? '\n' : ''),
+    reportJson: `${JSON.stringify(report.json, null, 2)}\n`,
+  };
+}

--- a/cli/src/quality-gate/runner.js
+++ b/cli/src/quality-gate/runner.js
@@ -1,0 +1,95 @@
+import { join } from 'node:path';
+
+function normalizeCheckResult(check, severity, result) {
+  return {
+    check,
+    severity,
+    status: result?.status ?? 'skip',
+    detail: result?.detail ?? '',
+  };
+}
+
+export async function runQualityGate({ windowNames, rootDir, config, checkers }) {
+  const enabledChecks = Object.entries(config.checks ?? {})
+    .filter(([, definition]) => definition?.enabled)
+    .map(([check, definition]) => ({ check, severity: definition.severity ?? 'blocker' }));
+
+  const windows = [];
+
+  for (const windowName of windowNames) {
+    const windowDir = join(rootDir, 'artifacts', windowName);
+    const checks = [];
+    const blockerFailures = [];
+    let applicableChecks = 0;
+    let passingChecks = 0;
+    let blockerChecks = 0;
+    let skippedBlockers = 0;
+
+    for (const { check, severity } of enabledChecks) {
+      let result;
+      try {
+        const checker = checkers[check];
+        if (!checker) {
+          result = { status: 'skip', detail: `Check '${check}' is not registered` };
+        } else {
+          result = await checker(windowName, { rootDir, windowDir, config });
+        }
+      } catch (error) {
+        result = {
+          status: 'error',
+          detail: error?.stack || error?.message || String(error),
+        };
+      }
+
+      const normalized = normalizeCheckResult(check, severity, result);
+      checks.push(normalized);
+
+      if (normalized.status !== 'skip') {
+        applicableChecks += 1;
+      }
+      if (normalized.status === 'pass') {
+        passingChecks += 1;
+      }
+
+      if (severity === 'blocker') {
+        blockerChecks += 1;
+        if (normalized.status === 'skip') {
+          skippedBlockers += 1;
+        }
+        if (normalized.status === 'fail' || normalized.status === 'error') {
+          blockerFailures.push(check);
+        }
+      }
+    }
+
+    const verdict = blockerChecks > 0 && blockerChecks === skippedBlockers
+      ? 'NO-OP'
+      : blockerFailures.length > 0
+        ? 'FAIL'
+        : 'PASS';
+
+    windows.push({
+      window: windowName,
+      verdict,
+      score: {
+        passed: passingChecks,
+        total: applicableChecks,
+      },
+      blockerFailures,
+      checks,
+    });
+  }
+
+  const scoredWindows = windows.filter((window) => window.verdict !== 'NO-OP');
+  const failedWindows = scoredWindows.filter((window) => window.verdict === 'FAIL');
+
+  return {
+    windows,
+    summary: {
+      gateVerdict: failedWindows.length > 0 ? 'FAIL' : 'PASS',
+      affectedWindows: windows.length,
+      scoredWindows: scoredWindows.length,
+      failedWindows: failedWindows.length,
+    },
+  };
+}

--- a/cli/src/resolve-curated.js
+++ b/cli/src/resolve-curated.js
@@ -203,6 +203,7 @@ function buildCuratedField(rawField, fieldDecision, discardPatterns) {
     form,
     searchable,
   };
+  if (rawField.mandatory === true) field.sourceRequired = true;
 
   // Section (only for visible fields)
   const section = fieldDecision.section || null;

--- a/cli/test/generate-contract.test.js
+++ b/cli/test/generate-contract.test.js
@@ -934,6 +934,9 @@ const uiHintsSchema = {
         precision: 2, isTranslated: true },
       { name: 'plainField', column: 'PlainCol', type: 'string', visibility: 'editable',
         required: false, searchable: false, grid: true, form: true },
+      { name: 'configuredWarehouse', column: 'M_Warehouse_ID', type: 'foreignKey', visibility: 'editable',
+        required: false, searchable: false, grid: false, form: true, sourceRequired: true,
+        derivation: { type: 'fromConfig', source: 'context.defaultWarehouse' } },
     ]
   }]
 };
@@ -967,6 +970,18 @@ describe('generateFrontendContract — UI hints', () => {
     const fc = generateFrontendContract(uiHintsSchema);
     const gt = fc.entities.order.fields.find(f => f.name === 'grandTotal');
     assert.equal(gt.isIdentifier, true);
+  });
+
+  it('field with sourceRequired appears in contract', () => {
+    const fc = generateFrontendContract(uiHintsSchema);
+    const configured = fc.entities.order.fields.find(f => f.name === 'configuredWarehouse');
+    assert.equal(configured.sourceRequired, true);
+  });
+
+  it('field with derivation appears in contract', () => {
+    const fc = generateFrontendContract(uiHintsSchema);
+    const configured = fc.entities.order.fields.find(f => f.name === 'configuredWarehouse');
+    assert.deepEqual(configured.derivation, { type: 'fromConfig', source: 'context.defaultWarehouse' });
   });
 
   it('field without hints has no hint keys present', () => {

--- a/cli/test/quality-gate-baseline.test.js
+++ b/cli/test/quality-gate-baseline.test.js
@@ -1,0 +1,61 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveBaseline } from '../src/quality-gate/baseline.js';
+
+describe('resolveBaseline', () => {
+  it('reuses a cached baseline when present', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'quality-gate-baseline-'));
+    const cacheDir = join(rootDir, '.quality-gate-cache');
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(
+      join(cacheDir, 'main-sha123-config-hash456.json'),
+      JSON.stringify({ windows: [{ window: 'sales-order', score: { passed: 2, total: 2 } }] }, null, 2),
+    );
+
+    let computed = false;
+
+    try {
+      const result = await resolveBaseline({
+        baselineRef: 'origin/main',
+        cacheDir,
+        configHash: 'config-hash456',
+        resolveRefSha: async () => 'main-sha123',
+        computeBaseline: async () => {
+          computed = true;
+          return { windows: [] };
+        },
+      });
+
+      assert.equal(computed, false);
+      assert.equal(result.source, 'cache');
+      assert.equal(result.data.windows[0].window, 'sales-order');
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back gracefully when baseline computation fails', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'quality-gate-baseline-'));
+
+    try {
+      const result = await resolveBaseline({
+        baselineRef: 'origin/main',
+        cacheDir: join(rootDir, '.quality-gate-cache'),
+        configHash: 'config-hash456',
+        resolveRefSha: async () => 'main-sha123',
+        computeBaseline: async () => {
+          throw new Error('worktree add failed');
+        },
+      });
+
+      assert.equal(result.data, null);
+      assert.equal(result.source, 'unavailable');
+      assert.match(result.warning, /worktree add failed/);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/test/quality-gate-checks-contract.test.js
+++ b/cli/test/quality-gate-checks-contract.test.js
@@ -1,0 +1,65 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runContractCheck } from '../src/quality-gate/checks/contract.js';
+
+function makeRoot() {
+  const rootDir = mkdtempSync(join(tmpdir(), 'quality-gate-contract-'));
+  const windowDir = join(rootDir, 'artifacts', 'sales-order');
+  mkdirSync(join(rootDir, 'schemas'), { recursive: true });
+  mkdirSync(windowDir, { recursive: true });
+  return { rootDir, windowDir };
+}
+
+describe('runContractCheck', () => {
+  it('passes when contract.json matches the schema', async () => {
+    const { rootDir, windowDir } = makeRoot();
+
+    try {
+      writeFileSync(
+        join(rootDir, 'schemas', 'contract.schema.json'),
+        JSON.stringify({
+          type: 'object',
+          required: ['frontendContract'],
+          properties: {
+            frontendContract: { type: 'object' },
+          },
+          additionalProperties: true,
+        }, null, 2),
+      );
+      writeFileSync(join(windowDir, 'contract.json'), JSON.stringify({ frontendContract: {} }, null, 2));
+
+      const result = await runContractCheck('sales-order', { rootDir, windowDir });
+      assert.deepEqual(result, { status: 'pass', detail: 'contract.json matches schemas/contract.schema.json.' });
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails with Ajv errors when contract.json is invalid', async () => {
+    const { rootDir, windowDir } = makeRoot();
+
+    try {
+      writeFileSync(
+        join(rootDir, 'schemas', 'contract.schema.json'),
+        JSON.stringify({
+          type: 'object',
+          required: ['frontendContract'],
+          properties: {
+            frontendContract: { type: 'object' },
+          },
+          additionalProperties: false,
+        }, null, 2),
+      );
+      writeFileSync(join(windowDir, 'contract.json'), JSON.stringify({ wrong: true }, null, 2));
+
+      const result = await runContractCheck('sales-order', { rootDir, windowDir });
+      assert.equal(result.status, 'fail');
+      assert.match(result.detail, /frontendContract/);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/test/quality-gate-checks-i18n.test.js
+++ b/cli/test/quality-gate-checks-i18n.test.js
@@ -1,0 +1,85 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runI18nCheck } from '../src/quality-gate/checks/i18n.js';
+
+function makeFixture({ missingColumn = false, hardcoded = false, allowlisted = false } = {}) {
+  const rootDir = mkdtempSync(join(tmpdir(), 'quality-gate-i18n-'));
+  const windowDir = join(rootDir, 'artifacts', 'sales-order');
+  mkdirSync(join(windowDir, 'custom'), { recursive: true });
+  mkdirSync(join(rootDir, 'tools', 'app-shell', 'src', 'windows', 'custom', 'sales-order'), { recursive: true });
+
+  const contract = {
+    frontendContract: {
+      window: { primaryEntity: 'header' },
+      entities: {
+        header: {
+          fields: [
+            {
+              name: 'documentNo',
+              form: true,
+              visibility: 'editable',
+              column: missingColumn ? '' : 'DocumentNo',
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  const customComponent = hardcoded
+    ? `${allowlisted ? '// i18n-allowlist: ["Move to warehouse"]\n' : ''}export default function Sidebar() { return <button title="Move to warehouse">Move to warehouse</button>; }`
+    : `import { useUI } from '@/i18n';\nexport default function Sidebar() { const ui = useUI(); return <button title={ui('save')}>{ui('save')}</button>; }`;
+
+  writeFileSync(join(windowDir, 'contract.json'), JSON.stringify(contract, null, 2));
+  writeFileSync(join(windowDir, 'custom', 'Sidebar.jsx'), customComponent);
+
+  return { rootDir, windowDir };
+}
+
+describe('runI18nCheck', () => {
+  it('passes when fields have column keys and custom code uses translators', async () => {
+    const { rootDir, windowDir } = makeFixture();
+
+    try {
+      const result = await runI18nCheck('sales-order', { rootDir, windowDir });
+      assert.deepEqual(result, { status: 'pass', detail: 'i18n coverage and custom code checks passed.' });
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails when a form field lacks a column key', async () => {
+    const { rootDir, windowDir } = makeFixture({ missingColumn: true });
+
+    try {
+      const result = await runI18nCheck('sales-order', { rootDir, windowDir });
+      assert.equal(result.status, 'fail');
+      assert.match(result.detail, /documentNo/);
+      assert.match(result.detail, /column/i);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails on hardcoded user-facing strings unless allowlisted', async () => {
+    const failing = makeFixture({ hardcoded: true });
+    try {
+      const result = await runI18nCheck('sales-order', { rootDir: failing.rootDir, windowDir: failing.windowDir });
+      assert.equal(result.status, 'fail');
+      assert.match(result.detail, /Move to warehouse/);
+    } finally {
+      rmSync(failing.rootDir, { recursive: true, force: true });
+    }
+
+    const passing = makeFixture({ hardcoded: true, allowlisted: true });
+    try {
+      const result = await runI18nCheck('sales-order', { rootDir: passing.rootDir, windowDir: passing.windowDir });
+      assert.equal(result.status, 'pass');
+    } finally {
+      rmSync(passing.rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/test/quality-gate-checks-imports.test.js
+++ b/cli/test/quality-gate-checks-imports.test.js
@@ -1,0 +1,67 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runImportsCheck } from '../src/quality-gate/checks/imports.js';
+
+function makeWindowDir() {
+  const rootDir = mkdtempSync(join(tmpdir(), 'quality-gate-imports-'));
+  const windowDir = join(rootDir, 'artifacts', 'sales-order');
+  const sourceDir = join(windowDir, 'generated', 'web', 'sales-order');
+  mkdirSync(sourceDir, { recursive: true });
+  return { rootDir, windowDir, sourceDir };
+}
+
+describe('runImportsCheck', () => {
+  it('passes when every relative import resolves to a real file', async () => {
+    const { rootDir, windowDir, sourceDir } = makeWindowDir();
+
+    try {
+      writeFileSync(join(sourceDir, 'helpers.js'), 'export const answer = 42;');
+      writeFileSync(
+        join(sourceDir, 'SalesOrderPage.jsx'),
+        "import { answer } from './helpers';\nexport default function SalesOrderPage() { return <div>{answer}</div>; }",
+      );
+
+      const result = await runImportsCheck('sales-order', { rootDir, windowDir });
+      assert.deepEqual(result, { status: 'pass', detail: 'Resolved 1 relative import(s).' });
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails when a relative import cannot be resolved', async () => {
+    const { rootDir, windowDir, sourceDir } = makeWindowDir();
+
+    try {
+      writeFileSync(
+        join(sourceDir, 'Broken.jsx'),
+        "import MissingThing from './missing';\nexport default function Broken() { return <div />; }",
+      );
+
+      const result = await runImportsCheck('sales-order', { rootDir, windowDir });
+      assert.equal(result.status, 'fail');
+      assert.match(result.detail, /\.\/missing/);
+      assert.match(result.detail, /Broken\.jsx:1/);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('ignores bare specifiers', async () => {
+    const { rootDir, windowDir, sourceDir } = makeWindowDir();
+
+    try {
+      writeFileSync(
+        join(sourceDir, 'SalesOrderPage.jsx'),
+        "import React from 'react';\nimport { Button } from '@/components/ui/button';\nexport default function SalesOrderPage() { return <Button />; }",
+      );
+
+      const result = await runImportsCheck('sales-order', { rootDir, windowDir });
+      assert.deepEqual(result, { status: 'pass', detail: 'Resolved 0 relative import(s).' });
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/test/quality-gate-checks-invariants.test.js
+++ b/cli/test/quality-gate-checks-invariants.test.js
@@ -1,0 +1,132 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runInvariantsCheck } from '../src/quality-gate/checks/invariants.js';
+
+function buildFixture({ withViolations = false } = {}) {
+  const rootDir = mkdtempSync(join(tmpdir(), 'quality-gate-invariants-'));
+  const windowDir = join(rootDir, 'artifacts', 'sales-order');
+  const generatedDir = join(windowDir, 'generated', 'web', 'sales-order');
+  mkdirSync(generatedDir, { recursive: true });
+  mkdirSync(join(rootDir, 'tools', 'app-shell', 'src', 'windows', 'custom', 'sales-order'), { recursive: true });
+
+  const contract = {
+    frontendContract: {
+      window: {
+        primaryEntity: 'header',
+        headerExtra: {
+          customForm: withViolations ? 'MissingPanel' : 'ExistingPanel',
+        },
+      },
+      entities: {
+        header: {
+          draftMode: { enabled: true },
+          fields: [
+            {
+              name: 'documentNo',
+              form: true,
+              visibility: 'editable',
+              required: true,
+              sourceRequired: true,
+              readOnlyLogic: withViolations ? undefined : { raw: "@Processed@='Y'" },
+            },
+          ],
+        },
+        lines: {
+          fields: [
+            {
+              name: 'product',
+              required: true,
+              lookup: withViolations ? false : true,
+              sourceRequired: true,
+            },
+            {
+              name: 'priceList',
+              required: withViolations ? false : true,
+              sourceRequired: true,
+              derivation: withViolations ? undefined : { type: 'fromParent', source: 'header.priceList' },
+            },
+          ],
+        },
+      },
+    },
+  };
+
+  const addLineFieldsBlock = withViolations
+    ? `const addLineFields = {\n  entry: [\n    { key: 'product', lookup: false },\n    { key: 'quantity' },\n  ],\n  hidden: ['grossUnitPrice'],\n};\n`
+    : `const addLineFields = {\n  entry: [\n    { key: 'product', lookup: true },\n    { key: 'quantity', defaultValue: 1 },\n  ],\n  hidden: ['grossUnitPrice', 'priceList'],\n};\n`;
+
+  writeFileSync(join(windowDir, 'contract.json'), JSON.stringify(contract, null, 2));
+  writeFileSync(join(generatedDir, 'SalesOrderPage.jsx'), addLineFieldsBlock);
+  if (!withViolations) {
+    writeFileSync(
+      join(rootDir, 'tools', 'app-shell', 'src', 'windows', 'custom', 'sales-order', 'ExistingPanel.jsx'),
+      'export default function ExistingPanel() { return null; }',
+    );
+  }
+
+  return { rootDir, windowDir };
+}
+
+describe('runInvariantsCheck', () => {
+  it('passes when contract and generated page satisfy the invariants', async () => {
+    const { rootDir, windowDir } = buildFixture();
+
+    try {
+      const result = await runInvariantsCheck('sales-order', {
+        rootDir,
+        windowDir,
+        config: {
+          invariants: {
+            addLineFields: {
+              requiredProductLookup: true,
+              quantityDefaultOne: true,
+              hiddenContainsGrossUnitPriceAndPriceList: true,
+            },
+            draftModeReadOnlyLogic: true,
+            notNullRequiresRequired: true,
+            customFormPathRoot: '@/windows/custom/',
+          },
+        },
+      });
+
+      assert.deepEqual(result, { status: 'pass', detail: 'All invariants satisfied.' });
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails and enumerates invariant violations', async () => {
+    const { rootDir, windowDir } = buildFixture({ withViolations: true });
+
+    try {
+      const result = await runInvariantsCheck('sales-order', {
+        rootDir,
+        windowDir,
+        config: {
+          invariants: {
+            addLineFields: {
+              requiredProductLookup: true,
+              quantityDefaultOne: true,
+              hiddenContainsGrossUnitPriceAndPriceList: true,
+            },
+            draftModeReadOnlyLogic: true,
+            notNullRequiresRequired: true,
+            customFormPathRoot: '@/windows/custom/',
+          },
+        },
+      });
+
+      assert.equal(result.status, 'fail');
+      assert.match(result.detail, /documentNo/);
+      assert.match(result.detail, /product/);
+      assert.match(result.detail, /quantity/);
+      assert.match(result.detail, /priceList/);
+      assert.match(result.detail, /MissingPanel/);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/test/quality-gate-checks-parse.test.js
+++ b/cli/test/quality-gate-checks-parse.test.js
@@ -1,0 +1,59 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runParseCheck } from '../src/quality-gate/checks/parse.js';
+
+function makeWindowDir() {
+  const rootDir = mkdtempSync(join(tmpdir(), 'quality-gate-parse-'));
+  const windowDir = join(rootDir, 'artifacts', 'sales-order');
+  mkdirSync(join(windowDir, 'generated', 'web', 'sales-order'), { recursive: true });
+  return { rootDir, windowDir };
+}
+
+describe('runParseCheck', () => {
+  it('passes when every generated JSX file parses', async () => {
+    const { rootDir, windowDir } = makeWindowDir();
+
+    try {
+      writeFileSync(
+        join(windowDir, 'generated', 'web', 'sales-order', 'SalesOrderPage.jsx'),
+        'export default function SalesOrderPage() { return <section>Ready</section>; }',
+      );
+
+      const result = await runParseCheck('sales-order', { rootDir, windowDir });
+      assert.deepEqual(result, { status: 'pass', detail: 'Parsed 1 generated source file(s).' });
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fails with file context when a generated JSX file is invalid', async () => {
+    const { rootDir, windowDir } = makeWindowDir();
+
+    try {
+      writeFileSync(
+        join(windowDir, 'generated', 'web', 'sales-order', 'Broken.jsx'),
+        'export default function Broken() { return <section>oops</div>; }',
+      );
+
+      const result = await runParseCheck('sales-order', { rootDir, windowDir });
+      assert.equal(result.status, 'fail');
+      assert.match(result.detail, /Broken\.jsx/);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('skips windows without generated source files', async () => {
+    const { rootDir, windowDir } = makeWindowDir();
+
+    try {
+      const result = await runParseCheck('sales-order', { rootDir, windowDir });
+      assert.deepEqual(result, { status: 'skip', detail: 'No generated .js or .jsx files found.' });
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/test/quality-gate-cli.test.js
+++ b/cli/test/quality-gate-cli.test.js
@@ -1,0 +1,191 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseQualityGateArgs, runQualityGateCli } from '../src/quality-gate.js';
+
+const CONFIG = {
+  checks: {
+    parse: { enabled: true, severity: 'blocker' },
+    imports: { enabled: true, severity: 'blocker' },
+  },
+  gate: {
+    onBlockerFail: 'fail',
+    regressionPolicy: 'no-worse-than-main',
+    baselineRef: 'origin/main',
+  },
+  blastRadius: [
+    { pattern: 'artifacts/*/decisions.json', scope: 'touched-window' },
+    { pattern: 'cli/src/generate-frontend.js', scope: 'all-windows' },
+  ],
+  invariants: {},
+};
+
+describe('parseQualityGateArgs', () => {
+  it('parses CLI flags into a normalized options object', () => {
+    const options = parseQualityGateArgs([
+      '--window', 'sales-order',
+      '--baseline-ref', 'origin/develop',
+      '--format', 'json',
+      '--output', 'report.md',
+      '--json', 'report.json',
+      '--analysis-dir', 'analysis-bundle'
+    ]);
+
+    assert.equal(options.mode, 'window');
+    assert.equal(options.windowName, 'sales-order');
+    assert.equal(options.baselineRef, 'origin/develop');
+    assert.equal(options.format, 'json');
+    assert.equal(options.outputPath, 'report.md');
+    assert.equal(options.jsonPath, 'report.json');
+    assert.equal(options.analysisDir, 'analysis-bundle');
+  });
+});
+
+describe('runQualityGateCli', () => {
+  it('skips cleanly when no windows are affected', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'quality-gate-cli-'));
+
+    try {
+      const result = await runQualityGateCli({
+        args: ['--pr-affected'],
+        rootDir,
+        deps: {
+          loadConfig: async () => CONFIG,
+          collectDecisionWindows: () => ['sales-order'],
+          getChangedFiles: async () => ['README.md'],
+          detectAffectedWindows: () => [],
+        },
+      });
+
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.summary, null);
+      assert.match(result.stdout, /No windows affected; gate skipped/);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes markdown and json outputs and returns a failing exit code when the gate fails', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'quality-gate-cli-'));
+    const markdownPath = join(rootDir, 'qg-report.md');
+    const jsonPath = join(rootDir, 'qg-report.json');
+
+    try {
+      const result = await runQualityGateCli({
+        args: ['--window', 'sales-order', '--output', markdownPath, '--json', jsonPath],
+        rootDir,
+        deps: {
+          loadConfig: async () => CONFIG,
+          runQualityGate: async () => ({
+            summary: { gateVerdict: 'FAIL', affectedWindows: 1 },
+            windows: [{
+              window: 'sales-order',
+              verdict: 'FAIL',
+              score: { passed: 1, total: 2 },
+              blockerFailures: ['imports'],
+              checks: [
+                { check: 'parse', severity: 'blocker', status: 'pass', detail: 'ok' },
+                { check: 'imports', severity: 'blocker', status: 'fail', detail: 'Broken import' },
+              ],
+            }],
+          }),
+          resolveBaseline: async () => ({
+            source: 'cache',
+            baselineSha: 'abc1234',
+            data: { windows: [{ window: 'sales-order', score: { passed: 2, total: 2 } }] },
+          }),
+        },
+      });
+
+      assert.equal(result.exitCode, 1);
+      assert.match(readFileSync(markdownPath, 'utf8'), /sales-order/);
+      const json = JSON.parse(readFileSync(jsonPath, 'utf8'));
+      assert.equal(json.summary.gateVerdict, 'FAIL');
+      assert.equal(json.windows[0].delta, -1);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes an analyzable bundle for --all runs', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'quality-gate-cli-'));
+    const analysisDir = join(rootDir, 'analysis');
+
+    try {
+      const result = await runQualityGateCli({
+        args: ['--all', '--analysis-dir', analysisDir],
+        rootDir,
+        deps: {
+          loadConfig: async () => CONFIG,
+          collectDecisionWindows: () => ['sales-order'],
+          runQualityGate: async () => ({
+            summary: { gateVerdict: 'FAIL', affectedWindows: 1 },
+            windows: [{
+              window: 'sales-order',
+              verdict: 'FAIL',
+              score: { passed: 1, total: 2 },
+              blockerFailures: ['imports'],
+              checks: [
+                { check: 'parse', severity: 'blocker', status: 'pass', detail: 'ok' },
+                { check: 'imports', severity: 'blocker', status: 'fail', detail: 'Broken import' }
+              ]
+            }]
+          }),
+          resolveBaseline: async () => ({
+            source: 'cache',
+            baselineSha: 'abc1234',
+            data: { windows: [{ window: 'sales-order', score: { passed: 2, total: 2 } }] }
+          })
+        }
+      });
+
+      assert.equal(result.exitCode, 1);
+      assert.match(readFileSync(join(analysisDir, 'report.json'), 'utf8'), /sales-order/);
+      assert.match(readFileSync(join(analysisDir, 'summary.csv'), 'utf8'), /window,verdict,score_passed/);
+      assert.match(readFileSync(join(analysisDir, 'checks.csv'), 'utf8'), /window,check,severity,status/);
+      assert.match(readFileSync(join(analysisDir, 'checks.jsonl'), 'utf8'), /"check":"imports"/);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('defaults the analysis bundle path for --all', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'quality-gate-cli-'));
+
+    try {
+      const result = await runQualityGateCli({
+        args: ['--all'],
+        rootDir,
+        deps: {
+          loadConfig: async () => CONFIG,
+          collectDecisionWindows: () => ['sales-order'],
+          runQualityGate: async () => ({
+            summary: { gateVerdict: 'PASS', affectedWindows: 1 },
+            windows: [{
+              window: 'sales-order',
+              verdict: 'PASS',
+              score: { passed: 2, total: 2 },
+              blockerFailures: [],
+              checks: [
+                { check: 'parse', severity: 'blocker', status: 'pass', detail: 'ok' }
+              ]
+            }]
+          }),
+          resolveBaseline: async () => ({
+            source: 'cache',
+            baselineSha: 'abc1234',
+            data: { windows: [{ window: 'sales-order', score: { passed: 2, total: 2 } }] }
+          })
+        }
+      });
+
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.analysisDir, join(rootDir, '.quality-gate-cache', 'analysis', 'quality-gate-all'));
+      assert.match(readFileSync(join(result.analysisDir, 'report.json'), 'utf8'), /sales-order/);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/test/quality-gate-detect.test.js
+++ b/cli/test/quality-gate-detect.test.js
@@ -1,0 +1,163 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { collectDecisionWindows, detectAffectedWindows } from '../src/quality-gate/detect.js';
+
+const SAMPLE_CONFIG = {
+  blastRadius: [
+    { pattern: 'artifacts/*/decisions.json', scope: 'touched-window' },
+    { pattern: 'artifacts/*/contract.json', scope: 'touched-window' },
+    { pattern: 'artifacts/*/custom/**', scope: 'touched-window' },
+    { pattern: 'artifacts/*/generated/**', scope: 'touched-window' },
+    { pattern: 'tools/app-shell/src/windows/custom/*/**', scope: 'touched-window' },
+    { pattern: 'cli/src/generate-frontend.js', scope: 'all-windows' },
+    { pattern: 'tools/app-shell/src/components/contract-ui/**', scope: 'all-windows' },
+    { pattern: 'tools/app-shell/src/i18n/*.js', scope: 'all-windows' },
+    { pattern: 'tools/app-shell/src/i18n/*.jsx', scope: 'all-windows' },
+    { pattern: 'tools/app-shell/src/windows/registry.js', scope: 'all-windows' },
+    { pattern: 'schemas/contract.schema.json', scope: 'all-windows' },
+  ],
+};
+
+describe('collectDecisionWindows', () => {
+  it('collects tracked windows from artifacts directories', () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'quality-gate-detect-'));
+
+    try {
+      mkdirSync(join(rootDir, 'artifacts', 'sales-order'), { recursive: true });
+      mkdirSync(join(rootDir, 'artifacts', 'purchase-order'), { recursive: true });
+      mkdirSync(join(rootDir, 'artifacts', 'ignore-me'), { recursive: true });
+      writeFileSync(join(rootDir, 'artifacts', 'sales-order', 'decisions.json'), '{}');
+      writeFileSync(join(rootDir, 'artifacts', 'purchase-order', 'decisions.json'), '{}');
+      writeFileSync(join(rootDir, 'artifacts', 'ignore-me', 'schema-raw.json'), '{}');
+
+      assert.deepEqual(collectDecisionWindows(rootDir), ['purchase-order', 'sales-order']);
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('detectAffectedWindows', () => {
+  it('returns only the touched window for artifact-local changes', () => {
+    const affected = detectAffectedWindows({
+      changedFiles: ['artifacts/purchase-order/decisions.json'],
+      blastRadius: SAMPLE_CONFIG.blastRadius,
+      availableWindows: ['purchase-order', 'sales-order'],
+    });
+
+    assert.deepEqual(affected, ['purchase-order']);
+  });
+
+  it('returns all windows for shared generator changes', () => {
+    const affected = detectAffectedWindows({
+      changedFiles: ['cli/src/generate-frontend.js'],
+      blastRadius: SAMPLE_CONFIG.blastRadius,
+      availableWindows: ['purchase-order', 'sales-order'],
+    });
+
+    assert.deepEqual(affected, ['purchase-order', 'sales-order']);
+  });
+
+  it('returns the touched window for artifact custom code changes', () => {
+    const affected = detectAffectedWindows({
+      changedFiles: ['artifacts/purchase-order/custom/Sidebar.jsx'],
+      blastRadius: SAMPLE_CONFIG.blastRadius,
+      availableWindows: ['purchase-order', 'sales-order'],
+    });
+
+    assert.deepEqual(affected, ['purchase-order']);
+  });
+
+  it('returns the touched window for app-shell custom window changes', () => {
+    const affected = detectAffectedWindows({
+      changedFiles: ['tools/app-shell/src/windows/custom/sales-order/Sidebar.jsx'],
+      blastRadius: SAMPLE_CONFIG.blastRadius,
+      availableWindows: ['purchase-order', 'sales-order'],
+    });
+
+    assert.deepEqual(affected, ['sales-order']);
+  });
+
+  it('returns the touched window for generated artifact changes', () => {
+    const affected = detectAffectedWindows({
+      changedFiles: ['artifacts/sales-order/generated/web/sales-order/HeaderPage.jsx'],
+      blastRadius: SAMPLE_CONFIG.blastRadius,
+      availableWindows: ['purchase-order', 'sales-order'],
+    });
+
+    assert.deepEqual(affected, ['sales-order']);
+  });
+
+  it('returns all windows for shared i18n runtime javascript changes', () => {
+    const affected = detectAffectedWindows({
+      changedFiles: ['tools/app-shell/src/i18n/useLabel.js'],
+      blastRadius: SAMPLE_CONFIG.blastRadius,
+      availableWindows: ['purchase-order', 'sales-order'],
+    });
+
+    assert.deepEqual(affected, ['purchase-order', 'sales-order']);
+  });
+
+  it('returns all windows for shared i18n runtime jsx changes', () => {
+    const affected = detectAffectedWindows({
+      changedFiles: ['tools/app-shell/src/i18n/LocaleProvider.jsx'],
+      blastRadius: SAMPLE_CONFIG.blastRadius,
+      availableWindows: ['purchase-order', 'sales-order'],
+    });
+
+    assert.deepEqual(affected, ['purchase-order', 'sales-order']);
+  });
+
+  it('returns all windows for registry changes', () => {
+    const affected = detectAffectedWindows({
+      changedFiles: ['tools/app-shell/src/windows/registry.js'],
+      blastRadius: SAMPLE_CONFIG.blastRadius,
+      availableWindows: ['purchase-order', 'sales-order'],
+    });
+
+    assert.deepEqual(affected, ['purchase-order', 'sales-order']);
+  });
+
+  it('returns all windows for contract schema changes', () => {
+    const affected = detectAffectedWindows({
+      changedFiles: ['schemas/contract.schema.json'],
+      blastRadius: SAMPLE_CONFIG.blastRadius,
+      availableWindows: ['purchase-order', 'sales-order'],
+    });
+
+    assert.deepEqual(affected, ['purchase-order', 'sales-order']);
+  });
+
+  it('maps businessPartner shared custom code back to contacts', () => {
+    const affected = detectAffectedWindows({
+      changedFiles: ['tools/app-shell/src/windows/custom/businessPartner/BusinessPartnerSidebar.jsx'],
+      blastRadius: SAMPLE_CONFIG.blastRadius,
+      availableWindows: ['contacts', 'purchase-order'],
+    });
+
+    assert.deepEqual(affected, ['contacts']);
+  });
+
+  it('treats shared custom helpers as affecting every window', () => {
+    const affected = detectAffectedWindows({
+      changedFiles: ['tools/app-shell/src/windows/custom/shared/InvoicePaymentModal.jsx'],
+      blastRadius: SAMPLE_CONFIG.blastRadius,
+      availableWindows: ['contacts', 'purchase-order'],
+    });
+
+    assert.deepEqual(affected, ['contacts', 'purchase-order']);
+  });
+
+  it('returns no windows for unrelated changes', () => {
+    const affected = detectAffectedWindows({
+      changedFiles: ['README.md'],
+      blastRadius: SAMPLE_CONFIG.blastRadius,
+      availableWindows: ['purchase-order', 'sales-order'],
+    });
+
+    assert.deepEqual(affected, []);
+  });
+});

--- a/cli/test/quality-gate-runner.test.js
+++ b/cli/test/quality-gate-runner.test.js
@@ -1,0 +1,149 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { runQualityGate } from '../src/quality-gate/runner.js';
+import { buildQualityGateReport } from '../src/quality-gate/report.js';
+
+const CONFIG = {
+  checks: {
+    parse: { enabled: true, severity: 'blocker' },
+    imports: { enabled: true, severity: 'blocker' },
+  },
+  gate: {
+    onBlockerFail: 'fail',
+    regressionPolicy: 'no-worse-than-main',
+    baselineRef: 'origin/main',
+  },
+};
+
+describe('runQualityGate', () => {
+  it('marks a window FAIL when any blocker fails', async () => {
+    const result = await runQualityGate({
+      windowNames: ['alpha', 'beta'],
+      rootDir: '/repo',
+      config: CONFIG,
+      checkers: {
+        parse: async (windowName) => ({
+          status: 'pass',
+          detail: `${windowName} parsed`,
+        }),
+        imports: async (windowName) => windowName === 'beta'
+          ? { status: 'fail', detail: 'Broken relative import' }
+          : { status: 'pass', detail: 'Imports resolved' },
+      },
+    });
+
+    assert.equal(result.summary.gateVerdict, 'FAIL');
+    assert.equal(result.windows[0].verdict, 'PASS');
+    assert.equal(result.windows[0].score.passed, 2);
+    assert.equal(result.windows[0].score.total, 2);
+    assert.equal(result.windows[1].verdict, 'FAIL');
+    assert.deepEqual(result.windows[1].blockerFailures, ['imports']);
+  });
+
+  it('treats thrown checks as blocker failures without masking other results', async () => {
+    const result = await runQualityGate({
+      windowNames: ['alpha'],
+      rootDir: '/repo',
+      config: CONFIG,
+      checkers: {
+        parse: async () => {
+          throw new Error('parser blew up');
+        },
+        imports: async () => ({ status: 'pass', detail: 'Imports resolved' }),
+      },
+    });
+
+    assert.equal(result.summary.gateVerdict, 'FAIL');
+    assert.equal(result.windows[0].checks[0].status, 'error');
+    assert.match(result.windows[0].checks[0].detail, /parser blew up/);
+    assert.equal(result.windows[0].checks[1].status, 'pass');
+  });
+
+  it('marks a window NO-OP when every enabled blocker skips', async () => {
+    const result = await runQualityGate({
+      windowNames: ['alpha'],
+      rootDir: '/repo',
+      config: CONFIG,
+      checkers: {
+        parse: async () => ({ status: 'skip', detail: 'No generated files' }),
+        imports: async () => ({ status: 'skip', detail: 'No generated files' }),
+      },
+    });
+
+    assert.equal(result.summary.gateVerdict, 'PASS');
+    assert.equal(result.windows[0].verdict, 'NO-OP');
+    assert.equal(result.summary.scoredWindows, 0);
+  });
+});
+
+describe('buildQualityGateReport', () => {
+  it('computes score deltas against baseline and renders markdown', () => {
+    const report = buildQualityGateReport({
+      baselineRef: 'origin/main',
+      baselineSha: 'abc1234',
+      headResult: {
+        summary: { gateVerdict: 'FAIL' },
+        windows: [
+          {
+            window: 'internal-consumption',
+            verdict: 'FAIL',
+            score: { passed: 1, total: 2 },
+            blockerFailures: ['imports'],
+            checks: [
+              { check: 'parse', severity: 'blocker', status: 'pass', detail: 'ok' },
+              { check: 'imports', severity: 'blocker', status: 'fail', detail: 'Broken relative import' },
+            ],
+          },
+        ],
+      },
+      baselineResult: {
+        windows: [
+          {
+            window: 'internal-consumption',
+            score: { passed: 2, total: 2 },
+          },
+        ],
+      },
+    });
+
+    assert.equal(report.summary.gateVerdict, 'FAIL');
+    assert.equal(report.summary.windows[0].delta, -1);
+    assert.match(report.markdown, /Schema Forge Quality Gate/);
+    assert.match(report.markdown, /internal-consumption/);
+    assert.match(report.markdown, /Broken relative import/);
+    assert.match(report.markdown, /<!-- sfqg-report -->/);
+  });
+
+  it('fails the gate when a window regresses below baseline even without blocker failures', () => {
+    const report = buildQualityGateReport({
+      baselineRef: 'origin/main',
+      baselineSha: 'abc1234',
+      headResult: {
+        summary: { gateVerdict: 'PASS' },
+        windows: [
+          {
+            window: 'sales-order',
+            verdict: 'PASS',
+            score: { passed: 1, total: 2 },
+            blockerFailures: [],
+            checks: [
+              { check: 'parse', severity: 'blocker', status: 'pass', detail: 'ok' },
+              { check: 'imports', severity: 'blocker', status: 'skip', detail: 'not applicable' }
+            ]
+          }
+        ]
+      },
+      baselineResult: {
+        windows: [
+          {
+            window: 'sales-order',
+            score: { passed: 2, total: 2 }
+          }
+        ]
+      }
+    });
+
+    assert.equal(report.summary.gateVerdict, 'FAIL');
+    assert.equal(report.summary.windows[0].delta, -1);
+  });
+});

--- a/cli/test/quality-gate-source-required.test.js
+++ b/cli/test/quality-gate-source-required.test.js
@@ -1,0 +1,33 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { resolveCurated } from '../src/resolve-curated.js';
+
+describe('resolveCurated sourceRequired metadata', () => {
+  it('preserves raw mandatory information on curated fields', async () => {
+    const schemaRaw = {
+      window: { id: '1', name: 'Sales Order' },
+      entities: [{
+        name: 'cOrder',
+        tableName: 'C_Order',
+        tabId: '10',
+        tabName: 'Header',
+        fields: [{
+          name: 'documentNo',
+          columnName: 'DocumentNo',
+          label: 'Document No.',
+          type: 'string',
+          visibility: 'editable',
+          mandatory: true,
+        }],
+      }],
+    };
+
+    const { schema } = await resolveCurated(schemaRaw, { rules: [] }, {
+      version: 2,
+      window: {},
+      entities: {},
+    });
+
+    assert.equal(schema.entities[0].fields[0].sourceRequired, true);
+  });
+});

--- a/cli/test/schemas.test.js
+++ b/cli/test/schemas.test.js
@@ -21,6 +21,7 @@ describe('JSON Schemas', () => {
       'rules.schema.json',
       'processes.schema.json',
       'contract.schema.json',
+      'quality-gate-config.schema.json',
       'step-operation.schema.json'
     ];
     for (const f of files) {
@@ -42,5 +43,12 @@ describe('JSON Schemas', () => {
     assert.ok(types.includes('validate'));
     assert.ok(types.includes('mutation'));
     assert.ok(types.includes('forEach'));
+  });
+
+  it('contract schema exposes frontend field metadata used by the quality gate', async () => {
+    const schema = await loadSchema('contract.schema.json');
+    const fieldProps = schema.properties.frontendContract.properties.entities.additionalProperties.properties.fields.items.properties;
+    assert.equal(fieldProps.sourceRequired.type, 'boolean');
+    assert.equal(fieldProps.derivation.type, 'object');
   });
 });

--- a/docs/index.md
+++ b/docs/index.md
@@ -71,6 +71,25 @@ General findings about how the Etendo Application Dictionary works. Not window-s
 | [ops/copilot-pr-review.md](ops/copilot-pr-review.md) | Copilot-aligned PR review gate: review instructions, deterministic findings, PR comments, and request-changes behavior |
 | [ops/epic-rollup-report.md](ops/epic-rollup-report.md) | Develop-targeted epic rollout report: included feature PRs, prior review findings, and aggregated release-risk summary |
 
+## Proposals
+
+Design proposals and RFCs awaiting review and approval. See [proposals/INDEX.md](proposals/INDEX.md) for lifecycle details.
+
+| File | Status | Description |
+|------|--------|-------------|
+| [proposals/etendo-go-apps.md](proposals/etendo-go-apps.md) | Draft | External apps framework for Etendo Go (Jira Connect-style) — executive summary |
+| [proposals/etendo-go-apps-technical-annex.md](proposals/etendo-go-apps-technical-annex.md) | Draft | External apps framework — technical annex (architecture, descriptor, JWT+JWKS, BFF, SDK) |
+| [plans/2026-04-17-etendo-go-apps-f1-spike-plan.md](plans/2026-04-17-etendo-go-apps-f1-spike-plan.md) | Ready | F1 spike execution plan (10 tasks, validates JWT+JWKS+BFF end-to-end) |
+| [proposals/initial-organization-setup-accounting.md](proposals/initial-organization-setup-accounting.md) | Reviewed / Pending plan | Initial Organization Setup accounting proposal — global package reuse, org wiring, completeness validation, and standard `AD_Org_Ready` finish |
+
+## Presentations
+
+Slide-deck style walkthroughs (Marp Markdown). See [presentations/INDEX.md](presentations/INDEX.md) for how to render.
+
+| File | Description |
+|------|-------------|
+| [presentations/etendo-apps-sdk-demo.md](presentations/etendo-apps-sdk-demo.md) | Etendo Apps SDK + `quick-order-app` demo — architecture, JWT bridge, styling, trade-offs |
+
 ## Plans & Evaluations
 
 Plans follow a lifecycle: active in `plans/`, completed in `plans/completed/YYYY-MM-DD/`, discarded in `plans/discarded/`.

--- a/docs/proposals/INDEX.md
+++ b/docs/proposals/INDEX.md
@@ -1,0 +1,26 @@
+# Proposals
+
+Design proposals and RFCs awaiting review, approval, or decomposition into implementation plans.
+
+Proposals differ from plans:
+
+- **Proposals** describe the *what* and *why* at a strategic level. They are reviewed by stakeholders, approved or rejected, and may be superseded by newer proposals. They live here until promoted.
+- **Plans** (`../plans/`) describe the *how* at an execution level, with task breakdown and acceptance criteria.
+
+## Lifecycle
+
+1. Proposal written and committed in this folder
+2. Stakeholders review and approve
+3. If approved, the proposal is promoted to an implementation plan under `../plans/`
+4. If rejected or deferred, the proposal stays here for historical reference or moves to `discarded/` (to be created when first discard happens)
+
+## Index
+
+| File | Status | Description |
+|------|--------|-------------|
+| [etendo-go-apps.md](etendo-go-apps.md) | Draft / Pending approval | Executive summary — external apps framework for Etendo Go (Jira Connect-style) |
+| [etendo-go-apps-technical-annex.md](etendo-go-apps-technical-annex.md) | Draft / Pending approval | Technical annex — architecture, descriptor, JWT+JWKS, BFF, lifecycle, SDK |
+| [etendo-apps-sdk.md](etendo-apps-sdk.md) | Draft / Pending approval | Apps SDK v1 (internal apps) — `@etendo/apps-sdk` + `@etendo/apps-sdk-bff`, migration from spike, quick-order as first consumer |
+| [apps-sdk-styling.md](apps-sdk-styling.md) | Draft / Pending approval | Apps SDK styling (Option A) — ship shared CSS tokens + base.css so iframe apps inherit shell look with one import |
+| [apps-sdk-mock-installer.md](apps-sdk-mock-installer.md) | Draft / Pending approval | Mock App Store installer — localStorage-backed install toggle, catalog-driven menu entries for SDK apps |
+| [initial-organization-setup-accounting.md](initial-organization-setup-accounting.md) | Reviewed / Pending plan | Source-grounded proposal for automatic accounting in Initial Organization Setup: global package resolution, org wiring, pre-ready validation, and standard `AD_Org_Ready` completion |

--- a/docs/proposals/initial-organization-setup-accounting.md
+++ b/docs/proposals/initial-organization-setup-accounting.md
@@ -1,0 +1,278 @@
+# Initial Organization Setup with Automatic Accounting
+
+## Context
+
+This document validates the proposed hybrid approach for `Initial Organization Setup` against the current Etendo source code in this repository.
+
+The product decision for this iteration is:
+
+- use one global accounting package for now
+- keep a clean seam to resolve a package by localization/template later
+- run onboarding with currency selected in the flow; current target currency is `EUR`
+- require `AD_ORG.C_ACCTSCHEMA_ID` to be populated in the final state
+
+## Objective
+
+Make a newly onboarded organization end in a source-valid accounting state without manual follow-up:
+
+- organization type `Legal with Accounting`
+- `AD_ORG.C_ACCTSCHEMA_ID` assigned
+- `AD_ORG_ACCTSCHEMA` consistent with that schema
+- fiscal calendar available
+- years and periods available
+- base taxes available
+- `Allow Period Control = Y`
+- `Ready = Y` only after the standard setup validation passes
+
+## What the code confirms
+
+### 1. The resolver/apply split fits the current flow
+
+The current entrypoint is:
+
+- `etendo_core/src/org/openbravo/erpCommon/ad_forms/InitialOrgSetup.java`
+- `etendo_core/src/org/openbravo/erpCommon/businessUtility/InitialOrgSetup.java`
+
+`ad_forms.InitialOrgSetup` only collects form inputs and delegates everything to `businessUtility.InitialOrgSetup.createOrganization(...)`.
+
+Inside `createOrganization(...)`, the clean seams are:
+
+1. after duplicate validation and before `insertOrganization(...)` -> resolve which accounting package to use
+2. after the organization exists and before accounting/reference-data logic -> apply package wiring to the new org
+
+### 2. `Ready` must remain owned by `AD_Org_Ready`
+
+Current source behavior:
+
+- `AD_ORG.ISREADY` defaults to `N`
+- `InitialOrgSetup.createOrganization(...)` does not set `Ready`
+- `AD_ORG_READY` performs the standard validation and rolls back on failure
+
+Relevant sources:
+
+- `etendo_core/src-db/database/model/tables/AD_ORG.xml`
+- `etendo_core/src-db/database/model/functions/AD_ORG_READY.xml`
+- `etendo_core/src-db/database/model/functions/AD_ORG_CHK_READY.xml`
+- `etendo_core/src-db/database/model/functions/AD_ORG_CHK_SCHEMAS.xml`
+- `etendo_core/src-db/database/model/functions/AD_ORG_CHK_CALENDAR.xml`
+
+This means the onboarding must never force `Ready` with a direct update.
+
+### 3. The current accounting path is creation-first, not reuse-first
+
+The existing `boCreateAccounting` path is implemented through `COAUtility`.
+
+Relevant source:
+
+- `etendo_core/src/org/openbravo/erpCommon/businessUtility/COAUtility.java`
+
+For initial organization setup, `COAUtility` explicitly skips calendar/year creation for org setup, but it still creates a fresh:
+
+- `C_ELEMENT`
+- `C_ACCTSCHEMA`
+- `C_ELEMENTVALUE`
+- `C_ACCTSCHEMA_GL`
+- `C_ACCTSCHEMA_DEFAULT`
+- `AD_ORG_ACCTSCHEMA`
+
+Therefore the current path cannot be reused as the implementation for a shared global accounting package.
+
+### 4. Organization-level dataset import is not a shared-package mechanism
+
+Relevant sources:
+
+- `etendo_core/src/org/openbravo/erpCommon/businessUtility/InitialSetupUtility.java`
+- `etendo_core/src/org/openbravo/service/db/DataImportService.java`
+- `etendo_core/src/org/openbravo/dal/xml/EntityResolver.java`
+
+`InitialSetupUtility.insertReferenceData(...)` imports XML using the target organization context. For organization-enabled tables, `EntityResolver.setClientOrganization(...)` assigns the imported rows to the target organization.
+
+This is appropriate for org-scoped reference data, but it is not appropriate for a single reusable package that must be shared instead of cloned on every onboarding.
+
+### 5. The shipped sample data proves the target end state is native
+
+Relevant sample data:
+
+- `etendo_core/referencedata/sampledata/F_B_International_Group/AD_ORG.xml`
+- `etendo_core/referencedata/sampledata/F_B_International_Group/AD_ORG_ACCTSCHEMA.xml`
+- `etendo_core/referencedata/sampledata/F_B_International_Group/C_ACCTSCHEMA.xml`
+- `etendo_core/referencedata/sampledata/F_B_International_Group/C_CALENDAR.xml`
+- `etendo_core/referencedata/sampledata/F_B_International_Group/C_YEAR.xml`
+- `etendo_core/referencedata/sampledata/F_B_International_Group/C_PERIOD.xml`
+- `etendo_core/referencedata/sampledata/F_B_International_Group/C_PERIODCONTROL.xml`
+- `etendo_core/referencedata/sampledata/F_B_International_Group/C_TAX.xml`
+- `etendo_core/referencedata/sampledata/F_B_International_Group/C_TAXCATEGORY.xml`
+- `etendo_core/referencedata/sampledata/F_B_International_Group/C_TAX_ACCT.xml`
+
+The sample shows:
+
+- legal entities with accounting are type `1`
+- they own calendars
+- they allow period control
+- they are ready
+- descendant orgs inherit calendar/period-control semantics from the legal entity
+
+This validates the target business state itself.
+
+## Final design decision
+
+## Package model
+
+For this iteration, the accounting package must be treated as a pre-seeded global package, not as org-by-org imported dataset content during onboarding.
+
+The package can still originate from dataset-managed content operationally, but by the time onboarding runs it must already exist once in the client and be resolvable as a reusable source package.
+
+## Resolver responsibility
+
+Introduce an explicit resolver responsibility:
+
+- `resolveAccountingPackage(onboardingContext) -> AccountingPackage`
+
+For this iteration, the resolver returns the single global package and validates that the requested onboarding currency is supported.
+
+Future evolution changes only this resolver layer:
+
+- localization
+- country
+- template
+- equivalent product configuration key
+
+The wiring layer remains unchanged.
+
+## Wiring responsibility
+
+Introduce a separate wiring responsibility:
+
+- `applyAccountingPackageWiring(newOrg, package, onboardingContext)`
+
+The wiring step must:
+
+1. set organization type to `Legal with Accounting`
+2. set onboarding currency on the organization
+3. set `Allow Period Control = Y`
+4. assign `AD_ORG.C_ACCTSCHEMA_ID`
+5. guarantee a consistent `AD_ORG_ACCTSCHEMA` row
+6. associate the correct fiscal calendar owner path
+7. prepare the org so that `AD_Org_Ready` can perform the final standard validation
+
+The derived persist-info fields remain the responsibility of `AD_Org_Ready`:
+
+- `AD_PERIODCONTROLALLOWED_ORG_ID`
+- `AD_CALENDAROWNER_ORG_ID`
+- `AD_LEGALENTITY_ORG_ID`
+- `AD_INHERITEDCALENDAR_ID`
+- `AD_BUSINESSUNIT_ORG_ID`
+
+## Validation before `AD_Org_Ready`
+
+The standard ready process is necessary but not sufficient for the business promise of automatic accounting.
+
+Before calling `AD_Org_Ready`, onboarding must validate that the resolved package is complete enough to satisfy the product contract.
+
+### Required package contents
+
+Minimum required:
+
+- `C_ACCTSCHEMA`
+- `C_ELEMENT`
+- `C_ELEMENTVALUE`
+- `C_CALENDAR`
+- `C_YEAR`
+- `C_PERIOD`
+- `C_TAX`
+
+Required consistency companions:
+
+- `AD_ORG_ACCTSCHEMA`
+- `C_ACCTSCHEMA_DEFAULT`
+- `C_ACCTSCHEMA_ELEMENT`
+- `C_ACCTSCHEMA_GL`
+- `C_ACCTSCHEMA_TABLE`
+- `C_TAXCATEGORY`
+- `C_TAX_ACCT`
+
+Optional / not central:
+
+- `C_VALIDCOMBINATION` may exist as derived support data, but it must not be the center of onboarding design
+
+### Period control rule
+
+`C_PERIODCONTROL` for the newly onboarded organization must not be pre-materialized by onboarding.
+
+Reason:
+
+- `AD_ORG_READY` already creates `C_PERIODCONTROL` rows when `Allow Period Control = Y`
+- pre-inserting them for the same org risks duplication and breaks the clean lifecycle
+
+Therefore:
+
+- the package must provide calendar + years + periods
+- `AD_Org_Ready` must materialize `C_PERIODCONTROL` for the new org
+
+## Proposed flow
+
+1. validate onboarding inputs
+2. resolve accounting package from onboarding context
+3. create the new organization
+4. apply accounting wiring to the new organization
+5. validate package completeness for the selected package
+6. call the standard `AD_Org_Ready` process
+7. commit only if the ready process succeeds
+
+## Source-grounded risks to avoid
+
+### Reusing `COAUtility` as-is
+
+Not valid for this design.
+
+`COAUtility` creates a new schema instead of linking an existing package.
+
+### Importing the package as org-level reference data during onboarding
+
+Not valid for this design.
+
+The current dataset import path assigns organization-enabled rows to the target org and behaves like cloning, not shared reuse.
+
+### Marking `Ready` before wiring is complete
+
+Not valid for this design.
+
+Runtime code already treats `Ready` as a lifecycle gate.
+
+### Using `C_VALIDCOMBINATION` as the core contract
+
+Not valid for this design.
+
+It can remain derived support data, but the org setup contract must be expressed in terms of schema, calendar, periods, taxes, and standard ready validation.
+
+## Implementation seam in current code
+
+Primary target:
+
+- `etendo_core/src/org/openbravo/erpCommon/businessUtility/InitialOrgSetup.java`
+
+Recommended internal split:
+
+- `resolveAccountingPackage(...)`
+- `applyAccountingPackageWiring(...)`
+- `validateAccountingPackage(...)`
+- existing final invocation of standard readiness logic
+
+## Acceptance criteria
+
+The design is considered correct when a new organization created through onboarding:
+
+- ends as `Legal with Accounting`
+- has `AD_ORG.C_ACCTSCHEMA_ID` populated
+- has a consistent `AD_ORG_ACCTSCHEMA` linkage
+- has a usable fiscal calendar
+- has years and periods available
+- has base taxes available
+- has `Allow Period Control = Y`
+- reaches `Ready = Y` only through the standard ready process, with no manual post-setup steps
+
+## Status
+
+Validated against current source with product decisions resolved on 2026-04-21.
+
+Ready to be converted into an implementation plan.

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "sf-validate": "src/validate-schema.js"
       },
       "devDependencies": {
+        "@babel/parser": "^7.29.2",
         "ajv": "^8.17.0"
       },
       "engines": {
@@ -246,7 +247,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -565,9 +565,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2715,7 +2715,6 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4567,7 +4566,6 @@
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -4706,7 +4704,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5135,7 +5132,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7116,7 +7112,6 @@
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7901,7 +7896,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8827,7 +8821,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9039,7 +9032,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9390,7 +9382,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9403,7 +9394,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9780,7 +9770,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11334,7 +11323,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -11789,7 +11777,6 @@
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -12182,7 +12169,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/quality-gate.config.json
+++ b/quality-gate.config.json
@@ -1,0 +1,41 @@
+{
+  "checks": {
+    "parse": { "severity": "blocker", "enabled": true },
+    "imports": { "severity": "blocker", "enabled": true },
+    "contract": { "severity": "blocker", "enabled": true },
+    "invariants": { "severity": "blocker", "enabled": true },
+    "i18n": { "severity": "blocker", "enabled": true }
+  },
+  "gate": {
+    "onBlockerFail": "fail",
+    "regressionPolicy": "no-worse-than-main",
+    "baselineRef": "origin/main"
+  },
+  "blastRadius": [
+    { "pattern": "artifacts/*/decisions.json", "scope": "touched-window" },
+    { "pattern": "artifacts/*/contract.json", "scope": "touched-window" },
+    { "pattern": "artifacts/*/custom/**", "scope": "touched-window" },
+    { "pattern": "artifacts/*/generated/**", "scope": "touched-window" },
+    { "pattern": "tools/app-shell/src/windows/custom/*/**", "scope": "touched-window" },
+    { "pattern": "cli/src/generate-frontend.js", "scope": "all-windows" },
+    { "pattern": "cli/src/generate-contract.js", "scope": "all-windows" },
+    { "pattern": "cli/src/resolve-curated.js", "scope": "all-windows" },
+    { "pattern": "tools/app-shell/src/components/contract-ui/**", "scope": "all-windows" },
+    { "pattern": "tools/app-shell/src/i18n/*.js", "scope": "all-windows" },
+    { "pattern": "tools/app-shell/src/i18n/*.jsx", "scope": "all-windows" },
+    { "pattern": "tools/app-shell/src/i18n/locales/*.json", "scope": "all-windows" },
+    { "pattern": "tools/app-shell/src/windows/registry.js", "scope": "all-windows" },
+    { "pattern": "schemas/contract.schema.json", "scope": "all-windows" }
+  ],
+  "gracePeriod": [],
+  "invariants": {
+    "addLineFields": {
+      "requiredProductLookup": true,
+      "quantityDefaultOne": true,
+      "hiddenContainsGrossUnitPriceAndPriceList": true
+    },
+    "draftModeReadOnlyLogic": true,
+    "notNullRequiresRequired": true,
+    "customFormPathRoot": "@/windows/custom/"
+  }
+}

--- a/schemas/contract.schema.json
+++ b/schemas/contract.schema.json
@@ -1,17 +1,145 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Contract",
-  "description": "Generation contract artifact. TDD 2.4.",
+  "description": "Generation contract artifact.",
   "type": "object",
-  "required": ["version", "schemaChecksum", "rulesChecksum", "processesChecksum", "frontendContract", "backendContract", "testManifest"],
+  "required": [
+    "version",
+    "generatedAt",
+    "checksum",
+    "frontendContract",
+    "backendContract",
+    "testManifest"
+  ],
   "properties": {
     "version": { "type": "string" },
-    "schemaChecksum": { "type": "string" },
-    "rulesChecksum": { "type": "string" },
-    "processesChecksum": { "type": "string" },
-    "frontendContract": { "type": "object" },
-    "backendContract": { "type": "object" },
-    "testManifest": { "type": "object" }
+    "generatedAt": { "type": "string" },
+    "checksum": { "type": "string" },
+    "frontendContract": {
+      "type": "object",
+      "required": ["window", "entities"],
+      "properties": {
+        "window": {
+          "type": "object",
+          "required": ["primaryEntity"],
+          "properties": {
+            "primaryEntity": { "type": ["string", "null"] }
+          },
+          "additionalProperties": true
+        },
+        "entities": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "required": ["fields", "searchableFields", "computedFields"],
+            "properties": {
+              "fields": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["name", "type", "visibility", "required", "grid", "form"],
+                  "properties": {
+                    "name": { "type": "string" },
+                    "apiKey": { "type": "string" },
+                    "column": { "type": "string" },
+                    "label": { "type": "string" },
+                    "type": { "type": "string" },
+                    "tsType": { "type": "string" },
+                    "visibility": { "type": "string" },
+                    "required": { "type": "boolean" },
+                    "sourceRequired": { "type": "boolean" },
+                    "grid": { "type": "boolean" },
+                    "form": { "type": "boolean" },
+                    "defaultValue": {},
+                    "reference": { "type": "string" },
+                    "inputMode": { "type": "string" },
+                    "lookup": { "type": "boolean" },
+                    "popup": { "type": "boolean" },
+                    "section": { "type": "string" },
+                    "seq": { "type": "number" },
+                    "derivation": {
+                      "type": "object",
+                      "required": ["type"],
+                      "properties": {
+                        "type": { "type": "string" },
+                        "source": {}
+                      },
+                      "additionalProperties": true
+                    },
+                    "callout": {
+                      "type": "object",
+                      "properties": {
+                        "className": { "type": "string" }
+                      },
+                      "additionalProperties": true
+                    },
+                    "displayLogic": { "type": "object", "additionalProperties": true },
+                    "readOnlyLogic": { "type": "object", "additionalProperties": true }
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "searchableFields": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "computedFields": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["name", "derivation"],
+                  "properties": {
+                    "name": { "type": "string" },
+                    "derivation": {
+                      "type": "object",
+                      "required": ["type"],
+                      "properties": {
+                        "type": { "type": "string" },
+                        "source": {}
+                      },
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "draftMode": { "type": "object", "additionalProperties": true }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
+    },
+    "backendContract": {
+      "type": "object",
+      "required": ["window", "entities"],
+      "properties": {
+        "window": { "type": "object", "additionalProperties": true },
+        "entities": { "type": "object", "additionalProperties": true },
+        "endpoints": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "processEndpoints": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+      },
+      "additionalProperties": true
+    },
+    "apiPrediction": {
+      "type": "object",
+      "properties": {
+        "selectors": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "actions": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "crud": { "type": "object", "additionalProperties": { "type": "object", "additionalProperties": true } }
+      },
+      "additionalProperties": true
+    },
+    "testManifest": {
+      "type": "object",
+      "required": ["tests", "summary"],
+      "properties": {
+        "tests": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "summary": { "type": "object", "additionalProperties": true }
+      },
+      "additionalProperties": true
+    }
   },
   "additionalProperties": false
 }

--- a/schemas/quality-gate-config.schema.json
+++ b/schemas/quality-gate-config.schema.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Schema Forge Quality Gate Config",
+  "type": "object",
+  "required": ["checks", "gate", "blastRadius", "gracePeriod", "invariants"],
+  "properties": {
+    "checks": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "object",
+        "required": ["severity", "enabled"],
+        "properties": {
+          "severity": { "enum": ["blocker", "warning"] },
+          "enabled": { "type": "boolean" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "gate": {
+      "type": "object",
+      "required": ["onBlockerFail", "regressionPolicy", "baselineRef"],
+      "properties": {
+        "onBlockerFail": { "enum": ["fail"] },
+        "regressionPolicy": { "enum": ["no-worse-than-main"] },
+        "baselineRef": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "blastRadius": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["pattern", "scope"],
+        "properties": {
+          "pattern": { "type": "string", "minLength": 1 },
+          "scope": { "enum": ["touched-window", "all-windows"] }
+        },
+        "additionalProperties": false
+      }
+    },
+    "gracePeriod": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["until"],
+        "properties": {
+          "window": { "type": "string" },
+          "check": { "type": "string" },
+          "until": { "type": "string", "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$" },
+          "reason": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
+    "invariants": {
+      "type": "object",
+      "required": ["addLineFields", "draftModeReadOnlyLogic", "notNullRequiresRequired", "customFormPathRoot"],
+      "properties": {
+        "addLineFields": {
+          "type": "object",
+          "required": ["requiredProductLookup", "quantityDefaultOne", "hiddenContainsGrossUnitPriceAndPriceList"],
+          "properties": {
+            "requiredProductLookup": { "type": "boolean" },
+            "quantityDefaultOne": { "type": "boolean" },
+            "hiddenContainsGrossUnitPriceAndPriceList": { "type": "boolean" }
+          },
+          "additionalProperties": false
+        },
+        "draftModeReadOnlyLogic": { "type": "boolean" },
+        "notNullRequiresRequired": { "type": "boolean" },
+        "customFormPathRoot": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add the Schema Forge quality gate CLI, checks, config schema, workflow, and local entrypoints
- preserve the contract metadata the gate needs (`sourceRequired`, `derivation`) and align the contract schema with generated output
- widen PR blast radius detection for custom code, generated artifacts, shared i18n runtime files, registry changes, and contract schema changes

## Test Plan
- [x] `make test`
- [x] `cd cli && node --test test/quality-gate-*.test.js test/generate-contract.test.js test/schemas.test.js`
- [x] `cd cli && node --test test/quality-gate-detect.test.js test/quality-gate-cli.test.js test/schemas.test.js`
- [x] `node cli/src/quality-gate.js --all --analysis-dir .quality-gate-cache/analysis/quality-gate-all --output .quality-gate-cache/analysis/quality-gate-all/REPORT.md --format md`
