### PR TITLE
Feature ETP-3585: Add E2E tests for Physical Inventory window

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-frontend test-e2e test-e2e-headless test-e2e-debug test-e2e-ui test-e2e-report test-e2e-record generate dev build install install-e2e deploy clean help report-serve report-serve-detach report-stop report-preview
+.PHONY: test test-frontend test-e2e test-e2e-headless test-e2e-debug test-e2e-ui test-e2e-report test-e2e-record generate dev dev-mock build install install-e2e deploy clean help report-serve report-serve-detach report-stop report-preview
 
 # --- Testing ---
 
@@ -41,6 +41,9 @@ generate: ## Generate frontend from Sales Order contract
 
 dev: ## Start app-shell dev server (http://localhost:3100)
 	cd tools/app-shell && npm run dev
+
+dev-mock: ## Start app-shell dev server with mock data (http://localhost:3100) — required for E2E tests
+	cd tools/app-shell && npm run dev:mock
 
 build: ## Build app-shell for production
 	cd tools/app-shell && npm run build

--- a/e2e/tests/flows/physical-inventory.spec.js
+++ b/e2e/tests/flows/physical-inventory.spec.js
@@ -82,53 +82,46 @@ test.describe('Physical Inventory', () => {
 
     // Clicking "Añadir línea" saves the header first, then shows the inline add row
     await page.locator('button', { hasText: 'Añadir línea' }).first().click();
-    await page.waitForTimeout(1000);
 
-    // Inline row fields: lineNo and userCount are number inputs
-    await expect(page.locator('input[placeholder="Line No."]')).toBeVisible();
+    // Wait for the inline row to appear (placeholders come from the generated addLineFields,
+    // not from the locale dictionary — they are always English regardless of UI locale)
+    await expect(page.locator('input[placeholder="Line No."]')).toBeVisible({ timeout: 5_000 });
     await expect(page.locator('input[placeholder="User Count"]')).toBeVisible();
   });
 
   // --- forceCalloutFields invariant ---
   // Verifies ETP-3585: selecting a product must overwrite user-typed userCount,
   // even if the user pre-filled it manually (forceCalloutFields bypasses the touch guard).
-  // NOTE: this test requires VITE_MOCK=true (make dev-mock) so the callout mock
-  // returns actual quantityCount/bookQuantity values from mockData.
-  // Without VITE_MOCK, the API returns {} and the test is skipped gracefully.
+  // The route intercept in auth.js returns a synthetic product suggestion and callout
+  // response ({ quantityCount: 42 }), so this test runs without VITE_MOCK=true.
   test('selecting a product overwrites user-typed userCount (forceCalloutFields)', async ({ page }) => {
     await page.locator('button', { hasText: 'Nuevo' }).last().click();
     await page.waitForURL('**/physical-inventory/new', { timeout: 5_000 });
     await byRole(page, physicalInventoryDetail.addLine).click();
-    await page.waitForTimeout(300);
 
-    // Check if there's a number input (userCount field) — skip if no inline row appeared
-    const userCountInput = page.locator('input[type="number"]').first();
-    if (!await userCountInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
-      test.skip();
-      return;
-    }
+    // Wait for inline add row (POST saves the header first, then row appears)
+    const userCountInput = page.locator('input[placeholder="User Count"]');
+    await expect(userCountInput).toBeVisible({ timeout: 5_000 });
 
     // User manually types 999 in userCount BEFORE selecting a product
     await userCountInput.fill('999');
 
-    // Type in product search field to trigger callout
-    const productInput = page.locator('input[placeholder*="roducto"], input[placeholder*="roduct"]').first();
-    if (!await productInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
-      test.skip();
-      return;
-    }
-    await productInput.fill('Test');
+    // The product field is a PopupSearchInput: a button that opens a drawer dialog.
+    // Click the button to open it, then type in the inner search input.
+    const productButton = page.locator('td button:has(svg)').first();
+    await expect(productButton).toBeVisible({ timeout: 3_000 });
+    await productButton.click();
 
-    // Select first dropdown suggestion
-    const firstSuggestion = page.locator('[role="option"], [role="listitem"]').first();
-    if (await firstSuggestion.isVisible({ timeout: 3_000 }).catch(() => false)) {
-      await firstSuggestion.click();
-      await page.waitForTimeout(500);
-      // forceCalloutFields: value must NOT be 999 anymore
-      await expect(userCountInput).not.toHaveValue('999');
-    } else {
-      // No suggestions available (no mock data) — test is inconclusive, skip
-      test.skip();
-    }
+    const drawerInput = page.locator('[role="dialog"] input[type="text"]');
+    await expect(drawerInput).toBeVisible({ timeout: 3_000 });
+    await drawerInput.fill('Test');
+
+    // Select first result — route intercept ensures "Test Product" appears
+    const firstResult = page.locator('[role="dialog"] li button').first();
+    await expect(firstResult).toBeVisible({ timeout: 3_000 });
+    await firstResult.click();
+
+    // forceCalloutFields: callout returns quantityCount=42, must overwrite the 999
+    await expect(userCountInput).not.toHaveValue('999', { timeout: 3_000 });
   });
 });

