### PR TITLE
Feature ETP-3585: Add forceCalloutFields to allow callout results to win

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@
 
 # --- Testing ---
 
-test: ## Run all CLI tests
+test: ## Run all CLI tests and app-shell lib tests
 	cd cli && node --test 'test/*.test.js'
+	node --test tools/app-shell/src/lib/__tests__/*.test.js
 
 test-frontend: ## Run only frontend generator tests
 	cd cli && node --test 'test/generate-frontend.test.js'

--- a/artifacts/physical-inventory/contract.json
+++ b/artifacts/physical-inventory/contract.json
@@ -1,7 +1,7 @@
 {
   "version": "0.16.2",
-  "generatedAt": "2026-04-22T11:16:14.418Z",
-  "checksum": "93487654081e7e69",
+  "generatedAt": "2026-04-23T11:25:36.627Z",
+  "checksum": "644d7123166367ce",
   "frontendContract": {
     "window": {
       "id": "168",
@@ -253,6 +253,10 @@
             "reference": "Product",
             "inputMode": "search",
             "lookup": true,
+            "forceCalloutFields": [
+              "quantityCount",
+              "bookQuantity"
+            ],
             "callout": {
               "className": "org.openbravo.erpCommon.ad_callouts.SL_Inventory_Product"
             },

--- a/artifacts/physical-inventory/decisions.json
+++ b/artifacts/physical-inventory/decisions.json
@@ -77,6 +77,7 @@
         "product": {
           "grid": true,
           "lookup": true,
+          "forceCalloutFields": ["quantityCount", "bookQuantity"],
           "readOnlyLogic": null
         },
         "lineNo": {

--- a/artifacts/physical-inventory/generated/web/physical-inventory/InventoryPage.jsx
+++ b/artifacts/physical-inventory/generated/web/physical-inventory/InventoryPage.jsx
@@ -38,7 +38,7 @@ const draftMode = null;
 const addLineFields = {
   entry: [
     { key: 'lineNo', column: 'Line', type: 'number', label: 'Line No.', defaultValue: '@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM M_InventoryLine WHERE M_Inventory_ID=@M_Inventory_ID@' },
-    { key: 'product', column: 'M_Product_ID', type: 'search', required: true, lookup: true, label: 'Product', reference: 'Product', inputMode: 'search' },
+    { key: 'product', column: 'M_Product_ID', type: 'search', required: true, lookup: true, label: 'Product', reference: 'Product', inputMode: 'search', forceCalloutFields: ['quantityCount', 'bookQuantity'] },
     { key: 'description', column: 'Description', type: 'textarea', label: 'Description' },
     { key: 'quantityCount', column: 'QtyCount', type: 'number', required: true, label: 'User Count' },
   ],

--- a/cli/src/generate-contract.js
+++ b/cli/src/generate-contract.js
@@ -154,6 +154,7 @@ export function generateFrontendContract(schema, rules = []) {
       if (f.dependsOn) mapped.dependsOn = f.dependsOn;
       if (f.lookup) mapped.lookup = true;
       if (f.popup) mapped.popup = true;
+      if (Array.isArray(f.forceCalloutFields) && f.forceCalloutFields.length > 0) mapped.forceCalloutFields = f.forceCalloutFields;
 
       // UI hints
       if (f.defaultValue) mapped.defaultValue = f.defaultValue;

--- a/cli/src/generate-frontend.js
+++ b/cli/src/generate-frontend.js
@@ -583,7 +583,10 @@ export function generatePageComponent(headerEntity, detailEntity, contract) {
       const numDv = Number(rawDv);
       defaultValuePart = `, defaultValue: ${(!isNaN(numDv) && String(rawDv).trim() !== '') ? numDv : `'${String(rawDv).replace(/'/g, "\\'")}'`}`;
     }
-    return `    { key: '${f.name}', column: '${f.column}', type: '${type}'${requiredPart}${lookupPart}${labelPart}${referencePart}${inputModePart}${dependsOnPart}${defaultValuePart} },`;
+    const forceCalloutFieldsPart = Array.isArray(f.forceCalloutFields) && f.forceCalloutFields.length > 0
+      ? `, forceCalloutFields: ${JSON.stringify(f.forceCalloutFields)}`
+      : '';
+    return `    { key: '${f.name}', column: '${f.column}', type: '${type}'${requiredPart}${lookupPart}${labelPart}${referencePart}${inputModePart}${dependsOnPart}${defaultValuePart}${forceCalloutFieldsPart} },`;
   }).join('\n');
 
   const derivedArray = derivedFields.map(f => {

--- a/cli/src/resolve-curated.js
+++ b/cli/src/resolve-curated.js
@@ -255,6 +255,11 @@ function buildCuratedField(rawField, fieldDecision, discardPatterns) {
     if (fieldDecision.popup) field.popup = true;
   }
 
+  // forceCalloutFields is not FK-specific — any visible field that triggers a callout
+  // may declare which fields the callout result should always override.
+  if (isVisible && Array.isArray(fieldDecision.forceCalloutFields) && fieldDecision.forceCalloutFields.length > 0)
+    field.forceCalloutFields = fieldDecision.forceCalloutFields;
+
   // derivation — carry from raw field
   if (rawField.derivation) {
     field.derivation = rawField.derivation;

--- a/cli/test/generate-contract.test.js
+++ b/cli/test/generate-contract.test.js
@@ -179,6 +179,86 @@ describe('generateFrontendContract — behavioral metadata', () => {
   });
 });
 
+describe('generateFrontendContract — forceCalloutFields', () => {
+  const schemaWithForceCallout = {
+    version: '0.1.0',
+    window: { id: '168', name: 'Physical Inventory', primaryEntity: 'inventory', category: 'inventory' },
+    entities: [
+      {
+        name: 'inventory',
+        table: 'M_Inventory',
+        level: 'header',
+        fields: [
+          { name: 'warehouse', column: 'M_Warehouse_ID', type: 'foreignKey',
+            reference: 'Warehouse', inputMode: 'search',
+            visibility: 'editable', required: true, searchable: true, grid: true, form: true },
+        ]
+      },
+      {
+        name: 'inventoryLine',
+        table: 'M_InventoryLine',
+        level: 'line',
+        fields: [
+          { name: 'product', column: 'M_Product_ID', type: 'foreignKey',
+            reference: 'Product', inputMode: 'search',
+            visibility: 'editable', required: true, grid: true, form: true,
+            lookup: true, forceCalloutFields: ['quantityCount', 'bookQuantity'] },
+          { name: 'quantityCount', column: 'QtyCount', type: 'number',
+            visibility: 'editable', required: true, grid: true, form: true },
+          { name: 'bookQuantity', column: 'QtyBook', type: 'number',
+            visibility: 'readOnly', required: false, grid: true, form: true },
+        ]
+      }
+    ]
+  };
+
+  it('preserves forceCalloutFields from curated field into frontendContract', () => {
+    const fc = generateFrontendContract(schemaWithForceCallout);
+    const product = fc.entities.inventoryLine.fields.find(f => f.name === 'product');
+    assert.deepStrictEqual(product.forceCalloutFields, ['quantityCount', 'bookQuantity']);
+  });
+
+  it('does not add forceCalloutFields when not declared on field', () => {
+    const fc = generateFrontendContract(schemaWithForceCallout);
+    const qty = fc.entities.inventoryLine.fields.find(f => f.name === 'quantityCount');
+    assert.equal(qty.forceCalloutFields, undefined);
+  });
+
+  it('does not add forceCalloutFields to a field that has an empty array', () => {
+    const schema = {
+      ...schemaWithForceCallout,
+      entities: schemaWithForceCallout.entities.map(e =>
+        e.name === 'inventoryLine'
+          ? { ...e, fields: e.fields.map(f =>
+              f.name === 'product' ? { ...f, forceCalloutFields: [] } : f
+            )}
+          : e
+      ),
+    };
+    const fc = generateFrontendContract(schema);
+    const product = fc.entities.inventoryLine.fields.find(f => f.name === 'product');
+    assert.equal(product.forceCalloutFields, undefined);
+  });
+
+  it('preserves forceCalloutFields on a non-FK (number) field', () => {
+    const schema = {
+      ...schemaWithForceCallout,
+      entities: schemaWithForceCallout.entities.map(e =>
+        e.name === 'inventoryLine'
+          ? { ...e, fields: e.fields.map(f =>
+              f.name === 'quantityCount'
+                ? { ...f, forceCalloutFields: ['bookQuantity'] }
+                : f
+            )}
+          : e
+      ),
+    };
+    const fc = generateFrontendContract(schema);
+    const qty = fc.entities.inventoryLine.fields.find(f => f.name === 'quantityCount');
+    assert.deepStrictEqual(qty.forceCalloutFields, ['bookQuantity']);
+  });
+});
+
 describe('generateBackendContract', () => {
   it('includes all fields including system', () => {
     const bc = generateBackendContract(minimalSchema, sampleRules, sampleProcesses);

--- a/cli/test/generate-frontend.test.js
+++ b/cli/test/generate-frontend.test.js
@@ -581,6 +581,33 @@ describe('generatePageComponent', () => {
     assert.ok(code.includes("inputMode: 'selector'"));
   });
 
+  it('emits forceCalloutFields as JSON array when declared on entry field', () => {
+    const contract = {
+      ...masterDetailContract,
+      frontendContract: {
+        ...masterDetailContract.frontendContract,
+        entities: {
+          ...masterDetailContract.frontendContract.entities,
+          orderLine: {
+            ...masterDetailContract.frontendContract.entities.orderLine,
+            fields: masterDetailContract.frontendContract.entities.orderLine.fields.map(f =>
+              f.name === 'product'
+                ? { ...f, forceCalloutFields: ['quantity', 'tax'] }
+                : f
+            ),
+          },
+        },
+      },
+    };
+    const code = generatePageComponent('order', 'orderLine', contract);
+    assert.ok(code.includes('forceCalloutFields: ["quantity","tax"]'), `expected forceCalloutFields in generated code, got:\n${code}`);
+  });
+
+  it('omits forceCalloutFields when not declared on entry field', () => {
+    const code = generatePageComponent('order', 'orderLine', masterDetailContract);
+    assert.ok(!code.includes('forceCalloutFields'));
+  });
+
   it('passes config props to MasterDetailPage', () => {
     const code = generatePageComponent('order', 'orderLine', masterDetailContract);
     assert.ok(code.includes('entity="order"'));

--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -16,6 +16,7 @@ import { Tag } from '@/components/ui/tag';
 import { resolveIdentifier } from '@/lib/resolveIdentifier.js';
 import { resolveColumnLabel } from '@/lib/resolveColumnLabel.js';
 import { formatAmount } from '@/lib/formatAmount.js';
+import { applyCalloutUpdates } from '@/lib/applyCalloutUpdates.js';
 import ProductSearchDrawer from './ProductSearchDrawer.jsx';
 import InternalConsumptionProductSearchDrawer from './InternalConsumptionProductSearchDrawer.jsx';
 
@@ -424,21 +425,7 @@ function InlineAddRow({ columns, fields, onAdd, onCancel, data, catalogs, onFiel
     }
     // Notify parent for callout execution — pass computed snapshot (not stale React state)
     onFieldChange?.(key, val, snapshot, (updates, forceFields = new Set()) => {
-      // Callback to apply callout results to the inline row.
-      // forceFields: Set of field keys whose callout value always wins over touched state.
-      // Used when a lookup field (e.g., product) fires a callout that should reset
-      // dependent quantity/locator fields regardless of what the user typed before.
-      setValues((prev) => {
-        const next = { ...prev };
-        for (const [field, value] of Object.entries(updates)) {
-          const isTouched = touchedFieldsRef.current.has(field);
-          const hasUserValue = prev[field] !== '' && prev[field] != null;
-          if (!forceFields.has(field) && field !== key && isTouched && hasUserValue) continue;
-          if (!forceFields.has(field) && (value === '' || value == null) && hasUserValue) continue;
-          next[field] = value;
-        }
-        return next;
-      });
+      setValues((prev) => applyCalloutUpdates(prev, updates, forceFields, key, touchedFieldsRef.current));
     });
   }, [handleChange, onFieldChange, values]);
 

--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -423,16 +423,18 @@ function InlineAddRow({ columns, fields, onAdd, onCancel, data, catalogs, onFiel
       }
     }
     // Notify parent for callout execution — pass computed snapshot (not stale React state)
-    onFieldChange?.(key, val, snapshot, (updates) => {
+    onFieldChange?.(key, val, snapshot, (updates, forceFields = new Set()) => {
       // Callback to apply callout results to the inline row.
-      // Never overwrite fields manually set by the user in this add-row session.
+      // forceFields: Set of field keys whose callout value always wins over touched state.
+      // Used when a lookup field (e.g., product) fires a callout that should reset
+      // dependent quantity/locator fields regardless of what the user typed before.
       setValues((prev) => {
         const next = { ...prev };
         for (const [field, value] of Object.entries(updates)) {
           const isTouched = touchedFieldsRef.current.has(field);
           const hasUserValue = prev[field] !== '' && prev[field] != null;
-          if (field !== key && isTouched && hasUserValue) continue;
-          if ((value === '' || value == null) && hasUserValue) continue;
+          if (!forceFields.has(field) && field !== key && isTouched && hasUserValue) continue;
+          if (!forceFields.has(field) && (value === '' || value == null) && hasUserValue) continue;
           next[field] = value;
         }
         return next;

--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -720,7 +720,12 @@ export function DetailView({
           }
         }
       }
-      applyUpdates?.(result);
+      // forceCalloutFields: explicit opt-in list declared per field in decisions.json.
+      // Only those fields bypass the touched-guard when this field triggers a callout.
+      // No other window or field is affected unless it declares forceCalloutFields.
+      const triggerFieldDef = (addLineFields?.entry ?? []).find(f => f.key === field);
+      const forceFields = new Set(triggerFieldDef?.forceCalloutFields ?? []);
+      applyUpdates?.(result, forceFields);
 
       // Cascade to SL_Order_Amt when a price-setting callout (e.g. SL_Order_Product) returned
       // unitPrice or grossUnitPrice but did not compute lineNetAmount.

--- a/tools/app-shell/src/lib/__tests__/applyCalloutUpdates.test.js
+++ b/tools/app-shell/src/lib/__tests__/applyCalloutUpdates.test.js
@@ -1,0 +1,109 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { applyCalloutUpdates } from '../applyCalloutUpdates.js';
+
+const noForce  = new Set();
+const noTouch  = new Set();
+
+describe('applyCalloutUpdates — normal guard (touched field preserved)', () => {
+  it('applies callout value to an untouched field', () => {
+    const prev    = { quantityCount: '', bookQuantity: '' };
+    const updates = { quantityCount: 300, bookQuantity: 300 };
+    const result  = applyCalloutUpdates(prev, updates, noForce, 'product', noTouch);
+    assert.equal(result.quantityCount, 300);
+    assert.equal(result.bookQuantity, 300);
+  });
+
+  it('preserves a touched field with a user value', () => {
+    const prev    = { quantityCount: 50, bookQuantity: '' };
+    const updates = { quantityCount: 300, bookQuantity: 300 };
+    const touched = new Set(['quantityCount']);
+    const result  = applyCalloutUpdates(prev, updates, noForce, 'product', touched);
+    assert.equal(result.quantityCount, 50,  'touched field should be preserved');
+    assert.equal(result.bookQuantity,  300, 'untouched field should be updated');
+  });
+
+  it('does not overwrite a non-empty field with empty/null', () => {
+    const prev    = { quantityCount: 50 };
+    const updates = { quantityCount: '' };
+    const result  = applyCalloutUpdates(prev, updates, noForce, 'product', noTouch);
+    assert.equal(result.quantityCount, 50);
+  });
+
+  it('does not overwrite a non-empty field with null', () => {
+    const prev    = { quantityCount: 50 };
+    const updates = { quantityCount: null };
+    const result  = applyCalloutUpdates(prev, updates, noForce, 'product', noTouch);
+    assert.equal(result.quantityCount, 50);
+  });
+
+  it('always applies callout value to the trigger field itself', () => {
+    const prev    = { product: 'old-id' };
+    const updates = { product: 'new-id' };
+    const touched = new Set(['product']);
+    const result  = applyCalloutUpdates(prev, updates, noForce, 'product', touched);
+    assert.equal(result.product, 'new-id');
+  });
+});
+
+describe('applyCalloutUpdates — forceFields bypass', () => {
+  it('overwrites a touched field when it is in forceFields', () => {
+    const prev      = { quantityCount: 50, bookQuantity: 100 };
+    const updates   = { quantityCount: 300, bookQuantity: 300 };
+    const touched   = new Set(['quantityCount', 'bookQuantity']);
+    const forced    = new Set(['quantityCount', 'bookQuantity']);
+    const result    = applyCalloutUpdates(prev, updates, forced, 'product', touched);
+    assert.equal(result.quantityCount, 300, 'forced field should be overwritten');
+    assert.equal(result.bookQuantity,  300, 'forced field should be overwritten');
+  });
+
+  it('overwrites with empty/null when field is in forceFields', () => {
+    const prev    = { quantityCount: 50 };
+    const updates = { quantityCount: '' };
+    const forced  = new Set(['quantityCount']);
+    const result  = applyCalloutUpdates(prev, updates, forced, 'product', noTouch);
+    assert.equal(result.quantityCount, '');
+  });
+
+  it('only forces the declared fields — other touched fields still protected', () => {
+    const prev    = { quantityCount: 50, description: 'my note' };
+    const updates = { quantityCount: 300, description: 'auto desc' };
+    const touched = new Set(['quantityCount', 'description']);
+    const forced  = new Set(['quantityCount']);
+    const result  = applyCalloutUpdates(prev, updates, forced, 'product', touched);
+    assert.equal(result.quantityCount, 300,       'forced field overwritten');
+    assert.equal(result.description,   'my note', 'non-forced touched field preserved');
+  });
+});
+
+describe('applyCalloutUpdates — edge cases', () => {
+  it('returns a new object (does not mutate prev)', () => {
+    const prev    = { quantityCount: 50 };
+    const updates = { quantityCount: 300 };
+    const result  = applyCalloutUpdates(prev, updates, noForce, 'product', noTouch);
+    assert.equal(prev.quantityCount, 50, 'prev must not be mutated');
+    assert.equal(result.quantityCount, 300);
+  });
+
+  it('applies update when prev field is empty string (no user value)', () => {
+    const prev    = { quantityCount: '' };
+    const updates = { quantityCount: 300 };
+    const touched = new Set(['quantityCount']);
+    const result  = applyCalloutUpdates(prev, updates, noForce, 'product', touched);
+    assert.equal(result.quantityCount, 300, 'empty string is not a user value — callout wins');
+  });
+
+  it('applies update when prev field is null (no user value)', () => {
+    const prev    = { quantityCount: null };
+    const updates = { quantityCount: 300 };
+    const touched = new Set(['quantityCount']);
+    const result  = applyCalloutUpdates(prev, updates, noForce, 'product', touched);
+    assert.equal(result.quantityCount, 300, 'null is not a user value — callout wins');
+  });
+
+  it('handles empty updates gracefully', () => {
+    const prev   = { quantityCount: 50 };
+    const result = applyCalloutUpdates(prev, {}, noForce, 'product', noTouch);
+    assert.deepStrictEqual(result, prev);
+  });
+});

--- a/tools/app-shell/src/lib/applyCalloutUpdates.js
+++ b/tools/app-shell/src/lib/applyCalloutUpdates.js
@@ -1,0 +1,30 @@
+/**
+ * Merges callout result updates into the current inline-row state.
+ *
+ * Rules (in priority order):
+ * 1. Fields in `forceFields` always win — touched state and empty-value guards are bypassed.
+ * 2. The trigger field (`triggerKey`) always wins — it was just changed by the user.
+ * 3. Touched fields with a non-empty user value are preserved (callout cannot overwrite them).
+ * 4. Callout results that are empty/null do not overwrite an existing non-empty user value.
+ *
+ * @param {Record<string, unknown>} prev         Current row state
+ * @param {Record<string, unknown>} updates      Callout result fields
+ * @param {Set<string>}             forceFields  Fields that always get the callout value
+ * @param {string}                  triggerKey   Field that triggered the callout
+ * @param {Set<string>}             touched      Fields the user has manually set this session
+ * @returns {Record<string, unknown>} New row state (shallow copy of prev with updates applied)
+ */
+export function applyCalloutUpdates(prev, updates, forceFields, triggerKey, touched) {
+  const next = { ...prev };
+  for (const [field, value] of Object.entries(updates)) {
+    const isForced    = forceFields.has(field);
+    const isTrigger   = field === triggerKey;
+    const isTouched   = touched.has(field);
+    const hasUserValue = prev[field] !== '' && prev[field] != null;
+
+    if (!isForced && !isTrigger && isTouched && hasUserValue) continue;
+    if (!isForced && (value === '' || value == null) && hasUserValue) continue;
+    next[field] = value;
+  }
+  return next;
+}


