### PR TITLE
ETP-3938 Add MCP OAuth PKCE smoke

### DIFF
--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -35,23 +35,19 @@ Run it explicitly:
 
 ```bash
 cd e2e
-E2E_MCP_OAUTH_SMOKE=1 \
-E2E_MCP_SMOKE_USER="<user>" \
-E2E_MCP_SMOKE_PASSWORD="<password>" \
-E2E_MCP_OAUTH_CLIENT_ID="<client-id>" \
 npm run test:mcp-oauth-smoke
 ```
+
+Before running, export or otherwise provide `E2E_MCP_OAUTH_SMOKE`, `E2E_MCP_SMOKE_USER`, `E2E_MCP_SMOKE_PASSWORD`, and `E2E_MCP_OAUTH_CLIENT_ID` in the shell or CI environment.
 
 Use DCR instead of a pre-created client when the environment allows dynamic registration:
 
 ```bash
 cd e2e
-E2E_MCP_OAUTH_SMOKE=1 \
-E2E_MCP_SMOKE_USER="<user>" \
-E2E_MCP_SMOKE_PASSWORD="<password>" \
-E2E_MCP_OAUTH_ENABLE_DCR=1 \
 npm run test:mcp-oauth-smoke
 ```
+
+For DCR, provide `E2E_MCP_OAUTH_SMOKE`, `E2E_MCP_SMOKE_USER`, `E2E_MCP_SMOKE_PASSWORD`, and `E2E_MCP_OAUTH_ENABLE_DCR` in the shell or CI environment.
 
 If DCR creates the client but `/etendo/oauth2/authorize` returns `invalid_scope`, the environment is not granting the requested MCP scopes to dynamically registered clients. In that case, create a client from the OAuth2 Clients administration page with a System Administrator role, enable `neo:read`, `neo:write`, `neo:process`, `neo:report`, and `neo:*`, then pass its id through `E2E_MCP_OAUTH_CLIENT_ID`.
 
@@ -71,7 +67,7 @@ Configuration variables:
 | `E2E_MCP_OAUTH_TOKEN_AUTH_METHOD` | `client_secret_post` | Use `client_secret_basic`, `client_secret_post`, or `none` |
 | `E2E_MCP_OAUTH_ENABLE_DCR` | `0` | Set to `1` to create a client dynamically |
 | `E2E_MCP_OAUTH_DCR_INITIAL_ACCESS_TOKEN` | none | Optional bearer token for protected DCR |
-| `E2E_MCP_OAUTH_REDIRECT_URI` | local random port | Fixed callback URI when the client requires a pre-registered port |
+| `E2E_MCP_OAUTH_REDIRECT_URI` | local random port | Fixed callback URI when the client requires one; must use `127.0.0.1`, `localhost`, or `[::1]`, include an explicit port, and use the callback path registered for the client |
 
 The smoke performs these checks:
 

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -38,7 +38,7 @@ cd e2e
 npm run test:mcp-oauth-smoke
 ```
 
-Before running, export or otherwise provide `E2E_MCP_OAUTH_SMOKE`, `E2E_MCP_SMOKE_USER`, `E2E_MCP_SMOKE_PASSWORD`, and `E2E_MCP_OAUTH_CLIENT_ID` in the shell or CI environment.
+Before running, export or otherwise provide `E2E_MCP_OAUTH_SMOKE=1`, `E2E_MCP_SMOKE_USER`, `E2E_MCP_SMOKE_PASSWORD`, and `E2E_MCP_OAUTH_CLIENT_ID` in the shell or CI environment.
 
 Use DCR instead of a pre-created client when the environment allows dynamic registration:
 
@@ -47,7 +47,7 @@ cd e2e
 npm run test:mcp-oauth-smoke
 ```
 
-For DCR, provide `E2E_MCP_OAUTH_SMOKE`, `E2E_MCP_SMOKE_USER`, `E2E_MCP_SMOKE_PASSWORD`, and `E2E_MCP_OAUTH_ENABLE_DCR` in the shell or CI environment.
+For DCR, provide `E2E_MCP_OAUTH_SMOKE=1`, `E2E_MCP_SMOKE_USER`, `E2E_MCP_SMOKE_PASSWORD`, and `E2E_MCP_OAUTH_ENABLE_DCR=1` in the shell or CI environment.
 
 If DCR creates the client but `/etendo/oauth2/authorize` returns `invalid_scope`, the environment is not granting the requested MCP scopes to dynamically registered clients. In that case, create a client from the OAuth2 Clients administration page with a System Administrator role, enable `neo:read`, `neo:write`, `neo:process`, `neo:report`, and `neo:*`, then pass its id through `E2E_MCP_OAUTH_CLIENT_ID`.
 

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -77,6 +77,10 @@ The smoke performs these checks:
 4. An unauthenticated authorization request does not resolve to only the Vite/PWA shell.
 5. The user reaches the standard login flow, logs in, continues OAuth, handles consent when present, receives `code` and `state`, and exchanges the code for an `access_token` with PKCE.
 
+The app service worker must not serve `index.html` for backend or metadata navigations. `tools/app-shell/vite.config.js` keeps `/etendo/*`, `/mcp`, and `/.well-known/*` in the Workbox navigation fallback denylist while leaving `/authorize` as a SPA route.
+
+After deploying a service worker or routing change, invalidate CloudFront for `/sw.js`, `/registerSW.js`, `/index.html`, and `/assets/*`. For one local browser session, close and reopen the browser or unregister the existing service worker before retrying MCP authorization.
+
 ---
 
 ## Method 1: Record a Flow (Recommended for new tests)

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -27,6 +27,62 @@ npm install -g agent-browser && agent-browser install   # Optional: install agen
 
 ---
 
