### PR TITLE
Feature ETP-3875: Remove clear selection button from list and detail views

### DIFF
--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -1726,12 +1726,6 @@ export function DetailView({
                               <Trash2 className="h-3.5 w-3.5" />
                               {deletingChildren ? ui('loading') : ui('delete')}
                             </button>
-                            <button
-                              onClick={() => setSelectedChildRows([])}
-                              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md border hover:bg-accent transition-colors text-muted-foreground"
-                            >
-                              {ui('clear')}
-                            </button>
                           </div>
                         </div>
                       )}

--- a/tools/app-shell/src/components/contract-ui/ListView.jsx
+++ b/tools/app-shell/src/components/contract-ui/ListView.jsx
@@ -390,9 +390,6 @@ export function ListView({
                 </Button>
               )}
               {bulkActions && bulkActions({ selectedRows, clearSelection: () => setSelectedRows([]), token, apiBaseUrl, windowName, api })}
-              <Button variant="outline" size="sm" className="text-muted-foreground" onClick={() => setSelectedRows([])}>
-                {ui('clear')}
-              </Button>
             </div>
           </div>
         ) : (


### PR DESCRIPTION
## Summary
- Removed the "Limpiar" button from the ListView selection bar (`ListView.jsx`)
- Removed the "Limpiar" button from the DetailView child-rows selection bar (`DetailView.jsx`)

Selection can still be cleared via the header checkbox.

## Jira
ETP-3875