--- a/e2e/tests/flows/physical-inventory.spec.js
+++ b/e2e/tests/flows/physical-inventory.spec.js
@@ -1,0 +1,134 @@
+import { test, expect } from '@playwright/test';
+import { login, navigateTo } from '../helpers/auth.js';
+import { physicalInventoryList, physicalInventoryDetail, byRole } from '../helpers/selectors.js';
+
+/**
+ * Physical Inventory — flow tests.
+ *
+ * Requires the dev server running (make dev or make dev-mock).
+ * Auth is seeded via localStorage; /sws/* API calls are intercepted to return empty lists.
+ *
+ * UI is rendered in es_ES locale — all selectors use Spanish text.
+ * Column headers are sortable <button> elements, not role="columnheader".
+ */
+
+test.describe('Physical Inventory', () => {
+
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await navigateTo(page, 'physical-inventory');
+  });
+
+  // --- List view ---
+
+  test('list view shows window title and New button', async ({ page }) => {
+    await expect(page.locator('text=Inventario físico').first()).toBeVisible();
+    await expect(page.locator('button', { hasText: 'Nuevo' }).last()).toBeVisible();
+  });
+
+  test('list view shows correct sortable column headers', async ({ page }) => {
+    const cols = physicalInventoryList.columns;
+    await expect(byRole(page, cols.movementDate)).toBeVisible();
+    await expect(byRole(page, cols.name)).toBeVisible();
+    await expect(byRole(page, cols.warehouse)).toBeVisible();
+    await expect(byRole(page, cols.inventoryType)).toBeVisible();
+  });
+
+  // --- New form ---
+
+  test('clicking New opens detail form with required fields', async ({ page }) => {
+    await page.locator('button', { hasText: 'Nuevo' }).last().click();
+    await page.waitForURL('**/physical-inventory/new', { timeout: 5_000 });
+
+    // Breadcrumb shows "Nuevo"
+    await expect(page.locator('text=Nuevo').first()).toBeVisible();
+
+    // Required fields present
+    await expect(page.locator('input[type="date"]')).toBeVisible();
+    await expect(byRole(page, physicalInventoryDetail.cancel)).toBeVisible();
+    await expect(byRole(page, physicalInventoryDetail.save)).toBeVisible();
+  });
+
+  test('New form shows Lines tab with correct columns', async ({ page }) => {
+    await page.locator('button', { hasText: 'Nuevo' }).last().click();
+    await page.waitForURL('**/physical-inventory/new', { timeout: 5_000 });
+
+    // Lines tab
+    await expect(page.locator('button', { hasText: /Líneas/ })).toBeVisible();
+
+    // Line columns are <th> elements (not sortable buttons in detail view)
+    await expect(page.locator('th', { hasText: 'Línea' })).toBeVisible();
+    await expect(page.locator('th', { hasText: 'Producto' })).toBeVisible();
+    await expect(page.locator('th', { hasText: 'Conteo del usuario' })).toBeVisible();
+    await expect(page.locator('th', { hasText: 'Unidad' })).toBeVisible();
+    await expect(page.locator('th', { hasText: 'Conteo del sistema' })).toBeVisible();
+  });
+
+  test('Cancel returns to list view', async ({ page }) => {
+    await page.locator('button', { hasText: 'Nuevo' }).last().click();
+    await page.waitForURL('**/physical-inventory/new', { timeout: 5_000 });
+
+    await byRole(page, physicalInventoryDetail.cancel).click();
+
+    await page.waitForURL('**/physical-inventory', { timeout: 5_000 });
+    await expect(page.locator('text=Inventario físico').first()).toBeVisible();
+  });
+
+  // --- Inline add line ---
+
+  test('Add line button opens inline row with product and count fields', async ({ page }) => {
+    await page.locator('button', { hasText: 'Nuevo' }).last().click();
+    await page.waitForURL('**/physical-inventory/new', { timeout: 5_000 });
+
+    // Clicking "Añadir línea" saves the header first, then shows the inline add row
+    await page.locator('button', { hasText: 'Añadir línea' }).first().click();
+    await page.waitForTimeout(1000);
+
+    // Inline row fields: lineNo and userCount are number inputs
+    await expect(page.locator('input[placeholder="Line No."]')).toBeVisible();
+    await expect(page.locator('input[placeholder="User Count"]')).toBeVisible();
+  });
+
+  // --- forceCalloutFields invariant ---
+  // Verifies ETP-3585: selecting a product must overwrite user-typed userCount,
+  // even if the user pre-filled it manually (forceCalloutFields bypasses the touch guard).
+  // NOTE: this test requires VITE_MOCK=true (make dev-mock) so the callout mock
+  // returns actual quantityCount/bookQuantity values from mockData.
+  // Without VITE_MOCK, the API returns {} and the test is skipped gracefully.
+  test('selecting a product overwrites user-typed userCount (forceCalloutFields)', async ({ page }) => {
+    await page.locator('button', { hasText: 'Nuevo' }).last().click();
+    await page.waitForURL('**/physical-inventory/new', { timeout: 5_000 });
+    await byRole(page, physicalInventoryDetail.addLine).click();
+    await page.waitForTimeout(300);
+
+    // Check if there's a number input (userCount field) — skip if no inline row appeared
+    const userCountInput = page.locator('input[type="number"]').first();
+    if (!await userCountInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      test.skip();
+      return;
+    }
+
+    // User manually types 999 in userCount BEFORE selecting a product
+    await userCountInput.fill('999');
+
+    // Type in product search field to trigger callout
+    const productInput = page.locator('input[placeholder*="roducto"], input[placeholder*="roduct"]').first();
+    if (!await productInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      test.skip();
+      return;
+    }
+    await productInput.fill('Test');
+
+    // Select first dropdown suggestion
+    const firstSuggestion = page.locator('[role="option"], [role="listitem"]').first();
+    if (await firstSuggestion.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await firstSuggestion.click();
+      await page.waitForTimeout(500);
+      // forceCalloutFields: value must NOT be 999 anymore
+      await expect(userCountInput).not.toHaveValue('999');
+    } else {
+      // No suggestions available (no mock data) — test is inconclusive, skip
+      test.skip();
+    }
+  });
+});

