### PR TITLE
Feature ETP-3890: Fix quality gate false regressions for new artifact

### DIFF
--- a/cli/src/quality-gate/checks/i18n.js
+++ b/cli/src/quality-gate/checks/i18n.js
@@ -48,14 +48,12 @@ function collectCustomFiles(rootDir, windowDir, windowName) {
   }
 
   const appShellCustomDir = join(rootDir, 'tools', 'app-shell', 'src', 'windows', 'custom');
-  const appShellPagesDir = join(rootDir, 'tools', 'app-shell', 'src', 'pages');
   const aliases = windowName === 'contacts' ? ['businessPartner'] : [];
   return [
     ...collectSourceFiles(join(windowDir, 'custom'), isJavaScriptModule),
     ...collectSourceFiles(join(appShellCustomDir, windowName), isJavaScriptModule),
     ...aliases.flatMap((alias) => collectSourceFiles(join(appShellCustomDir, alias), isJavaScriptModule)),
     ...collectSourceFiles(join(appShellCustomDir, 'shared'), isJavaScriptModule),
-    ...collectSourceFiles(appShellPagesDir, isJavaScriptModule),
   ].sort((left, right) => left.localeCompare(right));
 }
 

--- a/cli/src/quality-gate/checks/shared.js
+++ b/cli/src/quality-gate/checks/shared.js
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join, relative } from 'node:path';
+import { join, relative, sep } from 'node:path';
 import { parse } from '@babel/parser';
 
 export function collectSourceFiles(dir, predicate = () => true) {
@@ -30,8 +30,9 @@ export function isOnboardingTarget(targetName) {
 }
 
 export function collectTargetSourceFiles(rootDir, targetName) {
+  const pagesDir = join(rootDir, 'tools', 'app-shell', 'src', 'pages');
+
   if (isOnboardingTarget(targetName)) {
-    const pagesDir = join(rootDir, 'tools', 'app-shell', 'src', 'pages');
     const onboardingFiles = collectSourceFiles(
       join(pagesDir, 'onboarding'),
       (filePath) => isJavaScriptModule(filePath) && !filePath.includes('/__tests__/')
@@ -42,6 +43,20 @@ export function collectTargetSourceFiles(rootDir, targetName) {
       ...onboardingFiles,
     ].sort((left, right) => left.localeCompare(right));
   }
+
+  if (targetName === 'app-shell:pages') {
+    const onboardingDir = join(pagesDir, 'onboarding');
+    const onboardingPagePath = join(pagesDir, 'OnboardingPage.jsx');
+    return collectSourceFiles(
+      pagesDir,
+      (filePath) => {
+        const rel = relative(pagesDir, filePath);
+        const isOnboarding = filePath === onboardingPagePath || rel.startsWith('onboarding' + sep);
+        return isJavaScriptModule(filePath) && !filePath.includes('/__tests__/') && !isOnboarding;
+      }
+    );
+  }
+
   return [];
 }
 

--- a/cli/src/quality-gate/checks/shared.js
+++ b/cli/src/quality-gate/checks/shared.js
@@ -35,7 +35,7 @@ export function collectTargetSourceFiles(rootDir, targetName) {
   if (isOnboardingTarget(targetName)) {
     const onboardingFiles = collectSourceFiles(
       join(pagesDir, 'onboarding'),
-      (filePath) => isJavaScriptModule(filePath) && !filePath.includes('/__tests__/')
+      (filePath) => isJavaScriptModule(filePath) && !filePath.split(sep).includes('__tests__')
     );
     const onboardingPagePath = join(pagesDir, 'OnboardingPage.jsx');
     return [
@@ -45,14 +45,14 @@ export function collectTargetSourceFiles(rootDir, targetName) {
   }
 
   if (targetName === 'app-shell:pages') {
-    const onboardingDir = join(pagesDir, 'onboarding');
     const onboardingPagePath = join(pagesDir, 'OnboardingPage.jsx');
     return collectSourceFiles(
       pagesDir,
       (filePath) => {
         const rel = relative(pagesDir, filePath);
         const isOnboarding = filePath === onboardingPagePath || rel.startsWith('onboarding' + sep);
-        return isJavaScriptModule(filePath) && !filePath.includes('/__tests__/') && !isOnboarding;
+        const isTest = filePath.split(sep).includes('__tests__');
+        return isJavaScriptModule(filePath) && !isTest && !isOnboarding;
       }
     );
   }

--- a/cli/src/quality-gate/detect.js
+++ b/cli/src/quality-gate/detect.js
@@ -85,7 +85,10 @@ export function detectAffectedWindowsDetailed({ changedFiles, blastRadius, avail
       }
 
       if (rule.scope === 'named-target' && rule.target) {
-        affected.set(rule.target, 'direct');
+        const excluded = (rule.excludePatterns ?? []).some((p) => globToRegExp(p).test(changedFile));
+        if (!excluded) {
+          affected.set(rule.target, 'direct');
+        }
       }
     }
   }

--- a/cli/test/quality-gate-checks-i18n.test.js
+++ b/cli/test/quality-gate-checks-i18n.test.js
@@ -11,8 +11,9 @@ function makeFixture({
   allowlisted = false,
   sharedHardcoded = false,
   aliasHardcoded = false,
-  pageHardcoded = false,
-  pageModuleHardcoded = false,
+  onboardingPageHardcoded = false,
+  onboardingModuleHardcoded = false,
+  appPageHardcoded = false,
 } = {}) {
   const rootDir = mkdtempSync(join(tmpdir(), 'quality-gate-i18n-'));
   const windowDir = join(rootDir, 'artifacts', 'sales-order');
@@ -49,14 +50,18 @@ function makeFixture({
   writeFileSync(join(windowDir, 'contract.json'), JSON.stringify(contract, null, 2));
   writeFileSync(join(windowDir, 'custom', 'Sidebar.jsx'), customComponent);
 
-  if (pageHardcoded) {
+  if (onboardingPageHardcoded) {
     writeFileSync(join(pagesDir, 'OnboardingPage.jsx'), 'export default function OnboardingPage() { return <button title="Crear cuenta">Crear cuenta</button>; }');
   }
 
-  if (pageModuleHardcoded) {
+  if (onboardingModuleHardcoded) {
     writeFileSync(join(pagesDir, 'onboarding', 'onboardingState.js'), `export const SETUP_STEP_DEFINITIONS = [
   { name: 'setup', label: 'Preparando contexto', description: 'Crear empresa' },
 ];`);
+  }
+
+  if (appPageHardcoded) {
+    writeFileSync(join(pagesDir, 'SalesPage.jsx'), 'export default function SalesPage() { return <h1>Sales Orders</h1>; }');
   }
 
   if (sharedHardcoded) {
@@ -125,10 +130,52 @@ describe('runI18nCheck', () => {
     }
   });
 
-  it('fails on hardcoded strings inside top-level app shell pages', async () => {
-    const fixture = makeFixture({ pageHardcoded: true });
+  it('artifact window is not polluted by hardcoded strings in app shell pages', async () => {
+    const fixture = makeFixture({ appPageHardcoded: true });
     try {
       const result = await runI18nCheck('sales-order', { rootDir: fixture.rootDir, windowDir: fixture.windowDir });
+      assert.equal(result.status, 'pass', 'pages violations must not bleed into artifact window checks');
+    } finally {
+      rmSync(fixture.rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('artifact window is not polluted by hardcoded strings in onboarding page', async () => {
+    const fixture = makeFixture({ onboardingPageHardcoded: true });
+    try {
+      const result = await runI18nCheck('sales-order', { rootDir: fixture.rootDir, windowDir: fixture.windowDir });
+      assert.equal(result.status, 'pass', 'onboarding page violations must not bleed into artifact window checks');
+    } finally {
+      rmSync(fixture.rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('app-shell:pages target catches hardcoded strings in app pages', async () => {
+    const fixture = makeFixture({ appPageHardcoded: true });
+    try {
+      const result = await runI18nCheck('app-shell:pages', { rootDir: fixture.rootDir, windowDir: fixture.rootDir });
+      assert.equal(result.status, 'fail');
+      assert.match(result.detail, /SalesPage.jsx/);
+      assert.match(result.detail, /Sales Orders/);
+    } finally {
+      rmSync(fixture.rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('app-shell:pages target does not scan onboarding files (those belong to app-shell:onboarding)', async () => {
+    const fixture = makeFixture({ onboardingPageHardcoded: true });
+    try {
+      const result = await runI18nCheck('app-shell:pages', { rootDir: fixture.rootDir, windowDir: fixture.rootDir });
+      assert.equal(result.status, 'pass', 'OnboardingPage.jsx must not appear in app-shell:pages scan');
+    } finally {
+      rmSync(fixture.rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('app-shell:onboarding target catches hardcoded strings in OnboardingPage', async () => {
+    const fixture = makeFixture({ onboardingPageHardcoded: true });
+    try {
+      const result = await runI18nCheck('app-shell:onboarding', { rootDir: fixture.rootDir, windowDir: fixture.rootDir });
       assert.equal(result.status, 'fail');
       assert.match(result.detail, /OnboardingPage.jsx/);
       assert.match(result.detail, /Crear cuenta/);
@@ -137,10 +184,10 @@ describe('runI18nCheck', () => {
     }
   });
 
-  it('fails on hardcoded user-facing string literals inside page helper modules', async () => {
-    const fixture = makeFixture({ pageModuleHardcoded: true });
+  it('app-shell:onboarding target catches hardcoded strings in onboarding helper modules', async () => {
+    const fixture = makeFixture({ onboardingModuleHardcoded: true });
     try {
-      const result = await runI18nCheck('sales-order', { rootDir: fixture.rootDir, windowDir: fixture.windowDir });
+      const result = await runI18nCheck('app-shell:onboarding', { rootDir: fixture.rootDir, windowDir: fixture.rootDir });
       assert.equal(result.status, 'fail');
       assert.match(result.detail, /onboardingState.js/);
       assert.match(result.detail, /Preparando contexto/);

--- a/cli/test/quality-gate-detect.test.js
+++ b/cli/test/quality-gate-detect.test.js
@@ -17,6 +17,7 @@ const SAMPLE_CONFIG = {
     { pattern: 'tools/app-shell/src/i18n/*.js', scope: 'all-windows' },
     { pattern: 'tools/app-shell/src/i18n/*.jsx', scope: 'all-windows' },
     { pattern: 'tools/app-shell/src/windows/registry.js', scope: 'all-windows' },
+    { pattern: 'tools/app-shell/src/pages/**', scope: 'named-target', target: 'app-shell:pages', excludePatterns: ['tools/app-shell/src/pages/OnboardingPage.jsx', 'tools/app-shell/src/pages/onboarding/**'] },
     { pattern: 'tools/app-shell/src/pages/OnboardingPage.jsx', scope: 'named-target', target: 'app-shell:onboarding' },
     { pattern: 'tools/app-shell/src/pages/onboarding/**', scope: 'named-target', target: 'app-shell:onboarding' },
     { pattern: 'schemas/contract.schema.json', scope: 'all-windows' },
@@ -233,5 +234,28 @@ describe('detectAffectedWindowsDetailed', () => {
     assert.deepEqual(affected, [
       { window: 'app-shell:onboarding', source: 'direct' },
     ]);
+  });
+
+  it('excludePatterns prevents onboarding files from triggering app-shell:pages', () => {
+    const onboardingPage = detectAffectedWindowsDetailed({
+      changedFiles: ['tools/app-shell/src/pages/OnboardingPage.jsx'],
+      blastRadius: SAMPLE_CONFIG.blastRadius,
+      availableWindows: [],
+    });
+    assert.ok(!onboardingPage.some((e) => e.window === 'app-shell:pages'), 'OnboardingPage.jsx must not trigger app-shell:pages');
+
+    const onboardingModule = detectAffectedWindowsDetailed({
+      changedFiles: ['tools/app-shell/src/pages/onboarding/onboardingState.js'],
+      blastRadius: SAMPLE_CONFIG.blastRadius,
+      availableWindows: [],
+    });
+    assert.ok(!onboardingModule.some((e) => e.window === 'app-shell:pages'), 'onboarding/** must not trigger app-shell:pages');
+
+    const regularPage = detectAffectedWindowsDetailed({
+      changedFiles: ['tools/app-shell/src/pages/SalesPage.jsx'],
+      blastRadius: SAMPLE_CONFIG.blastRadius,
+      availableWindows: [],
+    });
+    assert.ok(regularPage.some((e) => e.window === 'app-shell:pages'), 'regular pages must still trigger app-shell:pages');
   });
 });

--- a/quality-gate.config.json
+++ b/quality-gate.config.json
@@ -25,7 +25,7 @@
     { "pattern": "tools/app-shell/src/i18n/*.jsx", "scope": "all-windows" },
     { "pattern": "tools/app-shell/src/locales/*.json", "scope": "all-windows" },
     { "pattern": "tools/app-shell/src/windows/registry.js", "scope": "all-windows" },
-    { "pattern": "tools/app-shell/src/pages/**", "scope": "named-target", "target": "app-shell:pages" },
+    { "pattern": "tools/app-shell/src/pages/**", "scope": "named-target", "target": "app-shell:pages", "excludePatterns": ["tools/app-shell/src/pages/OnboardingPage.jsx", "tools/app-shell/src/pages/onboarding/**"] },
     { "pattern": "tools/app-shell/src/pages/OnboardingPage.jsx", "scope": "named-target", "target": "app-shell:onboarding" },
     { "pattern": "tools/app-shell/src/pages/onboarding/**", "scope": "named-target", "target": "app-shell:onboarding" },
     { "pattern": "schemas/contract.schema.json", "scope": "all-windows" }

--- a/quality-gate.config.json
+++ b/quality-gate.config.json
@@ -23,8 +23,9 @@
     { "pattern": "tools/app-shell/src/components/contract-ui/**", "scope": "all-windows" },
     { "pattern": "tools/app-shell/src/i18n/*.js", "scope": "all-windows" },
     { "pattern": "tools/app-shell/src/i18n/*.jsx", "scope": "all-windows" },
-    { "pattern": "tools/app-shell/src/i18n/locales/*.json", "scope": "all-windows" },
+    { "pattern": "tools/app-shell/src/locales/*.json", "scope": "all-windows" },
     { "pattern": "tools/app-shell/src/windows/registry.js", "scope": "all-windows" },
+    { "pattern": "tools/app-shell/src/pages/**", "scope": "named-target", "target": "app-shell:pages" },
     { "pattern": "tools/app-shell/src/pages/OnboardingPage.jsx", "scope": "named-target", "target": "app-shell:onboarding" },
     { "pattern": "tools/app-shell/src/pages/onboarding/**", "scope": "named-target", "target": "app-shell:onboarding" },
     { "pattern": "schemas/contract.schema.json", "scope": "all-windows" }

--- a/schemas/quality-gate-config.schema.json
+++ b/schemas/quality-gate-config.schema.json
@@ -35,7 +35,11 @@
         "properties": {
           "pattern": { "type": "string", "minLength": 1 },
           "scope": { "enum": ["touched-window", "all-windows", "named-target"] },
-          "target": { "type": "string", "minLength": 1 }
+          "target": { "type": "string", "minLength": 1 },
+          "excludePatterns": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          }
         },
         "additionalProperties": false,
         "allOf": [


### PR DESCRIPTION
## Summary

  - `collectCustomFiles` was unconditionally appending the entire `src/pages/`
    directory to the i18n scan of every artifact window. New windows with no
    baseline row (e.g. `sii-config`) had all pre-existing page violations
    reported as regressions introduced by the PR.
  - Fix: add `app-shell:pages` as a proper named quality gate target, following
    the existing `app-shell:onboarding` pattern. Pages now have their own
    dedicated check and no longer pollute artifact window results.
  - Scopes are disjoint: `app-shell:pages` covers all of `src/pages/` except
    `OnboardingPage.jsx` and `onboarding/**`, which remain exclusively under
    `app-shell:onboarding`.

  ## Changed files

  - `cli/src/quality-gate/checks/i18n.js` — remove `appShellPagesDir` from
    `collectCustomFiles`
  - `cli/src/quality-gate/checks/shared.js` — add `app-shell:pages` case to
    `collectTargetSourceFiles`
  - `quality-gate.config.json` — add blastRadius rule routing
    `tools/app-shell/src/pages/**` changes to the `app-shell:pages` named target
  - `cli/test/quality-gate-checks-i18n.test.js` — invert two page tests (pages
    no longer bleed into artifact window checks); add independent tests for
    `app-shell:pages` and `app-shell:onboarding` boundary

  ## Test plan

  - [ ] `node --test cli/test/quality-gate-checks-i18n.test.js` — 10 tests pass
  - [ ] `node --test cli/test/*.test.js` — full suite passes (10 345 tests)
  - [ ] Adding a new artifact window on a future PR no longer produces i18n
    regressions from unrelated pages
  - [ ] Changing a file under `src/pages/` triggers `app-shell:pages` check
  - [ ] Changing `OnboardingPage.jsx` or `src/pages/onboarding/**` still triggers
    `app-shell:onboarding`