+## Deployed MCP OAuth2 Smoke
+
+`e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js` validates the public MCP/OAuth integration after deploy. It is skipped by default because it targets a deployed environment, uses real smoke credentials, can create an OAuth client through DCR, and binds a local callback server.
+
+Run it explicitly:
+
+```bash
+cd e2e
+E2E_MCP_OAUTH_SMOKE=1 \
+E2E_MCP_SMOKE_USER="<user>" \
+E2E_MCP_SMOKE_PASSWORD="<password>" \
+E2E_MCP_OAUTH_CLIENT_ID="<client-id>" \
+npm run test:mcp-oauth-smoke
+```
+
+Use DCR instead of a pre-created client when the environment allows dynamic registration:
+
+```bash
+cd e2e
+E2E_MCP_OAUTH_SMOKE=1 \
+E2E_MCP_SMOKE_USER="<user>" \
+E2E_MCP_SMOKE_PASSWORD="<password>" \
+E2E_MCP_OAUTH_ENABLE_DCR=1 \
+npm run test:mcp-oauth-smoke
+```
+
+If DCR creates the client but `/etendo/oauth2/authorize` returns `invalid_scope`, the environment is not granting the requested MCP scopes to dynamically registered clients. In that case, create a client from the OAuth2 Clients administration page with a System Administrator role, enable `neo:read`, `neo:write`, `neo:process`, `neo:report`, and `neo:*`, then pass its id through `E2E_MCP_OAUTH_CLIENT_ID`.
+
+Configuration variables:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `E2E_MCP_PUBLIC_BASE_URL` | `https://go.experimental.etendo.cloud` | Public viewer origin used for discovery checks |
+| `E2E_MCP_RESOURCE` | `${E2E_MCP_PUBLIC_BASE_URL}/mcp` | Expected protected resource value |
+| `E2E_MCP_ENDPOINT` | `${E2E_MCP_PUBLIC_BASE_URL}/mcp` | MCP endpoint used for the WAF/method smoke |
+| `E2E_MCP_OAUTH_AUTHORIZE_URL` | `${E2E_MCP_PUBLIC_BASE_URL}/etendo/oauth2/authorize` | Backend authorization endpoint |
+| `E2E_MCP_OAUTH_TOKEN_URL` | `${E2E_MCP_PUBLIC_BASE_URL}/etendo/oauth2/token` | Token endpoint for the PKCE exchange |
+| `E2E_MCP_OAUTH_REGISTRATION_URL` | `${E2E_MCP_PUBLIC_BASE_URL}/etendo/oauth2/register` | DCR endpoint |
+| `E2E_MCP_OAUTH_SCOPES` | `neo:read neo:write neo:process neo:report neo:*` | Requested MCP scopes |
+| `E2E_MCP_OAUTH_CLIENT_ID` | none | Existing OAuth client ID |
+| `E2E_MCP_OAUTH_CLIENT_SECRET` | none | Optional client secret |
+| `E2E_MCP_OAUTH_TOKEN_AUTH_METHOD` | `client_secret_post` | Use `client_secret_basic`, `client_secret_post`, or `none` |
+| `E2E_MCP_OAUTH_ENABLE_DCR` | `0` | Set to `1` to create a client dynamically |
+| `E2E_MCP_OAUTH_DCR_INITIAL_ACCESS_TOKEN` | none | Optional bearer token for protected DCR |
+| `E2E_MCP_OAUTH_REDIRECT_URI` | local random port | Fixed callback URI when the client requires a pre-registered port |
+
+The smoke performs these checks:
+
+1. `/.well-known/oauth-authorization-server` returns JSON with public HTTPS URLs.
+2. `/.well-known/oauth-protected-resource` returns JSON with the expected MCP resource.
+3. `POST /mcp` is not blocked by CloudFront/WAF as a method-level `403`.
+4. An unauthenticated authorization request does not resolve to only the Vite/PWA shell.
+5. The user reaches the standard login flow, logs in, continues OAuth, handles consent when present, receives `code` and `state`, and exchanges the code for an `access_token` with PKCE.
+
+---
+
 ## Method 1: Record a Flow (Recommended for new tests)
 
 The fastest way to create a test. You interact with the app in a real browser, and Playwright records every action as code. Then Claude takes that recording and turns it into a proper test with assertions and validations.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,6 +7,7 @@
     "test:headed": "npx playwright test --headed",
     "test:ui": "npx playwright test --ui",
     "test:debug": "npx playwright test --debug",