--- a/e2e/tests/helpers/auth.js
+++ b/e2e/tests/helpers/auth.js
@@ -1,36 +1,56 @@
 /**
  * Authentication and navigation helpers for E2E tests.
  *
- * Login flow discovered via agent-browser:
- *   - /login page: textbox "Username", textbox "Password", button "Sign in"
- *   - After login: redirects to /dashboard
+ * These helpers target the mock dev server (make dev-mock / VITE_MOCK=true).
+ * The app has no login form in mock mode — authentication is done by seeding
+ * localStorage with a fake token before React boots.
  *
- * Context switch discovered via agent-browser:
- *   - Click Etendo logo (always visible) → opens popover
- *   - Popover has two <select>: Role + Organization, and an "Apply" button
+ * API calls are intercepted via page.route() so that /sws/* requests return
+ * empty-list responses (not 401), preventing useEntity from calling logout().
+ *
+ * Real Etendo mode (BASE_URL=http://localhost:8080/...) is not covered here.
  */
 
-/** Default role/org for all E2E tests */
+/** Default role/org — kept for future real-backend tests */
 export const DEFAULT_ROLE = 'F&B International Group Admin';
 export const DEFAULT_ORG = 'F&B España - Región Norte';
 
 /**
- * Login and switch to the default role/org context.
+ * Authenticate for E2E tests running against the mock dev server.
+ *
+ * Seeds localStorage before React boots and intercepts /sws/* API calls so
+ * useEntity never receives a 401 and never calls logout().
  */
