### PR TITLE
Feature ETP-3868: Fix dropdown spinner, filter title and inline product Enter

### DIFF
--- a/tools/app-shell/src/components/contract-ui/AdvancedFilterBuilder.jsx
+++ b/tools/app-shell/src/components/contract-ui/AdvancedFilterBuilder.jsx
@@ -632,6 +632,7 @@ function IdentifierMultiPicker({ col, entity, apiBaseUrl, rows, value, onChange,
   const [open, setOpen] = useState(false);
   const selected = Array.isArray(value) ? value : [];
   const sentinelRef = useRef(null);
+  const labelOf = useLabel();
 
   // Pulls {id, _identifier} pairs from the list GET's `_distinct` branch so
   // the picker shows all values in the filterable universe, not only those on
@@ -711,7 +712,7 @@ function IdentifierMultiPicker({ col, entity, apiBaseUrl, rows, value, onChange,
       ? selectedLabels[0]
       : `${selectedLabels[0]} +${selected.length - 1}`;
 
-  const colLabelKey = col.label || col.key;
+  const colLabelKey = labelOf(col.column) ?? col.label ?? col.key;
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -731,8 +732,8 @@ function IdentifierMultiPicker({ col, entity, apiBaseUrl, rows, value, onChange,
         </button>
       </PopoverTrigger>
       <PopoverContent align="start" className="w-64 p-0">
-        <div className="px-3 pt-3 pb-2 text-[11px] uppercase tracking-wide text-muted-foreground">
-          {`${ui('advancedFilterSelectValue')}: ${colLabelKey}`}
+        <div className="px-3 pt-3 pb-2 text-xs font-normal leading-6" style={{ color: '#6C6C89' }}>
+          {ui('advancedFilterSelectorOf', { label: colLabelKey })}
         </div>
         <div className="px-3 pb-2">
           <Input

--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -748,6 +748,13 @@ function LookupField({ value, placeholder, selectorUrl, selectorContext, token, 
         type="button"
         onClick={() => setOpen(true)}
         onKeyDown={(e) => {
+          // Once a value is selected, Enter should bubble up so the row's
+          // handleKeyDown can save the line. Space still re-opens the picker
+          // for re-selection.
+          if (e.key === 'Enter' && value) {
+            if (onKeyDown) onKeyDown(e);
+            return;
+          }
           if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setOpen(true); }
           else if (onKeyDown) onKeyDown(e);
         }}
@@ -764,7 +771,13 @@ function LookupField({ value, placeholder, selectorUrl, selectorContext, token, 
         <InternalConsumptionProductSearchDrawer
           open={open}
           onClose={() => setOpen(false)}
-          onSelect={(item) => { onSelect(item); setOpen(false); }}
+          onSelect={(item) => {
+            onSelect(item);
+            setOpen(false);
+            // Restore focus to the field button so keyboard users do not lose
+            // tab position after the picker closes (Enter then saves the row).
+            setTimeout(() => btnRef.current?.focus(), 0);
+          }}
           selectorUrl={selectorUrl}
           selectorContext={selectorContext}
           token={token}
@@ -774,7 +787,13 @@ function LookupField({ value, placeholder, selectorUrl, selectorContext, token, 
         <ProductSearchDrawer
           open={open}
           onClose={() => setOpen(false)}
-          onSelect={(item) => { onSelect(item); setOpen(false); }}
+          onSelect={(item) => {
+            onSelect(item);
+            setOpen(false);
+            // Restore focus to the field button so keyboard users do not lose
+            // tab position after the picker closes (Enter then saves the row).
+            setTimeout(() => btnRef.current?.focus(), 0);
+          }}
           selectorUrl={selectorUrl}
           selectorContext={selectorContext}
           token={token}

--- a/tools/app-shell/src/components/contract-ui/EntityForm.jsx
+++ b/tools/app-shell/src/components/contract-ui/EntityForm.jsx
@@ -251,11 +251,6 @@ function SearchInput({ entityName, field, value, displayValue, onChange, catalog
           ))}
         </div>
       )}
-      {open && query.length > 0 && fetching && (
-        <div className="absolute z-50 top-full left-0 right-0 mt-1 bg-white border rounded-md shadow-lg">
-          <div className="px-3 py-2 text-xs text-muted-foreground">{ui('searching')}</div>
-        </div>
-      )}
       {open && query.length > 0 && !fetching && filtered.length === 0 && (
         <div className="absolute z-50 top-full left-0 right-0 mt-1 bg-white border rounded-md shadow-lg max-h-48 overflow-auto">
           {createBtn}

--- a/tools/app-shell/src/locales/en_US.json
+++ b/tools/app-shell/src/locales/en_US.json
@@ -16573,6 +16573,7 @@
     "advancedFilterSelectField": "Select field",
     "advancedFilterSelectOp": "Select condition",
     "advancedFilterSelectValue": "Select value",
+    "advancedFilterSelectorOf": "{label} selector",
     "advancedFilterAddCondition": "Add condition",
     "advancedFilterApply": "Apply",
     "advancedFilterClear": "Clear",

--- a/tools/app-shell/src/locales/es_ES.json
+++ b/tools/app-shell/src/locales/es_ES.json
@@ -16804,6 +16804,7 @@
     "advancedFilterSelectField": "Selector de campo",
     "advancedFilterSelectOp": "Seleccionar condición",
     "advancedFilterSelectValue": "Seleccionar valor",
+    "advancedFilterSelectorOf": "Selector de {label}",
     "advancedFilterAddCondition": "Añadir condición",
     "advancedFilterApply": "Aplicar",
     "advancedFilterClear": "Limpiar",


### PR DESCRIPTION
## Summary
- **EntityForm**: removed the `Buscando…` overlay shown in dropdown search inputs while typing — the spinner alone is enough.
- **AdvancedFilterBuilder**: renamed the value-picker popover title to `Selector de {column}` with Inter 12px / 24px / #6C6C89 styling, and translated the column label via `useLabel()` (e.g. `Selector de Moneda` instead of `Selector de Currency`).
- **DataTable LookupField**: after the product picker drawer closes, focus is restored to the field button and Enter on a field that already has a value now saves the line instead of re-opening the picker. Space still re-opens the picker.

## Jira
[ETP-3868](https://etendoproject.atlassian.net/browse/ETP-3868) (under epic ETP-3504)

## Test plan
- [ ] Sales Order → open a search dropdown, type — verify there is no `Buscando…` text, only the spinner.
- [ ] Sales Order → conditional filter → pick a column with options — verify popover title says `Selector de <Columna>` with the new style; verify the column label is translated (e.g. `Moneda` in es_ES).
- [ ] Sales Order line creation → click Producto → keyboard select with Enter → press Enter again → line is saved.

[ETP-3868]: https://etendoproject.atlassian.net/browse/ETP-3868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