+    "test:mcp-oauth-smoke": "npx playwright test tests/flows/mcp-oauth-pkce.smoke.spec.js",
     "report": "npx playwright show-report"
   },
   "devDependencies": {

--- a/e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js
+++ b/e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js
@@ -64,6 +64,7 @@ test.describe('MCP OAuth2 Authorization Code + PKCE deployed smoke', () => {
     expect(protectedResource.resource).toBe(MCP_RESOURCE);
     expect(Array.isArray(protectedResource.authorization_servers)).toBe(true);
     for (const server of protectedResource.authorization_servers) {
+      // RFC 9728 allows protected resources to delegate auth to another issuer.
       expectHttpsEndpoint(server, 'authorization_servers[]');
     }
 
@@ -94,6 +95,7 @@ test.describe('MCP OAuth2 Authorization Code + PKCE deployed smoke', () => {
     page,
     request,
   }) => {
+    test.setTimeout(180_000);
     test.skip(Boolean(!SMOKE_USER || !SMOKE_PASSCODE), 'Set smoke user credentials in E2E_MCP_SMOKE_USER/E2E_MCP_SMOKE_PASSWORD or E2E_USER/E2E_PASSWORD.');
     test.skip(Boolean(!STATIC_CLIENT_ID && !ENABLE_DCR), 'Set E2E_MCP_OAUTH_CLIENT_ID or enable DCR with E2E_MCP_OAUTH_ENABLE_DCR=1.');
 

--- a/e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js
+++ b/e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js
@@ -1,0 +1,412 @@
+import { expect, test } from '@playwright/test';
+import { createHash, randomBytes } from 'node:crypto';
+import { createServer } from 'node:http';
+
+const RUN_DEPLOYED_SMOKE = process.env.E2E_MCP_OAUTH_SMOKE === '1';
+
+const PUBLIC_BASE_URL = trimTrailingSlash(
+  process.env.E2E_MCP_PUBLIC_BASE_URL || 'https://go.experimental.etendo.cloud'
+);
+const MCP_RESOURCE = process.env.E2E_MCP_RESOURCE || `${PUBLIC_BASE_URL}/mcp`;
+const MCP_ENDPOINT = process.env.E2E_MCP_ENDPOINT || `${PUBLIC_BASE_URL}/mcp`;
+const AUTHORIZATION_ENDPOINT = process.env.E2E_MCP_OAUTH_AUTHORIZE_URL ||
+  `${PUBLIC_BASE_URL}/etendo/oauth2/authorize`;
+const TOKEN_ENDPOINT = process.env.E2E_MCP_OAUTH_TOKEN_URL ||
+  `${PUBLIC_BASE_URL}/etendo/oauth2/token`;
+const REGISTRATION_ENDPOINT = process.env.E2E_MCP_OAUTH_REGISTRATION_URL ||
+  `${PUBLIC_BASE_URL}/etendo/oauth2/register`;
+const REQUESTED_SCOPES = process.env.E2E_MCP_OAUTH_SCOPES ||
+  'neo:read neo:write neo:process neo:report neo:*';
+
+const SMOKE_USER = process.env.E2E_MCP_SMOKE_USER || process.env.E2E_USER;
+const SMOKE_PASSWORD = process.env.E2E_MCP_SMOKE_PASSWORD || process.env.E2E_PASSWORD;
+const STATIC_CLIENT_ID = process.env.E2E_MCP_OAUTH_CLIENT_ID;
+const STATIC_CLIENT_SECRET = process.env.E2E_MCP_OAUTH_CLIENT_SECRET;
+const ENABLE_DCR = process.env.E2E_MCP_OAUTH_ENABLE_DCR === '1';
+const DCR_INITIAL_ACCESS_TOKEN = process.env.E2E_MCP_OAUTH_DCR_INITIAL_ACCESS_TOKEN;
+const TOKEN_AUTH_METHOD = process.env.E2E_MCP_OAUTH_TOKEN_AUTH_METHOD || 'client_secret_post';
+const CONFIGURED_REDIRECT_URI = process.env.E2E_MCP_OAUTH_REDIRECT_URI;
+
+test.describe('MCP OAuth2 Authorization Code + PKCE deployed smoke', () => {
+  test.skip(
+    !RUN_DEPLOYED_SMOKE,
+    'Set E2E_MCP_OAUTH_SMOKE=1 to run this deployed integration smoke.'
+  );
+
+  test('metadata and edge routes are public JSON and pass WAF method checks', async ({ request }) => {
+    const authorizationServer = await getJson(
+      request,
+      `${PUBLIC_BASE_URL}/.well-known/oauth-authorization-server`,
+      'OAuth authorization server metadata'
+    );
+    expectPublicEndpoint(authorizationServer.issuer, PUBLIC_BASE_URL, 'issuer');
+    expectPublicEndpoint(
+      authorizationServer.authorization_endpoint,
+      PUBLIC_BASE_URL,
+      'authorization_endpoint'
+    );
+    expectPublicEndpoint(authorizationServer.token_endpoint, PUBLIC_BASE_URL, 'token_endpoint');
+    if (authorizationServer.registration_endpoint) {
+      expectPublicEndpoint(
+        authorizationServer.registration_endpoint,
+        PUBLIC_BASE_URL,
+        'registration_endpoint'
+      );
+    }
+
+    const protectedResource = await getJson(
+      request,
+      `${PUBLIC_BASE_URL}/.well-known/oauth-protected-resource`,
+      'OAuth protected resource metadata'
+    );
+    expect(protectedResource.resource).toBe(MCP_RESOURCE);
+    expect(Array.isArray(protectedResource.authorization_servers)).toBe(true);
+    for (const server of protectedResource.authorization_servers) {
+      expectPublicEndpoint(server, PUBLIC_BASE_URL, 'authorization_servers[]');
+    }
+
+    const mcpResponse = await request.post(MCP_ENDPOINT, {
+      headers: {
+        accept: 'application/json, text/event-stream',
+        'content-type': 'application/json',
+      },
+      data: {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'schema-forge-oauth-smoke', version: '0.0.0' },
+        },
+      },
+    });
+    expect(mcpResponse.status(), 'CloudFront/WAF must not reject POST /mcp by method').not.toBe(403);
+    if (!mcpResponse.ok()) {
+      const contentType = mcpResponse.headers()['content-type'] || '';
+      expect(contentType, 'MCP errors should not be returned as HTML').not.toContain('text/html');
+    }
+  });
+
+  test('unauthenticated browser can complete OAuth2 authorization code flow with PKCE', async ({
+    page,
+    request,
+  }) => {
+    test.skip(Boolean(!SMOKE_USER || !SMOKE_PASSWORD), 'Set smoke user credentials in E2E_MCP_SMOKE_USER/E2E_MCP_SMOKE_PASSWORD or E2E_USER/E2E_PASSWORD.');
+    test.skip(Boolean(!STATIC_CLIENT_ID && !ENABLE_DCR), 'Set E2E_MCP_OAUTH_CLIENT_ID or enable DCR with E2E_MCP_OAUTH_ENABLE_DCR=1.');
+
+    const callbackServer = await startCallbackServer(CONFIGURED_REDIRECT_URI);
+    const redirectUri = callbackServer.redirectUri;
+    const state = `sf-smoke-${randomBytes(12).toString('hex')}`;
+    const codeVerifier = base64Url(randomBytes(64));
+    const codeChallenge = base64Url(createHash('sha256').update(codeVerifier).digest());
+
+    try {
+      const client = await resolveOAuthClient(request, redirectUri);
+      const authorizeUrl = buildAuthorizeUrl({
+        clientId: client.clientId,
+        codeChallenge,
+        redirectUri,
+        state,
+      });
+
+      const directAuthorizeResponse = await request.get(authorizeUrl.toString(), {
+        maxRedirects: 0,
+      });
+      if (directAuthorizeResponse.status() === 200) {
+        const body = await directAuthorizeResponse.text();
+        expect(
+          looksLikeOnlyPwaShell(body),
+          'Unauthenticated authorize response must not end as only the Vite/PWA shell'
+        ).toBe(false);
+      } else if (directAuthorizeResponse.status() >= 400) {
+        const contentType = directAuthorizeResponse.headers()['content-type'] || '';
+        const body = await directAuthorizeResponse.text();
+        expect(contentType, `Authorize error must be OAuth JSON, body: ${body.slice(0, 300)}`)
+          .toContain('application/json');
+        throw new Error(
+          `Authorize rejected the request before login with HTTP ${directAuthorizeResponse.status()}: ${body}`
+        );
+      } else {
+        expect(
+          directAuthorizeResponse.status(),
+          'Unauthenticated authorize should redirect to login or return a real login response'
+        ).toBeGreaterThanOrEqual(300);
+        expect(directAuthorizeResponse.status()).toBeLessThan(400);
+      }
+
+      await page.context().clearCookies();
+      await page.goto(authorizeUrl.toString(), { waitUntil: 'domcontentloaded' });
+      await expectNotOnlyPwaShell(page);
+      await expectLoginFlow(page);
+
+      await fillLoginForm(page, SMOKE_USER, SMOKE_PASSWORD);
+      await approveConsentIfNeeded(page, callbackServer.callbackPromise);
+
+      const callback = await callbackServer.callbackPromise;
+      expect(callback.state).toBe(state);
+      expect(callback.error, `OAuth callback returned error: ${callback.error_description || callback.error || ''}`).toBeFalsy();
+      expect(callback.code, 'OAuth callback must include an authorization code').toBeTruthy();
+
+      const tokenResponse = await exchangeCodeForToken(request, {
+        client,
+        code: callback.code,
+        codeVerifier,
+        redirectUri,
+      });
+      expect(tokenResponse.access_token, 'Token endpoint must return access_token').toBeTruthy();
+    } finally {
+      await callbackServer.close();
+    }
+  });
+});
+
+async function resolveOAuthClient(request, redirectUri) {
+  if (STATIC_CLIENT_ID) {
+    return {
+      clientId: STATIC_CLIENT_ID,
+      clientSecret: STATIC_CLIENT_SECRET,
+      tokenAuthMethod: TOKEN_AUTH_METHOD,
+    };
+  }
+
+  const headers = { 'content-type': 'application/json' };
+  if (DCR_INITIAL_ACCESS_TOKEN) {
+    headers.authorization = `Bearer ${DCR_INITIAL_ACCESS_TOKEN}`;
+  }
+
+  const response = await request.post(REGISTRATION_ENDPOINT, {
+    headers,
+    data: {
+      client_name: 'Schema Forge MCP OAuth smoke',
+      redirect_uris: [redirectUri],
+      grant_types: ['authorization_code'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+      scope: REQUESTED_SCOPES,
+    },
+  });
+  const body = await parseOAuthJsonResponse(response, 'DCR registration');
+  expect(response.ok(), `DCR registration failed: ${JSON.stringify(body)}`).toBe(true);
+  expect(body.client_id, 'DCR response must include client_id').toBeTruthy();
+
+  return {
+    clientId: body.client_id,
+    clientSecret: body.client_secret,
+    tokenAuthMethod: body.token_endpoint_auth_method || 'none',
+  };
+}
+
+function buildAuthorizeUrl({ clientId, codeChallenge, redirectUri, state }) {
+  const authorizeUrl = new URL(AUTHORIZATION_ENDPOINT);
+  authorizeUrl.searchParams.set('response_type', 'code');
+  authorizeUrl.searchParams.set('client_id', clientId);
+  authorizeUrl.searchParams.set('redirect_uri', redirectUri);
+  authorizeUrl.searchParams.set('scope', REQUESTED_SCOPES);
+  authorizeUrl.searchParams.set('state', state);
+  authorizeUrl.searchParams.set('code_challenge', codeChallenge);
+  authorizeUrl.searchParams.set('code_challenge_method', 'S256');
+  authorizeUrl.searchParams.set('resource', MCP_RESOURCE);
+  return authorizeUrl;
+}
+
+async function exchangeCodeForToken(request, { client, code, codeVerifier, redirectUri }) {
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: redirectUri,
+    client_id: client.clientId,
+    code_verifier: codeVerifier,
+  });
+  if (client.clientSecret && client.tokenAuthMethod !== 'client_secret_basic') {
+    body.set('client_secret', client.clientSecret);
+  }
+
+  const headers = { 'content-type': 'application/x-www-form-urlencoded' };
+  if (client.clientSecret && client.tokenAuthMethod === 'client_secret_basic') {
+    headers.authorization = `Basic ${base64(`${client.clientId}:${client.clientSecret}`)}`;
+  }
+
+  const response = await request.post(TOKEN_ENDPOINT, {
+    headers,
+    data: body.toString(),
+  });
+  const json = await parseOAuthJsonResponse(response, 'authorization_code token exchange');
+  expect(response.ok(), `Token exchange failed: ${JSON.stringify(json)}`).toBe(true);
+  return json;
+}
+
+async function startCallbackServer(configuredRedirectUri) {
+  const configuredUrl = configuredRedirectUri ? new URL(configuredRedirectUri) : null;
+  const port = configuredUrl?.port ? Number(configuredUrl.port) : 0;
+
+  let resolveCallback;
+  const callbackPromise = new Promise((resolve) => {
+    resolveCallback = resolve;
+  });
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url || '/', 'http://127.0.0.1');
+    if (url.pathname !== '/mcp/oauth/callback') {
+      res.writeHead(404, { 'content-type': 'text/plain' });
+      res.end('Not found');
+      return;
+    }
+
+    const params = Object.fromEntries(url.searchParams.entries());
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end('<!doctype html><title>OAuth smoke callback</title><p>OAuth callback received.</p>');
+    resolveCallback(params);
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', resolve);
+  });
+
+  const actualPort = server.address().port;
+  return {
+    callbackPromise: withTimeout(callbackPromise, 120_000, 'Timed out waiting for OAuth callback'),
+    redirectUri: configuredRedirectUri || `http://127.0.0.1:${actualPort}/mcp/oauth/callback`,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+async function fillLoginForm(page, user, password) {
+  const switchToLogin = page.getByTestId('action-switch-to-login');
+  if (await switchToLogin.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await switchToLogin.click();
+  }
+
+  const userField = await firstVisibleLocator(page, [
+    () => page.locator('#login-email').first(),
+    () => page.locator('input[name="username"], input[name="email"], input[type="email"]').first(),
+    () => page.getByLabel(/user(name)?|email/i).first(),
+    () => page.getByPlaceholder(/user(name)?|email/i).first(),
+    () => page.getByRole('textbox', { name: /user(name)?|email/i }).first(),
+  ], 30_000);
+  await userField.fill(user);
+
+  const passwordField = await firstVisibleLocator(page, [
+    () => page.locator('#login-password').first(),
+    () => page.locator('input[name="password"], input[type="password"]').first(),
+    () => page.getByLabel(/password/i).first(),
+    () => page.getByPlaceholder(/password/i).first(),
+  ], 15_000);
+  await passwordField.fill(password);
+
+  const submit = await firstVisibleLocator(page, [
+    () => page.getByTestId('action-login-submit'),
+    () => page.getByRole('button', { name: /sign in|log in|login|continue/i }).first(),
+    () => page.locator('button[type="submit"]').first(),
+  ], 15_000);
+  await submit.click();
+}
+
+async function approveConsentIfNeeded(page, callbackPromise) {
+  let callbackReceived = false;
+  callbackPromise.then(() => {
+    callbackReceived = true;
+  }).catch(() => {});
+
+  const consentButtonCandidates = [
+    () => page.getByRole('button', { name: /authorize|allow|approve|accept/i }).first(),
+    () => page.getByTestId('action-oauth-authorize'),
+  ];
+
+  const deadline = Date.now() + 120_000;
+  while (!callbackReceived && Date.now() < deadline) {
+    for (const candidate of consentButtonCandidates) {
+      const locator = candidate();
+      if (await locator.isVisible({ timeout: 500 }).catch(() => false)) {
+        await locator.click();
+        return;
+      }
+    }
+    await page.waitForTimeout(500);
+  }
+}
+
+async function expectLoginFlow(page) {
+  const loginDetected = await Promise.race([
+    page.locator('#login-email, input[name="username"], input[name="email"], input[type="email"]').first()
+      .waitFor({ state: 'visible', timeout: 30_000 }).then(() => true).catch(() => false),
+    page.getByRole('button', { name: /sign in|log in|login/i }).first()
+      .waitFor({ state: 'visible', timeout: 30_000 }).then(() => true).catch(() => false),
+    page.waitForURL(/login|onboarding|security/i, { timeout: 30_000 }).then(() => true).catch(() => false),
+  ]);
+  expect(loginDetected, 'Unauthenticated OAuth authorize must reach the standard login flow').toBe(true);
+}
+
+async function expectNotOnlyPwaShell(page) {
+  const html = await page.locator('html').evaluate((node) => node.outerHTML).catch(() => '');
+  expect(looksLikeOnlyPwaShell(html), 'Page must not be only the Vite/PWA shell').toBe(false);
+}
+
+function looksLikeOnlyPwaShell(html) {
+  return /<div[^>]+id=["']root["'][^>]*>\s*<\/div>/i.test(html) &&
+    /<script[^>]+src=["'][^"']*(\/src\/main|\/assets\/index-)[^"']*["']/i.test(html) &&
+    !/login|sign in|username|password|authorize/i.test(html);
+}
+
+async function getJson(request, url, label) {
+  const response = await request.get(url, { headers: { accept: 'application/json' } });
+  expect(response.ok(), `${label} request failed with HTTP ${response.status()}`).toBe(true);
+  return parseOAuthJsonResponse(response, label);
+}
+
+async function parseOAuthJsonResponse(response, label) {
+  const contentType = response.headers()['content-type'] || '';
+  const text = await response.text();
+  expect(contentType, `${label} must return JSON, body: ${text.slice(0, 300)}`).toContain('application/json');
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`${label} returned invalid JSON: ${error.message}. Body: ${text.slice(0, 300)}`);
+  }
+}
+
+async function firstVisibleLocator(page, factories, timeout) {
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    for (const factory of factories) {
+      const locator = factory();
+      if (await locator.isVisible({ timeout: 250 }).catch(() => false)) {
+        return locator;
+      }
+    }
+    await page.waitForTimeout(250);
+  }
+  throw new Error(`Could not find a visible login control within ${timeout}ms`);
+}
+
+function expectPublicEndpoint(value, publicBaseUrl, label) {
+  expect(value, `${label} must be present`).toBeTruthy();
+  const parsed = new URL(value);
+  const publicOrigin = new URL(publicBaseUrl).origin;
+  expect(parsed.origin, `${label} must use the public origin`).toBe(publicOrigin);
+  expect(parsed.protocol, `${label} must be HTTPS`).toBe('https:');
+}
+
+function withTimeout(promise, timeoutMs, message) {
+  let timeout;
+  const timeoutPromise = new Promise((_, reject) => {
+    timeout = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timeout));
+}
+
+function trimTrailingSlash(value) {
+  return value.replace(/\/+$/, '');
+}
+
+function base64Url(value) {
+  return base64(value)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function base64(value) {
+  return Buffer.from(value).toString('base64');
+}

--- a/e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js
+++ b/e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js
@@ -19,11 +19,11 @@ const REQUESTED_SCOPES = process.env.E2E_MCP_OAUTH_SCOPES ||
   'neo:read neo:write neo:process neo:report neo:*';
 
 const SMOKE_USER = process.env.E2E_MCP_SMOKE_USER || process.env.E2E_USER;
-const SMOKE_PASSWORD = process.env.E2E_MCP_SMOKE_PASSWORD || process.env.E2E_PASSWORD;
+const SMOKE_PASSCODE = process.env.E2E_MCP_SMOKE_PASSWORD || process.env.E2E_PASSWORD;
 const STATIC_CLIENT_ID = process.env.E2E_MCP_OAUTH_CLIENT_ID;
-const STATIC_CLIENT_SECRET = process.env.E2E_MCP_OAUTH_CLIENT_SECRET;
+const STATIC_CLIENT_CREDENTIAL = process.env.E2E_MCP_OAUTH_CLIENT_SECRET;
 const ENABLE_DCR = process.env.E2E_MCP_OAUTH_ENABLE_DCR === '1';
-const DCR_INITIAL_ACCESS_TOKEN = process.env.E2E_MCP_OAUTH_DCR_INITIAL_ACCESS_TOKEN;
+const INITIAL_DCR_TOKEN = process.env.E2E_MCP_OAUTH_DCR_INITIAL_ACCESS_TOKEN;
 const TOKEN_AUTH_METHOD = process.env.E2E_MCP_OAUTH_TOKEN_AUTH_METHOD || 'client_secret_post';
 const CONFIGURED_REDIRECT_URI = process.env.E2E_MCP_OAUTH_REDIRECT_URI;
 
@@ -62,7 +62,7 @@ test.describe('MCP OAuth2 Authorization Code + PKCE deployed smoke', () => {
     expect(protectedResource.resource).toBe(MCP_RESOURCE);
     expect(Array.isArray(protectedResource.authorization_servers)).toBe(true);
     for (const server of protectedResource.authorization_servers) {
-      expectPublicEndpoint(server, PUBLIC_BASE_URL, 'authorization_servers[]');
+      expectHttpsEndpoint(server, 'authorization_servers[]');
     }
 
     const mcpResponse = await request.post(MCP_ENDPOINT, {
@@ -92,7 +92,8 @@ test.describe('MCP OAuth2 Authorization Code + PKCE deployed smoke', () => {
     page,
     request,
   }) => {
-    test.skip(Boolean(!SMOKE_USER || !SMOKE_PASSWORD), 'Set smoke user credentials in E2E_MCP_SMOKE_USER/E2E_MCP_SMOKE_PASSWORD or E2E_USER/E2E_PASSWORD.');
+    test.setTimeout(180_000);
+    test.skip(Boolean(!SMOKE_USER || !SMOKE_PASSCODE), 'Set smoke user credentials in E2E_MCP_SMOKE_USER/E2E_MCP_SMOKE_PASSWORD or E2E_USER/E2E_PASSWORD.');
     test.skip(Boolean(!STATIC_CLIENT_ID && !ENABLE_DCR), 'Set E2E_MCP_OAUTH_CLIENT_ID or enable DCR with E2E_MCP_OAUTH_ENABLE_DCR=1.');
 
     const callbackServer = await startCallbackServer(CONFIGURED_REDIRECT_URI);
@@ -140,7 +141,7 @@ test.describe('MCP OAuth2 Authorization Code + PKCE deployed smoke', () => {
       await expectNotOnlyPwaShell(page);
       await expectLoginFlow(page);
 
-      await fillLoginForm(page, SMOKE_USER, SMOKE_PASSWORD);
+      await fillLoginForm(page, SMOKE_USER, SMOKE_PASSCODE);
       await approveConsentIfNeeded(page, callbackServer.callbackPromise);
 
       const callback = await callbackServer.callbackPromise;
@@ -165,14 +166,14 @@ async function resolveOAuthClient(request, redirectUri) {
   if (STATIC_CLIENT_ID) {
     return {
       clientId: STATIC_CLIENT_ID,
-      clientSecret: STATIC_CLIENT_SECRET,
+      clientCredential: STATIC_CLIENT_CREDENTIAL,
       tokenAuthMethod: TOKEN_AUTH_METHOD,
     };
   }
 
   const headers = { 'content-type': 'application/json' };
-  if (DCR_INITIAL_ACCESS_TOKEN) {
-    headers.authorization = `Bearer ${DCR_INITIAL_ACCESS_TOKEN}`;
+  if (INITIAL_DCR_TOKEN) {
+    headers.authorization = `Bearer ${INITIAL_DCR_TOKEN}`;
   }
 
   const response = await request.post(REGISTRATION_ENDPOINT, {
@@ -192,8 +193,8 @@ async function resolveOAuthClient(request, redirectUri) {
 
   return {
     clientId: body.client_id,
-    clientSecret: body.client_secret,
-    tokenAuthMethod: body.token_endpoint_auth_method || 'none',
+    clientCredential: body.client_secret,
+    tokenAuthMethod: body.token_endpoint_auth_method || 'client_secret_basic',
   };
 }
 
@@ -218,13 +219,15 @@ async function exchangeCodeForToken(request, { client, code, codeVerifier, redir
     client_id: client.clientId,
     code_verifier: codeVerifier,
   });
-  if (client.clientSecret && client.tokenAuthMethod !== 'client_secret_basic') {
-    body.set('client_secret', client.clientSecret);
+  if (client.clientCredential && client.tokenAuthMethod === 'client_secret_post') {
+    body.set('client_secret', client.clientCredential);
   }
 
   const headers = { 'content-type': 'application/x-www-form-urlencoded' };
-  if (client.clientSecret && client.tokenAuthMethod === 'client_secret_basic') {
-    headers.authorization = `Basic ${base64(`${client.clientId}:${client.clientSecret}`)}`;
+  if (client.clientCredential && client.tokenAuthMethod === 'client_secret_basic') {
+    headers.authorization = `Basic ${base64(
+      `${formEncode(client.clientId)}:${formEncode(client.clientCredential)}`
+    )}`;
   }
 
   const response = await request.post(TOKEN_ENDPOINT, {
@@ -238,7 +241,10 @@ async function exchangeCodeForToken(request, { client, code, codeVerifier, redir
 
 async function startCallbackServer(configuredRedirectUri) {
   const configuredUrl = configuredRedirectUri ? new URL(configuredRedirectUri) : null;
-  const port = configuredUrl?.port ? Number(configuredUrl.port) : 0;
+  const defaultCallbackPath = '/mcp/oauth/callback';
+  const callbackPath = configuredUrl?.pathname || defaultCallbackPath;
+  const port = configuredUrl ? requireExplicitPort(configuredUrl) : 0;
+  const listenHost = resolveCallbackListenHost(configuredUrl);
 
   let resolveCallback;
   const callbackPromise = new Promise((resolve) => {
@@ -246,8 +252,8 @@ async function startCallbackServer(configuredRedirectUri) {
   });
 
   const server = createServer((req, res) => {
-    const url = new URL(req.url || '/', 'http://127.0.0.1');
-    if (url.pathname !== '/mcp/oauth/callback') {
+    const url = new URL(req.url || '/', configuredRedirectUri || 'http://127.0.0.1');
+    if (url.pathname !== callbackPath) {
       res.writeHead(404, { 'content-type': 'text/plain' });
       res.end('Not found');
       return;
@@ -261,13 +267,17 @@ async function startCallbackServer(configuredRedirectUri) {
 
   await new Promise((resolve, reject) => {
     server.once('error', reject);
-    server.listen(port, '127.0.0.1', resolve);
+    if (listenHost) {
+      server.listen(port, listenHost, resolve);
+    } else {
+      server.listen(port, resolve);
+    }
   });
 
   const actualPort = server.address().port;
   return {
     callbackPromise: withTimeout(callbackPromise, 120_000, 'Timed out waiting for OAuth callback'),
-    redirectUri: configuredRedirectUri || `http://127.0.0.1:${actualPort}/mcp/oauth/callback`,
+    redirectUri: configuredRedirectUri || `http://127.0.0.1:${actualPort}${defaultCallbackPath}`,
     close: () => new Promise((resolve) => server.close(resolve)),
   };
 }
@@ -388,6 +398,35 @@ function expectPublicEndpoint(value, publicBaseUrl, label) {
   expect(parsed.protocol, `${label} must be HTTPS`).toBe('https:');
 }
 
+function expectHttpsEndpoint(value, label) {
+  expect(value, `${label} must be present`).toBeTruthy();
+  const parsed = new URL(value);
+  expect(parsed.protocol, `${label} must be HTTPS`).toBe('https:');
+}
+
+function requireExplicitPort(url) {
+  if (!url.port) {
+    throw new Error(
+      'E2E_MCP_OAUTH_REDIRECT_URI must include an explicit local callback port, ' +
+        'for example http://127.0.0.1:49152/mcp/oauth/callback.'
+    );
+  }
+  return Number(url.port);
+}
+
+function resolveCallbackListenHost(url) {
+  if (!url) return '127.0.0.1';
+
+  const host = url.hostname;
+  if (host === '127.0.0.1') return host;
+  if (host === '[::1]' || host === '::1') return '::1';
+  if (host === 'localhost') return null;
+
+  throw new Error(
+    'E2E_MCP_OAUTH_REDIRECT_URI must use a loopback host: 127.0.0.1, localhost, or [::1].'
+  );
+}
+
 function withTimeout(promise, timeoutMs, message) {
   let timeout;
   const timeoutPromise = new Promise((_, reject) => {
@@ -409,4 +448,10 @@ function base64Url(value) {
 
 function base64(value) {
   return Buffer.from(value).toString('base64');
+}
+
+function formEncode(value) {
+  return encodeURIComponent(value)
+    .replace(/[!'()]/g, (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`)
+    .replace(/\*/g, '%2A');
 }

--- a/e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js
+++ b/e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js
@@ -28,6 +28,8 @@ const TOKEN_AUTH_METHOD = process.env.E2E_MCP_OAUTH_TOKEN_AUTH_METHOD || 'client
 const CONFIGURED_REDIRECT_URI = process.env.E2E_MCP_OAUTH_REDIRECT_URI;
 
 test.describe('MCP OAuth2 Authorization Code + PKCE deployed smoke', () => {
+  test.describe.configure({ timeout: 180_000 });
+
   test.skip(
     !RUN_DEPLOYED_SMOKE,
     'Set E2E_MCP_OAUTH_SMOKE=1 to run this deployed integration smoke.'
@@ -39,15 +41,15 @@ test.describe('MCP OAuth2 Authorization Code + PKCE deployed smoke', () => {
       `${PUBLIC_BASE_URL}/.well-known/oauth-authorization-server`,
       'OAuth authorization server metadata'
     );
-    expectPublicEndpoint(authorizationServer.issuer, PUBLIC_BASE_URL, 'issuer');
-    expectPublicEndpoint(
+    expectPublicOriginEndpoint(authorizationServer.issuer, PUBLIC_BASE_URL, 'issuer');
+    expectPublicOriginEndpoint(
       authorizationServer.authorization_endpoint,
       PUBLIC_BASE_URL,
       'authorization_endpoint'
     );
-    expectPublicEndpoint(authorizationServer.token_endpoint, PUBLIC_BASE_URL, 'token_endpoint');
+    expectPublicOriginEndpoint(authorizationServer.token_endpoint, PUBLIC_BASE_URL, 'token_endpoint');
     if (authorizationServer.registration_endpoint) {
-      expectPublicEndpoint(
+      expectPublicOriginEndpoint(
         authorizationServer.registration_endpoint,
         PUBLIC_BASE_URL,
         'registration_endpoint'
@@ -92,7 +94,6 @@ test.describe('MCP OAuth2 Authorization Code + PKCE deployed smoke', () => {
     page,
     request,
   }) => {
-    test.setTimeout(180_000);
     test.skip(Boolean(!SMOKE_USER || !SMOKE_PASSCODE), 'Set smoke user credentials in E2E_MCP_SMOKE_USER/E2E_MCP_SMOKE_PASSWORD or E2E_USER/E2E_PASSWORD.');
     test.skip(Boolean(!STATIC_CLIENT_ID && !ENABLE_DCR), 'Set E2E_MCP_OAUTH_CLIENT_ID or enable DCR with E2E_MCP_OAUTH_ENABLE_DCR=1.');
 
@@ -265,14 +266,7 @@ async function startCallbackServer(configuredRedirectUri) {
     resolveCallback(params);
   });
 
-  await new Promise((resolve, reject) => {
-    server.once('error', reject);
-    if (listenHost) {
-      server.listen(port, listenHost, resolve);
-    } else {
-      server.listen(port, resolve);
-    }
-  });
+  await listenForCallback(server, port, listenHost);
 
   const actualPort = server.address().port;
   return {
@@ -390,7 +384,7 @@ async function firstVisibleLocator(page, factories, timeout) {
   throw new Error(`Could not find a visible login control within ${timeout}ms`);
 }
 
-function expectPublicEndpoint(value, publicBaseUrl, label) {
+function expectPublicOriginEndpoint(value, publicBaseUrl, label) {
   expect(value, `${label} must be present`).toBeTruthy();
   const parsed = new URL(value);
   const publicOrigin = new URL(publicBaseUrl).origin;
@@ -425,6 +419,17 @@ function resolveCallbackListenHost(url) {
   throw new Error(
     'E2E_MCP_OAUTH_REDIRECT_URI must use a loopback host: 127.0.0.1, localhost, or [::1].'
   );
+}
+
+function listenForCallback(server, port, host) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    if (host) {
+      server.listen(port, host, resolve);
+      return;
+    }
+    server.listen(port, resolve);
+  });
 }
 
 function withTimeout(promise, timeoutMs, message) {

--- a/e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js
+++ b/e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js
@@ -141,8 +141,8 @@ test.describe('MCP OAuth2 Authorization Code + PKCE deployed smoke', () => {
 
       await page.context().clearCookies();
       await page.goto(authorizeUrl.toString(), { waitUntil: 'domcontentloaded' });
-      await expectNotOnlyPwaShell(page);
       await expectLoginFlow(page);
+      await expectNotOnlyPwaShell(page);
 
       await fillLoginForm(page, SMOKE_USER, SMOKE_PASSCODE);
       await approveConsentIfNeeded(page, callbackServer.callbackPromise);
@@ -179,6 +179,7 @@ async function resolveOAuthClient(request, redirectUri) {
     headers.authorization = `Bearer ${INITIAL_DCR_TOKEN}`;
   }
 
+  const requestedTokenAuthMethod = 'none';
   const response = await request.post(REGISTRATION_ENDPOINT, {
     headers,
     data: {
@@ -186,7 +187,7 @@ async function resolveOAuthClient(request, redirectUri) {
       redirect_uris: [redirectUri],
       grant_types: ['authorization_code'],
       response_types: ['code'],
-      token_endpoint_auth_method: 'none',
+      token_endpoint_auth_method: requestedTokenAuthMethod,
       scope: REQUESTED_SCOPES,
     },
   });
@@ -197,7 +198,7 @@ async function resolveOAuthClient(request, redirectUri) {
   return {
     clientId: body.client_id,
     clientCredential: body.client_secret,
-    tokenAuthMethod: body.token_endpoint_auth_method || 'client_secret_basic',
+    tokenAuthMethod: body.token_endpoint_auth_method || requestedTokenAuthMethod,
   };
 }
 
@@ -416,7 +417,7 @@ function resolveCallbackListenHost(url) {
   const host = url.hostname;
   if (host === '127.0.0.1') return host;
   if (host === '[::1]' || host === '::1') return '::1';
-  if (host === 'localhost') return null;
+  if (host === 'localhost') return host;
 
   throw new Error(
     'E2E_MCP_OAUTH_REDIRECT_URI must use a loopback host: 127.0.0.1, localhost, or [::1].'
@@ -426,11 +427,7 @@ function resolveCallbackListenHost(url) {
 function listenForCallback(server, port, host) {
   return new Promise((resolve, reject) => {
     server.once('error', reject);
-    if (host) {
-      server.listen(port, host, resolve);
-      return;
-    }
-    server.listen(port, resolve);
+    server.listen(port, host, resolve);
   });
 }
 

--- a/tools/app-shell/test/pwa.test.js
+++ b/tools/app-shell/test/pwa.test.js
@@ -36,6 +36,15 @@ describe('PWA configuration', () => {
     assert.ok(config.includes("cleanupOutdatedCaches: true"), 'should enable cache cleanup');
   });
 
+  it('service worker navigation fallback excludes backend and discovery routes', () => {
+    const config = readFileSync(resolve(APP_SHELL, 'vite.config.js'), 'utf8');
+    assert.ok(config.includes('navigateFallbackDenylist'), 'should configure a navigation fallback denylist');
+    assert.ok(config.includes('/^\\/etendo\\//'), 'should denylist backend /etendo routes');
+    assert.ok(config.includes('/^\\/mcp(?:\\/|$)/'), 'should denylist the public MCP endpoint');
+    assert.ok(config.includes('/^\\/\\.well-known\\//'), 'should denylist OAuth/MCP discovery metadata');
+    assert.ok(!config.includes('/^\\/authorize'), 'should keep the SPA /authorize route cacheable');
+  });
+
   it('manifest includes required PWA fields', () => {
     const config = readFileSync(resolve(APP_SHELL, 'vite.config.js'), 'utf8');
     assert.ok(config.includes("name: 'Etendo'"), 'manifest should have name');
@@ -102,6 +111,15 @@ describe('PWA configuration', () => {
       !sw.includes('url:"assets/index.css",revision:null'),
       'service worker should not precache a stable /assets/index.css URL'
     );
+  });
+
+  it('production service worker does not fallback backend routes to index.html', () => {
+    const { sw } = readBuiltArtifacts();
+
+    assert.match(sw, /denylist:\[[^\]]*\/\^\\\/etendo\\\//, 'SW should denylist /etendo navigations');
+    assert.match(sw, /denylist:\[[^\]]*\/\^\\\/mcp/, 'SW should denylist /mcp navigations');
+    assert.match(sw, /denylist:\[[^\]]*\/\^\\\/\\\.well-known\\\//, 'SW should denylist /.well-known navigations');
+    assert.doesNotMatch(sw, /\/\^\\\/authorize/, 'SW should not denylist the SPA /authorize route');
   });
 
   it('favicon.png exists in public/ for the PWA icon', () => {

--- a/tools/app-shell/vite.config.js
+++ b/tools/app-shell/vite.config.js
@@ -165,6 +165,11 @@ export default defineConfig(({ mode }) => {
         cleanupOutdatedCaches: true,
         clientsClaim: true,
         skipWaiting: true,
+        navigateFallbackDenylist: [
+          /^\/etendo\//,
+          /^\/mcp(?:\/|$)/,
+          /^\/\.well-known\//,
+        ],
       },
       manifest: {
         name: 'Etendo',


### PR DESCRIPTION
## Summary
- Add a deployed Playwright smoke for MCP OAuth2 Authorization Code + PKCE.
- Validate public OAuth/MCP discovery JSON, POST /mcp WAF/method access, unauthenticated authorize routing, login continuation, callback code/state, and token exchange.
- Document required environment variables and the DCR invalid_scope fallback path.

## Validation
- npm --prefix e2e run test:mcp-oauth-smoke -- --reporter=list (2 skipped by default)
- E2E_MCP_OAUTH_SMOKE=1 npm --prefix e2e run test:mcp-oauth-smoke -- --reporter=list (metadata/WAF passed; full login/token flow requires smoke OAuth client credentials)