-export async function login(page, {
-  user = 'admin',
-  password = 'admin',
-  role = DEFAULT_ROLE,
-  org = DEFAULT_ORG,
-} = {}) {
-  await page.goto('/login');
-  await page.getByRole('textbox', { name: 'Username' }).fill(user);
-  await page.getByRole('textbox', { name: 'Password' }).fill(password);
-  await page.getByRole('button', { name: 'Sign in' }).click();
-  await page.waitForURL('**/dashboard', { timeout: 15_000 });
+export async function login(page) {
+  // Inject token before React boots so AuthContext.isAuthenticated = true.
+  await page.addInitScript(() => {
+    localStorage.setItem('sf_auth_token', 'e2e-mock-token');
+    localStorage.setItem('sf_auth_user', 'admin');
+  });
 
-  // Switch role/org context
-  await switchContext(page, role, org);
+  // Intercept all /sws/* API calls to prevent the real Etendo backend from
+  // receiving our fake token (which would return 401 and trigger logout()).
+  // - GET → empty list
+  // - POST/PUT/PATCH → synthetic saved record so the UI can transition to detail view
+  await page.route('**/sws/**', (route) => {
+    const method = route.request().method();
+    if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ id: 'e2e-record-id', data: {}, success: true }),
+      });
+    } else {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ data: [], totalRows: 0 }),
+      });
+    }
+  });
+
+  await page.goto('/dashboard');
+  await page.waitForURL('**/dashboard', { timeout: 10_000 });
 }
 
 /**

--- a/e2e/tests/helpers/auth.js
+++ b/e2e/tests/helpers/auth.js
@@ -1,56 +1,89 @@
 /**
  * Authentication and navigation helpers for E2E tests.
  *
- * These helpers target the mock dev server (make dev-mock / VITE_MOCK=true).
- * The app has no login form in mock mode — authentication is done by seeding
- * localStorage with a fake token before React boots.
+ * Two modes, selected automatically based on the BASE_URL env var:
  *
- * API calls are intercepted via page.route() so that /sws/* requests return
- * empty-list responses (not 401), preventing useEntity from calling logout().
+ * Mock mode (default — no BASE_URL set, server started with make dev or make dev-mock):
+ *   Seeds localStorage with a fake token before React boots and intercepts /sws/*
+ *   so useEntity never receives a 401 and never calls logout().
  *
- * Real Etendo mode (BASE_URL=http://localhost:8080/...) is not covered here.
+ * Real Etendo mode (BASE_URL=http://localhost:8080/...):
+ *   Uses the original login form + switchContext flow.
+ *   Route interception is NOT applied so real API calls go through unchanged.
  */
 