### PR DESCRIPTION
## Summary

  - Adds `forceCalloutFields` — a declarative, per-field config that lets callout
    results always win over user-typed values, bypassing the `touchedFieldsRef` guard.
  - Generic and pipeline-driven: declared in `decisions.json`, flows through
    `resolve-curated → generate-contract → generate-frontend` automatically.
  - Applied to `product` in Physical Inventory lines so that selecting a product
    always resets `quantityCount` and `bookQuantity` to the warehouse-scoped stock
    returned by `SL_Inventory_Product`, even if the user typed a value first.
  - No other window is affected unless it explicitly declares `forceCalloutFields`.

  ## Files changed

  - `decisions.json` (physical-inventory): declares `forceCalloutFields: ["quantityCount",
  "bookQuantity"]` on `product`
  - `cli/src/resolve-curated.js`: propagates `forceCalloutFields` from decision to curated field
  - `cli/src/generate-contract.js`: passes `forceCalloutFields` through to `contract.json`
  - `cli/src/generate-frontend.js`: emits `forceCalloutFields` in generated `addLineFields.entry`
  - `DataTable.jsx`: `applyUpdates` callback accepts optional `forceFields: Set` parameter
  - `DetailView.jsx`: reads `triggerFieldDef.forceCalloutFields` and passes it to `applyUpdates`

  ## Test plan

  - [ ] Select a product on a new inventory line → `quantityCount` and `bookQuantity` show
  warehouse-scoped stock
  - [ ] Manually type a value in `quantityCount`, then select a product → value is overwritten by
  callout result
  - [ ] Open a Sales Order or Sales Invoice line → no change in behavior (no `forceCalloutFields`
  declared)
  - [ ] `make test` passes (9849 tests, 0 failures)