-/** Default role/org — kept for future real-backend tests */
+const IS_MOCK_MODE = !process.env.BASE_URL;
+
+/** Default role/org for real-backend tests */
 export const DEFAULT_ROLE = 'F&B International Group Admin';
 export const DEFAULT_ORG = 'F&B España - Región Norte';
 
 /**
- * Authenticate for E2E tests running against the mock dev server.
+ * Authenticate for E2E tests.
  *
- * Seeds localStorage before React boots and intercepts /sws/* API calls so
- * useEntity never receives a 401 and never calls logout().
+ * In mock mode: seeds localStorage + intercepts /sws/* API calls.
+ * In real mode: fills the login form and switches role/org context.
  */
-export async function login(page) {
-  // Inject token before React boots so AuthContext.isAuthenticated = true.
-  await page.addInitScript(() => {
-    localStorage.setItem('sf_auth_token', 'e2e-mock-token');
-    localStorage.setItem('sf_auth_user', 'admin');
-  });
+export async function login(page, {
+  user = 'admin',
+  password = 'admin',
+  role = DEFAULT_ROLE,
+  org = DEFAULT_ORG,
+} = {}) {
+  if (IS_MOCK_MODE) {
+    // Inject token before React boots so AuthContext.isAuthenticated = true.
+    await page.addInitScript(() => {
+      localStorage.setItem('sf_auth_token', 'e2e-mock-token');
+      localStorage.setItem('sf_auth_user', 'admin');
+    });
 
-  // Intercept all /sws/* API calls to prevent the real Etendo backend from
-  // receiving our fake token (which would return 401 and trigger logout()).
-  // - GET → empty list
-  // - POST/PUT/PATCH → synthetic saved record so the UI can transition to detail view
-  await page.route('**/sws/**', (route) => {
-    const method = route.request().method();
-    if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ id: 'e2e-record-id', data: {}, success: true }),
-      });
-    } else {
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ data: [], totalRows: 0 }),
-      });
-    }
-  });
+    // Intercept /sws/* to prevent the real Etendo backend receiving our fake
+    // token (which would return 401 and trigger logout()).
+    // - GET /selectors/**  → single synthetic item so product search dropdowns populate
+    // - POST /**/callout   → synthetic updates so forceCalloutFields can override user values
+    // - POST/PUT/PATCH     → synthetic saved record so the UI can navigate to detail
+    // - GET (other)        → empty list
+    await page.route('**/sws/**', (route) => {
+      const url = route.request().url();
+      const method = route.request().method();
+      if (url.includes('/selectors/')) {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ items: [{ id: 'prod-e2e', label: 'Test Product', name: 'Test Product', _identifier: 'Test Product' }] }),
+        });
+      } else if (method === 'POST' && url.includes('/callout')) {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ updates: { quantityCount: 42, bookQuantity: 42 }, combos: {}, messages: [] }),
+        });
+      } else if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ id: 'e2e-record-id', data: {}, success: true }),
+        });
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ data: [], totalRows: 0 }),
+        });
+      }
+    });
 
-  await page.goto('/dashboard');
-  await page.waitForURL('**/dashboard', { timeout: 10_000 });
+    await page.goto('/dashboard');
+    await page.waitForURL('**/dashboard', { timeout: 10_000 });
+  } else {
+    // Real Etendo mode: login form + context switch
+    await page.goto('/login');
+    await page.getByRole('textbox', { name: 'Username' }).fill(user);
+    await page.getByRole('textbox', { name: 'Password' }).fill(password);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL('**/dashboard', { timeout: 15_000 });
+    await switchContext(page, role, org);
+  }
 }
 
 /**

--- a/e2e/tests/helpers/selectors.js
+++ b/e2e/tests/helpers/selectors.js
@@ -116,6 +116,50 @@ export const purchaseOrderDetail = {
   },
 };
 
+// --- Physical Inventory: List View ---
+// UI is in Spanish (es_ES locale). Column headers are sortable buttons, not columnheader role.
+export const physicalInventoryList = {
+  // Title shown in the top-left header area (not a heading role element)
+  titleText: 'Inventario físico',
+  newButton: { role: 'button', name: 'Nuevo' },
+  columns: {
+    movementDate: { role: 'button', name: 'Fecha del movimiento' },
+    name: { role: 'button', name: 'Nombre' },
+    warehouse: { role: 'button', name: 'Almacén' },
+    inventoryType: { role: 'button', name: 'Tipo de Inventario' },
+    status: { role: 'button', name: 'Procesar Declaración' },
+  },
+};
+
+// --- Physical Inventory: Detail (New Inventory form) ---
+export const physicalInventoryDetail = {
+  // Title is "Nuevo" in the breadcrumb/header area
+  titleText: 'Nuevo',
+  cancel: { role: 'button', name: 'Cancelar' },
+  save: { role: 'button', name: 'Guardar', exact: true },
+  // Fields
+  movementDate: 'input[type="date"]',
+  name: 'input[placeholder=""]',
+  warehouse: 'input[placeholder*="Almacén"]',
+  // Lines tab
+  linesTab: /^Líneas \d+$/,
+  addLine: { role: 'button', name: /Añadir línea/ },
+  processButton: { role: 'button', name: /Recuento de Inventario|Process Inventory/ },
+  // Line columns (buttons — sortable)
+  lineColumns: {
+    lineNo: { role: 'button', name: 'Línea' },
+    product: { role: 'button', name: 'Producto' },
+    userCount: { role: 'button', name: 'Conteo del usuario' },
+    uOM: { role: 'button', name: 'Unidad' },
+    systemCount: { role: 'button', name: 'Conteo del sistema' },
+  },
+  // Inline add row fields
+  addLineFields: {
+    product: 'input[placeholder*="Producto"]',
+    userCount: 'input[type="number"]',
+  },
+};
+
 // --- Context Switcher ---
 export const contextSwitcher = {
   apply: { role: 'button', name: 'Apply' },

--- a/package-lock.json
+++ b/package-lock.json
@@ -246,7 +246,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2715,7 +2714,6 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -4567,7 +4565,6 @@
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -4706,7 +4703,6 @@
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -5135,7 +5131,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7116,7 +7111,6 @@
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -7901,7 +7895,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -8827,7 +8820,6 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.12.0",
         "pg-pool": "^3.13.0",
@@ -9039,7 +9031,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9390,7 +9381,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9403,7 +9393,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -9780,7 +9769,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11334,7 +11322,6 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -11789,7 +11776,6 @@
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -12182,7 +12168,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:mock": "VITE_MOCK=true vite",
     "build": "vite build",
     "preview": "vite preview"
   },


### PR DESCRIPTION
## Summary

  - Adds Playwright E2E spec for the Physical Inventory window (6 tests)
  - Fixes E2E auth helper to work against the mock dev server (no real Etendo backend required)
  - Adds dev-mock Makefile target (VITE_MOCK=true) for running the dev server with mock data

##  Changes

  - e2e/tests/flows/physical-inventory.spec.js: list view, new form, lines tab, cancel, add-line inline row, forceCalloutFields invariant (skipped
  without mock data)
  - e2e/tests/helpers/auth.js: seeds localStorage via addInitScript and intercepts /sws/* routes to avoid 401 from fake token triggering logout
  - e2e/tests/helpers/selectors.js: adds physicalInventoryList and physicalInventoryDetail selectors
  - Makefile + tools/app-shell/package.json: dev-mock / npm run dev:mock target

## Test plan

  - npx playwright test tests/flows/physical-inventory.spec.js → 6 passed, 1 skipped
  - npx playwright test tests/flows/navigation.spec.js --grep "dashboard loads" → still passes