### PR TITLE
Feature ETP-3662: fix hardcoded i18n strings in app-shell pages

### DIFF
--- a/tools/app-shell/src/locales/en_US.json
+++ b/tools/app-shell/src/locales/en_US.json
@@ -2638,7 +2638,7 @@
     },
     "EM_Aeat390_Istotal": {
       "label": "Modelo 390: Generar total",
-      "description": "Este parámetro incluye un campo con el total"
+      "description": "Este par\u00e1metro incluye un campo con el total"
     },
     "ReleaseNo": {
       "label": "Release No",
@@ -8414,7 +8414,7 @@
     },
     "EM_Tbai_Issue_Date": {
       "label": "Fecha de expedicion",
-      "description": "Fecha en la que se registró la factura en el sistema contable."
+      "description": "Fecha en la que se registr\u00f3 la factura en el sistema contable."
     },
     "Iseditlinenetamt": {
       "label": "Edit Line Net Amount",
@@ -10349,12 +10349,12 @@
       "description": "The location of the selected business partner."
     },
     "Descripcion": {
-      "label": "Descripción",
-      "description": "Breve descripción o detalles adicionales sobre la factura."
+      "label": "Descripci\u00f3n",
+      "description": "Breve descripci\u00f3n o detalles adicionales sobre la factura."
     },
     "Policy_Url": {
       "label": "Politica url",
-      "description": "URL de la política utilizada para el procesamiento de la factura."
+      "description": "URL de la pol\u00edtica utilizada para el procesamiento de la factura."
     },
     "T_Due_Trans_Acct": {
       "label": "Tax Due Transitory",
@@ -10365,11 +10365,11 @@
       "description": "SII Exercise"
     },
     "EM_Tbai_Nonsubjectcause": {
-      "label": "TBAI - Causa de No Sujeción",
-      "description": "Razón por la cual la factura no está sujeta a impuestos."
+      "label": "TBAI - Causa de No Sujeci\u00f3n",
+      "description": "Raz\u00f3n por la cual la factura no est\u00e1 sujeta a impuestos."
     },
     "Type_Operation": {
-      "label": "Tipo de Operación",
+      "label": "Tipo de Operaci\u00f3n",
       "description": "Operaciones de Alta o Baja."
     },
     "totalgross": {
@@ -11166,7 +11166,7 @@
     },
     "NumColumn": {
       "label": "Column Number",
-      "description": "Column number in which the current field is set (allowed values ​​between 1 and 4)"
+      "description": "Column number in which the current field is set (allowed values \u200b\u200bbetween 1 and 4)"
     },
     "Obuiapp_View_Impl_ID": {
       "label": "View Implementation",
@@ -11985,8 +11985,8 @@
       "description": "Sent to SII"
     },
     "Epiae_Epigraph_ID": {
-      "label": "Epígrafe IAE",
-      "description": "Epígrafe del Impuesto sobre Actividades Económicas"
+      "label": "Ep\u00edgrafe IAE",
+      "description": "Ep\u00edgrafe del Impuesto sobre Actividades Econ\u00f3micas"
     },
     "Codigo_Csv": {
       "label": "CSV code",
@@ -12069,8 +12069,8 @@
       "description": "Correct synchronization error"
     },
     "Etvfac_C_Invoice_Verifactu_ID": {
-      "label": "Datos Envío Verifactu",
-      "description": "Datos de envío de la factura a Verifactu."
+      "label": "Datos Env\u00edo Verifactu",
+      "description": "Datos de env\u00edo de la factura a Verifactu."
     },
     "Received_Documentno": {
       "label": "Document Number",
@@ -12101,8 +12101,8 @@
       "description": "Month when invoice is sent to SII"
     },
     "Issubsanation": {
-      "label": "Es Subsanación",
-      "description": "Especifica que se trata de una subsanación de un registro de facturación de alta previamente generado."
+      "label": "Es Subsanaci\u00f3n",
+      "description": "Especifica que se trata de una subsanaci\u00f3n de un registro de facturaci\u00f3n de alta previamente generado."
     },
     "Orig_C_Country_ID": {
       "label": "Country of Origin",
@@ -12117,7 +12117,7 @@
       "description": ""
     },
     "Epiae_Code_ID": {
-      "label": "Código",
+      "label": "C\u00f3digo",
       "description": ""
     },
     "EM_OBTIK_Tax_ID_Key": {
@@ -12138,11 +12138,11 @@
     },
     "EM_Etvfac_Invnoidart61d": {
       "label": "Sin ID Destinatario Art61d",
-      "description": "Factura sin identificación destinatario artículo 6.1.d) RD 1619/2012."
+      "description": "Factura sin identificaci\u00f3n destinatario art\u00edculo 6.1.d) RD 1619/2012."
     },
     "EM_Etvfac_Entity_ID": {
       "label": "ID Entidad Productora",
-      "description": "Número de identificación de la persona o entidad productora."
+      "description": "N\u00famero de identificaci\u00f3n de la persona o entidad productora."
     },
     "EM_Aeatsii_Unsubscribe": {
       "label": "Unsubscribe in SII",
@@ -12174,15 +12174,15 @@
     },
     "Orep_Representative_Info_ID": {
       "label": "Representante legal",
-      "description": "Representante legal de la Organización"
+      "description": "Representante legal de la Organizaci\u00f3n"
     },
     "EM_Etvfac_Company_Name": {
       "label": "Nombre Entidad Productora",
-      "description": "Nombre-razón social de la persona o entidad productora."
+      "description": "Nombre-raz\u00f3n social de la persona o entidad productora."
     },
     "EM_Etvfac_Reversed_Invoice": {
       "label": "Factura Rectificada",
-      "description": "Factura original que se utilizará para enlazarla a la rectificativa."
+      "description": "Factura original que se utilizar\u00e1 para enlazarla a la rectificativa."
     },
     "PO_Transportation_Type": {
       "label": "Transportation Type",
@@ -12190,7 +12190,7 @@
     },
     "Auto_Send_Invoices": {
       "label": "Auto enviar facturas al completarse",
-      "description": "Configuración que permite el envío automático de facturas cuando se completen."
+      "description": "Configuraci\u00f3n que permite el env\u00edo autom\u00e1tico de facturas cuando se completen."
     },
     "EM_AEAT349_BP_BaseAmount_S": {
       "label": "Base Imponible del 349 Servicios",
@@ -12205,12 +12205,12 @@
       "description": "Country Tax ID - this field is only required in case the BP does not have an Spanish NIF (Tax ID key = 2, 3, 4, 5 and 6)"
     },
     "Certificate_Password": {
-      "label": "Contraseña del Certificado",
-      "description": "La contraseña del certificado."
+      "label": "Contrase\u00f1a del Certificado",
+      "description": "La contrase\u00f1a del certificado."
     },
     "EM_AEAT349_C_Year_ID": {
-      "label": "Año",
-      "description": "Seleccionar el año en caso de que la factura rectificada haya sido declarada anteriormente en el modelo 349"
+      "label": "A\u00f1o",
+      "description": "Seleccionar el a\u00f1o en caso de que la factura rectificada haya sido declarada anteriormente en el modelo 349"
     },
     "EM_Etvfac_Id_Type": {
       "label": "Tipo ID Entidad Productora",
@@ -12222,7 +12222,7 @@
     },
     "EM_AEAT349_IsCorrective": {
       "label": "Correctiva del 349",
-      "description": "Indica si será necesario realizar una corrección en el modelo oficial 349"
+      "description": "Indica si ser\u00e1 necesario realizar una correcci\u00f3n en el modelo oficial 349"
     },
     "EM_Aeatsii_Ejercicio": {
       "label": "SII exercise",
@@ -12234,7 +12234,7 @@
     },
     "EM_Tbai_Ad_Sequence_ID": {
       "label": "Secuencia de encadenamiento para TBAI",
-      "description": "Número de secuencia utilizado para el encadenamiento de las facturas."
+      "description": "N\u00famero de secuencia utilizado para el encadenamiento de las facturas."
     },
     "taxAmount": {
       "label": "Tax Amount",
@@ -12253,8 +12253,8 @@
       "description": "SII error reason"
     },
     "Etvfac_Inv_Sent_Status_Mv_ID": {
-      "label": "Estado de Envío de Factura",
-      "description": "Vista materializada que muestra datos de los registros de facturación enviados a Verifactu."
+      "label": "Estado de Env\u00edo de Factura",
+      "description": "Vista materializada que muestra datos de los registros de facturaci\u00f3n enviados a Verifactu."
     },
     "Lastname1": {
       "label": "Primer Apellido",
@@ -12265,8 +12265,8 @@
       "description": ""
     },
     "EM_Etvfac_Installation_Number": {
-      "label": "Número de Instalación",
-      "description": "Número de instalación del sistema informático de facturación (SIF) utilizado."
+      "label": "N\u00famero de Instalaci\u00f3n",
+      "description": "N\u00famero de instalaci\u00f3n del sistema inform\u00e1tico de facturaci\u00f3n (SIF) utilizado."
     },
     "EM_Aeatsii_Modified": {
       "label": "Modified in SII",
@@ -12293,7 +12293,7 @@
       "description": "Casilla utilizada para enviar factura a Verifactu."
     },
     "Notary_Name": {
-      "label": "Notaría",
+      "label": "Notar\u00eda",
       "description": ""
     },
     "EM_Aeatsii_Cause_Exemption_ID": {
@@ -12313,8 +12313,8 @@
       "description": "El NIF del emisor."
     },
     "Code_Error": {
-      "label": "Código de Error",
-      "description": "Código de Error."
+      "label": "C\u00f3digo de Error",
+      "description": "C\u00f3digo de Error."
     },
     "EM_Obspti_Isexport": {
       "label": "Export tax",
@@ -12329,8 +12329,8 @@
       "description": "The government defined unique number for assigning and paying taxes."
     },
     "EM_Aeat303_Is_Nat_Per": {
-      "label": "Es Persona Física",
-      "description": "Es Persona Física"
+      "label": "Es Persona F\u00edsica",
+      "description": "Es Persona F\u00edsica"
     },
     "C_Tax_Id_Vat": {
       "label": "VAT Tax",
@@ -12338,7 +12338,7 @@
     },
     "Version_Test": {
       "label": "Version test",
-      "description": "Versión utilizada para el entorno de pruebas."
+      "description": "Versi\u00f3n utilizada para el entorno de pruebas."
     },
     "Docaction": {
       "label": "Reactivate",
@@ -12353,20 +12353,20 @@
       "description": "Operation description to send to SII."
     },
     "EM_Etsg_Date_Operation": {
-      "label": "Fecha operación",
-      "description": "Fecha en la que se ha realizado la operación"
+      "label": "Fecha operaci\u00f3n",
+      "description": "Fecha en la que se ha realizado la operaci\u00f3n"
     },
     "Comunicacion": {
       "label": "Communication type",
       "description": "Communication type"
     },
     "EM_Etvfac_Verifac_Desc": {
-      "label": "Descripción Operación",
-      "description": "Descripción del objeto de la factura."
+      "label": "Descripci\u00f3n Operaci\u00f3n",
+      "description": "Descripci\u00f3n del objeto de la factura."
     },
     "EM_Etvfac_External_Ref": {
       "label": "Referencia Externa",
-      "description": "Dato adicional con el objetivo de que se pueda asociar opcionalmente información interna del SIF al registro de facturación."
+      "description": "Dato adicional con el objetivo de que se pueda asociar opcionalmente informaci\u00f3n interna del SIF al registro de facturaci\u00f3n."
     },
     "EM_Aeatsii_Authorizationno": {
       "label": "Authorization No.",
@@ -12386,7 +12386,7 @@
     },
     "URL_Cancel_Test": {
       "label": "Url para anulacion de factura test",
-      "description": "URL utilizada en entornos de prueba para la anulación de facturas en TBAI."
+      "description": "URL utilizada en entornos de prueba para la anulaci\u00f3n de facturas en TBAI."
     },
     "Fecha_Ultima_Modif_Sii": {
       "label": "SII last modification date",
@@ -12413,12 +12413,12 @@
       "description": "Invoice Cash VAT"
     },
     "EM_Tbai_Exemptioncause": {
-      "label": "TBAI - Causa de Exención",
-      "description": "Razón por la cual la factura está exenta de impuestos."
+      "label": "TBAI - Causa de Exenci\u00f3n",
+      "description": "Raz\u00f3n por la cual la factura est\u00e1 exenta de impuestos."
     },
     "Nif": {
       "label": "NIF",
-      "description": "NIF (Número de Identificación Fiscal)"
+      "description": "NIF (N\u00famero de Identificaci\u00f3n Fiscal)"
     },
     "Tbai_License_Test": {
       "label": "Licencia TBAI test",
@@ -12453,8 +12453,8 @@
       "description": "This Line is generated"
     },
     "EM_Etvfac_Exemption_Cause": {
-      "label": "Verifactu - Causa de Exención",
-      "description": "Causa de exención."
+      "label": "Verifactu - Causa de Exenci\u00f3n",
+      "description": "Causa de exenci\u00f3n."
     },
     "Lastname2": {
       "label": "Segundo Apellido",
@@ -12462,7 +12462,7 @@
     },
     "EM_Etvfac_Reverseinvtype": {
       "label": "Tipo de Factura Rectificativa",
-      "description": "Tipos de rectificación."
+      "description": "Tipos de rectificaci\u00f3n."
     },
     "Intr_Setup_ID": {
       "label": "Intr_Setup_ID",
@@ -12474,7 +12474,7 @@
     },
     "Default_Qr": {
       "label": "QR Por Defecto",
-      "description": "Implementación por defecto del QR Verifactu en facturas."
+      "description": "Implementaci\u00f3n por defecto del QR Verifactu en facturas."
     },
     "EM_OBSPTI_Declaration": {
       "label": "Tax Book Type",
@@ -12493,8 +12493,8 @@
       "description": "Operation date"
     },
     "TAX_Type": {
-      "label": "Impuesto de Aplicación",
-      "description": "Impuestos indirectos sobre el consumo en España."
+      "label": "Impuesto de Aplicaci\u00f3n",
+      "description": "Impuestos indirectos sobre el consumo en Espa\u00f1a."
     },
     "Total_Pymnts_Wrong": {
       "label": "Wrong payments",
@@ -12509,8 +12509,8 @@
       "description": "The periodicity for submitting the Tax Report"
     },
     "em_etvfac_igic_regime": {
-      "label": "Régimen Especial IGIC",
-      "description": "Lista de claves de régimen IGIC"
+      "label": "R\u00e9gimen Especial IGIC",
+      "description": "Lista de claves de r\u00e9gimen IGIC"
     },
     "Intr_C_Invoiceline_ID": {
       "label": "Intr_C_Invoiceline_ID",
@@ -12521,20 +12521,20 @@
       "description": "Cash receipt transaction"
     },
     "EM_Etvfac_Invoice_Status": {
-      "label": "Estado de Envío a Verifactu",
-      "description": "Muestra el estado de envío a Verifactu de la factura."
+      "label": "Estado de Env\u00edo a Verifactu",
+      "description": "Muestra el estado de env\u00edo a Verifactu de la factura."
     },
     "EM_Tbai_Claveregimeniva": {
-      "label": "Clave de Régimen Especial de IVA",
-      "description": "Código que identifica si la factura se encuentra bajo un régimen especial de tributación."
+      "label": "Clave de R\u00e9gimen Especial de IVA",
+      "description": "C\u00f3digo que identifica si la factura se encuentra bajo un r\u00e9gimen especial de tributaci\u00f3n."
     },
     "Aeatsii_Description_ID": {
       "label": "SII Description",
       "description": "SII Description"
     },
     "Calculated_Hashcode": {
-      "label": "Código Hash Calculado",
-      "description": "El código hash calculado durante la verificación."
+      "label": "C\u00f3digo Hash Calculado",
+      "description": "El c\u00f3digo hash calculado durante la verificaci\u00f3n."
     },
     "Error_Msg": {
       "label": "SII error message",
@@ -12542,19 +12542,19 @@
     },
     "Csv": {
       "label": "CSV",
-      "description": "Código Seguro de Verificación"
+      "description": "C\u00f3digo Seguro de Verificaci\u00f3n"
     },
     "Certificate_Pass": {
-      "label": "Contraseña del Certificado",
-      "description": "Contraseña del Certificado"
+      "label": "Contrase\u00f1a del Certificado",
+      "description": "Contrase\u00f1a del Certificado"
     },
     "Production_Env": {
-      "label": "Entorno de Producción",
-      "description": "Indica si el sistema está en un entorno de producción o de prueba."
+      "label": "Entorno de Producci\u00f3n",
+      "description": "Indica si el sistema est\u00e1 en un entorno de producci\u00f3n o de prueba."
     },
     "EM_Etvfac_Ipsi_Regime": {
-      "label": "Régimen Especial IPSI",
-      "description": "Identificadores del tipo de régimen IPSI."
+      "label": "R\u00e9gimen Especial IPSI",
+      "description": "Identificadores del tipo de r\u00e9gimen IPSI."
     },
     "EM_Aeat303_Person_Surnames": {
       "label": "Apellidos",
@@ -12585,12 +12585,12 @@
       "description": "Button that executes SII last connection report."
     },
     "EM_Etvfac_Rect_Create": {
-      "label": "Crear Rectificación Importe Negativo",
+      "label": "Crear Rectificaci\u00f3n Importe Negativo",
       "description": "Clona la factura pero con signo invertido."
     },
     "Etvfac_Verifactu_Config_ID": {
-      "label": "Configuración Verifactu",
-      "description": "Configuración general de Verifactu."
+      "label": "Configuraci\u00f3n Verifactu",
+      "description": "Configuraci\u00f3n general de Verifactu."
     },
     "Aeatsii_Payment_ID": {
       "label": "SII Payment",
@@ -12602,7 +12602,7 @@
     },
     "EM_Tbai_Isreverseinvoice": {
       "label": "Factura Rectificativa",
-      "description": "Indica si la factura es una rectificación de una anterior."
+      "description": "Indica si la factura es una rectificaci\u00f3n de una anterior."
     },
     "EM_Aeat390_Is_BI_And_Cuota": {
       "label": "Modelo 390: Separar Base Imponible y Cuota",
@@ -12614,7 +12614,7 @@
     },
     "URL_Cancel": {
       "label": "Url para anulacion de factura",
-      "description": "URL utilizada para enviar una solicitud de anulación de una factura registrada en TBAI."
+      "description": "URL utilizada para enviar una solicitud de anulaci\u00f3n de una factura registrada en TBAI."
     },
     "Intr_M_Product_ID": {
       "label": "Intr_M_Product_ID",
@@ -12657,7 +12657,7 @@
       "description": "Parameter for a Tax Report"
     },
     "EM_Etaf_Issuer_Name": {
-      "label": "Razón Social de Emisor",
+      "label": "Raz\u00f3n Social de Emisor",
       "description": "Nombre legal del emisor que genera la factura."
     },
     "EM_Aeatsii_Rep_Taxid": {
@@ -12722,7 +12722,7 @@
     },
     "EM_Aeat390_Xml_Element": {
       "label": "Modelo 390: Elemento del fichero XML",
-      "description": "Elemento del fichero XML por el que se representa el parámetro"
+      "description": "Elemento del fichero XML por el que se representa el par\u00e1metro"
     },
     "Operationdate": {
       "label": "Operation Date",
@@ -12733,7 +12733,7 @@
       "description": ""
     },
     "EM_Aeat390_Isperson": {
-      "label": "Persona Física 390",
+      "label": "Persona F\u00edsica 390",
       "description": ""
     },
     "EM_Aeatsii_Isauthorization": {
@@ -12813,8 +12813,8 @@
       "description": "Street number qualifier"
     },
     "EM_Etvfac_Version": {
-      "label": "Versión SIF",
-      "description": "Versión del Sistema Informático (SIF)."
+      "label": "Versi\u00f3n SIF",
+      "description": "Versi\u00f3n del Sistema Inform\u00e1tico (SIF)."
     },
     "Obirb_Invbook_ID": {
       "label": "Invoice Register Book",
@@ -12830,7 +12830,7 @@
     },
     "Incident_Report": {
       "label": "Detalle Incidencia",
-      "description": "Información acerca del problema técnico que ocurrió."
+      "description": "Informaci\u00f3n acerca del problema t\u00e9cnico que ocurri\u00f3."
     },
     "Plazo": {
       "label": "SII sending deadline",
@@ -12842,19 +12842,19 @@
     },
     "License_Name": {
       "label": "Nombre licencia",
-      "description": "Nombre de la licencia utilizada en la integración de TicketBAI."
+      "description": "Nombre de la licencia utilizada en la integraci\u00f3n de TicketBAI."
     },
     "License_Name_Test": {
       "label": "Nombre licencia test",
-      "description": "Nombre de la licencia de prueba utilizada para testear la integración."
+      "description": "Nombre de la licencia de prueba utilizada para testear la integraci\u00f3n."
     },
     "Aeat347_Doctype_ID": {
       "label": "Aeat347_Doctype_ID",
       "description": "AEAT 347 Document type id"
     },
     "EM_Etvfac_Date_Issue": {
-      "label": "Fecha Generación RF",
-      "description": "Fecha de generación del registro de facturación."
+      "label": "Fecha Generaci\u00f3n RF",
+      "description": "Fecha de generaci\u00f3n del registro de facturaci\u00f3n."
     },
     "EM_Etvfac_Inv_Type": {
       "label": "Tipo de Factura",
@@ -12866,11 +12866,11 @@
     },
     "EM_Tbai_Invoiceseq": {
       "label": "Secuencia Factura",
-      "description": "Secuencia numérica asignada a la factura."
+      "description": "Secuencia num\u00e9rica asignada a la factura."
     },
     "EM_Etvfac_System_Name": {
-      "label": "Nombre Sistema Informático",
-      "description": "Nombre dado por la persona o entidad productora a su sistema informático de facturación (SIF)."
+      "label": "Nombre Sistema Inform\u00e1tico",
+      "description": "Nombre dado por la persona o entidad productora a su sistema inform\u00e1tico de facturaci\u00f3n (SIF)."
     },
     "Vatrate": {
       "label": "VAT Rate",
@@ -12882,7 +12882,7 @@
     },
     "EM_Etvfac_Is_Gen_Manual": {
       "label": "Generado Manualmente",
-      "description": "Indicador de como se emitió la factura."
+      "description": "Indicador de como se emiti\u00f3 la factura."
     },
     "Sent_Amount": {
       "label": "Sent amount",
@@ -12894,11 +12894,11 @@
     },
     "EM_Aeat390_Box": {
       "label": "Modelo 390: Casilla",
-      "description": "Casilla a la que corresponde el parámetro en el Modelo"
+      "description": "Casilla a la que corresponde el par\u00e1metro en el Modelo"
     },
     "EM_Etvfac_Issue": {
       "label": "Incidencia",
-      "description": "Indica si hubo un problema técnico en el envío."
+      "description": "Indica si hubo un problema t\u00e9cnico en el env\u00edo."
     },
     "EM_Obspti_Isintracommunity": {
       "label": "Intracommunity tax",
@@ -12930,7 +12930,7 @@
     },
     "Jasperreport_Path": {
       "label": "Ruta de Reporte Jasper",
-      "description": "Ruta del archivo de reporte Jasper utilizado para la generación de reportes de factura."
+      "description": "Ruta del archivo de reporte Jasper utilizado para la generaci\u00f3n de reportes de factura."
     },
     "Total_Fact_Correctas": {
       "label": "Right invoices",
@@ -12942,7 +12942,7 @@
     },
     "Tbai_Valcode_ID": {
       "label": "Tbai_Valcode_ID",
-      "description": "Código de validación asignado por el sistema TBAI a la factura."
+      "description": "C\u00f3digo de validaci\u00f3n asignado por el sistema TBAI a la factura."
     },
     "Isfinal": {
       "label": "Final",
@@ -12977,7 +12977,7 @@
       "description": "The final monetary amount (including taxes) charge listed in a document."
     },
     "Epiae_Orginfo_Epigraph_ID": {
-      "label": "Epígrafe del IAE para la Organización",
+      "label": "Ep\u00edgrafe del IAE para la Organizaci\u00f3n",
       "description": ""
     },
     "EM_AEAT349_C_Bpartner_ID": {
@@ -12990,11 +12990,11 @@
     },
     "Tbai_Config_ID": {
       "label": "Tbai_Config_ID",
-      "description": "Identificador de configuración del sistema TBAI."
+      "description": "Identificador de configuraci\u00f3n del sistema TBAI."
     },
     "Date_Found": {
-      "label": "Fecha Detección",
-      "description": "Fecha en la que se detectó la discrepancia."
+      "label": "Fecha Detecci\u00f3n",
+      "description": "Fecha en la que se detect\u00f3 la discrepancia."
     },
     "C_Invoicetax_Cashvat_V_ID": {
       "label": "Invoice Cash VAT",
@@ -13046,11 +13046,11 @@
     },
     "EM_Etvfac_Qr_Url": {
       "label": "URL para QR Factura",
-      "description": "Contiene la URL con la que se debe formar el código QR que se añadirá en la impresión de la factura"
+      "description": "Contiene la URL con la que se debe formar el c\u00f3digo QR que se a\u00f1adir\u00e1 en la impresi\u00f3n de la factura"
     },
     "EM_Aeat390_Factorymethod": {
-      "label": "Modelo 390: Método de la factoría",
-      "description": "Método de la factoría usado para construir el objeto"
+      "label": "Modelo 390: M\u00e9todo de la factor\u00eda",
+      "description": "M\u00e9todo de la factor\u00eda usado para construir el objeto"
     },
     "EM_Intr_C_Calendar_ID": {
       "label": "Intrastat Calendar",
@@ -13066,19 +13066,19 @@
     },
     "Refresh_Data": {
       "label": "Refrescar Datos",
-      "description": "Refrescar los datos de envío a Verifactu, organizados por estado."
+      "description": "Refrescar los datos de env\u00edo a Verifactu, organizados por estado."
     },
     "EM_Tbai_Issent": {
       "label": "Enviada a TBAI",
-      "description": "Estado de envío de la factura al sistema TBAI."
+      "description": "Estado de env\u00edo de la factura al sistema TBAI."
     },
     "Adjuntos": {
       "label": "Attach XML files",
       "description": "Check that indicates XML files will be attached."
     },
     "EM_Tbai_Voidxmlgenerator": {
-      "label": "Enviar anulación a TIcketbai",
-      "description": "Permite el envío de la anulación de una factura al sistema TicketBAI."
+      "label": "Enviar anulaci\u00f3n a TIcketbai",
+      "description": "Permite el env\u00edo de la anulaci\u00f3n de una factura al sistema TicketBAI."
     },
     "OBTL_Tax_Parameter_ID": {
       "label": "Tax Parameter",
@@ -13093,20 +13093,20 @@
       "description": "This column is to make sure weather this country belongs to European Union Country.."
     },
     "Next_Send_Wait_Time": {
-      "label": "Tiempo de Espera para el Siguiente Envío",
+      "label": "Tiempo de Espera para el Siguiente Env\u00edo",
       "description": "El tiempo de espera para enviar el siguiente grupo de facturas a Verifactu."
     },
     "Error_Reason": {
-      "label": "Descripción Error Registro",
+      "label": "Descripci\u00f3n Error Registro",
       "description": "Error recibido al enviar la factura."
     },
     "Etaf_Audit_Discrepancy_ID": {
-      "label": "Discrepancia de Auditoría",
-      "description": "Discrepancia en la cadena de registros de la auditoría."
+      "label": "Discrepancia de Auditor\u00eda",
+      "description": "Discrepancia en la cadena de registros de la auditor\u00eda."
     },
     "Developer_Nif": {
       "label": "Nif desarrollador",
-      "description": "NIF del desarrollador responsable de la integración."
+      "description": "NIF del desarrollador responsable de la integraci\u00f3n."
     },
     "C_Bpartner_Name": {
       "label": "Business Partner Name",
@@ -13121,8 +13121,8 @@
       "description": "The date you want to put in Document Date field"
     },
     "EM_Etsg_Add_Certificate": {
-      "label": "Añadir Certificado Digital",
-      "description": "Cargar un certificado digital a esta organización."
+      "label": "A\u00f1adir Certificado Digital",
+      "description": "Cargar un certificado digital a esta organizaci\u00f3n."
     },
     "Intr_Lines_ID": {
       "label": "Intr_Lines_ID",
@@ -13133,8 +13133,8 @@
       "description": "Import (DUA)"
     },
     "Invoice_Description": {
-      "label": "Descripción de Facturas",
-      "description": "Descripción general de las facturas emitidas."
+      "label": "Descripci\u00f3n de Facturas",
+      "description": "Descripci\u00f3n general de las facturas emitidas."
     },
     "PoTaxamt": {
       "label": "Purchase Tax Amount",
@@ -13181,7 +13181,7 @@
       "description": ""
     },
     "Schema_Uri_Void": {
-      "label": "Uri del esquema de anulación para Factura (Cliente)",
+      "label": "Uri del esquema de anulaci\u00f3n para Factura (Cliente)",
       "description": "URI del esquema utilizado para anular facturas en el sistema."
     },
     "CheckDate": {
@@ -13202,7 +13202,7 @@
     },
     "Tbai_Destiny_Config_ID": {
       "label": "Destino",
-      "description": "Destino de la configuración de TicketBAI."
+      "description": "Destino de la configuraci\u00f3n de TicketBAI."
     },
     "C_Bpartner_TaxID": {
       "label": "Tax Id",
@@ -13210,7 +13210,7 @@
     },
     "EM_Tbai_Invoicenum": {
       "label": "Serie Factura",
-      "description": "Serie de la factura para su identificación dentro del sistema."
+      "description": "Serie de la factura para su identificaci\u00f3n dentro del sistema."
     },
     "Insiisystemdate": {
       "label": "In SII system date",
@@ -13282,7 +13282,7 @@
     },
     "EM_Etaf_Iscash": {
       "label": "Es en Efectivo",
-      "description": "Indica si el método de pago es en efectivo. Marcar obligatoriamente si el método de pago es en efectivo."
+      "description": "Indica si el m\u00e9todo de pago es en efectivo. Marcar obligatoriamente si el m\u00e9todo de pago es en efectivo."
     },
     "SO_Port": {
       "label": "Port/Airport",
@@ -13318,7 +13318,7 @@
     },
     "em_tbai_qrcode": {
       "label": "Imprimir factura con QR",
-      "description": "Opción para imprimir la factura con un código QR."
+      "description": "Opci\u00f3n para imprimir la factura con un c\u00f3digo QR."
     },
     "Obirb_Invbook_Setup_ID": {
       "label": "Invoices Register Book",
@@ -13337,8 +13337,8 @@
       "description": "Indica si la factura es una factura simplificada."
     },
     "EM_Etvfac_Vat_Regime": {
-      "label": "Régimen Especial IVA",
-      "description": "Lista de claves de régimen IVA."
+      "label": "R\u00e9gimen Especial IVA",
+      "description": "Lista de claves de r\u00e9gimen IVA."
     },
     "Private_Customer": {
       "label": "Private customer",
@@ -13349,7 +13349,7 @@
       "description": "Defines the child tax that will be added to SII-IGIC when invoice belongs to RECM."
     },
     "Expiration_Date": {
-      "label": "Fecha de Expiración",
+      "label": "Fecha de Expiraci\u00f3n",
       "description": "La fecha en la cual el certificado expira."
     },
     "PoTaxbaseamt": {
@@ -13357,8 +13357,8 @@
       "description": "The total sum on which taxes are added for purchase flow"
     },
     "USE_Asproduct_Desc": {
-      "label": "Utilizar descripción también para nombre producto",
-      "description": "Indica si la descripción del producto también se debe utilizar como el nombre del producto en la factura."
+      "label": "Utilizar descripci\u00f3n tambi\u00e9n para nombre producto",
+      "description": "Indica si la descripci\u00f3n del producto tambi\u00e9n se debe utilizar como el nombre del producto en la factura."
     },
     "Obcvat_Manualsettlementline_ID": {
       "label": "Manual Cash VAT Settlement Line",
@@ -13410,7 +13410,7 @@
     },
     "EM_Etvfac_Issue_Description": {
       "label": "Detalle de la Incidencia",
-      "description": "Información acerca del problema técnico que ocurrió."
+      "description": "Informaci\u00f3n acerca del problema t\u00e9cnico que ocurri\u00f3."
     },
     "c_invoicetax_cashvat_v_id": {
       "label": "Invoice Tax Cash VAT",
@@ -13445,16 +13445,16 @@
       "description": "Last query period"
     },
     "EM_Etvfac_System_ID": {
-      "label": "ID Sistema Informático",
-      "description": "Código identificativo dado por la persona o entidad productora a su sistema informático de facturación (SIF)."
+      "label": "ID Sistema Inform\u00e1tico",
+      "description": "C\u00f3digo identificativo dado por la persona o entidad productora a su sistema inform\u00e1tico de facturaci\u00f3n (SIF)."
     },
     "EM_Tbai_Reverseinvoicetype": {
       "label": "Tipo de rectificativa",
       "description": "Tipo de factura rectificativa."
     },
     "em_etvfac_cause_not_taxable": {
-      "label": "Verifactu - Causa No Sujeción",
-      "description": "Tipos de transacciones según su tratamiento fiscal, en relación a si están sujetas o exentas del impuesto correspondiente."
+      "label": "Verifactu - Causa No Sujeci\u00f3n",
+      "description": "Tipos de transacciones seg\u00fan su tratamiento fiscal, en relaci\u00f3n a si est\u00e1n sujetas o exentas del impuesto correspondiente."
     },
     "Tbai_License": {
       "label": "Licencia TBAI",
@@ -13470,11 +13470,11 @@
     },
     "URL_Qr_Base_Test": {
       "label": "Url base para QR Test",
-      "description": "URL base para generar el código QR en un entorno de pruebas."
+      "description": "URL base para generar el c\u00f3digo QR en un entorno de pruebas."
     },
     "Codigo": {
-      "label": "Código",
-      "description": "Código de identificación de la factura."
+      "label": "C\u00f3digo",
+      "description": "C\u00f3digo de identificaci\u00f3n de la factura."
     },
     "EM_Intr_Transportation_Type": {
       "label": "Transportation Type",
@@ -13486,7 +13486,7 @@
     },
     "IN_Vfactu_System": {
       "label": "Fecha de Acogida",
-      "description": "Indica la fecha de adhesión a Verifactu."
+      "description": "Indica la fecha de adhesi\u00f3n a Verifactu."
     },
     "CheckNumber": {
       "label": "Check Number",
@@ -13513,8 +13513,8 @@
       "description": "Indica la fecha que se inicio el sistema."
     },
     "EM_Etvfac_Issubsanation": {
-      "label": "Subsanación",
-      "description": "Especifica que se trata de una subsanación de un registro de facturación de alta previamente generado."
+      "label": "Subsanaci\u00f3n",
+      "description": "Especifica que se trata de una subsanaci\u00f3n de un registro de facturaci\u00f3n de alta previamente generado."
     },
     "doctype": {
       "label": "Document Type",
@@ -13525,7 +13525,7 @@
       "description": "Button than executes a new query about invoices sent to SII."
     },
     "EM_Aeat390_DocumentType": {
-      "label": "Modelo 390: Incluir sólo facturas",
+      "label": "Modelo 390: Incluir s\u00f3lo facturas",
       "description": ""
     },
     "Schema_Uri": {
@@ -13534,7 +13534,7 @@
     },
     "EM_Tbai_Sequence": {
       "label": "Secuencia de encadenamiento",
-      "description": "Secuencia que identifica la relación entre las facturas emitidas."
+      "description": "Secuencia que identifica la relaci\u00f3n entre las facturas emitidas."
     },
     "EM_Aeat390_IsCashVATPayment": {
       "label": "Modelo 390: Importe cobrado/pagado IVA de Caja",
@@ -13554,7 +13554,7 @@
     },
     "IS_Ready": {
       "label": "Marcar Como Listo",
-      "description": "Deja la configuración lista para usarse."
+      "description": "Deja la configuraci\u00f3n lista para usarse."
     },
     "DecTaxAmt": {
       "label": "Deductible tax amount ",
@@ -13566,23 +13566,23 @@
     },
     "URL_Qr_Base": {
       "label": "Url base para QR",
-      "description": "URL base que se utiliza para generar el código QR en las facturas."
+      "description": "URL base que se utiliza para generar el c\u00f3digo QR en las facturas."
     },
     "Authorizationno": {
       "label": "Authorization No.",
       "description": "Authorization number"
     },
     "EM_Tbai_Reverseinvoicecode": {
-      "label": "Código de Factura Rectificativa",
-      "description": "Código asignado a la factura rectificativa."
+      "label": "C\u00f3digo de Factura Rectificativa",
+      "description": "C\u00f3digo asignado a la factura rectificativa."
     },
     "Paymentnumber": {
       "label": "Payment Number",
       "description": "Payment Number"
     },
     "Epigraph": {
-      "label": "Epígrafe",
-      "description": "Número del Epígrafe del IAE"
+      "label": "Ep\u00edgrafe",
+      "description": "N\u00famero del Ep\u00edgrafe del IAE"
     },
     "Aeatsii_Cause_Exemption_ID": {
       "label": "Cause exemption",
@@ -14395,8 +14395,8 @@
     "SII Invoices Query": {
       "label": "SII Invoices Query"
     },
-    "Configuración Verifactu": {
-      "label": "Configuración Verifactu"
+    "Configuraci\u00f3n Verifactu": {
+      "label": "Configuraci\u00f3n Verifactu"
     },
     "IAE Activity Type": {
       "label": "IAE Activity Type"
@@ -14416,8 +14416,8 @@
     "Intrastat Supplementary Unit of Measure": {
       "label": "Intrastat Supplementary Unit of Measure"
     },
-    "Código de Actividad": {
-      "label": "Código de Actividad"
+    "C\u00f3digo de Actividad": {
+      "label": "C\u00f3digo de Actividad"
     },
     "AEAT347 Document Types": {
       "label": "AEAT347 Document Types"
@@ -14425,8 +14425,8 @@
     "SII Connections": {
       "label": "SII Connections"
     },
-    "Discrepancias de Auditoría": {
-      "label": "Discrepancias de Auditoría"
+    "Discrepancias de Auditor\u00eda": {
+      "label": "Discrepancias de Auditor\u00eda"
     },
     "SII Cash Receipts": {
       "label": "SII Cash Receipts"
@@ -14455,11 +14455,11 @@
     "SII Configuration": {
       "label": "SII Configuration"
     },
-    "Configuración TBAI": {
-      "label": "Configuración TBAI"
+    "Configuraci\u00f3n TBAI": {
+      "label": "Configuraci\u00f3n TBAI"
     },
-    "Epígrafes IAE": {
-      "label": "Epígrafes IAE"
+    "Ep\u00edgrafes IAE": {
+      "label": "Ep\u00edgrafes IAE"
     },
     "Cash VAT pending to be settled P&E": {
       "label": "Cash VAT pending to be settled P&E"
@@ -15705,8 +15705,8 @@
     "Received Invoices SII Data": {
       "label": "Received Invoices SII Data"
     },
-    "Resultado Validación": {
-      "label": "Resultado Validación"
+    "Resultado Validaci\u00f3n": {
+      "label": "Resultado Validaci\u00f3n"
     },
     "Etendo Payment Tab": {
       "label": "Etendo Payment Tab"
@@ -15849,8 +15849,8 @@
     "Log Hash": {
       "label": "Log Hash"
     },
-    "Facturas Inválidas": {
-      "label": "Facturas Inválidas"
+    "Facturas Inv\u00e1lidas": {
+      "label": "Facturas Inv\u00e1lidas"
     },
     "Number to Word Converter": {
       "label": "Number to Word Converter"
@@ -15900,8 +15900,8 @@
     "Analytics Synchronization Header": {
       "label": "Analytics Synchronization Header"
     },
-    "Cabecera de Configuración Verifactu": {
-      "label": "Cabecera de Configuración Verifactu"
+    "Cabecera de Configuraci\u00f3n Verifactu": {
+      "label": "Cabecera de Configuraci\u00f3n Verifactu"
     },
     "SII cash receipt": {
       "label": "SII cash receipt"
@@ -15963,8 +15963,8 @@
     "Invoice Register Book": {
       "label": "Invoice Register Book"
     },
-    "Sincronización": {
-      "label": "Sincronización"
+    "Sincronizaci\u00f3n": {
+      "label": "Sincronizaci\u00f3n"
     },
     "Ticketbai": {
       "label": "Ticketbai"
@@ -16002,8 +16002,8 @@
     "Batuz": {
       "label": "Batuz"
     },
-    "Discrepancias de Auditoría - Cabecera": {
-      "label": "Discrepancias de Auditoría - Cabecera"
+    "Discrepancias de Auditor\u00eda - Cabecera": {
+      "label": "Discrepancias de Auditor\u00eda - Cabecera"
     },
     "Defined Selector": {
       "label": "Defined Selector"
@@ -16035,8 +16035,8 @@
     "Withholding Parameter": {
       "label": "Withholding Parameter"
     },
-    "Código de Actividad": {
-      "label": "Código de Actividad"
+    "C\u00f3digo de Actividad": {
+      "label": "C\u00f3digo de Actividad"
     },
     "IAE Activity Type": {
       "label": "IAE Activity Type"
@@ -16068,8 +16068,8 @@
     "Widget Class": {
       "label": "Widget Class"
     },
-    "Epígrafes IAE": {
-      "label": "Epígrafes IAE"
+    "Ep\u00edgrafes IAE": {
+      "label": "Ep\u00edgrafes IAE"
     },
     "Intrastat Adquisitions": {
       "label": "Intrastat Adquisitions"
@@ -16347,13 +16347,13 @@
     "refresh": "Refresh",
     "forceAppRefresh": "Force app refresh",
     "newPayment": "New payment",
-    "paymentRecordedLocally": "Payment recorded locally — it will sync when the endpoint is available",
-    "financeCollections": "Finance · Collections",
+    "paymentRecordedLocally": "Payment recorded locally \u2014 it will sync when the endpoint is available",
+    "financeCollections": "Finance \u00b7 Collections",
     "activity": "Activity",
     "closeActivityPanel": "Close activity panel",
     "paymentCreated": "Payment created",
     "linkedToInvoice": "Linked to Invoice #{number}",
-    "statusChangedTo": "Status → {status}",
+    "statusChangedTo": "Status \u2192 {status}",
     "noActivityYet": "No activity yet",
     "add": "Add",
     "unallocatedCredit": "unallocated credit",
@@ -16386,8 +16386,8 @@
     "amount": "Amount",
     "description": "Description",
     "fillAllRequiredFields": "Fill all required fields",
-    "createPayment": "Create payment →",
-    "createCredit": "Create credit →",
+    "createPayment": "Create payment \u2192",
+    "createCredit": "Create credit \u2192",
     "creating": "Creating...",
     "selectBusinessPartnerToViewPendingInvoices": "Select a business partner to view pending invoices.",
     "noInvoicesAppliedToThisPayment": "No invoices applied to this payment.",
@@ -16422,13 +16422,13 @@
     "shipmentRef": "Shipment #",
     "createdAsDraft": "created as Draft",
     "reviewBeforeConfirming": "Review before confirming",
-    "viewInvoice": "View Invoice →",
+    "viewInvoice": "View Invoice \u2192",
     "loadingShipmentLines": "Loading shipment lines...",
     "noLinesInSelectedShipments": "No lines found in selected shipments.",
     "noLinesInThisShipment": "No lines found in this shipment.",
     "draftInvoiceExistsForShipments": "Draft invoice already exists for these shipments",
     "thisShipmentHasDraftInvoice": "This shipment already has a Draft invoice",
-    "viewExistingInvoice": "View existing invoice →",
+    "viewExistingInvoice": "View existing invoice \u2192",
     "createAnotherAnyway": "Create another anyway",
     "selectLinesToInvoice": "Select lines to invoice",
     "createReturnFromShipment": "Create Return from Shipment",
@@ -16480,7 +16480,7 @@
     "priceColUnitPrice": "Unit Price",
     "priceColListPrice": "List Price",
     "priceRemove": "Remove",
-    "priceSelectVersion": "Select version…",
+    "priceSelectVersion": "Select version\u2026",
     "priceZeroPlaceholder": "0.00",
     "priceSalesPrice": "Sales price",
     "priceSalesDescription": "Initial price used for sales lists.",
@@ -16600,7 +16600,7 @@
     "filterPresets": "Saved filters",
     "filterPresetsButton": "My filters",
     "filterPresetsEmpty": "No saved filters yet",
-    "filterPresetSaveCurrent": "Save current filters as…",
+    "filterPresetSaveCurrent": "Save current filters as\u2026",
     "filterPresetDelete": "Delete",
     "filterPresetPromptName": "Name for this filter preset:",
     "filterPresetOverwriteConfirm": "A preset named \"{name}\" already exists. Overwrite?",
@@ -16757,7 +16757,7 @@
     "fetchingAllRecords": "Fetching all records...",
     "renderingReport": "Rendering report...",
     "jsreportNotAvailable": "jsreport not available",
-    "jsreportNotAvailableBanner": "jsreport not available — PDF, Excel, CSV exports disabled. Start it with:",
+    "jsreportNotAvailableBanner": "jsreport not available \u2014 PDF, Excel, CSV exports disabled. Start it with:",
     "excel": "Excel",
     "csv": "CSV",
     "pdf": "PDF",
@@ -16802,7 +16802,7 @@
     "pendingDeliveryOnly": "Pending delivery",
     "clearAllFilters": "Clear all filters",
     "cancelEsc": "Cancel (Esc)",
-    "inlineAddHint": "Enter or click outside to save · Esc to cancel",
+    "inlineAddHint": "Enter or click outside to save \u00b7 Esc to cancel",
     "statusComplete": "Confirmed",
     "statusCompleted": "Confirmed",
     "statusVoid": "Void",
@@ -16888,7 +16888,7 @@
     "invoiceFullyPaid": "Invoice fully paid",
     "paymentRegistered": "Payment registered",
     "fullyPaid": "Fully paid",
-    "viewArrow": "View →",
+    "viewArrow": "View \u2192",
     "paidAmount": "Paid",
     "outstandingLabel": "Outstanding",
     "registerPayment": "Register payment",
@@ -16902,8 +16902,8 @@
     "subject": "Subject",
     "message": "Message",
     "outstandingColon": "Outstanding:",
-    "viewPaymentArrow": "View payment →",
-    "registerPaymentLabel": "+ Register payment ·",
+    "viewPaymentArrow": "View payment \u2192",
+    "registerPaymentLabel": "+ Register payment \u00b7",
     "outstandingLower": "outstanding",
     "emailPlaceholder": "email@company.com",
     "Customer": "Customer",
@@ -16974,8 +16974,8 @@
     "financialSummaryIncome": "Income",
     "financialSummaryExpenses": "Expenses",
     "financialSummaryProfit": "Profit",
-    "yoyUp": "↑ {pct}% vs previous year",
-    "yoyDown": "↓ {pct}% vs previous year",
+    "yoyUp": "\u2191 {pct}% vs previous year",
+    "yoyDown": "\u2193 {pct}% vs previous year",
     "quickActionsTitle": "QUICK ACCESS",
     "quickAccessSalesOrders": "Sales orders",
     "quickAccessSalesInvoices": "Sales invoices",
@@ -17156,9 +17156,9 @@
     "openCopilot": "Open Copilot",
     "copilotWelcome": "Hi! I'm your ERP assistant. What do you need today?",
     "copilotInvoiceResponse": "I'll help you create an invoice. Opening Sales Invoice...\n\nYou can also say 'show pending invoices' to see what's outstanding.",
-    "copilotStockResponse": "Here's a quick stock summary:\n• Cerveza Ale 0.5L: 150 units\n• Vino Tinto Reserva: 80 units\n• Aceite de Oliva 1L: 230 units\n\nWould you like to check a specific product?",
-    "copilotOrderResponse": "You have 5 pending orders:\n• SO-2026-0234 — Empresa ABC ($8,500)\n• SO-2026-0235 — Tech Solutions ($3,200)\n• SO-2026-0236 — Global Trade ($15,000)\n\nShould I open the orders list?",
-    "copilotContactResponse": "I found 156 contacts. Top customers by revenue:\n1. Global Trade Ltd — $85,000\n2. Empresa ABC — $52,000\n3. Ibérica Industrial — $34,000\n\nWho are you looking for?",
+    "copilotStockResponse": "Here's a quick stock summary:\n\u2022 Cerveza Ale 0.5L: 150 units\n\u2022 Vino Tinto Reserva: 80 units\n\u2022 Aceite de Oliva 1L: 230 units\n\nWould you like to check a specific product?",
+    "copilotOrderResponse": "You have 5 pending orders:\n\u2022 SO-2026-0234 \u2014 Empresa ABC ($8,500)\n\u2022 SO-2026-0235 \u2014 Tech Solutions ($3,200)\n\u2022 SO-2026-0236 \u2014 Global Trade ($15,000)\n\nShould I open the orders list?",
+    "copilotContactResponse": "I found 156 contacts. Top customers by revenue:\n1. Global Trade Ltd \u2014 $85,000\n2. Empresa ABC \u2014 $52,000\n3. Ib\u00e9rica Industrial \u2014 $34,000\n\nWho are you looking for?",
     "copilotDefaultResponse": "I can help with invoices, orders, stock, contacts, and more. What would you like to do?",
     "createInvoice": "Create an invoice",
     "checkStockLevels": "Check stock levels",
@@ -17204,21 +17204,21 @@
     "warehouseBarChart": "Bar chart",
     "warehouseExpandChart": "Expand chart",
     "warehouseNoMovementData": "No movement data for this period",
-    "warehouseLoadingStock": "Loading stock data…",
+    "warehouseLoadingStock": "Loading stock data\u2026",
     "warehouseStockError": "Could not load stock data.",
     "warehouseTooltipUnits": "{label}: {n} units",
     "warehouseTransactionsTab": "Transactions",
-    "warehouseFilterPlaceholder": "Filter by product or type…",
+    "warehouseFilterPlaceholder": "Filter by product or type\u2026",
     "warehouseDate": "Date",
     "warehouseProduct": "Product",
     "warehouseType": "Type",
     "warehouseQty": "Qty",
     "warehouseUom": "UoM",
     "warehouseQtyOnHand": "Qty on Hand",
-    "warehouseLoadingProducts": "Loading products…",
+    "warehouseLoadingProducts": "Loading products\u2026",
     "warehouseProductsError": "Could not load products: {error}",
     "warehouseNoStock": "No stock found for this warehouse.",
-    "warehouseLoadingTransactions": "Loading transactions…",
+    "warehouseLoadingTransactions": "Loading transactions\u2026",
     "warehouseTransactionsError": "Could not load transactions: {error}",
     "warehouseNoTransactions": "No transactions found for this warehouse.",
     "warehouseNoFilterResults": "No results match your filter.",
@@ -17227,15 +17227,15 @@
     "warehouseMoveQtyLabel": "Quantity to Transfer",
     "warehouseMoveQtyMax": "(max {n})",
     "warehouseMoveConfirm": "Transfer",
-    "warehouseMoveLoadingWarehouses": "Loading warehouses…",
+    "warehouseMoveLoadingWarehouses": "Loading warehouses\u2026",
     "warehouseMoveNoWarehouses": "No other warehouses available",
     "warehouseMoveActionTooltip": "Transfer to another warehouse",
     "warehouseMoveComingSoon": "Transfer process coming soon",
-    "warehouseMoveTransferring": "Transferring…",
+    "warehouseMoveTransferring": "Transferring\u2026",
     "warehouseMoveSuccess": "Stock transferred successfully",
     "warehouseMoveError": "Transfer failed: {error}",
     "internalConsumptionProcess": "Process",
-    "internalConsumptionProcessing": "Processing…",
+    "internalConsumptionProcessing": "Processing\u2026",
     "internalConsumptionProcessed": "Internal consumption processed successfully",
     "internalConsumptionProcessError": "Could not process: {error}",
     "movTypeVendorReceipt": "Vendor Receipt",
@@ -17294,8 +17294,8 @@
     "revenue": "Revenue",
     "revenueVsExpenses12m": "Revenue vs Expenses (12 months)",
     "topClients12m": "Top Clients (12 months)",
-    "months12ByRevenue": "12 months · by revenue",
-    "months12ByQty": "12 months · by qty",
+    "months12ByRevenue": "12 months \u00b7 by revenue",
+    "months12ByQty": "12 months \u00b7 by qty",
     "noDataAvailable": "No data available",
     "dragCardsToReorder": "Drag cards to reorder. Toggle to show/hide.",
     "dragToReorder": "drag to reorder",
@@ -17336,7 +17336,7 @@
     "onboardingMarketingDescription": "Invoice, record expenses, and get reports in seconds with a simple guided interface.",
     "onboardingSwitchToLoginPrompt": "Already have an account?",
     "onboardingSwitchToLoginAction": "Sign in",
-    "onboardingSwitchToRegisterPrompt": "Don’t have an account yet?",
+    "onboardingSwitchToRegisterPrompt": "Don\u2019t have an account yet?",
     "onboardingSwitchToRegisterAction": "Create account",
     "onboardingRegisterTitle": "Create your free account",
     "onboardingRegisterSubtitle": "Get started in less than 1 minute",
@@ -17374,7 +17374,7 @@
     "onboardingProgressAlmostReady": "One more step",
     "onboardingProgressAlmostDone": "Almost done",
     "onboardingGreetingFallback": "there",
-    "onboardingGreeting": "Hi {name} 👋",
+    "onboardingGreeting": "Hi {name} \ud83d\udc4b",
     "onboardingSetupSubtitle": "We will get everything ready in less than 1 minute",
     "onboardingFullNameLabel": "Full name",
     "onboardingFullNamePlaceholder": "John Doe",
@@ -17429,9 +17429,9 @@
     "vendor": "Vendor",
     "creditTax": "Credit",
     "creditTaxDescription": "Credit line limit for this contact.",
-    "searchAddress": "Search address…",
-    "typeToSearch": "Type to search…",
-    "searching": "Searching…",
+    "searchAddress": "Search address\u2026",
+    "typeToSearch": "Type to search\u2026",
+    "searching": "Searching\u2026",
     "typeAtLeast2Characters": "Type at least 2 characters",
     "setLocation": "Set location",
     "locationSelectorTitle": "Location",
@@ -17461,16 +17461,16 @@
     "soConfirmWithInvoice": "Confirm and invoice",
     "soConfirmWithInvoiceDesc": "A draft invoice will be created",
     "soProcessing": "Processing...",
-    "soConfirmAction": "Confirm →",
+    "soConfirmAction": "Confirm \u2192",
     "soErrorOccurred": "An error occurred",
-    "soManageShipmentAndInvoice": "Manage shipment & invoice ▾",
-    "soManageShipment": "Manage shipment ▾",
-    "soManageInvoice": "Manage invoice ▾",
+    "soManageShipmentAndInvoice": "Manage shipment & invoice \u25be",
+    "soManageShipment": "Manage shipment \u25be",
+    "soManageInvoice": "Manage invoice \u25be",
     "soShipmentSection": "Shipment",
     "soInvoiceSection": "Invoice",
-    "soQtyDeliveredOf": "{delivered} / {total} units delivered · {pending} pending",
+    "soQtyDeliveredOf": "{delivered} / {total} units delivered \u00b7 {pending} pending",
     "soQtyPendingDelivery": "{pending} units pending delivery",
-    "soAmountInvoicedOf": "{invoiced} / {total} invoiced · {pending} pending",
+    "soAmountInvoicedOf": "{invoiced} / {total} invoiced \u00b7 {pending} pending",
     "soAmountPendingInvoice": "{pending} pending invoice",
     "soCreateShipment": "+ Create shipment",
     "soCreateInvoice": "+ Create invoice",
@@ -17489,9 +17489,9 @@
     "soLines": "{count} lines",
     "soLine": "1 line",
     "soSubtotal": "Subtotal",
-    "soConfirmActionShipment": "Confirm + shipment →",
-    "soConfirmActionInvoice": "Confirm + invoice →",
-    "soConfirmActionBoth": "Confirm + shipment + invoice →",
+    "soConfirmActionShipment": "Confirm + shipment \u2192",
+    "soConfirmActionInvoice": "Confirm + invoice \u2192",
+    "soConfirmActionBoth": "Confirm + shipment + invoice \u2192",
     "soGenerateDocs": "Generate documents (optional)",
     "soCreateInvoiceTitle": "Create invoice",
     "soCreateShipmentCheckDesc": "A draft shipment will be created, independent of the invoice",
@@ -17501,7 +17501,7 @@
     "soConfirmedSubtitle": "The following documents were created as drafts:",
     "soConfirmActionOnly": "Confirm order",
     "soManageDocsTitle": "Manage documents",
-    "soCreateDocsBtn": "Create →",
+    "soCreateDocsBtn": "Create \u2192",
     "soDocsCreatedTitle": "Documents created",
     "soOrderConfirmed": "Order confirmed",
     "soOrderConfirmedDesc": "Order #{number} ready to invoice or generate a shipment.",
@@ -17509,8 +17509,8 @@
     "soInvoiceCreated": "Invoice created",
     "soShipmentCreatedNote": "Review quantities before processing delivery.",
     "soClose": "Close",
-    "soViewShipment": "View shipment →",
-    "soViewInvoice": "View invoice →",
+    "soViewShipment": "View shipment \u2192",
+    "soViewInvoice": "View invoice \u2192",
     "datePickerBack": "Back",
     "datePickerOk": "OK",
     "datePickerMonth": "Month",
@@ -17529,9 +17529,9 @@
     "sqCreateOrder": "Create sales order",
     "sqCreateOrderDesc": "For products with stock, deliveries or orders with multiple shipments.",
     "sqInvoiceDirectlyDesc": "For services or sales without physical delivery. No shipment.",
-    "sqConfirmActionOrder": "Confirm → Sales order",
+    "sqConfirmActionOrder": "Confirm \u2192 Sales order",
     "sqOrderCreated": "Order created",
-    "sqViewOrder": "View order →",
+    "sqViewOrder": "View order \u2192",
     "sqOrderConfirmedError": "Quotation confirmed, but order could not be created. ",
     "sqSendToEvalTitle": "Send to Under Evaluation?",
     "sqSendToEvalDesc": "The quotation will be ready to create an order or invoice.",
@@ -17579,7 +17579,7 @@
     "unsavedChangesDesc": "You have changes that haven't been saved yet. What would you like to do?",
     "pricingUpdated": "Pricing updated successfully.",
     "uploadImage": "Upload image",
-    "uploadingImage": "Uploading…",
+    "uploadingImage": "Uploading\u2026",
     "assetsAmortizationPlan": "Amortization Plan",
     "assetsAmortizationPlanDesc": "This shows what will happen to the asset over time.",
     "assetsPlannedLine": "planned line",
@@ -17632,7 +17632,7 @@
     "poConfirmOnlyDesc": "The order is confirmed without generating any additional documents",
     "poConfirmWithInvoice": "Confirm and invoice",
     "poConfirmWithInvoiceDesc": "A draft purchase invoice will be created",
-    "poConfirmAction": "Confirm →",
+    "poConfirmAction": "Confirm \u2192",
     "poProcessing": "Processing...",
     "poErrorOccurred": "An error occurred",
     "poOrderConfirmed": "Order confirmed",
@@ -17643,7 +17643,7 @@
     "poCreateInvoice": "Create invoice",
     "poInvoiceCreated": "Invoice created",
     "poReviewBeforeConfirming": "Review before confirming",
-    "poViewInvoice": "View invoice →",
+    "poViewInvoice": "View invoice \u2192",
     "poReceiveGoodsTitle": "Receive goods",
     "poProduct": "Product",
     "poOrdered": "Ordered",
@@ -17652,7 +17652,7 @@
     "poReceiveAll": "Receive all",
     "poConfirmReceive": "Confirm",
     "poReceiptCreated": "Receipt created",
-    "poViewReceipt": "View receipt →",
+    "poViewReceipt": "View receipt \u2192",
     "poConfirmWithReceipt": "Confirm and receive",
     "poConfirmWithReceiptDesc": "A draft goods receipt will be created",
     "poManageReceiptAndInvoice": "Manage receipt and invoice",
@@ -17662,18 +17662,18 @@
     "poInvoiceSection": "Purchase invoice",
     "poCreateReceipt": "+ Create goods receipt",
     "poPendingReceipt": "units pending to receive",
-    "poQtyReceivedOf": "Received: {received} / {total} units · {pending} pending",
+    "poQtyReceivedOf": "Received: {received} / {total} units \u00b7 {pending} pending",
     "poPendingInvoice": "pending to invoice",
-    "poAmountInvoicedOf": "Invoiced: {invoiced} · {pending} pending",
-    "poReceiptDraftChip": "📦 Receipt #{number} · Pending confirmation",
-    "poInvoiceDraftChip": "🧾 Invoice #{number} · Pending confirmation",
+    "poAmountInvoicedOf": "Invoiced: {invoiced} \u00b7 {pending} pending",
+    "poReceiptDraftChip": "\ud83d\udce6 Receipt #{number} \u00b7 Pending confirmation",
+    "poInvoiceDraftChip": "\ud83e\uddfe Invoice #{number} \u00b7 Pending confirmation",
     "poCreating": "Creating...",
     "poAllReceived": "Received",
     "poAllInvoiced": "Invoiced",
     "poNReceipts": "{count} receipts",
-    "poConfirmActionReceipt": "Confirm + receipt →",
-    "poConfirmActionInvoice": "Confirm + invoice →",
-    "poConfirmActionBoth": "Confirm + receipt + invoice →",
+    "poConfirmActionReceipt": "Confirm + receipt \u2192",
+    "poConfirmActionInvoice": "Confirm + invoice \u2192",
+    "poConfirmActionBoth": "Confirm + receipt + invoice \u2192",
     "poCreateReceiptTitle": "Create goods receipt",
     "poCreateReceiptCheckDesc": "A draft goods receipt will be created",
     "poCreateInvoiceCheckDesc": "A draft purchase invoice will be created",
@@ -17688,11 +17688,11 @@
     "cloneOrderBtn": "Clone",
     "cloneOrderConfirmTitle": "Clone order",
     "cloneOrderConfirmBody": "A draft copy of this order will be created with the same data.",
-    "cloneOrderAction": "Clone →",
+    "cloneOrderAction": "Clone \u2192",
     "cloneOrderError": "An error occurred while cloning the order",
     "cloneInvoiceConfirmTitle": "Clone invoice",
     "cloneInvoiceConfirmBody": "A draft copy of this invoice will be created with the same data.",
-    "cloneInvoiceAction": "Clone →",
+    "cloneInvoiceAction": "Clone \u2192",
     "cloneInvoiceError": "An error occurred while cloning the invoice",
     "cloneConfirmTitleOne": "Clone document",
     "cloneConfirmTitleMany": "Clone {count} documents",
@@ -17801,11 +17801,11 @@
     "fiscal.territory.ceuta": "Ceuta / Melilla (IPSI)",
     "fiscal.territory.navarra": "Navarre",
     "fiscal.territory.paisvasco": "Basque Country",
-    "fiscal.sii.question": "Is this organization enrolled in SII? (annual revenue > €6M or voluntary)",
+    "fiscal.sii.question": "Is this organization enrolled in SII? (annual revenue > \u20ac6M or voluntary)",
     "fiscal.sii.enrolled": "Yes, enrolled in SII",
     "fiscal.sii.notEnrolled": "No, use Verifactu",
     "fiscal.sii.badge.navarra": "Navarre Tax Authority",
-    "fiscal.tbai.sii.question": "Also obligated for national SII? (revenue > €6M)",
+    "fiscal.tbai.sii.question": "Also obligated for national SII? (revenue > \u20ac6M)",
     "fiscal.tbai.with.sii": "Yes, SII + TBAI",
     "fiscal.tbai.without.sii": "No, TBAI only",
     "fiscal.skip": "Skip for now",
@@ -17817,7 +17817,7 @@
     "fiscal.conflict.title": "Invalid configuration",
     "fiscal.conflict.body": "This organization has both Verifactu and SII/TBAI configured. These systems are incompatible. Remove one before continuing.",
     "fiscal.save": "Save",
-    "fiscal.saving": "Saving…",
+    "fiscal.saving": "Saving\u2026",
     "fiscal.noOrg": "No organization selected in the current session.",
     "fiscal.org.label": "Organization: {name}",
     "fiscal.loadError": "Error loading configuration: {error}",
@@ -17834,15 +17834,15 @@
     "fiscal.cert.step.confirm": "Confirmation",
     "fiscal.cert.close": "Close",
     "fiscal.cert.dropzone.drag": "Drag your certificate here",
-    "fiscal.cert.dropzone.click": "or click to select · .p12 or .pfx · max. 5 MB",
+    "fiscal.cert.dropzone.click": "or click to select \u00b7 .p12 or .pfx \u00b7 max. 5 MB",
     "fiscal.cert.dropzone.changeHint": "click to change",
     "fiscal.cert.pwd.label": "Certificate password",
     "fiscal.cert.pwd.hide": "Hide",
     "fiscal.cert.pwd.show": "Show",
-    "fiscal.cert.pwd.hint": "Etendo does not store the password in plain text · AES-256 encryption.",
+    "fiscal.cert.pwd.hint": "Etendo does not store the password in plain text \u00b7 AES-256 encryption.",
     "fiscal.cert.info.title": "Don't have the certificate?",
-    "fiscal.cert.info.body": "Request it from the FNMT or your Foral Tax Authority. Issuance takes 5–10 business days.",
-    "fiscal.cert.verifying.title": "Verifying certificate…",
+    "fiscal.cert.info.body": "Request it from the FNMT or your Foral Tax Authority. Issuance takes 5\u201310 business days.",
+    "fiscal.cert.verifying.title": "Verifying certificate\u2026",
     "fiscal.cert.verifying.body": "Checking PKCS#12 structure, password, validity and storing in Etendo.",
     "fiscal.cert.nif.warning.title": "The organization has no NIF configured",
     "fiscal.cert.nif.warning.body": "The certificate contains NIF {nif}. If you confirm, it will be set as the organization NIF and the certificate will be stored.",
@@ -17861,7 +17861,7 @@
     "fiscal.cert.btn.cancel": "Cancel",
     "fiscal.cert.btn.verify": "Verify certificate",
     "fiscal.cert.btn.change": "Change file",
-    "fiscal.cert.btn.use": "✓ Use this certificate",
+    "fiscal.cert.btn.use": "\u2713 Use this certificate",
     "fiscal.cert.btn.useNif": "Use NIF {nif}",
     "fiscal.cert.err.format": "Unsupported format. Use a .p12 or .pfx (PKCS#12) file.",
     "fiscal.cert.err.size": "The file exceeds the 5 MB limit.",
@@ -17873,7 +17873,7 @@
     "fiscal.cert.validUntil": "Valid until {date}",
     "fiscal.cert.replace": "Replace",
     "fiscal.cert.none.title": "No certificate",
-    "fiscal.cert.none.hint": "Required to authenticate with the Tax Authority · .p12 or .pfx",
+    "fiscal.cert.none.hint": "Required to authenticate with the Tax Authority \u00b7 .p12 or .pfx",
     "fiscal.cert.upload": "Upload certificate",
     "fiscal.sii.legend.status": "Status",
     "fiscal.sii.legend.env": "Environment",
@@ -17919,19 +17919,19 @@
     "fiscal.verifactu.field.systemStop": "System stop",
     "fiscal.verifactu.field.incident": "Incident detail",
     "fiscal.verifactu.field.enrollDate": "Enrollment date",
-    "fiscal.verifactu.saving": "Saving…",
+    "fiscal.verifactu.saving": "Saving\u2026",
     "fiscal.onboarding.step.territory": "Territory",
     "fiscal.onboarding.step.details": "Details",
     "fiscal.onboarding.step.confirm": "Confirm",
     "fiscal.onboarding.org.label": "Organization:",
-    "fiscal.onboarding.back": "← Back",
-    "fiscal.onboarding.continue": "Continue ›",
-    "fiscal.onboarding.saving": "Creating…",
+    "fiscal.onboarding.back": "\u2190 Back",
+    "fiscal.onboarding.continue": "Continue \u203a",
+    "fiscal.onboarding.saving": "Creating\u2026",
     "fiscal.onboarding.goHome": "Go home",
     "fiscal.onboarding.viewConfig": "View configuration",
-    "fiscal.onboarding.back.wizard": "← Back to wizard",
+    "fiscal.onboarding.back.wizard": "\u2190 Back to wizard",
     "fiscal.onboarding.skipped.title": "Configuration skipped",
-    "fiscal.onboarding.skipped.hint": "You can return to this screen at any time from Settings → Fiscal configuration.",
+    "fiscal.onboarding.skipped.hint": "You can return to this screen at any time from Settings \u2192 Fiscal configuration.",
     "fiscal.onboarding.applied.title": "Configuration applied",
     "fiscal.onboarding.applied.subtitle": "{system} is now active for this organization. You can start issuing electronic invoices or adjust operational details whenever you want.",
     "fiscal.onboarding.applied.configured": "{system} configured correctly",
@@ -17944,9 +17944,9 @@
     "fiscal.onboarding.applied.row.chosen": "Chosen system",
     "fiscal.onboarding.applied.row.env": "Environment",
     "fiscal.onboarding.applied.row.activated": "Activated",
-    "fiscal.onboarding.applied.env.sandbox": "Sandbox · testing",
-    "fiscal.onboarding.applied.volume.high": "> 6,010,121 €",
-    "fiscal.onboarding.applied.volume.low": "≤ 6,010,121 €",
+    "fiscal.onboarding.applied.env.sandbox": "Sandbox \u00b7 testing",
+    "fiscal.onboarding.applied.volume.high": "> 6,010,121 \u20ac",
+    "fiscal.onboarding.applied.volume.low": "\u2264 6,010,121 \u20ac",
     "fiscal.onboarding.applied.national.active": "Active",
     "fiscal.onboarding.applied.national.na": "Not applicable",
     "fiscal.onboarding.applied.chosen.sii": "SII voluntary",
@@ -17955,7 +17955,7 @@
     "fiscal.onboarding.cert.upload.title": "Upload digital certificate",
     "fiscal.onboarding.cert.loaded.title": "Digital certificate loaded",
     "fiscal.onboarding.cert.upload.desc": "Required to sign and authenticate invoices. Supports .p12 and .pfx.",
-    "fiscal.onboarding.cert.loaded.desc": "{name} · valid until {validTo} · click to replace.",
+    "fiscal.onboarding.cert.loaded.desc": "{name} \u00b7 valid until {validTo} \u00b7 click to replace.",
     "fiscal.onboarding.cert.pending": "Pending",
     "fiscal.onboarding.next.test.title": "Schedule first test submission",
     "fiscal.onboarding.next.test.desc": "Verify the connection with the Tax Authority in sandbox before going to production.",
@@ -17974,14 +17974,14 @@
     "fiscal.onboarding.breadcrumb.details": "Details",
     "fiscal.onboarding.breadcrumb.manual": "Manual configuration",
     "fiscal.onboarding.confirm.title": "Confirm configuration",
-    "fiscal.onboarding.confirm.subtitle": "Review the data before continuing. You can edit any field later in Settings → Fiscal configuration.",
+    "fiscal.onboarding.confirm.subtitle": "Review the data before continuing. You can edit any field later in Settings \u2192 Fiscal configuration.",
     "fiscal.onboarding.confirm.row.territory": "Territory",
     "fiscal.onboarding.confirm.row.hacienda": "Tax authority",
-    "fiscal.onboarding.confirm.row.national.yes": "Yes · also declares SII",
-    "fiscal.onboarding.confirm.row.national.no": "No · TicketBAI only",
+    "fiscal.onboarding.confirm.row.national.yes": "Yes \u00b7 also declares SII",
+    "fiscal.onboarding.confirm.row.national.no": "No \u00b7 TicketBAI only",
     "fiscal.onboarding.confirm.row.national": "National operation",
-    "fiscal.onboarding.confirm.row.volume.high": "> 6,010,121.04 €",
-    "fiscal.onboarding.confirm.row.volume.low": "≤ 6,010,121.04 €",
+    "fiscal.onboarding.confirm.row.volume.high": "> 6,010,121.04 \u20ac",
+    "fiscal.onboarding.confirm.row.volume.low": "\u2264 6,010,121.04 \u20ac",
     "fiscal.onboarding.confirm.row.volume": "Annual volume",
     "fiscal.onboarding.confirm.row.choice.sii": "Voluntary SII",
     "fiscal.onboarding.confirm.row.choice.verifactu": "Verifactu",
@@ -17989,7 +17989,7 @@
     "fiscal.onboarding.confirm.row.system": "Fiscal system",
     "fiscal.onboarding.confirm.next.title": "Next step",
     "fiscal.onboarding.confirm.next.body": "After confirming, you can add operational details (enrollment dates, submission cadences, test or production environment).",
-    "fiscal.onboarding.confirm.creating": "Creating…",
+    "fiscal.onboarding.confirm.creating": "Creating\u2026",
     "fiscal.onboarding.confirm.btn": "Confirm",
     "fiscal.onboarding.manual.title": "Manual configuration",
     "fiscal.onboarding.manual.subtitle": "Select the territory and fiscal system that corresponds to this organization. You can complete the details later.",
@@ -18006,34 +18006,34 @@
     "fiscal.onboarding.subq.tbai.label": "TicketBAI only",
     "fiscal.onboarding.subq.tbai.desc": "All our invoicing is declared to the Foral Tax Authority of {territory}.",
     "fiscal.onboarding.subq.sii.label": "SII + TicketBAI",
-    "fiscal.onboarding.subq.sii.desc": "We also issue invoices to clients in common territory — we need to declare through state SII.",
+    "fiscal.onboarding.subq.sii.desc": "We also issue invoices to clients in common territory \u2014 we need to declare through state SII.",
     "fiscal.onboarding.subq.volume.title": "What is your annual billing volume?",
-    "fiscal.onboarding.subq.volume.subtitle": "Companies exceeding €6,010,121.04 in transaction volume are required to submit SII. Below that, you can choose between SII (voluntary) or Verifactu.",
-    "fiscal.onboarding.subq.volume.low.label": "Up to 6,010,121.04 € per year",
-    "fiscal.onboarding.subq.volume.low.desc": "General regime · you can choose between SII (voluntary) or Verifactu in the next step.",
-    "fiscal.onboarding.subq.volume.high.label": "More than 6,010,121.04 € per year",
-    "fiscal.onboarding.subq.volume.high.desc": "Large company · SII mandatory (immediate submission to AEAT).",
+    "fiscal.onboarding.subq.volume.subtitle": "Companies exceeding \u20ac6,010,121.04 in transaction volume are required to submit SII. Below that, you can choose between SII (voluntary) or Verifactu.",
+    "fiscal.onboarding.subq.volume.low.label": "Up to 6,010,121.04 \u20ac per year",
+    "fiscal.onboarding.subq.volume.low.desc": "General regime \u00b7 you can choose between SII (voluntary) or Verifactu in the next step.",
+    "fiscal.onboarding.subq.volume.high.label": "More than 6,010,121.04 \u20ac per year",
+    "fiscal.onboarding.subq.volume.high.desc": "Large company \u00b7 SII mandatory (immediate submission to AEAT).",
     "fiscal.onboarding.subq.system.title": "Which system do you prefer?",
     "fiscal.onboarding.subq.system.subtitle": "Both options comply with AEAT regulations. SII sends each invoice instantly; Verifactu signs locally and allows deferred submission.",
     "fiscal.onboarding.subq.verifactu.label": "Verifactu",
-    "fiscal.onboarding.subq.verifactu.desc": "AEAT anti-fraud · local signature + QR + deferred submission. Recommended for SMEs.",
+    "fiscal.onboarding.subq.verifactu.desc": "AEAT anti-fraud \u00b7 local signature + QR + deferred submission. Recommended for SMEs.",
     "fiscal.onboarding.subq.sii.vol.label": "Voluntary SII",
-    "fiscal.onboarding.subq.sii.vol.desc": "Voluntary enrollment · immediate submission (4 days). Useful if your main client requires it.",
-    "fiscal.territory.alava": "Álava",
+    "fiscal.onboarding.subq.sii.vol.desc": "Voluntary enrollment \u00b7 immediate submission (4 days). Useful if your main client requires it.",
+    "fiscal.territory.alava": "\u00c1lava",
     "fiscal.territory.bizkaia": "Bizkaia",
     "fiscal.territory.gipuzkoa": "Gipuzkoa",
-    "fiscal.territory.navarra.systemLong": "SII Foral · Navarre Tax Authority",
-    "fiscal.territory.alava.systemLong": "TicketBAI · Álava Tax Authority",
-    "fiscal.territory.bizkaia.systemLong": "TicketBAI · Bizkaia Tax Authority",
-    "fiscal.territory.gipuzkoa.systemLong": "TicketBAI · Gipuzkoa Tax Authority",
-    "fiscal.territory.baleares.systemLong": "General regime · AEAT",
-    "fiscal.territory.canarias.systemLong": "IGIC · Canary Islands Tax Authority",
-    "fiscal.territory.ceuta.systemLong": "IPSI · Autonomous Cities",
+    "fiscal.territory.navarra.systemLong": "SII Foral \u00b7 Navarre Tax Authority",
+    "fiscal.territory.alava.systemLong": "TicketBAI \u00b7 \u00c1lava Tax Authority",
+    "fiscal.territory.bizkaia.systemLong": "TicketBAI \u00b7 Bizkaia Tax Authority",
+    "fiscal.territory.gipuzkoa.systemLong": "TicketBAI \u00b7 Gipuzkoa Tax Authority",
+    "fiscal.territory.baleares.systemLong": "General regime \u00b7 AEAT",
+    "fiscal.territory.canarias.systemLong": "IGIC \u00b7 Canary Islands Tax Authority",
+    "fiscal.territory.ceuta.systemLong": "IPSI \u00b7 Autonomous Cities",
     "fiscal.territory.navarra.example": "Companies with fiscal domicile in Navarre",
-    "fiscal.territory.alava.example": "Companies based in Álava",
+    "fiscal.territory.alava.example": "Companies based in \u00c1lava",
     "fiscal.territory.bizkaia.example": "Companies based in Bizkaia",
     "fiscal.territory.gipuzkoa.example": "Companies based in Gipuzkoa",
-    "fiscal.territory.baleares.example": "General regime · state VAT",
+    "fiscal.territory.baleares.example": "General regime \u00b7 state VAT",
     "fiscal.territory.canarias.example": "Companies with IGIC instead of VAT",
     "fiscal.territory.ceuta.example": "Companies with IPSI instead of VAT",
     "fiscal.territory.system.sii": "SII",
@@ -18046,7 +18046,7 @@
     "fiscal.territory.group.siiver.label": "SII / VERIFACTU",
     "fiscal.territory.group.siiver.desc": "You will be asked based on your billing volume",
     "fiscal.system.sii.long": "Immediate Information System",
-    "fiscal.system.sii.desc": "Immediate VAT Information Supply · AEAT",
+    "fiscal.system.sii.desc": "Immediate VAT Information Supply \u00b7 AEAT",
     "fiscal.system.tbai.long": "TicketBAI (Basque Country)",
     "fiscal.system.tbai.desc": "Anti-fraud system of the Basque Foral Tax Authorities",
     "fiscal.system.siitbai.long": "National SII and TicketBAI",
@@ -18100,7 +18100,7 @@
     "fiscalMonitor.col.signature": "Signature",
     "fiscalMonitor.col.issuerNIF": "Issuer NIF",
     "fiscalMonitor.col.errorReason": "Error reason",
-    "fiscalMonitor.orgMeta": "Invoice monitor · active fiscal system",
+    "fiscalMonitor.orgMeta": "Invoice monitor \u00b7 active fiscal system",
     "fiscalMonitor.synced": "Synchronized",
     "fiscalMonitor.setupDescription": "This organization has no active telematic submission system (SII, TicketBAI or Verifactu). Configure it in Fiscal Configuration to start tracking your invoices.",
     "fiscalMonitor.setupCta": "Configure fiscal system",
@@ -18197,7 +18197,121 @@
     "sifDataTabs.status.verifactu.invalid": "Invalid",
     "sifDataTabs.status.verifactu.rejected": "Rejected",
     "sifDataTabs.status.verifactu.pending": "Pending",
-    "sifDataTabs.status.verifactu.notSent": "Not sent"
+    "sifDataTabs.status.verifactu.notSent": "Not sent",
+    "recentSalesInvoices": "Recent Sales Invoices",
+    "recentPurchaseInvoices": "Recent Purchase Invoices",
+    "bankAccountsSummary": "Bank Accounts Summary",
+    "taxObligations": "Tax Obligations",
+    "installed": "Installed",
+    "addsMenuEntries": "Adds menu entries",
+    "uninstall": "Uninstall",
+    "installing": "Installing\u2026",
+    "appStore": "App Store",
+    "appStoreDescription": "External apps built on the Etendo Apps SDK. Each app runs in its own iframe with its own BFF \u2014 installing one here adds its menu entries to the shell; uninstalling removes them. No shell rebuild required.",
+    "appStoreTip": "Tip: this section is hidden by default \u2014 reveal it with",
+    "appStoreTipHide": ", hide it with",
+    "hideAppStoreTitle": "Hide the App Store from the sidebar",
+    "hideAppStore": "Hide App Store",
+    "artifactSchemaRaw": "Schema Raw",
+    "artifactSchemaCurated": "Schema Curated",
+    "artifactContract": "Contract",
+    "artifactsTitle": "Artifacts",
+    "searchWindows": "Search windows...",
+    "noWindowsFound": "No windows found",
+    "selectWindowFromList": "Select a window from the list",
+    "currentVersion": "Current version",
+    "noDataToDisplay": "No data to display",
+    "closeDetailPanel": "Close detail panel",
+    "activitySummary": "Activity Summary",
+    "lastSale": "Last sale",
+    "totalInvoiced12m": "Total invoiced (12m)",
+    "pendingBalanceLabel": "Pending balance",
+    "totalInvoicedHeader": "Total Invoiced",
+    "pendingBalanceHeader": "Pending Balance",
+    "category": "Category",
+    "viewKanban": "Kanban",
+    "viewList": "List",
+    "recentActivities": "Recent Activities",
+    "teamActivity": "Team Activity",
+    "firstStepsPageTitle": "First Steps",
+    "firstStepsCopilotBanner": "Copilot can help you set it up",
+    "firstStepsStart": "Start",
+    "firstStepsPrepareAccount": "Let's get your account ready",
+    "firstStepsSubtitle": "Follow these steps and in less than 10 minutes you'll be ready to start.",
+    "completed": "Completed",
+    "firstStepsConfigure": "Configure",
+    "minutes": "min",
+    "markAsCompleted": "Mark as completed",
+    "firstStepsCreateAccount": "Create account",
+    "firstStepsCompanyData": "Company data",
+    "firstStepsCompanyDataDesc": "Add the basic information to issue documents.",
+    "firstStepsCustomizeInvoices": "Customize your invoices",
+    "firstStepsConnectBank": "Connect your bank",
+    "firstStepsSetupPayments": "Set up payment methods",
+    "firstStepsInviteTeam": "Invite your team",
+    "firstStepsFirstInvoice": "Create your first invoice",
+    "employeeDirectory": "Employee Directory",
+    "hrUpdates": "HR Updates",
+    "stockLevels": "Stock Levels",
+    "minimum": "minimum",
+    "recentMovements": "Recent Movements",
+    "oauth2Clients": "OAuth2 Clients",
+    "manageMcpCredentials": "Manage MCP agent credentials",
+    "loadingClients": "Loading clients...",
+    "noOAuth2Clients": "No OAuth2 clients",
+    "createClientDescription": "Create a client to allow MCP agents to authenticate with Etendo.",
+    "createFirstClient": "Create First Client",
+    "clientId": "Client ID",
+    "scopes": "Scopes",
+    "active": "Active",
+    "clickToCopy": "Click to copy",
+    "regenerateSecret": "Regenerate Secret",
+    "revokeTokens": "Revoke Tokens",
+    "deleteClientDesc": "This will permanently delete the client and revoke all its tokens. This action cannot be undone.",
+    "regenerateSecretDesc": "Are you sure? The current secret will be invalidated immediately. Any agents using the old secret will stop working.",
+    "revokeTokensDesc": "This will invalidate all active tokens for this client. Agents will need to re-authenticate.",
+    "recentTimeEntries": "Recent Time Entries",
+    "recentDocuments": "Recent Documents",
+    "purchaseOrders": "Purchase Orders",
+    "docNo": "Doc No",
+    "documentNo": "Document No",
+    "settings": "Settings",
+    "settingsDescription": "Manage your session context. Changing role or organization will re-authenticate your session.",
+    "currentSession": "Current Session",
+    "user": "User",
+    "activeContext": "Active Context",
+    "balanceSheet": "Balance Sheet",
+    "profitLoss": "P&L",
+    "profitLossTitle": "Profit & Loss",
+    "agingReceivable": "Aging Receivable",
+    "agingReceivableTitle": "Aging of Receivables",
+    "agingPayable": "Aging Payable",
+    "agingPayableTitle": "Aging of Payables",
+    "required": "Required",
+    "selectedCount": "selected",
+    "loadingDetails": "Loading details...",
+    "detailReport": "Detail Report",
+    "detailsSuffix": " \u2014 Details",
+    "invoiceTitle": "Invoice",
+    "install": "Install",
+    "quotations": "Quotations",
+    "location": "Location",
+    "oauthClientNew": "New Client",
+    "oauthClientManage": "Manage MCP agent credentials",
+    "oauthClientNoClients": "No OAuth2 clients",
+    "oauthClientNoClientsDesc": "Create a client to allow MCP agents to authenticate with Etendo.",
+    "oauthClientCreateFirst": "Create First Client",
+    "oauthClientId": "Client ID",
+    "oauthScopes": "Scopes",
+    "oauthActive": "Active",
+    "oauthInactive": "Inactive",
+    "oauthRegenerateSecret": "Regenerate Secret",
+    "oauthRevokeTokens": "Revoke Tokens",
+    "oauthClickToCopy": "Click to copy",
+    "oauthDeleteDesc": "This will permanently delete the client and revoke all its tokens. This action cannot be undone.",
+    "oauthRegenerateDesc": "Are you sure? The current secret will be invalidated immediately. Any agents using the old secret will stop working.",
+    "oauthRevokeDesc": "This will invalidate all active tokens for this client. Agents will need to re-authenticate.",
+    "firstStepsCompleted": "Completed"
   },
   "menus": {
     "Currency": {
@@ -19328,11 +19442,11 @@
     "General Chart of Accounts Update": {
       "label": "General Chart of Accounts Update"
     },
-    "Configuración TBAI": {
-      "label": "Configuración TBAI"
+    "Configuraci\u00f3n TBAI": {
+      "label": "Configuraci\u00f3n TBAI"
     },
-    "Suministro Inmediato de Información (SII)": {
-      "label": "Suministro Inmediato de Información (SII)"
+    "Suministro Inmediato de Informaci\u00f3n (SII)": {
+      "label": "Suministro Inmediato de Informaci\u00f3n (SII)"
     },
     "AEAT347 Document Types": {
       "label": "AEAT347 Document Types"
@@ -19349,8 +19463,8 @@
     "Intrastat Launcher": {
       "label": "Intrastat Launcher"
     },
-    "Sistemas de Facturación": {
-      "label": "Sistemas de Facturación"
+    "Sistemas de Facturaci\u00f3n": {
+      "label": "Sistemas de Facturaci\u00f3n"
     },
     "Intrastat": {
       "label": "Intrastat"
@@ -19364,8 +19478,8 @@
     "Intrastat Supplementary Unit of Measure": {
       "label": "Intrastat Supplementary Unit of Measure"
     },
-    "Discrepancias de Auditoría": {
-      "label": "Discrepancias de Auditoría"
+    "Discrepancias de Auditor\u00eda": {
+      "label": "Discrepancias de Auditor\u00eda"
     },
     "Multidimensional Tax Report": {
       "label": "Multidimensional Tax Report"
@@ -19373,8 +19487,8 @@
     "Tax key": {
       "label": "Tax key"
     },
-    "Rellenar Fechas de Operación": {
-      "label": "Rellenar Fechas de Operación"
+    "Rellenar Fechas de Operaci\u00f3n": {
+      "label": "Rellenar Fechas de Operaci\u00f3n"
     },
     "SII Cash Receipts": {
       "label": "SII Cash Receipts"
@@ -19385,14 +19499,14 @@
     "Info.Conta.Impuestos": {
       "label": "Info.Conta.Impuestos"
     },
-    "Configuración Verifactu": {
-      "label": "Configuración Verifactu"
+    "Configuraci\u00f3n Verifactu": {
+      "label": "Configuraci\u00f3n Verifactu"
     },
     "TBAI Facturas Enviadas": {
       "label": "TBAI Facturas Enviadas"
     },
-    "Código de Actividad": {
-      "label": "Código de Actividad"
+    "C\u00f3digo de Actividad": {
+      "label": "C\u00f3digo de Actividad"
     },
     "PYMEs Chart of Accounts Update": {
       "label": "PYMEs Chart of Accounts Update"
@@ -19421,8 +19535,8 @@
     "Tax Report": {
       "label": "Tax Report"
     },
-    "Epígrafes IAE": {
-      "label": "Epígrafes IAE"
+    "Ep\u00edgrafes IAE": {
+      "label": "Ep\u00edgrafes IAE"
     },
     "SII Descriptions": {
       "label": "SII Descriptions"

--- a/tools/app-shell/src/locales/es_ES.json
+++ b/tools/app-shell/src/locales/es_ES.json
@@ -301,7 +301,7 @@
       "description": ""
     },
     "Filter_Definition": {
-      "label": "Definición de Filtro",
+      "label": "Definici\u00f3n de Filtro",
       "description": ""
     },
     "Isfilter": {
@@ -309,7 +309,7 @@
       "description": ""
     },
     "Parameters": {
-      "label": "Parámetros",
+      "label": "Par\u00e1metros",
       "description": ""
     },
     "Filter_Template_ID": {
@@ -329,7 +329,7 @@
       "description": ""
     },
     "Definition": {
-      "label": "Definición",
+      "label": "Definici\u00f3n",
       "description": ""
     },
     "Stops_On_Error": {
@@ -337,7 +337,7 @@
       "description": ""
     },
     "linesinvoiced": {
-      "label": "Líneas facturadas",
+      "label": "L\u00edneas facturadas",
       "description": ""
     },
     "FIN_Finacc_Transaction_Acct_ID": {
@@ -353,19 +353,19 @@
       "description": ""
     },
     "EM_APRM_Process": {
-      "label": "Proceso de ejecución de dudoso cobro",
+      "label": "Proceso de ejecuci\u00f3n de dudoso cobro",
       "description": ""
     },
     "EM_APRM_Process_Rec_Force": {
-      "label": "Forzar proceso de reconciliación",
+      "label": "Forzar proceso de reconciliaci\u00f3n",
       "description": ""
     },
     "Smfsws_Config_ID": {
-      "label": "Configuración de Secure Web Services",
+      "label": "Configuraci\u00f3n de Secure Web Services",
       "description": ""
     },
     "Expirationtime": {
-      "label": "Tiempo de expiración",
+      "label": "Tiempo de expiraci\u00f3n",
       "description": ""
     },
     "EM_Smfsws_Default_Ws_Role_ID": {
@@ -381,7 +381,7 @@
       "description": ""
     },
     "EM_APRM_Reconcile": {
-      "label": "Conciliación manual",
+      "label": "Conciliaci\u00f3n manual",
       "description": ""
     },
     "Aprm_Payment_Prop_Pick_Edit_ID": {
@@ -401,7 +401,7 @@
       "description": "Define si se permite el filtro"
     },
     "Obuiapp_Report_ID": {
-      "label": "Definición Informe",
+      "label": "Definici\u00f3n Informe",
       "description": ""
     },
     "PDF_Template": {
@@ -457,11 +457,11 @@
       "description": ""
     },
     "Allowfilterbyidentifier": {
-      "label": "Permitir filtrar claves foráneas por su identificador",
-      "description": "Si esta casilla está marcada, el usuario puede filtrar claves foráneas seleccionando algunas opciones desde el desplegable del filtro o introduciendo texto manualmente."
+      "label": "Permitir filtrar claves for\u00e1neas por su identificador",
+      "description": "Si esta casilla est\u00e1 marcada, el usuario puede filtrar claves for\u00e1neas seleccionando algunas opciones desde el desplegable del filtro o introduciendo texto manualmente."
     },
     "Obuiapp_View_Impl_ID": {
-      "label": "Implementación de la Vista",
+      "label": "Implementaci\u00f3n de la Vista",
       "description": "Define la implementacion de una vista mostrada en el interfaz de usuario"
     },
     "Obclker_Uidefinition_ID": {
@@ -473,28 +473,28 @@
       "description": ""
     },
     "Obkmo_Widget_Class_Menu_ID": {
-      "label": "Item de Menú de Clase de Widget",
-      "description": "Identificador único para la opción de menú"
+      "label": "Item de Men\u00fa de Clase de Widget",
+      "description": "Identificador \u00fanico para la opci\u00f3n de men\u00fa"
     },
     "Isseparator": {
       "label": "Es Separador",
-      "description": "Define si un item de menú es separador en el menú"
+      "description": "Define si un item de men\u00fa es separador en el men\u00fa"
     },
     "CAN_Maximize": {
       "label": "Puede ser Maximizado",
       "description": "Especifica si el widget puede ser maximizado"
     },
     "Title": {
-      "label": "Posición",
-      "description": "Posición del contacto"
+      "label": "Posici\u00f3n",
+      "description": "Posici\u00f3n del contacto"
     },
     "Showfieldtitle": {
-      "label": "Mostrar Título de Campo",
-      "description": "Define si el título del campo se debería mostrar en la parte superior del widget"
+      "label": "Mostrar T\u00edtulo de Campo",
+      "description": "Define si el t\u00edtulo del campo se deber\u00eda mostrar en la parte superior del widget"
     },
     "Available_In_Workspace": {
       "label": "Disponible en el Espacio de Trabajo",
-      "description": "Determina si el widget está disponible para mostrarse en el Espacio de Trabajo."
+      "description": "Determina si el widget est\u00e1 disponible para mostrarse en el Espacio de Trabajo."
     },
     "Javaclass": {
       "label": "Clase Java",
@@ -502,19 +502,19 @@
     },
     "Obkmo_Widget_Class_ID": {
       "label": "Clase del Widget",
-      "description": "Identifica una definición de clase de widget"
+      "description": "Identifica una definici\u00f3n de clase de widget"
     },
     "OBKMO_Widget_Class_ID": {
       "label": "Clase del Widget",
-      "description": "Identifica una definición de clase de widget"
+      "description": "Identifica una definici\u00f3n de clase de widget"
     },
     "Height": {
       "label": "Altura",
       "description": "Altura del widget en pixeles"
     },
     "Pos_Column": {
-      "label": "Posición de la columna",
-      "description": "Número que indica en qué columna del Espacio de Trabajo se mostrará el widget"
+      "label": "Posici\u00f3n de la columna",
+      "description": "N\u00famero que indica en qu\u00e9 columna del Espacio de Trabajo se mostrar\u00e1 el widget"
     },
     "Visibleat_User_ID": {
       "label": "Visible en Usuario",
@@ -526,7 +526,7 @@
     },
     "Obclker_template_ID": {
       "label": "Plantilla",
-      "description": "La plantilla utilizada para generar la representación en el cliente"
+      "description": "La plantilla utilizada para generar la representaci\u00f3n en el cliente"
     },
     "Classname": {
       "label": "Nombre de la clase Java",
@@ -534,7 +534,7 @@
     },
     "Obserds_Datasource_Field_ID": {
       "label": "Campo de Fuente de Datos",
-      "description": "El campo de fuente de datos es parte de la definición de la fuente de datos."
+      "description": "El campo de fuente de datos es parte de la definici\u00f3n de la fuente de datos."
     },
     "Obserds_Datasource_ID": {
       "label": "Fuente de datos",
@@ -545,12 +545,12 @@
       "description": "Permitir ordenar por este campo en el grid del popup."
     },
     "Default_Expression": {
-      "label": "Expresión por defecto",
+      "label": "Expresi\u00f3n por defecto",
       "description": "Define una expresion por defecto usada para filtrar esta propiedad"
     },
     "EM_Obuisel_Outfield_ID": {
       "label": "Campo de Salida de Selector",
-      "description": "Identifica el \"campo de salida\" del cual se puede obtener un valor en una selección de registro "
+      "description": "Identifica el \"campo de salida\" del cual se puede obtener un valor en una selecci\u00f3n de registro "
     },
     "Property": {
       "label": "Propiedad",
@@ -558,7 +558,7 @@
     },
     "Displayfield_ID": {
       "label": "Campo Mostrado",
-      "description": "El valor de este campo será mostrado en el cuadro de entrada del selector."
+      "description": "El valor de este campo ser\u00e1 mostrado en el cuadro de entrada del selector."
     },
     "Obuisel_Selector_Field_Trl_ID": {
       "label": "Obuisel_Selector_Field_Trl_ID",
@@ -629,8 +629,8 @@
       "description": "Enable this to include an endpoint for creating a new entity."
     },
     "Description": {
-      "label": "Descripción",
-      "description": "Descripción general"
+      "label": "Descripci\u00f3n",
+      "description": "Descripci\u00f3n general"
     },
     "Getbyid_Description": {
       "label": "GET by ID Description",
@@ -913,12 +913,12 @@
       "description": ""
     },
     "OperationCode": {
-      "label": "Clave de operación",
-      "description": "Las Claves de Operación están relacionadas con las líneas de factura"
+      "label": "Clave de operaci\u00f3n",
+      "description": "Las Claves de Operaci\u00f3n est\u00e1n relacionadas con las l\u00edneas de factura"
     },
     "Operationdate": {
-      "label": "Fecha operación",
-      "description": "Fecha en el que se realiza la operación"
+      "label": "Fecha operaci\u00f3n",
+      "description": "Fecha en el que se realiza la operaci\u00f3n"
     },
     "Error_Registral": {
       "label": "Register Error Modified",
@@ -958,15 +958,15 @@
     },
     "Inputtype": {
       "label": "Tipo",
-      "description": "Define el tipo de parámetro de entrada"
+      "description": "Define el tipo de par\u00e1metro de entrada"
     },
     "Obtl_Tax_Report_Parameter_ID": {
-      "label": "Parámetro de declaración",
-      "description": "Parámetro de declaración de impuestos"
+      "label": "Par\u00e1metro de declaraci\u00f3n",
+      "description": "Par\u00e1metro de declaraci\u00f3n de impuestos"
     },
     "OBTL_Tax_Parameter_ID": {
-      "label": "Parámetro de declaración",
-      "description": "Relación entre un tipo impositivo y un parámetro de declaración de impuestos"
+      "label": "Par\u00e1metro de declaraci\u00f3n",
+      "description": "Relaci\u00f3n entre un tipo impositivo y un par\u00e1metro de declaraci\u00f3n de impuestos"
     },
     "Insiisystem": {
       "label": "In SII system",
@@ -1025,16 +1025,16 @@
       "description": "Under-age"
     },
     "OBTL_Transactioncode_ID": {
-      "label": "Clave de operación (IVA)",
-      "description": "Claves de operación que se utilizan en las declaraciones de IVA"
+      "label": "Clave de operaci\u00f3n (IVA)",
+      "description": "Claves de operaci\u00f3n que se utilizan en las declaraciones de IVA"
     },
     "Obtl_Transactioncode_ID": {
-      "label": "Clave de operación (IVA)",
-      "description": "Claves de operación que se utilizan en las declaraciones de IVA"
+      "label": "Clave de operaci\u00f3n (IVA)",
+      "description": "Claves de operaci\u00f3n que se utilizan en las declaraciones de IVA"
     },
     "OBIRB_Invbooktax_Setup_ID": {
-      "label": "Configuración de los Libros de Facturas",
-      "description": "Este ID identifica a una Configuración de Libro de Facturas"
+      "label": "Configuraci\u00f3n de los Libros de Facturas",
+      "description": "Este ID identifica a una Configuraci\u00f3n de Libro de Facturas"
     },
     "EM_Aeatsii_Cause_Exemption_ID": {
       "label": "SII - Cause Exemption",
@@ -1097,16 +1097,16 @@
       "description": "Autoinvoice"
     },
     "EM_Obspti_Receive_Oss": {
-      "label": "Tipo de IVA acogido a ventanilla única",
+      "label": "Tipo de IVA acogido a ventanilla \u00fanica",
       "description": ""
     },
     "C_Bpartner_TaxID": {
       "label": "NIF",
-      "description": "El gobierno define un identificador único para la asignación y pago de impuestos."
+      "description": "El gobierno define un identificador \u00fanico para la asignaci\u00f3n y pago de impuestos."
     },
     "IsCorrective": {
       "label": "Nota de abono",
-      "description": "Un libro correctivo sólo incluye Notas de Abono"
+      "description": "Un libro correctivo s\u00f3lo incluye Notas de Abono"
     },
     "VATAmt": {
       "label": "Cuota del impuesto",
@@ -1145,16 +1145,16 @@
       "description": "Transaction type"
     },
     "EM_Obspti_Isreversecharge": {
-      "label": "Inversión sujeto pasivo",
-      "description": "Si está marcado, la clave de operación asociada será \"I\""
+      "label": "Inversi\u00f3n sujeto pasivo",
+      "description": "Si est\u00e1 marcado, la clave de operaci\u00f3n asociada ser\u00e1 \"I\""
     },
     "EM_Obspti_Isexport": {
-      "label": "Impuesto exportación",
-      "description": "Indica si se trata de un impuesto de exportación."
+      "label": "Impuesto exportaci\u00f3n",
+      "description": "Indica si se trata de un impuesto de exportaci\u00f3n."
     },
     "EM_Aeat347_Locationtype": {
-      "label": "Tipo de vía",
-      "description": "Tipo de vía"
+      "label": "Tipo de v\u00eda",
+      "description": "Tipo de v\u00eda"
     },
     "EM_Aeat347_Building": {
       "label": "Bloque",
@@ -1173,8 +1173,8 @@
       "description": "Subclave tributaria parte de una clave tributaria"
     },
     "Country_Tax_ID": {
-      "label": "NIF País Residencia",
-      "description": "Campo requerido en caso de que el tercero no tenga un NIF español (Clave NIF País Residencia = 2, 3, 4, 5 y 6)"
+      "label": "NIF Pa\u00eds Residencia",
+      "description": "Campo requerido en caso de que el tercero no tenga un NIF espa\u00f1ol (Clave NIF Pa\u00eds Residencia = 2, 3, 4, 5 y 6)"
     },
     "To_C_Period_ID": {
       "label": "Hasta Periodo",
@@ -1182,7 +1182,7 @@
     },
     "Isfinal": {
       "label": "Final",
-      "description": "El Libro de Facturas está marcado como final"
+      "description": "El Libro de Facturas est\u00e1 marcado como final"
     },
     "Docdate": {
       "label": "Fecha documento",
@@ -1190,7 +1190,7 @@
     },
     "FIN_Financial_Account_ID": {
       "label": "Cuenta",
-      "description": "Cuenta financiera utilizada para depósitos/retiros, como cuentas bancarias o caja chica"
+      "description": "Cuenta financiera utilizada para dep\u00f3sitos/retiros, como cuentas bancarias o caja chica"
     },
     "Amount": {
       "label": "Importe cobrado/pagado",
@@ -1230,43 +1230,43 @@
     },
     "EM_Obspti_Isintracommunity": {
       "label": "Impuesto Intracomunitario",
-      "description": "Indica que se trata de un impuesto para operaciones entre paises de la Unión Europea"
+      "description": "Indica que se trata de un impuesto para operaciones entre paises de la Uni\u00f3n Europea"
     },
     "EM_Aeat347_Streetnumbertype": {
-      "label": "Tipo de numeración",
-      "description": "Tipo de numeración"
+      "label": "Tipo de numeraci\u00f3n",
+      "description": "Tipo de numeraci\u00f3n"
     },
     "EM_Aeat347_Location": {
-      "label": "Localidad o población",
-      "description": "Localidad o población"
+      "label": "Localidad o poblaci\u00f3n",
+      "description": "Localidad o poblaci\u00f3n"
     },
     "EM_Aeat347_Zipcode": {
-      "label": "Código postal",
-      "description": "Código postal"
+      "label": "C\u00f3digo postal",
+      "description": "C\u00f3digo postal"
     },
     "EM_Aeat347_Streetnumber": {
-      "label": "Número",
-      "description": "Número"
+      "label": "N\u00famero",
+      "description": "N\u00famero"
     },
     "EM_Aeat347_Streetnumberqua": {
-      "label": "Calificación del número",
-      "description": "Calificación del número"
+      "label": "Calificaci\u00f3n del n\u00famero",
+      "description": "Calificaci\u00f3n del n\u00famero"
     },
     "EM_Aeat347_Streetname": {
-      "label": "Nombre de la vía",
-      "description": "Nombre de la vía"
+      "label": "Nombre de la v\u00eda",
+      "description": "Nombre de la v\u00eda"
     },
     "Period": {
       "label": "Periodicidad",
-      "description": "Periodicidad de presentación de la declaración de impuestos"
+      "description": "Periodicidad de presentaci\u00f3n de la declaraci\u00f3n de impuestos"
     },
     "Obtl_Tax_Report_ID": {
-      "label": "Declaración de impuestos",
-      "description": "Definición de la declaración de impuestos"
+      "label": "Declaraci\u00f3n de impuestos",
+      "description": "Definici\u00f3n de la declaraci\u00f3n de impuestos"
     },
     "OBTL_Tax_Report_ID": {
-      "label": "Declaración de impuestos",
-      "description": "Definición de la declaración de impuestos"
+      "label": "Declaraci\u00f3n de impuestos",
+      "description": "Definici\u00f3n de la declaraci\u00f3n de impuestos"
     },
     "Key": {
       "label": "Key",
@@ -1305,8 +1305,8 @@
       "description": "Modified in SII"
     },
     "Country_Code": {
-      "label": "Código País",
-      "description": "Código País (2 dígitos) - vea los códigos de país en la \"Orden EHA/3202/2008, 31 Octubre, Anexo IV (BOE 10/11/2008)"
+      "label": "C\u00f3digo Pa\u00eds",
+      "description": "C\u00f3digo Pa\u00eds (2 d\u00edgitos) - vea los c\u00f3digos de pa\u00eds en la \"Orden EHA/3202/2008, 31 Octubre, Anexo IV (BOE 10/11/2008)"
     },
     "EM_Obspti_Islease": {
       "label": "Lease tax",
@@ -1369,12 +1369,12 @@
       "description": "El impuesto se declara como de Recargo de equivalencia"
     },
     "Obtl_Tax_Report_Group_ID": {
-      "label": "Sección de declaración",
-      "description": "Secciones en las que se divide una declaración de impuestos"
+      "label": "Secci\u00f3n de declaraci\u00f3n",
+      "description": "Secciones en las que se divide una declaraci\u00f3n de impuestos"
     },
     "OBTL_Tax_Report_Group_ID": {
-      "label": "Sección de declaración",
-      "description": "Secciones en las que se divide una declaración de impuestos"
+      "label": "Secci\u00f3n de declaraci\u00f3n",
+      "description": "Secciones en las que se divide una declaraci\u00f3n de impuestos"
     },
     "Aeatsii_Cash_Receipt_Data_ID": {
       "label": "SII Cash Receipt Data",
@@ -1389,16 +1389,16 @@
       "description": "Un enlace web para el contacto."
     },
     "EM_Etgo_Email": {
-      "label": "Correo electrónico",
-      "description": "Dirección de correo electrónico del contacto."
+      "label": "Correo electr\u00f3nico",
+      "description": "Direcci\u00f3n de correo electr\u00f3nico del contacto."
     },
     "EM_Etgo_Phone": {
-      "label": "Teléfono",
-      "description": "Número de teléfono del contacto."
+      "label": "Tel\u00e9fono",
+      "description": "N\u00famero de tel\u00e9fono del contacto."
     },
     "EM_Etgo_Discount": {
       "label": "% Descuento",
-      "description": "Porcentaje de descuento aplicado sobre el precio tarifa de la línea de factura."
+      "description": "Porcentaje de descuento aplicado sobre el precio tarifa de la l\u00ednea de factura."
     },
     "Exercise": {
       "label": "Exercise",
@@ -1421,7 +1421,7 @@
       "description": "Last query exercise"
     },
     "EM_OBTIK_Tax_ID_Key": {
-      "label": "Clave NIF País Residencia",
+      "label": "Clave NIF Pa\u00eds Residencia",
       "description": ""
     },
     "Aeatsii_Facturas_ID": {
@@ -1454,19 +1454,19 @@
     },
     "Obirb_Invbook_ID": {
       "label": "Libro de Facturas",
-      "description": "Este ID identifica únicamente cada Libro de Facturas"
+      "description": "Este ID identifica \u00fanicamente cada Libro de Facturas"
     },
     "OBIRB_Invbook_ID": {
       "label": "Libro de Facturas",
-      "description": "Este ID identifica únicamente cada Libro de Facturas"
+      "description": "Este ID identifica \u00fanicamente cada Libro de Facturas"
     },
     "Obirb_Invbook_Setup_ID": {
       "label": "Libro de Facturas",
-      "description": "Este ID identifica una configuración de Libro de Facturas"
+      "description": "Este ID identifica una configuraci\u00f3n de Libro de Facturas"
     },
     "OBIRB_Invbook_Setup_ID": {
       "label": "Libro de Facturas",
-      "description": "Este ID identifica una configuración de Libro de Facturas"
+      "description": "Este ID identifica una configuraci\u00f3n de Libro de Facturas"
     },
     "complete_sent": {
       "label": "Complete sent",
@@ -1513,12 +1513,12 @@
       "description": "Modification in SII"
     },
     "Transaction_Type": {
-      "label": "Tipo de Transacción",
+      "label": "Tipo de Transacci\u00f3n",
       "description": ""
     },
     "Obirb_Invbookline_ID": {
       "label": "OBIRB_Invbookline_ID",
-      "description": "Este ID identifica una línea del Libro de Facturas"
+      "description": "Este ID identifica una l\u00ednea del Libro de Facturas"
     },
     "Modif": {
       "label": "Modification in SII",
@@ -1569,7 +1569,7 @@
       "description": "In SII system date"
     },
     "Conversion": {
-      "label": "Conversión",
+      "label": "Conversi\u00f3n",
       "description": ""
     },
     "C_Tax_Id_Ec": {
@@ -1614,15 +1614,15 @@
     },
     "OBTL_Tributarykey_ID": {
       "label": "Clave tributaria",
-      "description": "Clave tributaria única que se asocia a un tipo impositivo a través de los parametros de declaración, para que las transacciones asociadas a dicho tipo impositivo se incluyan en la correspondiente declaración de impuestos asociadas a dicha clave. "
+      "description": "Clave tributaria \u00fanica que se asocia a un tipo impositivo a trav\u00e9s de los parametros de declaraci\u00f3n, para que las transacciones asociadas a dicho tipo impositivo se incluyan en la correspondiente declaraci\u00f3n de impuestos asociadas a dicha clave. "
     },
     "Obtl_Tributarykey_ID": {
       "label": "Clave tributaria",
-      "description": "Clave tributaria única que se asocia a un tipo impositivo a través de los parametros de declaración, para que las transacciones asociadas a dicho tipo impositivo se incluyan en la correspondiente declaración de impuestos asociadas a dicha clave. "
+      "description": "Clave tributaria \u00fanica que se asocia a un tipo impositivo a trav\u00e9s de los parametros de declaraci\u00f3n, para que las transacciones asociadas a dicho tipo impositivo se incluyan en la correspondiente declaraci\u00f3n de impuestos asociadas a dicha clave. "
     },
     "DecTaxAmt": {
       "label": "Cuota deducible ",
-      "description": "Se usa únicamente para los Libros de Facturas Recibidas"
+      "description": "Se usa \u00fanicamente para los Libros de Facturas Recibidas"
     },
     "ECAmt": {
       "label": "Cuota recargo de equivalencia",
@@ -1653,8 +1653,8 @@
       "description": "Constant value"
     },
     "EM_Etsg_Date_Operation": {
-      "label": "Fecha operación",
-      "description": "Fecha en la que se ha realizado la operación"
+      "label": "Fecha operaci\u00f3n",
+      "description": "Fecha en la que se ha realizado la operaci\u00f3n"
     },
     "EM_Aeat347_Regioncode": {
       "label": "Region Code",
@@ -1665,12 +1665,12 @@
       "description": "Description of the Bank Statement line"
     },
     "EM_Intr_Statistical_Regime": {
-      "label": "Régimen estadístico",
+      "label": "R\u00e9gimen estad\u00edstico",
       "description": ""
     },
     "Received_Documentno": {
-      "label": "Número de Documento",
-      "description": "Número de Documento que se utilizará en el libro de facturas recibidas"
+      "label": "N\u00famero de Documento",
+      "description": "N\u00famero de Documento que se utilizar\u00e1 en el libro de facturas recibidas"
     },
     "Ecrate": {
       "label": "Recargo de equivalencia",
@@ -1682,35 +1682,35 @@
     },
     "bslUpdated": {
       "label": "lebActualizada",
-      "description": "<P>Indica la fecha en la que está petición fue actualizada por última vez.</P>"
+      "description": "<P>Indica la fecha en la que est\u00e1 petici\u00f3n fue actualizada por \u00faltima vez.</P>"
     },
     "Bpartnername": {
       "label": "Nombre del Tercero",
       "description": "Nombre del Tercero"
     },
     "transactionAmount": {
-      "label": "Importe Transacción",
+      "label": "Importe Transacci\u00f3n",
       "description": "Importe total."
     },
     "C_Country_ID": {
-      "label": "País de Origen",
-      "description": "Estado o país."
+      "label": "Pa\u00eds de Origen",
+      "description": "Estado o pa\u00eds."
     },
     "Priorityno": {
       "label": "Prioridad relativa",
-      "description": "Dónde primero se debería tomar en el almacén"
+      "description": "D\u00f3nde primero se deber\u00eda tomar en el almac\u00e9n"
     },
     "M_Attributeuse_ID": {
       "label": "Copia de atributo",
       "description": ""
     },
     "DocumentNo": {
-      "label": "Nº documento",
-      "description": "Identificador de documentos que puede generarse automáticamente."
+      "label": "N\u00ba documento",
+      "description": "Identificador de documentos que puede generarse autom\u00e1ticamente."
     },
     "EM_Aprm_Addpayment": {
-      "label": "Añadir pago",
-      "description": "Botón para añadir un cobro."
+      "label": "A\u00f1adir pago",
+      "description": "Bot\u00f3n para a\u00f1adir un cobro."
     },
     "OrigDueDate": {
       "label": "Fecha venicimiento original",
@@ -1718,19 +1718,19 @@
     },
     "Docaction": {
       "label": "Reactivate",
-      "description": "Forma de cambiar el estado de la transacción de un documento."
+      "description": "Forma de cambiar el estado de la transacci\u00f3n de un documento."
     },
     "Dateacct": {
       "label": "Manual Cash VAT Settlement Date",
-      "description": "Fecha de registro de esta transacción en el libro mayor."
+      "description": "Fecha de registro de esta transacci\u00f3n en el libro mayor."
     },
     "transactionBPName": {
       "label": "Tercero",
       "description": "Nombre del Tercero"
     },
     "fatDescription": {
-      "label": "Descripción de la Transacción",
-      "description": "Espacio para escribir información adicional relacionada."
+      "label": "Descripci\u00f3n de la Transacci\u00f3n",
+      "description": "Espacio para escribir informaci\u00f3n adicional relacionada."
     },
     "EM_Aprm_Isfundstrans_Enabled": {
       "label": "Habilitada para Transferencia de Fondos",
@@ -1738,18 +1738,18 @@
     },
     "Acctdescription": {
       "label": "Nombre",
-      "description": "Descripción del apunte contable"
+      "description": "Descripci\u00f3n del apunte contable"
     },
     "Amtacctdr": {
       "label": "Debit",
-      "description": "El importe cargado (debe) a una cuenta convertido a la moneda por defecto de la organización."
+      "description": "El importe cargado (debe) a una cuenta convertido a la moneda por defecto de la organizaci\u00f3n."
     },
     "Processed": {
-      "label": "Procesar Declaración",
-      "description": "Confirmación de que los documentos o peticiones asociadas están en proceso."
+      "label": "Procesar Declaraci\u00f3n",
+      "description": "Confirmaci\u00f3n de que los documentos o peticiones asociadas est\u00e1n en proceso."
     },
     "Orig_C_Country_ID": {
-      "label": "País de Origen",
+      "label": "Pa\u00eds de Origen",
       "description": ""
     },
     "Hasunit": {
@@ -1762,15 +1762,15 @@
     },
     "AD_Org_ID": {
       "label": "Organization",
-      "description": "Organización dentro del cliente"
+      "description": "Organizaci\u00f3n dentro del cliente"
     },
     "AD_Tab_ID": {
       "label": "Solapa",
-      "description": "Indicación de que una solapa aparece en una ventana."
+      "description": "Indicaci\u00f3n de que una solapa aparece en una ventana."
     },
     "Action": {
-      "label": "Acción",
-      "description": "Cuadro de lista desplegable que indica el próximo paso a seguir."
+      "label": "Acci\u00f3n",
+      "description": "Cuadro de lista desplegable que indica el pr\u00f3ximo paso a seguir."
     },
     "AD_Table_ID": {
       "label": "Log Table",
@@ -1778,11 +1778,11 @@
     },
     "Isgenerated": {
       "label": "Generar Fichero",
-      "description": "Esta línea está generada"
+      "description": "Esta l\u00ednea est\u00e1 generada"
     },
     "Intr_Javaclass_ID": {
       "label": "Formato de Fichero Intrastat",
-      "description": "Clase Java que implementa la lógica de negocio concreta para crear el fichero de Intrastat"
+      "description": "Clase Java que implementa la l\u00f3gica de negocio concreta para crear el fichero de Intrastat"
     },
     "Netmass_Kg": {
       "label": "Masa Neta (Kg)",
@@ -1798,7 +1798,7 @@
     },
     "AD_Column_ID": {
       "label": "Date Column to Check",
-      "description": "Vínculo a la columna base de datos de la tabla."
+      "description": "V\u00ednculo a la columna base de datos de la tabla."
     },
     "Servrevenue": {
       "label": "Ingresos del servicio",
@@ -1806,7 +1806,7 @@
     },
     "Isactive": {
       "label": "Incluida",
-      "description": "Cartel que indica si este registro está disponible para utilizar o está desactivado"
+      "description": "Cartel que indica si este registro est\u00e1 disponible para utilizar o est\u00e1 desactivado"
     },
     "cleared": {
       "label": "Conciliar",
@@ -1814,15 +1814,15 @@
     },
     "Isincluded": {
       "label": "Incluir",
-      "description": "Define si se incluye o si es sólo dependiente"
+      "description": "Define si se incluye o si es s\u00f3lo dependiente"
     },
     "Hqlwhereclause": {
       "label": "HQL Where Clause",
       "description": " By using this HQL filter, the user will never be able to see data that does not fit the criteria."
     },
     "Inuponclearinguse": {
-      "label": "Cuenta de reconciliación",
-      "description": "Cuenta utilizada tras la reconciliación"
+      "label": "Cuenta de reconciliaci\u00f3n",
+      "description": "Cuenta utilizada tras la reconciliaci\u00f3n"
     },
     "businessPartner": {
       "label": "Remitente",
@@ -1830,23 +1830,23 @@
     },
     "Supplier_Reference": {
       "label": "Referencia del Proveedor",
-      "description": "Número de referencia o de documento, según consta en la aplicación de un tercero"
+      "description": "N\u00famero de referencia o de documento, seg\u00fan consta en la aplicaci\u00f3n de un tercero"
     },
     "Iscreated": {
       "label": "Crear",
       "description": ""
     },
     "Seqno": {
-      "label": "Número de Registro",
-      "description": "Orden de los registros en un documento específico."
+      "label": "N\u00famero de Registro",
+      "description": "Orden de los registros en un documento espec\u00edfico."
     },
     "C_ValidCombination_ID": {
       "label": "Cuenta",
-      "description": "Código de identificación compuesto por un número individual de cuenta y dimensiones adicionales, como organización, producto y tercero."
+      "description": "C\u00f3digo de identificaci\u00f3n compuesto por un n\u00famero individual de cuenta y dimensiones adicionales, como organizaci\u00f3n, producto y tercero."
     },
     "AD_User_ID": {
       "label": "Usuario/Contacto",
-      "description": "Referente que puede aportar información sobre un tercero."
+      "description": "Referente que puede aportar informaci\u00f3n sobre un tercero."
     },
     "CheckDate": {
       "label": "Fecha",
@@ -1857,8 +1857,8 @@
       "description": ""
     },
     "CheckNumber": {
-      "label": "Nº de Cheque",
-      "description": "Número asociado al cheque al imprimir."
+      "label": "N\u00ba de Cheque",
+      "description": "N\u00famero asociado al cheque al imprimir."
     },
     "voidcheck": {
       "label": "Anular",
@@ -1866,7 +1866,7 @@
     },
     "IsUnitCost": {
       "label": "Coste Unitario",
-      "description": "Cuando está marcado, el importe se considera como una parte del coste unitario de la transacción o un coste añadido, como los gastos de transporte o los gastos de seguros."
+      "description": "Cuando est\u00e1 marcado, el importe se considera como una parte del coste unitario de la transacci\u00f3n o un coste a\u00f1adido, como los gastos de transporte o los gastos de seguros."
     },
     "M_Lc_Type_ID": {
       "label": "Tipo de Landed Cost",
@@ -1877,36 +1877,36 @@
       "description": "Define un tipo de importe Landed Cost que puede ser asignado a una entrega"
     },
     "M_Lc_Distribution_Alg_ID": {
-      "label": "Algoritmo de Distribución de Landed Cost",
-      "description": "Identifica el Algoritmo usado para distribuir los importes de Landed Cost entre las líneas del albarán."
+      "label": "Algoritmo de Distribuci\u00f3n de Landed Cost",
+      "description": "Identifica el Algoritmo usado para distribuir los importes de Landed Cost entre las l\u00edneas del albar\u00e1n."
     },
     "Inventory_Type": {
       "label": "Tipo de Inventario",
       "description": "Define el tipo de inventario."
     },
     "Version": {
-      "label": "Versión",
-      "description": "Versión de la tabla"
+      "label": "Versi\u00f3n",
+      "description": "Versi\u00f3n de la tabla"
     },
     "M_LC_Cost_ID": {
       "label": "Coste de Landed Cost",
-      "description": "Cada importe de Landed Cost que se incluirá en el documento de Landed Cost."
+      "description": "Cada importe de Landed Cost que se incluir\u00e1 en el documento de Landed Cost."
     },
     "M_Lc_Cost_ID": {
       "label": "Coste de Landed Cost",
-      "description": "Cada importe de Landed Cost que se incluirá en el documento de Landed Cost."
+      "description": "Cada importe de Landed Cost que se incluir\u00e1 en el documento de Landed Cost."
     },
     "M_Lc_Receipt_ID": {
       "label": "Entrega de Landed Cost",
-      "description": "Identifica cada Albarán asignado al documento de Landed Cost con su importe correspondiente."
+      "description": "Identifica cada Albar\u00e1n asignado al documento de Landed Cost con su importe correspondiente."
     },
     "M_Landedcost_ID": {
       "label": "Landed Cost",
       "description": "Documento que detalla los Landed Costs como gastos de transporte o aduanas en los Albaranes"
     },
     "M_Lc_Receiptline_Amt_ID": {
-      "label": "Importe Línea de Entrega de Landed Cost",
-      "description": "Identifica el importe correspondiente de cada coste de Landed Cost asignado a cada línea de Albarán"
+      "label": "Importe L\u00ednea de Entrega de Landed Cost",
+      "description": "Identifica el importe correspondiente de cada coste de Landed Cost asignado a cada l\u00ednea de Albar\u00e1n"
     },
     "AD_Legalentity_Org_ID": {
       "label": "Entidad Legal",
@@ -1914,7 +1914,7 @@
     },
     "AmtAcctCr": {
       "label": "Moneda del Esquema Contable para el Haber",
-      "description": "El importe abonado (haber) a una cuenta convertido a la moneda por defecto de la organización."
+      "description": "El importe abonado (haber) a una cuenta convertido a la moneda por defecto de la organizaci\u00f3n."
     },
     "Monday": {
       "label": "Lunes",
@@ -1949,11 +1949,11 @@
       "description": ""
     },
     "isMatchingAdjusted": {
-      "label": "Ajustar Asociación",
+      "label": "Ajustar Asociaci\u00f3n",
       "description": ""
     },
     "IsMatchingAdjusted": {
-      "label": "Ajustar Asociación",
+      "label": "Ajustar Asociaci\u00f3n",
       "description": ""
     },
     "costamt": {
@@ -1961,7 +1961,7 @@
       "description": ""
     },
     "iols": {
-      "label": "Líneas de Entrega",
+      "label": "L\u00edneas de Entrega",
       "description": ""
     },
     "amttomatch": {
@@ -1981,7 +1981,7 @@
       "description": ""
     },
     "ils": {
-      "label": "Otras líneas de factura que coinciden",
+      "label": "Otras l\u00edneas de factura que coinciden",
       "description": ""
     },
     "Match_Lccosts": {
@@ -1993,20 +1993,20 @@
       "description": ""
     },
     "Process_Matching": {
-      "label": "Procesar Asociación",
+      "label": "Procesar Asociaci\u00f3n",
       "description": ""
     },
     "Ismatchadjustment": {
-      "label": "Ajustar Asociación",
+      "label": "Ajustar Asociaci\u00f3n",
       "description": ""
     },
     "Copyservicemodifytaxconfig": {
-      "label": "Copiar Servicio Modificar Configuración Impuesto",
-      "description": "Proceso que copia la configuración del servicio actual a los servicios seleccionados"
+      "label": "Copiar Servicio Modificar Configuraci\u00f3n Impuesto",
+      "description": "Proceso que copia la configuraci\u00f3n del servicio actual a los servicios seleccionados"
     },
     "DaysToPasswordExpiration": {
-      "label": "Días para la Caducidad de Contraseña",
-      "description": "Define el número de días de validez de la contraseña desde el último cambio de contraseña"
+      "label": "D\u00edas para la Caducidad de Contrase\u00f1a",
+      "description": "Define el n\u00famero de d\u00edas de validez de la contrase\u00f1a desde el \u00faltimo cambio de contrase\u00f1a"
     },
     "Uponwithdrawaluse": {
       "label": "Cuenta del reintegro",
@@ -2018,14 +2018,14 @@
     },
     "WS_Rejected_Avg": {
       "label": "Media rechazada de WS",
-      "description": "Número medio de llamadas rechazadas a Web Service por día en los últimos 30 días"
+      "description": "N\u00famero medio de llamadas rechazadas a Web Service por d\u00eda en los \u00faltimos 30 d\u00edas"
     },
     "Explode": {
       "label": "Explotar",
       "description": ""
     },
     "FIN_Doubtful_Debt_Method_ID": {
-      "label": "Método de dudoso cobro",
+      "label": "M\u00e9todo de dudoso cobro",
       "description": ""
     },
     "C_Replacement_ID": {
@@ -2037,20 +2037,20 @@
       "description": "Enlace al Pedido de Reemplazo. Este pedido es el que reemplaza al pedido actual cancelado."
     },
     "Ismaintree": {
-      "label": "Es árbol principal",
-      "description": "Especifica si el árbol es el árbol principal de esta tabla"
+      "label": "Es \u00e1rbol principal",
+      "description": "Especifica si el \u00e1rbol es el \u00e1rbol principal de esta tabla"
     },
     "Your_Company_Big_Image": {
-      "label": "Imagen grande por defecto para su compañía",
+      "label": "Imagen grande por defecto para su compa\u00f1\u00eda",
       "description": ""
     },
     "AD_Acctprocess_ID": {
       "label": "Accounting Post_Process",
-      "description": "Proceso contable que se ejecutará al contabilizar"
+      "description": "Proceso contable que se ejecutar\u00e1 al contabilizar"
     },
     "Writeoff_Rev_Acct": {
-      "label": "Cancelación de ingresos",
-      "description": "Cuenta para cancelación de ingresos"
+      "label": "Cancelaci\u00f3n de ingresos",
+      "description": "Cuenta para cancelaci\u00f3n de ingresos"
     },
     "Endingtimethursday": {
       "label": "Hora fin Jueves",
@@ -2061,15 +2061,15 @@
       "description": "Dividido"
     },
     "Isrtv": {
-      "label": "Devolución a proveedor",
+      "label": "Devoluci\u00f3n a proveedor",
       "description": ""
     },
     "AmtSourceDr": {
-      "label": "Débito",
+      "label": "D\u00e9bito",
       "description": "La cantidad cargada desde la cuenta, en la moneda del proveedor."
     },
     "lastreconciliation": {
-      "label": "Última reconciliación",
+      "label": "\u00daltima reconciliaci\u00f3n",
       "description": ""
     },
     "FIN_Asset_Acct": {
@@ -2078,7 +2078,7 @@
     },
     "Iscompletelyinvoiced": {
       "label": "Totalmente Facturado",
-      "description": "Indica si el documento ha sido totalmente facturado o no. Sólo se usa para flujos de venta y se muestra en la cabecera de Albarán (Cliente)."
+      "description": "Indica si el documento ha sido totalmente facturado o no. S\u00f3lo se usa para flujos de venta y se muestra en la cabecera de Albar\u00e1n (Cliente)."
     },
     "FIN_Payment_ID": {
       "label": "Cobro",
@@ -2097,8 +2097,8 @@
       "description": "Mostrar en Barra de Estado"
     },
     "DefaultTreeViewLogic": {
-      "label": "Lógica para mostrar la vista de árbol",
-      "description": "Define una lógica que se utilizará para saber si la vista por defecto al abrir la ventana es la de árbol o la grid standard"
+      "label": "L\u00f3gica para mostrar la vista de \u00e1rbol",
+      "description": "Define una l\u00f3gica que se utilizar\u00e1 para saber si la vista por defecto al abrir la ventana es la de \u00e1rbol o la grid standard"
     },
     "IsAssetPositive": {
       "label": "Balance de activo al debe en positivo ",
@@ -2118,19 +2118,19 @@
     },
     "Iscostapplied": {
       "label": "Costo aplicado",
-      "description": "Especifica si una categoría salarial está pensada para ser aplicada al cálculo de costos"
+      "description": "Especifica si una categor\u00eda salarial est\u00e1 pensada para ser aplicada al c\u00e1lculo de costos"
     },
     "Abc": {
       "label": "ABC",
-      "description": "Clasificación ABC según la distribución de Pareto"
+      "description": "Clasificaci\u00f3n ABC seg\u00fan la distribuci\u00f3n de Pareto"
     },
     "C_Poc_Doctype_Template_ID": {
       "label": "Tipo de documento",
       "description": "El tipo de documento"
     },
     "Templatelocation": {
-      "label": "Ubicación de la Plantilla",
-      "description": "La ubicación de la plantilla"
+      "label": "Ubicaci\u00f3n de la Plantilla",
+      "description": "La ubicaci\u00f3n de la plantilla"
     },
     "C_Poc_Configuration_ID": {
       "label": "C_Poc_Configuration_ID",
@@ -2161,7 +2161,7 @@
       "description": ""
     },
     "Smtpserverpassword": {
-      "label": "Contraseña del servidor SMTP",
+      "label": "Contrase\u00f1a del servidor SMTP",
       "description": "Password used to authenticate against the SMTP server."
     },
     "C_Poc_Emaildefinition_ID": {
@@ -2185,24 +2185,24 @@
       "description": "Es porcentaje del importe base"
     },
     "Isofiscalcode": {
-      "label": "Código fiscal ISO",
-      "description": "Código fiscal ISO"
+      "label": "C\u00f3digo fiscal ISO",
+      "description": "C\u00f3digo fiscal ISO"
     },
     "Fiscalcode": {
-      "label": "Código fiscal",
-      "description": "Código fiscal"
+      "label": "C\u00f3digo fiscal",
+      "description": "C\u00f3digo fiscal"
     },
     "Withholdingamount": {
-      "label": "Importe de retención",
-      "description": "Importe de retención"
+      "label": "Importe de retenci\u00f3n",
+      "description": "Importe de retenci\u00f3n"
     },
     "Excludeforwithholding": {
-      "label": "Excluir de retención",
-      "description": "Excluir de retención"
+      "label": "Excluir de retenci\u00f3n",
+      "description": "Excluir de retenci\u00f3n"
     },
     "IsWithholdingTax": {
-      "label": "Impuesto de retención",
-      "description": "Es impuesto de retención"
+      "label": "Impuesto de retenci\u00f3n",
+      "description": "Es impuesto de retenci\u00f3n"
     },
     "TaxUndAmt": {
       "label": "Importe no deducible",
@@ -2217,16 +2217,16 @@
       "description": "Generar pago"
     },
     "C_Taxregisterline_ID": {
-      "label": "Línea de registro de impuesto",
-      "description": "Línea de registro de impuesto"
+      "label": "L\u00ednea de registro de impuesto",
+      "description": "L\u00ednea de registro de impuesto"
     },
     "C_Taxregister_Type_Lines_ID": {
       "label": "C_Taxregister_Type_Lines_ID",
       "description": ""
     },
     "Lastregaccumamt": {
-      "label": "Último registro importe",
-      "description": "Último registro del importe acumulado"
+      "label": "\u00daltimo registro importe",
+      "description": "\u00daltimo registro del importe acumulado"
     },
     "Registername": {
       "label": "Nombre registro",
@@ -2241,7 +2241,7 @@
       "description": "Importe exento"
     },
     "IsNoTaxable": {
-      "label": "No está sujeto a impuestos",
+      "label": "No est\u00e1 sujeto a impuestos",
       "description": "No sujeto a impuestos"
     },
     "C_Taxpayment_ID": {
@@ -2249,8 +2249,8 @@
       "description": "Pago impuesto"
     },
     "Pageno": {
-      "label": "Núm. página",
-      "description": "Número de página"
+      "label": "N\u00fam. p\u00e1gina",
+      "description": "N\u00famero de p\u00e1gina"
     },
     "Deducpercent": {
       "label": "Porcentaje deducible",
@@ -2301,7 +2301,7 @@
       "description": "Impuesto sobre factura"
     },
     "Reqstatus": {
-      "label": "Estado de la línea de necesidad",
+      "label": "Estado de la l\u00ednea de necesidad",
       "description": ""
     },
     "M_Requisitionorder_ID": {
@@ -2354,7 +2354,7 @@
     },
     "Isexternalservice": {
       "label": "Servicio externo",
-      "description": "Establece el proceso como un servicio externo que se carga desde el menú de la aplicación."
+      "description": "Establece el proceso como un servicio externo que se carga desde el men\u00fa de la aplicaci\u00f3n."
     },
     "Service_Type": {
       "label": "Tipo de servicio",
@@ -2362,14 +2362,14 @@
     },
     "Service_Source": {
       "label": "Origen del servicio",
-      "description": "Indica donde está ubicado el servicio externo. Puede ser una URL o una ruta."
+      "description": "Indica donde est\u00e1 ubicado el servicio externo. Puede ser una URL o una ruta."
     },
     "C_Activity_ID": {
       "label": "Actividad",
       "description": "Actividad del negocio"
     },
     "C_Bp_Salcategory_ID": {
-      "label": "Histórico categoría salarial",
+      "label": "Hist\u00f3rico categor\u00eda salarial",
       "description": ""
     },
     "C_Order_Discount_ID": {
@@ -2378,39 +2378,39 @@
     },
     "System_Identifier": {
       "label": "Identificador del sistema",
-      "description": "Identificador único de esta instancia de Openbravo ERP"
+      "description": "Identificador \u00fanico de esta instancia de Openbravo ERP"
     },
     "Java_Version": {
-      "label": "Versión de Java",
-      "description": "Versión de Java"
+      "label": "Versi\u00f3n de Java",
+      "description": "Versi\u00f3n de Java"
     },
     "Isproxyrequired": {
       "label": "Proxy requerido",
-      "description": "Configuración del Proxy requerida para acceder a Internet."
+      "description": "Configuraci\u00f3n del Proxy requerida para acceder a Internet."
     },
     "OS_Version": {
-      "label": "Versión del sistema operativo",
-      "description": "La versión del sistema operativo"
+      "label": "Versi\u00f3n del sistema operativo",
+      "description": "La versi\u00f3n del sistema operativo"
     },
     "Proxy_Port": {
       "label": "Puerto Proxy",
       "description": "Puerto del servidor Proxy"
     },
     "OB_Installmode": {
-      "label": "Modo de instalación de Openbravo",
-      "description": "El método utilizado para instalar Openbravo ERP"
+      "label": "Modo de instalaci\u00f3n de Openbravo",
+      "description": "El m\u00e9todo utilizado para instalar Openbravo ERP"
     },
     "Isheartbeatactive": {
       "label": "Activar Heartbeat",
       "description": "Activar/Desactivar proceso Heartbeat"
     },
     "Servlet_Container_Version": {
-      "label": "Versión del contenedor de Servlets",
-      "description": "La versión del contenedor de Servlets."
+      "label": "Versi\u00f3n del contenedor de Servlets",
+      "description": "La versi\u00f3n del contenedor de Servlets."
     },
     "ANT_Version": {
-      "label": "Versión de Ant",
-      "description": "La versión de Ant empleada para construir Openbravo ERP"
+      "label": "Versi\u00f3n de Ant",
+      "description": "La versi\u00f3n de Ant empleada para construir Openbravo ERP"
     },
     "Db": {
       "label": "Base de datos",
@@ -2418,15 +2418,15 @@
     },
     "Postpone_Date": {
       "label": "Fecha pospuesta",
-      "description": "Fecha establecida cuando el usuario selecciona 'Más tarde'"
+      "description": "Fecha establecida cuando el usuario selecciona 'M\u00e1s tarde'"
     },
     "Servlet_Container": {
       "label": "Contenedor de Servlets",
       "description": "El tipo de contenedor de Servlets en el que se ejecuta Openbravo."
     },
     "OB_Version": {
-      "label": "Versión de Openbravo",
-      "description": "La versión de Openbravo"
+      "label": "Versi\u00f3n de Openbravo",
+      "description": "La versi\u00f3n de Openbravo"
     },
     "Os": {
       "label": "Sistema operativo",
@@ -2437,8 +2437,8 @@
       "description": ""
     },
     "DB_Version": {
-      "label": "Versión de la base de datos",
-      "description": "La versión de la base de datos"
+      "label": "Versi\u00f3n de la base de datos",
+      "description": "La versi\u00f3n de la base de datos"
     },
     "Proxy_Server": {
       "label": "Servidor Proxy",
@@ -2453,32 +2453,32 @@
       "description": "El servidor Web que sirve Openbravo ERP"
     },
     "Webserver_Version": {
-      "label": "Versión del servidor Web",
-      "description": "La versión del servidor Web"
+      "label": "Versi\u00f3n del servidor Web",
+      "description": "La versi\u00f3n del servidor Web"
     },
     "NUM_Registered_Users": {
-      "label": "Número de usuarios registrados",
-      "description": "Número de usuarios registrados"
+      "label": "N\u00famero de usuarios registrados",
+      "description": "N\u00famero de usuarios registrados"
     },
     "ExportActual": {
       "label": "Exportar datos reales",
-      "description": "¿Exportar También Datos Reales?"
+      "description": "\u00bfExportar Tambi\u00e9n Datos Reales?"
     },
     "Iban": {
       "label": "IBAN",
-      "description": "Estándar internacional para identificar cuentas bancarias entre fronteras nacionales"
+      "description": "Est\u00e1ndar internacional para identificar cuentas bancarias entre fronteras nacionales"
     },
     "FreightCostRule": {
-      "label": "Regla de costo logístico",
-      "description": "Método para calcular el costo de envío."
+      "label": "Regla de costo log\u00edstico",
+      "description": "M\u00e9todo para calcular el costo de env\u00edo."
     },
     "IBANCountry": {
-      "label": "Código IBAN",
-      "description": "Código de país asignado a un país en la estructura IBAN."
+      "label": "C\u00f3digo IBAN",
+      "description": "C\u00f3digo de pa\u00eds asignado a un pa\u00eds en la estructura IBAN."
     },
     "IBANNoDigits": {
       "label": "Longitud IBAN",
-      "description": "La longitud del código IBAN de una cuenta bancaria es variable, dependiendo del país."
+      "description": "La longitud del c\u00f3digo IBAN de una cuenta bancaria es variable, dependiendo del pa\u00eds."
     },
     "DisplayedAccount": {
       "label": "Cuenta mostrada",
@@ -2493,36 +2493,36 @@
       "description": "Texto que va a identificar a esta cuenta bancaria"
     },
     "GenericAccount": {
-      "label": "Cuenta genérica",
-      "description": "Número de la cuenta bancaria, en un formato genérico. Útil si el banco no usa ni IBAN ni nuestra estructura numérica de cuenta bancaria de país"
+      "label": "Cuenta gen\u00e9rica",
+      "description": "N\u00famero de la cuenta bancaria, en un formato gen\u00e9rico. \u00datil si el banco no usa ni IBAN ni nuestra estructura num\u00e9rica de cuenta bancaria de pa\u00eds"
     },
     "AccountNo": {
-      "label": "Cuenta genérica",
-      "description": "Número de la cuenta bancaria, en un formato genérico. Útil si el banco no usa ni IBAN ni nuestra estructura numérica de cuenta bancaria de país"
+      "label": "Cuenta gen\u00e9rica",
+      "description": "N\u00famero de la cuenta bancaria, en un formato gen\u00e9rico. \u00datil si el banco no usa ni IBAN ni nuestra estructura num\u00e9rica de cuenta bancaria de pa\u00eds"
     },
     "GenericAccountNo": {
-      "label": "Cuenta genérica",
-      "description": "Número de la cuenta bancaria, en un formato genérico. Útil si el banco no usa ni IBAN ni nuestra estructura numérica de cuenta bancaria de país"
+      "label": "Cuenta gen\u00e9rica",
+      "description": "N\u00famero de la cuenta bancaria, en un formato gen\u00e9rico. \u00datil si el banco no usa ni IBAN ni nuestra estructura num\u00e9rica de cuenta bancaria de pa\u00eds"
     },
     "ShowGeneric": {
-      "label": "Mostrar genérica",
-      "description": "Mostrar genérica"
+      "label": "Mostrar gen\u00e9rica",
+      "description": "Mostrar gen\u00e9rica"
     },
     "ShowIBAN": {
       "label": "Mostrar IBAN",
       "description": "Mostrar IBAN"
     },
     "ShowSpanish": {
-      "label": "Mostrar Español",
-      "description": "Mostrar Español"
+      "label": "Mostrar Espa\u00f1ol",
+      "description": "Mostrar Espa\u00f1ol"
     },
     "Createtemppricelist": {
       "label": "Crear tarifa provisional",
       "description": "Crear tarifa provisional"
     },
     "Stdduration": {
-      "label": "Duración estándar en días",
-      "description": "Duración Estándar en Días de una Fase Estándar o de una Tarea Estándar"
+      "label": "Duraci\u00f3n est\u00e1ndar en d\u00edas",
+      "description": "Duraci\u00f3n Est\u00e1ndar en D\u00edas de una Fase Est\u00e1ndar o de una Tarea Est\u00e1ndar"
     },
     "Isfirstfocusedfield": {
       "label": "Campo con Primer Foco",
@@ -2530,11 +2530,11 @@
     },
     "Allownegative": {
       "label": "Permitir negativos",
-      "description": "Permitir entradas negativas en crédito y débito"
+      "description": "Permitir entradas negativas en cr\u00e9dito y d\u00e9bito"
     },
     "AllowNegative": {
       "label": "Permitir negativos",
-      "description": "Permitir entradas negativas en crédito y débito"
+      "description": "Permitir entradas negativas en cr\u00e9dito y d\u00e9bito"
     },
     "C_Acctschema_Table_Doctype_ID": {
       "label": "C_AcctSchema_Table_DocType_ID",
@@ -2546,19 +2546,19 @@
     },
     "C_Prepayment_Acct": {
       "label": "Prepago del cliente",
-      "description": "<P>Prepago&nbsp;del cliente indica la cuenta contable donde se registrarán los prepagos&nbsp;recibidos de cada&nbsp;cliente.</P>"
+      "description": "<P>Prepago&nbsp;del cliente indica la cuenta contable donde se registrar\u00e1n los prepagos&nbsp;recibidos de cada&nbsp;cliente.</P>"
     },
     "C_Receivable_Acct": {
       "label": "Recibos de clientes",
-      "description": "Número de cuenta del Libro Mayor para anotar las transacciones con un tercero. "
+      "description": "N\u00famero de cuenta del Libro Mayor para anotar las transacciones con un tercero. "
     },
     "Applyinorder": {
       "label": "Aplicar en pedido",
-      "description": "Aplica el descuento también en el Pedido"
+      "description": "Aplica el descuento tambi\u00e9n en el Pedido"
     },
     "CreditCardType": {
-      "label": "Tarjeta de crédito",
-      "description": "Tarjeta de crédito (Visa, MC, AmEx)"
+      "label": "Tarjeta de cr\u00e9dito",
+      "description": "Tarjeta de cr\u00e9dito (Visa, MC, AmEx)"
     },
     "DocSubTypeSO": {
       "label": "Subtipo de pedido de venta",
@@ -2566,147 +2566,147 @@
     },
     "AD_Client_ID": {
       "label": "Entidad",
-      "description": "Entidad para esta instalación"
+      "description": "Entidad para esta instalaci\u00f3n"
     },
     "Amt": {
       "label": "Importe",
-      "description": "Suma de dos o más importes."
+      "description": "Suma de dos o m\u00e1s importes."
     },
     "client": {
       "label": "Entidad",
-      "description": "Entidad para esta instalación"
+      "description": "Entidad para esta instalaci\u00f3n"
     },
     "M_Movement_ID": {
       "label": "Movimiento",
-      "description": "Movimiento de almacén"
+      "description": "Movimiento de almac\u00e9n"
     },
     "M_InOut_ID": {
-      "label": "Albarán",
-      "description": "Número de documento que identifica el envío o la recepción de bienes."
+      "label": "Albar\u00e1n",
+      "description": "N\u00famero de documento que identifica el env\u00edo o la recepci\u00f3n de bienes."
     },
     "M_LocatorTo_ID": {
       "label": "Movido a ",
-      "description": "Ubicación movido a"
+      "description": "Ubicaci\u00f3n movido a"
     },
     "AD_Tab_Trl_ID": {
-      "label": "Pestaña traducida",
+      "label": "Pesta\u00f1a traducida",
       "description": ""
     },
     "IsReport": {
       "label": "Informe",
-      "description": "Indicación de si algo es un documento o un informe que resume información."
+      "description": "Indicaci\u00f3n de si algo es un documento o un informe que resume informaci\u00f3n."
     },
     "M_Inout_ID": {
-      "label": "Albarán (Cliente)",
-      "description": "Número de documento que identifica el envío o la recepción de bienes."
+      "label": "Albar\u00e1n (Cliente)",
+      "description": "N\u00famero de documento que identifica el env\u00edo o la recepci\u00f3n de bienes."
     },
     "M_InOutLine_ID": {
-      "label": "Línea de albarán",
-      "description": "Enunciado que corresponde a un ítem, gasto o movimiento en un albarán."
+      "label": "L\u00ednea de albar\u00e1n",
+      "description": "Enunciado que corresponde a un \u00edtem, gasto o movimiento en un albar\u00e1n."
     },
     "shipmentInOutLine": {
-      "label": "Línea de albarán",
-      "description": "Enunciado que corresponde a un ítem, gasto o movimiento en un albarán."
+      "label": "L\u00ednea de albar\u00e1n",
+      "description": "Enunciado que corresponde a un \u00edtem, gasto o movimiento en un albar\u00e1n."
     },
     "M_Inoutline_ID": {
-      "label": "Línea de albarán",
-      "description": "Enunciado que corresponde a un ítem, gasto o movimiento en un albarán."
+      "label": "L\u00ednea de albar\u00e1n",
+      "description": "Enunciado que corresponde a un \u00edtem, gasto o movimiento en un albar\u00e1n."
     },
     "goodsShipmentLine": {
-      "label": "Línea de albarán",
-      "description": "Enunciado que corresponde a un ítem, gasto o movimiento en un albarán."
+      "label": "L\u00ednea de albar\u00e1n",
+      "description": "Enunciado que corresponde a un \u00edtem, gasto o movimiento en un albar\u00e1n."
     },
     "M_Inventory_ID": {
       "label": "Conteo de Inventario",
-      "description": "Parámetros para el inventario"
+      "description": "Par\u00e1metros para el inventario"
     },
     "M_InventoryLine_ID": {
-      "label": "Línea de almacén",
-      "description": "Enunciado en el que aparece un ítem de la lista del inventario físico."
+      "label": "L\u00ednea de almac\u00e9n",
+      "description": "Enunciado en el que aparece un \u00edtem de la lista del inventario f\u00edsico."
     },
     "M_Locatorto_ID": {
       "label": "Movido a ",
-      "description": "Ubicación movido a"
+      "description": "Ubicaci\u00f3n movido a"
     },
     "M_MovementLine_ID": {
-      "label": "Línea de movimiento",
-      "description": "Identificador de una línea de movimiento que puede generarse automáticamente."
+      "label": "L\u00ednea de movimiento",
+      "description": "Identificador de una l\u00ednea de movimiento que puede generarse autom\u00e1ticamente."
     },
     "M_Production_ID": {
-      "label": "Producción",
-      "description": "Indicación de que un ítem se utiliza en producción."
+      "label": "Producci\u00f3n",
+      "description": "Indicaci\u00f3n de que un \u00edtem se utiliza en producci\u00f3n."
     },
     "M_ProductionLine_ID": {
-      "label": "Línea de producción",
-      "description": "Enunciado de la aplicación en el que se muestra un ítem o una acción."
+      "label": "L\u00ednea de producci\u00f3n",
+      "description": "Enunciado de la aplicaci\u00f3n en el que se muestra un \u00edtem o una acci\u00f3n."
     },
     "M_Transaction_ID": {
-      "label": "Operaciones de almacén",
+      "label": "Operaciones de almac\u00e9n",
       "description": ""
     },
     "transaction": {
-      "label": "Operaciones de almacén",
+      "label": "Operaciones de almac\u00e9n",
       "description": ""
     },
     "movementDate": {
       "label": "Fecha del movimiento",
-      "description": "Fecha en que un ítem determinado se mueve de una ubicación a otra."
+      "description": "Fecha en que un \u00edtem determinado se mueve de una ubicaci\u00f3n a otra."
     },
     "MovementDate": {
       "label": "Fecha del movimiento",
-      "description": "Fecha en que un ítem determinado se mueve de una ubicación a otra."
+      "description": "Fecha en que un \u00edtem determinado se mueve de una ubicaci\u00f3n a otra."
     },
     "MovementQty": {
       "label": "Cant. movida",
-      "description": "Cantidad de ítems que se mueven de una ubicación a otra."
+      "description": "Cantidad de \u00edtems que se mueven de una ubicaci\u00f3n a otra."
     },
     "movementQuantity": {
       "label": "Cant. movida",
-      "description": "Cantidad de ítems que se mueven de una ubicación a otra."
+      "description": "Cantidad de \u00edtems que se mueven de una ubicaci\u00f3n a otra."
     },
     "Movementqty": {
       "label": "Cant. movida",
-      "description": "Cantidad de ítems que se mueven de una ubicación a otra."
+      "description": "Cantidad de \u00edtems que se mueven de una ubicaci\u00f3n a otra."
     },
     "MovementType": {
       "label": "Tipo de movimiento",
-      "description": "Tipo de ítem que se mueve de una ubicación a otra."
+      "description": "Tipo de \u00edtem que se mueve de una ubicaci\u00f3n a otra."
     },
     "movementType": {
       "label": "Tipo de movimiento",
-      "description": "Tipo de ítem que se mueve de una ubicación a otra."
+      "description": "Tipo de \u00edtem que se mueve de una ubicaci\u00f3n a otra."
     },
     "IsAdvancedFeature": {
-      "label": "Características avanzadas",
-      "description": "Es característica avanzada"
+      "label": "Caracter\u00edsticas avanzadas",
+      "description": "Es caracter\u00edstica avanzada"
     },
     "P_Asset_Acct": {
       "label": "Inmovilizado del producto",
-      "description": "Activo tangible que se utiliza en los negocios, del que no hay expectativa de venta en el año fiscal entrante."
+      "description": "Activo tangible que se utiliza en los negocios, del que no hay expectativa de venta en el a\u00f1o fiscal entrante."
     },
     "P_Cogs_Acct": {
       "label": "Costo del producto",
-      "description": "Costo de los bienes vendidos para un producto específico."
+      "description": "Costo de los bienes vendidos para un producto espec\u00edfico."
     },
     "P_Expense_Acct": {
       "label": "Gastos del producto",
-      "description": "Número de cuenta en el Libro Mayor donde se anotan las transacciones de este ítem."
+      "description": "N\u00famero de cuenta en el Libro Mayor donde se anotan las transacciones de este \u00edtem."
     },
     "P_Revenue_Acct": {
       "label": "Ingresos por el producto",
-      "description": "Número de cuenta en el Libro Mayor donde se anotan las transacciones de este producto."
+      "description": "N\u00famero de cuenta en el Libro Mayor donde se anotan las transacciones de este producto."
     },
     "processed_logic": {
       "label": "Procesado",
-      "description": "Confirmación de que los documentos o peticiones asociadas están en proceso."
+      "description": "Confirmaci\u00f3n de que los documentos o peticiones asociadas est\u00e1n en proceso."
     },
     "Process_Asset": {
-      "label": "Generar plan de amortización",
-      "description": "Confirmación de que los documentos o peticiones asociadas están en proceso."
+      "label": "Generar plan de amortizaci\u00f3n",
+      "description": "Confirmaci\u00f3n de que los documentos o peticiones asociadas est\u00e1n en proceso."
     },
     "QtyBook": {
       "label": "Conteo del sistema",
-      "description": "Cantidad teórica"
+      "description": "Cantidad te\u00f3rica"
     },
     "QtyCount": {
       "label": "Conteo del usuario",
@@ -2718,27 +2718,27 @@
     },
     "V_Liability_Acct": {
       "label": "Pasivo del proveedor",
-      "description": "Número de cuenta del Libro Mayor utilizado para anotar las transacciones con este tercero."
+      "description": "N\u00famero de cuenta del Libro Mayor utilizado para anotar las transacciones con este tercero."
     },
     "V_Prepayment_Acct": {
       "label": "Pagos por adelantado del proveedor",
-      "description": "Número de cuenta del Libro Mayor utilizado para anotar las transacciones con este tercero."
+      "description": "N\u00famero de cuenta del Libro Mayor utilizado para anotar las transacciones con este tercero."
     },
     "ValueMax": {
-      "label": "Valor máximo",
-      "description": "Valor máximo que puede tener un ítem."
+      "label": "Valor m\u00e1ximo",
+      "description": "Valor m\u00e1ximo que puede tener un \u00edtem."
     },
     "AD_Element_ID": {
       "label": "Elemento del sistema",
-      "description": "Elemento que consolida la ayuda, las descripciones y los términos de una columna de la base de datos y que permite el mantenimiento central."
+      "description": "Elemento que consolida la ayuda, las descripciones y los t\u00e9rminos de una columna de la base de datos y que permite el mantenimiento central."
     },
     "ValueMin": {
-      "label": "Valor mínimo",
-      "description": "Valor mínimo que puede tener un objeto."
+      "label": "Valor m\u00ednimo",
+      "description": "Valor m\u00ednimo que puede tener un objeto."
     },
     "W_Differences_Acct": {
-      "label": "Diferencias de almacén",
-      "description": "Total diferencias almacén"
+      "label": "Diferencias de almac\u00e9n",
+      "description": "Total diferencias almac\u00e9n"
     },
     "SalesRep_ID": {
       "label": "Agente comercial",
@@ -2750,7 +2750,7 @@
     },
     "AD_Field_ID": {
       "label": "Campo",
-      "description": "Elemento que puede mostrarse, editarse o añadirse en una ventana."
+      "description": "Elemento que puede mostrarse, editarse o a\u00f1adirse en una ventana."
     },
     "C_BPartnerCashTrx_ID": {
       "label": "Plantilla para terceros",
@@ -2761,51 +2761,51 @@
       "description": "Documento tipo utilizado para facturas generadas a partir de este pedido de venta"
     },
     "C_DocTypeShipment_ID": {
-      "label": "Tipo doc.albarán",
+      "label": "Tipo doc.albar\u00e1n",
       "description": "Documento tipo utilizado para albaranes generados a partir de este pedido de venta"
     },
     "C_InvoiceLine_ID": {
-      "label": "Línea de la factura",
-      "description": "Declaración que muestra un ítem o gasto en una factura."
+      "label": "L\u00ednea de la factura",
+      "description": "Declaraci\u00f3n que muestra un \u00edtem o gasto en una factura."
     },
     "C_Invoiceline_ID": {
-      "label": "Línea de la factura",
-      "description": "Declaración que muestra un ítem o gasto en una factura."
+      "label": "L\u00ednea de la factura",
+      "description": "Declaraci\u00f3n que muestra un \u00edtem o gasto en una factura."
     },
     "AD_Key": {
       "label": "Columna clave",
-      "description": "Identificador único de registro"
+      "description": "Identificador \u00fanico de registro"
     },
     "CommittedAmt": {
-      "label": "Cuantía del acuerdo",
-      "description": "Suma máxima facturable de un proyecto."
+      "label": "Cuant\u00eda del acuerdo",
+      "description": "Suma m\u00e1xima facturable de un proyecto."
     },
     "CreditCardExpMM": {
-      "label": "Válido hasta (Mes)",
-      "description": "Válido hasta (Mes)"
+      "label": "V\u00e1lido hasta (Mes)",
+      "description": "V\u00e1lido hasta (Mes)"
     },
     "CreditCardExpYY": {
-      "label": "Válido hasta (año)",
-      "description": "Válido hasta (año)"
+      "label": "V\u00e1lido hasta (a\u00f1o)",
+      "description": "V\u00e1lido hasta (a\u00f1o)"
     },
     "CurrentNextSys": {
       "label": "Valor actual (sistema)",
       "description": "Siguiente secuencia empleada por el sistema"
     },
     "DateLastInventory": {
-      "label": "F.último inventario",
-      "description": "Fecha del último inventario"
+      "label": "F.\u00faltimo inventario",
+      "description": "Fecha del \u00faltimo inventario"
     },
     "DateLastRun": {
-      "label": "Fecha del último proceso",
-      "description": "Momento concreto en que se ejecutó el proceso o la tarea anterior."
+      "label": "Fecha del \u00faltimo proceso",
+      "description": "Momento concreto en que se ejecut\u00f3 el proceso o la tarea anterior."
     },
     "AD_Language": {
       "label": "Idioma",
-      "description": "Método de comunicación en uso."
+      "description": "M\u00e9todo de comunicaci\u00f3n en uso."
     },
     "DatePrinted": {
-      "label": "F.impresión",
+      "label": "F.impresi\u00f3n",
       "description": "Fecha en que fue imprimido el documento"
     },
     "EvenInvoiceWeek": {
@@ -2817,20 +2817,20 @@
       "description": "Valor que aparece cada vez que se crea un registro."
     },
     "InvoiceDayCutoff": {
-      "label": "Día límite de facturación",
-      "description": "Último día para enviar albaranes"
+      "label": "D\u00eda l\u00edmite de facturaci\u00f3n",
+      "description": "\u00daltimo d\u00eda para enviar albaranes"
     },
     "InvoiceWeekDayCutoff": {
-      "label": "Día límite de facturación semanal",
-      "description": "Último día de la semana para incluir albaranes"
+      "label": "D\u00eda l\u00edmite de facturaci\u00f3n semanal",
+      "description": "\u00daltimo d\u00eda de la semana para incluir albaranes"
     },
     "AD_Menu_ID": {
-      "label": "Menú",
+      "label": "Men\u00fa",
       "description": "Identifica el menu"
     },
     "IsBankAccount": {
       "label": "Cuenta bancaria",
-      "description": "Cuenta bancaria de una institución bancaria reconocida."
+      "description": "Cuenta bancaria de una instituci\u00f3n bancaria reconocida."
     },
     "IsCommitment": {
       "label": "Acuerdo",
@@ -2845,24 +2845,24 @@
       "description": ""
     },
     "IsNextBusinessDay": {
-      "label": "En día laboral",
-      "description": "Pago en el siguiente día laboral"
+      "label": "En d\u00eda laboral",
+      "description": "Pago en el siguiente d\u00eda laboral"
     },
     "IsSOTrx": {
-      "label": "Operación de venta",
-      "description": "Indicación de que se están transfiriendo bienes o dinero entre terceros."
+      "label": "Operaci\u00f3n de venta",
+      "description": "Indicaci\u00f3n de que se est\u00e1n transfiriendo bienes o dinero entre terceros."
     },
     "Issotrx": {
-      "label": "Operación de venta",
-      "description": "Indicación de que se están transfiriendo bienes o dinero entre terceros."
+      "label": "Operaci\u00f3n de venta",
+      "description": "Indicaci\u00f3n de que se est\u00e1n transfiriendo bienes o dinero entre terceros."
     },
     "sotrx": {
-      "label": "Operación de venta",
-      "description": "Indicación de que se están transfiriendo bienes o dinero entre terceros."
+      "label": "Operaci\u00f3n de venta",
+      "description": "Indicaci\u00f3n de que se est\u00e1n transfiriendo bienes o dinero entre terceros."
     },
     "LanguageISO": {
-      "label": "Código ISO idioma",
-      "description": "Código de idioma ISO-3166 - http://www.ics.uci.edu/pub/ietf/http/related/iso639.txt "
+      "label": "C\u00f3digo ISO idioma",
+      "description": "C\u00f3digo de idioma ISO-3166 - http://www.ics.uci.edu/pub/ietf/http/related/iso639.txt "
     },
     "M_ProductFreight_ID": {
       "label": "Portes del producto",
@@ -2874,19 +2874,19 @@
     },
     "Note": {
       "label": "Observaciones",
-      "description": "Espacio para escribir información relacionada."
+      "description": "Espacio para escribir informaci\u00f3n relacionada."
     },
     "NotInvoicedReceipts_Acct": {
       "label": "Recibos no facturados",
       "description": "Total de recibos no facturados de materiales"
     },
     "AD_OrgTrx_ID": {
-      "label": "Organización de la transacción",
-      "description": "Organización que realiza o inicia la transacción."
+      "label": "Organizaci\u00f3n de la transacci\u00f3n",
+      "description": "Organizaci\u00f3n que realiza o inicia la transacci\u00f3n."
     },
     "AD_Orgtrx_ID": {
-      "label": "Organización de la transacción",
-      "description": "Organización que realiza o inicia la transacción."
+      "label": "Organizaci\u00f3n de la transacci\u00f3n",
+      "description": "Organizaci\u00f3n que realiza o inicia la transacci\u00f3n."
     },
     "PriceEffective": {
       "label": "Precio vigente desde",
@@ -2894,7 +2894,7 @@
     },
     "PricePO": {
       "label": "Precio de compra",
-      "description": "Precio de compra de un ítem específico."
+      "description": "Precio de compra de un \u00edtem espec\u00edfico."
     },
     "ProcCreate": {
       "label": "Crear lista de precios",
@@ -2902,11 +2902,11 @@
     },
     "TaxBaseAmt": {
       "label": "Base imponible",
-      "description": "Importe total sobre el que se añaden los impuestos."
+      "description": "Importe total sobre el que se a\u00f1aden los impuestos."
     },
     "IsValid": {
-      "label": "Válido",
-      "description": "Confirmación de que algo es correcto."
+      "label": "V\u00e1lido",
+      "description": "Confirmaci\u00f3n de que algo es correcto."
     },
     "AD_Process_ID": {
       "label": "Proceso",
@@ -2917,8 +2917,8 @@
       "description": ""
     },
     "organization": {
-      "label": "Organización",
-      "description": "Organización dentro del cliente"
+      "label": "Organizaci\u00f3n",
+      "description": "Organizaci\u00f3n dentro del cliente"
     },
     "DateOrdered": {
       "label": "Fecha de pedido",
@@ -2929,7 +2929,7 @@
       "description": ""
     },
     "C_Return_Reason_ID": {
-      "label": "Motivos de devolución",
+      "label": "Motivos de devoluci\u00f3n",
       "description": ""
     },
     "IsPaid": {
@@ -2938,43 +2938,43 @@
     },
     "taxableAmount": {
       "label": "Base imponible",
-      "description": "Importe total sobre el que se añaden los impuestos."
+      "description": "Importe total sobre el que se a\u00f1aden los impuestos."
     },
     "Taxbaseamt": {
       "label": "Base imponible",
-      "description": "Importe total sobre el que se añaden los impuestos."
+      "description": "Importe total sobre el que se a\u00f1aden los impuestos."
     },
     "Taxamt": {
       "label": "Impuestos",
-      "description": "Importe total exigido por el gobierno en una transacción específica."
+      "description": "Importe total exigido por el gobierno en una transacci\u00f3n espec\u00edfica."
     },
     "TaxAmt": {
       "label": "Impuestos",
-      "description": "Importe total exigido por el gobierno en una transacción específica."
+      "description": "Importe total exigido por el gobierno en una transacci\u00f3n espec\u00edfica."
     },
     "taxAmount": {
       "label": "Impuestos",
-      "description": "Importe total exigido por el gobierno en una transacción específica."
+      "description": "Importe total exigido por el gobierno en una transacci\u00f3n espec\u00edfica."
     },
     "TaxIndicator": {
       "label": "Identificador de impuestos",
-      "description": "Método rápido para hallar un impuesto específico."
+      "description": "M\u00e9todo r\u00e1pido para hallar un impuesto espec\u00edfico."
     },
     "TrxAmt": {
       "label": "Imp.transacc.",
-      "description": "Importe de la operación"
+      "description": "Importe de la operaci\u00f3n"
     },
     "PaymentRule": {
       "label": "Forma de pago",
-      "description": "Método utilizado para pagar la petición."
+      "description": "M\u00e9todo utilizado para pagar la petici\u00f3n."
     },
     "Greeting": {
       "label": "Tratamiento",
-      "description": "Descripción, a menudo abreviada, de cómo contactar a un tercero."
+      "description": "Descripci\u00f3n, a menudo abreviada, de c\u00f3mo contactar a un tercero."
     },
     "IsFirstNameOnly": {
       "label": "Solo apellido",
-      "description": "Imprimir sólamente en los tratamientos"
+      "description": "Imprimir s\u00f3lamente en los tratamientos"
     },
     "WriteOff_Acct": {
       "label": "Cancelaciones",
@@ -2985,7 +2985,7 @@
       "description": ""
     },
     "IsHighVolume": {
-      "label": "Búsqueda masiva",
+      "label": "B\u00fasqueda masiva",
       "description": "Utilizar la busqueda en lugar de la lista"
     },
     "IsInvoicePrintDetails": {
@@ -2993,16 +2993,16 @@
       "description": "Imprimir el detalle de los materiales en la factura"
     },
     "IsPickListPrintDetails": {
-      "label": "Imprimir detalle en una lista de selección",
-      "description": "Imprimir detalle en una lista de selección"
+      "label": "Imprimir detalle en una lista de selecci\u00f3n",
+      "description": "Imprimir detalle en una lista de selecci\u00f3n"
     },
     "PriorityNo": {
       "label": "Prioridad relativa",
-      "description": "Dónde primero se debería tomar en el almacén"
+      "description": "D\u00f3nde primero se deber\u00eda tomar en el almac\u00e9n"
     },
     "C_Greeting_ID": {
       "label": "Tratamientos",
-      "description": "Descripción, a menudo abreviada, de cómo contactar a un tercero."
+      "description": "Descripci\u00f3n, a menudo abreviada, de c\u00f3mo contactar a un tercero."
     },
     "Matching_Costadjustment_ID": {
       "label": "Asociar Ajuste de Costes",
@@ -3014,54 +3014,54 @@
     },
     "IsVerified": {
       "label": "Definido",
-      "description": "La configuración de la lista de materiales ha sido comprobada"
+      "description": "La configuraci\u00f3n de la lista de materiales ha sido comprobada"
     },
     "Ruletype": {
       "label": "Tipo de Regla",
       "description": "Selecciona el porcentaje para obtener el precio basado en el porcentaje del precio del producto relacionado o rangos para establecer diferentes reglas dependiendo del importe del producto relacionado"
     },
     "AD_Process_Para_ID": {
-      "label": "Parámetro proceso",
-      "description": "Parámetro proceso"
+      "label": "Par\u00e1metro proceso",
+      "description": "Par\u00e1metro proceso"
     },
     "M_Product_BOM_ID": {
-      "label": "Línea de la lista de materiales",
+      "label": "L\u00ednea de la lista de materiales",
       "description": ""
     },
     "AD_Ref_List_ID": {
       "label": "Lista Referencia",
-      "description": "Lista referencia según una tabla"
+      "description": "Lista referencia seg\u00fan una tabla"
     },
     "Confirmcancelandreplace": {
       "label": "Confirmar Cancelar y Reemplazar",
-      "description": "Botón que confirma el pedido temporal cerrándolo y creando el pedido de cancelación"
+      "description": "Bot\u00f3n que confirma el pedido temporal cerr\u00e1ndolo y creando el pedido de cancelaci\u00f3n"
     },
     "AD_Reference_ID": {
       "label": "Referencia",
       "description": "Tipo de datos de este campo."
     },
     "ConversionDate": {
-      "label": "F.conversión",
-      "description": "Fecha de la conversión"
+      "label": "F.conversi\u00f3n",
+      "description": "Fecha de la conversi\u00f3n"
     },
     "Limit_AddAmt": {
-      "label": "Recargo precio límite",
-      "description": "Importe añadido al precio convertido/copiado antes de multiplicarlo"
+      "label": "Recargo precio l\u00edmite",
+      "description": "Importe a\u00f1adido al precio convertido/copiado antes de multiplicarlo"
     },
     "Limit_Base": {
-      "label": "Base precio límite",
-      "description": "Precio base para el cálculo de los nuevos precios"
+      "label": "Base precio l\u00edmite",
+      "description": "Precio base para el c\u00e1lculo de los nuevos precios"
     },
     "Limit_MaxAmt": {
-      "label": "Margen máx precio límite",
-      "description": "Diferencia máxima sobre el precio límite original; ignorar si es cero"
+      "label": "Margen m\u00e1x precio l\u00edmite",
+      "description": "Diferencia m\u00e1xima sobre el precio l\u00edmite original; ignorar si es cero"
     },
     "Limit_MinAmt": {
-      "label": "Margen mín precio límite",
-      "description": "Mínima diferencia sobre el precio límite; ignorar si es cero"
+      "label": "Margen m\u00edn precio l\u00edmite",
+      "description": "M\u00ednima diferencia sobre el precio l\u00edmite; ignorar si es cero"
     },
     "Limit_Rounding": {
-      "label": "Redondeo precio límite",
+      "label": "Redondeo precio l\u00edmite",
       "description": "Redondea el resultado final"
     },
     "List_AddAmt": {
@@ -3070,75 +3070,75 @@
     },
     "List_Base": {
       "label": "Base precio tarifa",
-      "description": "Precio utilizado como base para el cálculo de la lista de precios"
+      "description": "Precio utilizado como base para el c\u00e1lculo de la lista de precios"
     },
     "List_MaxAmt": {
-      "label": "Margen máx precio tarifa",
-      "description": "Margen máximo sobre un producto"
+      "label": "Margen m\u00e1x precio tarifa",
+      "description": "Margen m\u00e1ximo sobre un producto"
     },
     "AD_Reference": {
       "label": "Referencia",
       "description": "Tipo de datos de este campo."
     },
     "List_MinAmt": {
-      "label": "Margen mín precio tarifa",
-      "description": "Margen mínimo sobre un producto"
+      "label": "Margen m\u00edn precio tarifa",
+      "description": "Margen m\u00ednimo sobre un producto"
     },
     "List_Rounding": {
       "label": "Redondeo precio tarifa",
       "description": "Regla de redondeo para la lista final de precios"
     },
     "Std_AddAmt": {
-      "label": "Recargo precio estándar",
-      "description": "Importe añadido como recargo al precio"
+      "label": "Recargo precio est\u00e1ndar",
+      "description": "Importe a\u00f1adido como recargo al precio"
     },
     "AD_Role_ID": {
       "label": "Rol",
-      "description": "Perfil de seguridad del usuario, que define qué ventanas y solapas se pueden mostrar."
+      "description": "Perfil de seguridad del usuario, que define qu\u00e9 ventanas y solapas se pueden mostrar."
     },
     "AD_Reference_Value_ID": {
       "label": "Referencia clave",
-      "description": "Especificación exacta de una referencia para una lista o tabla."
+      "description": "Especificaci\u00f3n exacta de una referencia para una lista o tabla."
     },
     "Std_MaxAmt": {
-      "label": "Margen máx precio estándar",
-      "description": "Margen máximo permitido para un producto"
+      "label": "Margen m\u00e1x precio est\u00e1ndar",
+      "description": "Margen m\u00e1ximo permitido para un producto"
     },
     "Std_MinAmt": {
-      "label": "Margen mín precio estándar",
-      "description": "Margen mínimo permitido para un producto"
+      "label": "Margen m\u00edn precio est\u00e1ndar",
+      "description": "Margen m\u00ednimo permitido para un producto"
     },
     "Std_Rounding": {
-      "label": "Redondeo precio estándar",
+      "label": "Redondeo precio est\u00e1ndar",
       "description": "Regla de redondeo para calcular un precio"
     },
     "IsCurrentVendor": {
       "label": "Proveedor actual",
-      "description": "Utilizar este proveedor para precios y reposición de stock"
+      "description": "Utilizar este proveedor para precios y reposici\u00f3n de stock"
     },
     "Limit_Discount": {
-      "label": "Descuento (%) precio límite",
-      "description": "Descuento en porcentaje a descontar de la base, si negativo se añadirá al precio base"
+      "label": "Descuento (%) precio l\u00edmite",
+      "description": "Descuento en porcentaje a descontar de la base, si negativo se a\u00f1adir\u00e1 al precio base"
     },
     "List_Discount": {
       "label": "Descuento (%) precio tarifa",
       "description": "Descuento de la lista de precios como porcentaje"
     },
     "Std_Discount": {
-      "label": "Descuento (%) precio estándar",
+      "label": "Descuento (%) precio est\u00e1ndar",
       "description": "Descuento en porcentaje a restar al precio base"
     },
     "IsDiscountPrinted": {
       "label": "Imprimir descuento",
-      "description": "Opción para solicitar un descuento impreso en la factura."
+      "description": "Opci\u00f3n para solicitar un descuento impreso en la factura."
     },
     "AD_Sequence_ID": {
       "label": "Secuencia",
-      "description": "Orden de los registros en un documento específico."
+      "description": "Orden de los registros en un documento espec\u00edfico."
     },
     "SO_Description": {
-      "label": "Descripción de pedidos",
-      "description": "Utilizar la descripción en los pedidos"
+      "label": "Descripci\u00f3n de pedidos",
+      "description": "Utilizar la descripci\u00f3n en los pedidos"
     },
     "SMTPHost": {
       "label": "Servidor de correo ",
@@ -3146,67 +3146,67 @@
     },
     "CostPerOrder": {
       "label": "Costo por pedido",
-      "description": "Costo fijo adicional añadido a un producto adquirido."
+      "description": "Costo fijo adicional a\u00f1adido a un producto adquirido."
     },
     "DeliveryTime_Actual": {
       "label": "F.entrega real",
-      "description": "Días reales entre el pedido y la entrega"
+      "description": "D\u00edas reales entre el pedido y la entrega"
     },
     "DeliveryTime_Promised": {
       "label": "Tiempo de entrega esperado",
-      "description": "Periodo en que debe completarse o entregarse una tarea, proceso o acción."
+      "description": "Periodo en que debe completarse o entregarse una tarea, proceso o acci\u00f3n."
     },
     "QualityRating": {
-      "label": "Valoración calidad",
-      "description": "Método para calificar a los proveedores"
+      "label": "Valoraci\u00f3n calidad",
+      "description": "M\u00e9todo para calificar a los proveedores"
     },
     "Info": {
-      "label": "Información",
-      "description": "Espacio para escribir información adicional relacionada."
+      "label": "Informaci\u00f3n",
+      "description": "Espacio para escribir informaci\u00f3n adicional relacionada."
     },
     "Trxtype": {
-      "label": "Tipo de operación",
-      "description": "Tipo de operación con la tarjeta de crédito"
+      "label": "Tipo de operaci\u00f3n",
+      "description": "Tipo de operaci\u00f3n con la tarjeta de cr\u00e9dito"
     },
     "DateTrx": {
-      "label": "Fecha de la transacción",
-      "description": "Fecha de ingreso de una transacción específica en la aplicación."
+      "label": "Fecha de la transacci\u00f3n",
+      "description": "Fecha de ingreso de una transacci\u00f3n espec\u00edfica en la aplicaci\u00f3n."
     },
     "Datetrx": {
-      "label": "Fecha de la transacción",
-      "description": "Fecha de ingreso de una transacción específica en la aplicación."
+      "label": "Fecha de la transacci\u00f3n",
+      "description": "Fecha de ingreso de una transacci\u00f3n espec\u00edfica en la aplicaci\u00f3n."
     },
     "transactionDate": {
-      "label": "Fecha de la transacción",
-      "description": "Fecha de ingreso de una transacción específica en la aplicación."
+      "label": "Fecha de la transacci\u00f3n",
+      "description": "Fecha de ingreso de una transacci\u00f3n espec\u00edfica en la aplicaci\u00f3n."
     },
     "trxDate": {
-      "label": "Fecha de la transacción",
-      "description": "Fecha de ingreso de una transacción específica en la aplicación."
+      "label": "Fecha de la transacci\u00f3n",
+      "description": "Fecha de ingreso de una transacci\u00f3n espec\u00edfica en la aplicaci\u00f3n."
     },
     "AD_Form_ID": {
       "label": "Formulario especial",
-      "description": "Nombre del formulario que se está editando."
+      "description": "Nombre del formulario que se est\u00e1 editando."
     },
     "Posted": {
       "label": "Contabilizado",
-      "description": "Estado contable en el que figura si una transacción específica fue anotada en el Libro Mayor."
+      "description": "Estado contable en el que figura si una transacci\u00f3n espec\u00edfica fue anotada en el Libro Mayor."
     },
     "M_ProductionPlan_ID": {
-      "label": "Plan de producción",
-      "description": "Propuesta de cómo llevar a cabo la producción."
+      "label": "Plan de producci\u00f3n",
+      "description": "Propuesta de c\u00f3mo llevar a cabo la producci\u00f3n."
     },
     "CategoryType": {
-      "label": "Tipo de categoría",
-      "description": "Fuente del asiento de la categoría"
+      "label": "Tipo de categor\u00eda",
+      "description": "Fuente del asiento de la categor\u00eda"
     },
     "AD_Tree_BPartner_ID": {
-      "label": "Árbol principal de terceros",
-      "description": "Árbol de terceros"
+      "label": "\u00c1rbol principal de terceros",
+      "description": "\u00c1rbol de terceros"
     },
     "AD_Tree_ID": {
-      "label": "Árbol",
-      "description": "Identifica un árbol"
+      "label": "\u00c1rbol",
+      "description": "Identifica un \u00e1rbol"
     },
     "IsSelected": {
       "label": "Seleccionado",
@@ -3225,72 +3225,72 @@
       "description": "Producto de la lista de materiales"
     },
     "AD_Tree_Menu_ID": {
-      "label": "Menu del árbol principal",
-      "description": "Menú en árbol"
+      "label": "Menu del \u00e1rbol principal",
+      "description": "Men\u00fa en \u00e1rbol"
     },
     "Parent_Costadjustmentline_ID": {
-      "label": "Línea de Ajuste de Costes Padre",
+      "label": "L\u00ednea de Ajuste de Costes Padre",
       "description": ""
     },
     "AD_Tree_Org_ID": {
-      "label": "Árbol principal de Organizaciones",
-      "description": "Árbol de organizaciones"
+      "label": "\u00c1rbol principal de Organizaciones",
+      "description": "\u00c1rbol de organizaciones"
     },
     "IsCreated": {
       "label": "Registros creados",
       "description": ""
     },
     "M_Productionplan_ID": {
-      "label": "Plan de producción",
-      "description": "Propuesta de cómo llevar a cabo la producción."
+      "label": "Plan de producci\u00f3n",
+      "description": "Propuesta de c\u00f3mo llevar a cabo la producci\u00f3n."
     },
     "ProductionQty": {
-      "label": "Cant.producción",
-      "description": "Cantidad de la producción"
+      "label": "Cant.producci\u00f3n",
+      "description": "Cantidad de la producci\u00f3n"
     },
     "Vendor_ID": {
       "label": "Proveedor",
       "description": "Tercero que vende productos o servicios."
     },
     "AD_Tree_Product_ID": {
-      "label": "Árbol principal del producto",
-      "description": "Árbol de productos"
+      "label": "\u00c1rbol principal del producto",
+      "description": "\u00c1rbol de productos"
     },
     "A_City": {
-      "label": "Población en que está domiciliada la cuenta",
-      "description": "Población en que está domiciliada la cuenta"
+      "label": "Poblaci\u00f3n en que est\u00e1 domiciliada la cuenta",
+      "description": "Poblaci\u00f3n en que est\u00e1 domiciliada la cuenta"
     },
     "A_EMail": {
-      "label": "Dir.correo electrónico",
-      "description": "Dirección de correo electrónico"
+      "label": "Dir.correo electr\u00f3nico",
+      "description": "Direcci\u00f3n de correo electr\u00f3nico"
     },
     "A_Ident_DL": {
       "label": "Carnet de conducir",
       "description": "Carnet de conducir"
     },
     "A_Ident_SSN": {
-      "label": "Número seguridad social",
-      "description": "Número Seguridad Social"
+      "label": "N\u00famero seguridad social",
+      "description": "N\u00famero Seguridad Social"
     },
     "A_Name": {
       "label": "Titular de la cuenta",
       "description": "Titular de la cuenta"
     },
     "A_State": {
-      "label": "Provincia en que está domiciliada la cuenta",
-      "description": "Provincia en que está domiciliada la cuenta"
+      "label": "Provincia en que est\u00e1 domiciliada la cuenta",
+      "description": "Provincia en que est\u00e1 domiciliada la cuenta"
     },
     "A_Street": {
-      "label": "Dir.domiciliación cuenta",
-      "description": "Dirección en la que está domiciliada la cuenta"
+      "label": "Dir.domiciliaci\u00f3n cuenta",
+      "description": "Direcci\u00f3n en la que est\u00e1 domiciliada la cuenta"
     },
     "A_Zip": {
-      "label": "Código postal de la cuenta",
-      "description": "Código postal de la cuenta"
+      "label": "C\u00f3digo postal de la cuenta",
+      "description": "C\u00f3digo postal de la cuenta"
     },
     "AD_Tree_Project_ID": {
-      "label": "Árbol principal del proyecto",
-      "description": "Árbol de proyectos"
+      "label": "\u00c1rbol principal del proyecto",
+      "description": "\u00c1rbol de proyectos"
     },
     "amount": {
       "label": "Importe",
@@ -3305,56 +3305,56 @@
       "description": "Gasto bancario"
     },
     "AD_Tree_SalesRegion_ID": {
-      "label": "Árbol principal de ventas de una región",
+      "label": "\u00c1rbol principal de ventas de una regi\u00f3n",
       "description": ""
     },
     "B_InTransit_Acct": {
-      "label": "Banco en tránsito",
-      "description": "Banco en tránsito"
+      "label": "Banco en tr\u00e1nsito",
+      "description": "Banco en tr\u00e1nsito"
     },
     "B_RevaluationGain_Acct": {
-      "label": "Beneficio por plusvalías",
-      "description": "Beneficio por plusvalías"
+      "label": "Beneficio por plusval\u00edas",
+      "description": "Beneficio por plusval\u00edas"
     },
     "B_RevaluationLoss_Acct": {
-      "label": "Pérdida por minusvalías",
-      "description": "Pérdida por minusvalías"
+      "label": "P\u00e9rdida por minusval\u00edas",
+      "description": "P\u00e9rdida por minusval\u00edas"
     },
     "BeginningBalance": {
       "label": "Balance inicial",
-      "description": "Balance inicial de cualquier operación"
+      "description": "Balance inicial de cualquier operaci\u00f3n"
     },
     "Email_Conf_AD_User_ID": {
       "label": "Usuario/Contacto",
-      "description": "Referente que puede aportar información sobre un tercero."
+      "description": "Referente que puede aportar informaci\u00f3n sobre un tercero."
     },
     "C_BankStatement_ID": {
       "label": "Extracto bancario",
       "description": "Extracto bancario"
     },
     "C_BankStatementLine_ID": {
-      "label": "Línea del extracto bancario",
-      "description": "Declaración que muestra una transacción del estado de cuenta."
+      "label": "L\u00ednea del extracto bancario",
+      "description": "Declaraci\u00f3n que muestra una transacci\u00f3n del estado de cuenta."
     },
     "C_BP_Group_ID": {
       "label": "Grupos de terceros",
-      "description": "Clasificación de terceros basada en similitudes definidas."
+      "description": "Clasificaci\u00f3n de terceros basada en similitudes definidas."
     },
     "C_Bp_Group_ID": {
       "label": "Grupos de terceros",
-      "description": "Clasificación de terceros basada en similitudes definidas."
+      "description": "Clasificaci\u00f3n de terceros basada en similitudes definidas."
     },
     "AD_Val_Rule_ID": {
-      "label": "Validación",
-      "description": "Regla de validación que define cómo se determina si una entrada es válida o inválida."
+      "label": "Validaci\u00f3n",
+      "description": "Regla de validaci\u00f3n que define c\u00f3mo se determina si una entrada es v\u00e1lida o inv\u00e1lida."
     },
     "discountsAmt": {
       "label": "Importe del descuento",
-      "description": "El Importe de Descuento indica el importe descontado para un documento o línea."
+      "description": "El Importe de Descuento indica el importe descontado para un documento o l\u00ednea."
     },
     "DiscountAmt": {
       "label": "Importe del descuento",
-      "description": "El Importe de Descuento indica el importe descontado para un documento o línea."
+      "description": "El Importe de Descuento indica el importe descontado para un documento o l\u00ednea."
     },
     "EndingBalance": {
       "label": "Balance final",
@@ -3365,7 +3365,7 @@
       "description": "Terminar o cerrar el balance"
     },
     "Mincharacters": {
-      "label": "Caracteres Mínimos",
+      "label": "Caracteres M\u00ednimos",
       "description": ""
     },
     "Ispaid": {
@@ -3374,7 +3374,7 @@
     },
     "PJ_WIP_Acct": {
       "label": "Trabajo en curso",
-      "description": "Cuenta que se utiliza en los proyectos de producción hasta que se define un bien como terminado."
+      "description": "Cuenta que se utiliza en los proyectos de producci\u00f3n hasta que se define un bien como terminado."
     },
     "price": {
       "label": "Precio",
@@ -3386,14 +3386,14 @@
     },
     "R_AvsZip": {
       "label": "CIP comprobado",
-      "description": "Este código postal ha sido comprobado"
+      "description": "Este c\u00f3digo postal ha sido comprobado"
     },
     "AD_Window_ID": {
       "label": "Ventana",
-      "description": "Área de trabajo que puede utilizarse para crear, mostrar, editar y procesar un registro."
+      "description": "\u00c1rea de trabajo que puede utilizarse para crear, mostrar, editar y procesar un registro."
     },
     "Remote_Addr": {
-      "label": "Dirección remota",
+      "label": "Direcci\u00f3n remota",
       "description": "no forma parte de una tarea"
     },
     "Remote_Host": {
@@ -3402,11 +3402,11 @@
     },
     "Statementdate": {
       "label": "Fecha",
-      "description": "Fecha en que se realiza una transacción y se la registra en el Libro de Diario."
+      "description": "Fecha en que se realiza una transacci\u00f3n y se la registra en el Libro de Diario."
     },
     "StatementDate": {
       "label": "Fecha",
-      "description": "Fecha en que se realiza una transacción y se la registra en el Libro de Diario."
+      "description": "Fecha en que se realiza una transacci\u00f3n y se la registra en el Libro de Diario."
     },
     "StatementDifference": {
       "label": "Diferencia ",
@@ -3421,11 +3421,11 @@
       "description": "Total de impuestos a pagar"
     },
     "W_Revaluation_Acct": {
-      "label": "Actualización del almacén",
-      "description": "Cuenta de la actualización de almacén"
+      "label": "Actualizaci\u00f3n del almac\u00e9n",
+      "description": "Cuenta de la actualizaci\u00f3n de almac\u00e9n"
     },
     "Withholding_Acct": {
-      "label": "Retención",
+      "label": "Retenci\u00f3n",
       "description": "no forma parte de una tarea"
     },
     "Accesslevel": {
@@ -3446,11 +3446,11 @@
     },
     "Account_ID": {
       "label": "Cuenta",
-      "description": "Código de identificación utilizado en la contabilidad."
+      "description": "C\u00f3digo de identificaci\u00f3n utilizado en la contabilidad."
     },
     "AccountSign": {
-      "label": "Naturaleza de la cuenta (crédito/débito)",
-      "description": "Indica la naturaleza de la cuenta como débito o crédito"
+      "label": "Naturaleza de la cuenta (cr\u00e9dito/d\u00e9bito)",
+      "description": "Indica la naturaleza de la cuenta como d\u00e9bito o cr\u00e9dito"
     },
     "BankAccountType": {
       "label": "Tipo de cuenta bancaria",
@@ -3465,8 +3465,8 @@
       "description": "Documento utilizado para administrar todas las transacciones de caja."
     },
     "C_CashLine_ID": {
-      "label": "Línea del diario",
-      "description": "Extracto que muestra una transacción en el Diario de caja."
+      "label": "L\u00ednea del diario",
+      "description": "Extracto que muestra una transacci\u00f3n en el Diario de caja."
     },
     "CashType": {
       "label": "Tipo de caja",
@@ -3494,11 +3494,11 @@
     },
     "IsManual": {
       "label": "Manual",
-      "description": "Tarea o proceso completados por directamente por el usuario y no automáticamente por la aplicación."
+      "description": "Tarea o proceso completados por directamente por el usuario y no autom\u00e1ticamente por la aplicaci\u00f3n."
     },
     "Ismanual": {
       "label": "Manual",
-      "description": "Tarea o proceso completados por directamente por el usuario y no automáticamente por la aplicación."
+      "description": "Tarea o proceso completados por directamente por el usuario y no autom\u00e1ticamente por la aplicaci\u00f3n."
     },
     "StmtAmt": {
       "label": "Imp.declarado",
@@ -3506,50 +3506,50 @@
     },
     "V_Number": {
       "label": "Valor",
-      "description": "Declaración del valor o la importancia de algo, expresada de muchas formas."
+      "description": "Declaraci\u00f3n del valor o la importancia de algo, expresada de muchas formas."
     },
     "V_String": {
       "label": "Texto",
-      "description": "Lugar para añadir observaciones relacionadas con un control específico."
+      "description": "Lugar para a\u00f1adir observaciones relacionadas con un control espec\u00edfico."
     },
     "ValutaDate": {
       "label": "Fecha valor",
-      "description": "Fecha en la que el dinero está disponible"
+      "description": "Fecha en la que el dinero est\u00e1 disponible"
     },
     "Acct2_Active": {
       "label": "Segundo esquema de contabilidad",
-      "description": "Para informes paralelos utilizar diferentes monedas o campos de selección"
+      "description": "Para informes paralelos utilizar diferentes monedas o campos de selecci\u00f3n"
     },
     "CreateFrom": {
-      "label": "Crear líneas de",
-      "description": "Acto de añadir declaraciones de documentos preexistentes."
+      "label": "Crear l\u00edneas de",
+      "description": "Acto de a\u00f1adir declaraciones de documentos preexistentes."
     },
     "GenerateTo": {
-      "label": "Crear albarán de factura",
+      "label": "Crear albar\u00e1n de factura",
       "description": "Crear hasta"
     },
     "Acct3_Active": {
       "label": "*Tercer Modo Contable",
-      "description": "Para informes paralelos utilizar diferentes monedas o campos de selección"
+      "description": "Para informes paralelos utilizar diferentes monedas o campos de selecci\u00f3n"
     },
     "AD_FieldGroup_ID": {
       "label": "Grupo de campos",
-      "description": "Clasificación de campos similares."
+      "description": "Clasificaci\u00f3n de campos similares."
     },
     "AD_Fieldgroup_ID": {
       "label": "Grupo de campos",
-      "description": "Clasificación de campos similares."
+      "description": "Clasificaci\u00f3n de campos similares."
     },
     "Frequency": {
       "label": "Frecuencia",
-      "description": "Cantidad de veces que algo ocurre durante un período específico de tiempo."
+      "description": "Cantidad de veces que algo ocurre durante un per\u00edodo espec\u00edfico de tiempo."
     },
     "FrequencyType": {
       "label": "Tipo de frecuencia",
-      "description": "Frecuencia de cálculo"
+      "description": "Frecuencia de c\u00e1lculo"
     },
     "AcqusitionCost": {
-      "label": "Costo de adquisición",
+      "label": "Costo de adquisici\u00f3n",
       "description": "Los costos de adquirir un futurible como cliente"
     },
     "Priority": {
@@ -3557,8 +3557,8 @@
       "description": "Nivel definido de importancia o precedencia."
     },
     "C_Commission_ID": {
-      "label": "Comisión",
-      "description": "El identificador de la comisión"
+      "label": "Comisi\u00f3n",
+      "description": "El identificador de la comisi\u00f3n"
     },
     "Supervisor_ID": {
       "label": "Supervisor",
@@ -3570,7 +3570,7 @@
     },
     "DefaultValue2": {
       "label": "Valor por defecto (2)",
-      "description": "Valor jerárquico por defecto, separado por"
+      "description": "Valor jer\u00e1rquico por defecto, separado por"
     },
     "TotalAmt": {
       "label": "Imp.total",
@@ -3601,24 +3601,24 @@
       "description": "Importe restado para generar comisiones"
     },
     "C_CommissionAmt_ID": {
-      "label": "Cuantía de la comisión",
-      "description": "Importe generado de la comisión"
+      "label": "Cuant\u00eda de la comisi\u00f3n",
+      "description": "Importe generado de la comisi\u00f3n"
     },
     "C_CommissionLine_ID": {
-      "label": "Línea de comisión",
-      "description": "Línea de comisión"
+      "label": "L\u00ednea de comisi\u00f3n",
+      "description": "L\u00ednea de comisi\u00f3n"
     },
     "C_Projectline_ID": {
-      "label": "Línea del proyecto",
+      "label": "L\u00ednea del proyecto",
       "description": "Tarea o fase de un proyecto"
     },
     "C_ProjectLine_ID": {
-      "label": "Línea del proyecto",
+      "label": "L\u00ednea del proyecto",
       "description": "Tarea o fase de un proyecto"
     },
     "CommissionAmt": {
       "label": "Importe",
-      "description": "Cuantía de la comisión"
+      "description": "Cuant\u00eda de la comisi\u00f3n"
     },
     "ConvertedAmt": {
       "label": "Imp. convertido",
@@ -3626,31 +3626,31 @@
     },
     "DateContract": {
       "label": "Fecha del contrato",
-      "description": "Fecha de registro de un contrato en la aplicación."
+      "description": "Fecha de registro de un contrato en la aplicaci\u00f3n."
     },
     "Datecontract": {
       "label": "Fecha del contrato",
-      "description": "Fecha de registro de un contrato en la aplicación."
+      "description": "Fecha de registro de un contrato en la aplicaci\u00f3n."
     },
     "DateFinish": {
-      "label": "Fecha de finalización",
-      "description": "Periodo en que debe completarse o enviarse una tarea, proceso o acción."
+      "label": "Fecha de finalizaci\u00f3n",
+      "description": "Periodo en que debe completarse o enviarse una tarea, proceso o acci\u00f3n."
     },
     "DocBasisType": {
-      "label": "Base de cálculo",
-      "description": "Base para el cálculo de la comisión"
+      "label": "Base de c\u00e1lculo",
+      "description": "Base para el c\u00e1lculo de la comisi\u00f3n"
     },
     "Address1": {
-      "label": "Primera línea",
-      "description": "Espacio para escribir la dirección de un tercero."
+      "label": "Primera l\u00ednea",
+      "description": "Espacio para escribir la direcci\u00f3n de un tercero."
     },
     "IsPositiveOnly": {
-      "label": "Sólo positivo",
+      "label": "S\u00f3lo positivo",
       "description": "No generar comisiones negativas"
     },
     "PlannedAmt": {
       "label": "Importe previsto",
-      "description": "Suma esperada para una línea de transacción."
+      "description": "Suma esperada para una l\u00ednea de transacci\u00f3n."
     },
     "PlannedMargin": {
       "label": "Margen (%) previsto",
@@ -3658,67 +3658,67 @@
     },
     "PlannedMarginAmt": {
       "label": "Margen previsto",
-      "description": "Fecha esperada o provisioria en que ocurre una transacción."
+      "description": "Fecha esperada o provisioria en que ocurre una transacci\u00f3n."
     },
     "PlannedQty": {
       "label": "Cant. prevista",
-      "description": "Cantidad esperada o provisoria de una línea de transacción."
+      "description": "Cantidad esperada o provisoria de una l\u00ednea de transacci\u00f3n."
     },
     "QtyMultiplier": {
       "label": "Multiplicador de cant.",
       "description": "Coeficiente con el que multiplicar a las cantidades para generar las comisiones "
     },
     "Address2": {
-      "label": "Segunda línea",
-      "description": "Espacio para escribir la dirección de un tercero."
+      "label": "Segunda l\u00ednea",
+      "description": "Espacio para escribir la direcci\u00f3n de un tercero."
     },
     "QtySubtract": {
       "label": "Cant.restada",
-      "description": "Cantidada que restar para el cálculo de comisiones"
+      "description": "Cantidada que restar para el c\u00e1lculo de comisiones"
     },
     "C_CommissionRun_ID": {
-      "label": "Procesar comisión",
-      "description": "Procesar comisión"
+      "label": "Procesar comisi\u00f3n",
+      "description": "Procesar comisi\u00f3n"
     },
     "CommissionOrders": {
-      "label": "Comisión sólo órdenes concretas",
-      "description": "Comisión sólo para pedidos o facturas dónde este representante participe"
+      "label": "Comisi\u00f3n s\u00f3lo \u00f3rdenes concretas",
+      "description": "Comisi\u00f3n s\u00f3lo para pedidos o facturas d\u00f3nde este representante participe"
     },
     "ListDetails": {
       "label": "Lista de detalles",
       "description": "Detalle de la lista"
     },
     "C_CommissionDetail_ID": {
-      "label": "Detalle de la comisión",
-      "description": "Información adicional sobre el importe de las comisiones"
+      "label": "Detalle de la comisi\u00f3n",
+      "description": "Informaci\u00f3n adicional sobre el importe de las comisiones"
     },
     "PO_PaymentTerm_ID": {
       "label": "Condiciones de pago",
-      "description": "Plan y fecha de cumplimiento definidos para completar un pago específico."
+      "description": "Plan y fecha de cumplimiento definidos para completar un pago espec\u00edfico."
     },
     "Datefrom": {
       "label": "Desde la fecha",
-      "description": "Parámetro que establece el intervalo de inicio de una petición específica."
+      "description": "Par\u00e1metro que establece el intervalo de inicio de una petici\u00f3n espec\u00edfica."
     },
     "DateFrom": {
       "label": "Desde la fecha",
-      "description": "Parámetro que establece el intervalo de inicio de una petición específica."
+      "description": "Par\u00e1metro que establece el intervalo de inicio de una petici\u00f3n espec\u00edfica."
     },
     "FromDate": {
       "label": "Desde la fecha",
-      "description": "Parámetro que establece el intervalo de inicio de una petición específica."
+      "description": "Par\u00e1metro que establece el intervalo de inicio de una petici\u00f3n espec\u00edfica."
     },
     "ToDate": {
       "label": "Fecha hasta",
-      "description": "Parámetro que establece el intervalo de finalización de una petición, consulta, etc. específicas."
+      "description": "Par\u00e1metro que establece el intervalo de finalizaci\u00f3n de una petici\u00f3n, consulta, etc. espec\u00edficas."
     },
     "DateTo": {
       "label": "Fecha hasta",
-      "description": "Parámetro que establece el intervalo de finalización de una petición, consulta, etc. específicas."
+      "description": "Par\u00e1metro que establece el intervalo de finalizaci\u00f3n de una petici\u00f3n, consulta, etc. espec\u00edficas."
     },
     "Dateto": {
       "label": "Fecha hasta",
-      "description": "Parámetro que establece el intervalo de finalización de una petición, consulta, etc. específicas."
+      "description": "Par\u00e1metro que establece el intervalo de finalizaci\u00f3n de una petici\u00f3n, consulta, etc. espec\u00edficas."
     },
     "Alias": {
       "label": "Alias",
@@ -3729,16 +3729,16 @@
       "description": "La moneda de la cuenta financiera asociada con el pago"
     },
     "Amtacctcr": {
-      "label": "Crédito contabilizado",
-      "description": "Suma acreditada en una cuenta, convertida a la moneda de la organización por defecto."
+      "label": "Cr\u00e9dito contabilizado",
+      "description": "Suma acreditada en una cuenta, convertida a la moneda de la organizaci\u00f3n por defecto."
     },
     "AD_Image_ID": {
       "label": "Imagen",
-      "description": "Imagen visual utilizada para describir un ítem."
+      "description": "Imagen visual utilizada para describir un \u00edtem."
     },
     "AmtAcctDr": {
-      "label": "Débito contabilizado",
-      "description": "Suma debitada en una cuenta, convertida a la moneda de la organización por defecto."
+      "label": "D\u00e9bito contabilizado",
+      "description": "Suma debitada en una cuenta, convertida a la moneda de la organizaci\u00f3n por defecto."
     },
     "DefPlanType": {
       "label": "Tipo de plan de ingresos",
@@ -3749,7 +3749,7 @@
       "description": "Tipo de plan a utilizar para periodificar los ingresos"
     },
     "P_InvoicePriceVariance_Acct": {
-      "label": "Desviación pr. factura",
+      "label": "Desviaci\u00f3n pr. factura",
       "description": "Indica la diferencia entre los costos actuales y el precio en la factura."
     },
     "IsView": {
@@ -3758,67 +3758,67 @@
     },
     "AmtApproval": {
       "label": "Imp.autorizado",
-      "description": "El importe límite autorizado para este rol"
+      "description": "El importe l\u00edmite autorizado para este rol"
     },
     "Isreceipt": {
       "label": "Cobro",
-      "description": "Confirmación de si la petición se ha cerrado mediante el cobro de una transacción monetaria."
+      "description": "Confirmaci\u00f3n de si la petici\u00f3n se ha cerrado mediante el cobro de una transacci\u00f3n monetaria."
     },
     "IsReceipt": {
       "label": "Cobro",
-      "description": "Confirmación de si la petición se ha cerrado mediante el cobro de una transacción monetaria."
+      "description": "Confirmaci\u00f3n de si la petici\u00f3n se ha cerrado mediante el cobro de una transacci\u00f3n monetaria."
     },
     "AmtSourceCr": {
-      "label": "Crédito moneda extranjera",
+      "label": "Cr\u00e9dito moneda extranjera",
       "description": "Suma acreditada de una cuenta, en la moneda del proveedor."
     },
     "Amtsourcecr": {
-      "label": "Crédito moneda extranjera",
+      "label": "Cr\u00e9dito moneda extranjera",
       "description": "Suma acreditada de una cuenta, en la moneda del proveedor."
     },
     "Amtsourcedr": {
-      "label": "Débito moneda extranjera",
+      "label": "D\u00e9bito moneda extranjera",
       "description": "Suma debitada de una cuenta, en la moneda del proveedor."
     },
     "DiscountType": {
       "label": "Tipo de descuento",
-      "description": "Tipos de cálculo de descuentos comerciales"
+      "description": "Tipos de c\u00e1lculo de descuentos comerciales"
     },
     "IsRelatedTrxAdjusted": {
-      "label": "Transacción Relacionada está Ajustada",
+      "label": "Transacci\u00f3n Relacionada est\u00e1 Ajustada",
       "description": ""
     },
     "IsSelectionColumn": {
-      "label": "Columna selección",
-      "description": "Si esta columna se usará para buscar filas en las ventanas"
+      "label": "Columna selecci\u00f3n",
+      "description": "Si esta columna se usar\u00e1 para buscar filas en las ventanas"
     },
     "PO_Description": {
-      "label": "Decripción ped. compra",
-      "description": "Espacio para escribir información adicional relacionada con el pedido de compra."
+      "label": "Decripci\u00f3n ped. compra",
+      "description": "Espacio para escribir informaci\u00f3n adicional relacionada con el pedido de compra."
     },
     "PO_Help": {
       "label": "Ayuda ped. compra",
-      "description": "Comentario que añade información y ayuda a los usuarios a recorrer los campos mientras confeccionan un pedido de compra."
+      "description": "Comentario que a\u00f1ade informaci\u00f3n y ayuda a los usuarios a recorrer los campos mientras confeccionan un pedido de compra."
     },
     "PO_Name": {
       "label": "Nombre ped. compra",
-      "description": "Identificador de un documento que puede utilizarse como herramienta de búsqueda de un pedido de compra."
+      "description": "Identificador de un documento que puede utilizarse como herramienta de b\u00fasqueda de un pedido de compra."
     },
     "PO_PrintName": {
       "label": "Imprimir nombre ped. compra",
-      "description": "Opción que permite imprimir el nombre que figura en el pedido de compra."
+      "description": "Opci\u00f3n que permite imprimir el nombre que figura en el pedido de compra."
     },
     "Readonlylogic": {
-      "label": "Sólo lectura",
-      "description": "Lógica para determinar si este campo es sólo de tipo lectura(aplicado en campos de leer o escribir)"
+      "label": "S\u00f3lo lectura",
+      "description": "L\u00f3gica para determinar si este campo es s\u00f3lo de tipo lectura(aplicado en campos de leer o escribir)"
     },
     "ReadOnlyLogic": {
-      "label": "Sólo lectura",
-      "description": "Lógica para determinar si este campo es sólo de tipo lectura(aplicado en campos de leer o escribir)"
+      "label": "S\u00f3lo lectura",
+      "description": "L\u00f3gica para determinar si este campo es s\u00f3lo de tipo lectura(aplicado en campos de leer o escribir)"
     },
     "B_PaymentSelect_Acct": {
-      "label": "Relación de pagos",
-      "description": "Cuenta puente de la selección de pagos"
+      "label": "Relaci\u00f3n de pagos",
+      "description": "Cuenta puente de la selecci\u00f3n de pagos"
     },
     "CB_CashTransfer_Acct": {
       "label": "Transferencia",
@@ -3834,23 +3834,23 @@
     },
     "Node_ID": {
       "label": "ID Nodo Maestro",
-      "description": "Identifica de forma unívoca el nodo de un entorno cluster que se encarga de maneja un servicio particular."
+      "description": "Identifica de forma un\u00edvoca el nodo de un entorno cluster que se encarga de maneja un servicio particular."
     },
     "RequestEMail": {
-      "label": "Petición de email",
-      "description": "Dirección de email a dónde enviar automáticamente mails o recibir mails de procesos automáticos"
+      "label": "Petici\u00f3n de email",
+      "description": "Direcci\u00f3n de email a d\u00f3nde enviar autom\u00e1ticamente mails o recibir mails de procesos autom\u00e1ticos"
     },
     "RequestFolder": {
-      "label": "Carpeta de petición",
-      "description": "Carpeta de entrada de mails; si está vacía INBOX se utiliza"
+      "label": "Carpeta de petici\u00f3n",
+      "description": "Carpeta de entrada de mails; si est\u00e1 vac\u00eda INBOX se utiliza"
     },
     "RequestUser": {
-      "label": "Petición de usuario",
+      "label": "Petici\u00f3n de usuario",
       "description": "Nombre de usuario (ID) del propietario del email"
     },
     "RequestUserPW": {
-      "label": "Petición de contraseña",
-      "description": "Contraseña del usuario de correo"
+      "label": "Petici\u00f3n de contrase\u00f1a",
+      "description": "Contrase\u00f1a del usuario de correo"
     },
     "IsAllNodes": {
       "label": "Todos los nodos",
@@ -3858,75 +3858,75 @@
     },
     "ImportFields": {
       "label": "Crear campos",
-      "description": "Crea campos según las columnas de las tablas"
+      "description": "Crea campos seg\u00fan las columnas de las tablas"
     },
     "M_DiscountSchema_ID": {
-      "label": "Esquema de tarificación",
+      "label": "Esquema de tarificaci\u00f3n",
       "description": "Pautas aplicadas a la tarifa actual para crear otra tarifa."
     },
     "M_DiscountSchemaLine_ID": {
       "label": "Descuento tarifas",
-      "description": "Línea de la lista de precios sujetos a descuentos comerciales"
+      "description": "L\u00ednea de la lista de precios sujetos a descuentos comerciales"
     },
     "Isgroup": {
       "label": "Grupo",
       "description": ""
     },
     "Startnewline": {
-      "label": "Empezar en nueva Línea",
+      "label": "Empezar en nueva L\u00ednea",
       "description": ""
     },
     "Restrictsalefrombackend": {
       "label": "Restringir ventas desde backend",
-      "description": "Indica si está permitido vender un producto desde backend"
+      "description": "Indica si est\u00e1 permitido vender un producto desde backend"
     },
     "ImageURL": {
       "label": "URL de la imagen",
-      "description": "Dirección de la imagen de un producto, a la que puede accederse via Internet."
+      "description": "Direcci\u00f3n de la imagen de un producto, a la que puede accederse via Internet."
     },
     "TabLevel": {
       "label": "Nivel solapa",
       "description": "Nivel jerarquico de la solapa (0= Primera)"
     },
     "BillTo_ID": {
-      "label": "Dirección de factura",
-      "description": "Ubicación a la que debe enviarse el pedido de pago de la factura."
+      "label": "Direcci\u00f3n de factura",
+      "description": "Ubicaci\u00f3n a la que debe enviarse el pedido de pago de la factura."
     },
     "Line_ID": {
-      "label": "Línea ID",
-      "description": "Identificador de la línea de la operación(interno)"
+      "label": "L\u00ednea ID",
+      "description": "Identificador de la l\u00ednea de la operaci\u00f3n(interno)"
     },
     "PPVOffset_Acct": {
-      "label": "Compensar variación pr.compra",
-      "description": "Total de compensar la variación del precio de compra"
+      "label": "Compensar variaci\u00f3n pr.compra",
+      "description": "Total de compensar la variaci\u00f3n del precio de compra"
     },
     "PriceLastInv": {
-      "label": "Pr. última factura",
-      "description": "Último precio pagado por este producto, como consta en la factura."
+      "label": "Pr. \u00faltima factura",
+      "description": "\u00daltimo precio pagado por este producto, como consta en la factura."
     },
     "IsDiscountLineAmt": {
-      "label": "Importe calculado de descuento de una línea",
-      "description": "Cálculo del descuento en los pagos sin incluir impuestos y cargos"
+      "label": "Importe calculado de descuento de una l\u00ednea",
+      "description": "C\u00e1lculo del descuento en los pagos sin incluir impuestos y cargos"
     },
     "Limit_Fixed": {
-      "label": "Fijo precio límite",
-      "description": "Precio límite fijado (no calculado)"
+      "label": "Fijo precio l\u00edmite",
+      "description": "Precio l\u00edmite fijado (no calculado)"
     },
     "List_Fixed": {
       "label": "Fijo precio tarifa",
       "description": "Lista precio fijado (no calculado)"
     },
     "Std_Fixed": {
-      "label": "Fijo precio estándar",
-      "description": "Precio estándar fijado (no calculado)"
+      "label": "Fijo precio est\u00e1ndar",
+      "description": "Precio est\u00e1ndar fijado (no calculado)"
     },
     "AD_Message_ID": {
       "label": "Mensaje",
-      "description": "Nombre del mensaje de inicio de la aplicación."
+      "description": "Nombre del mensaje de inicio de la aplicaci\u00f3n."
     },
     "Invoicefromshipment": {
-      "label": "Crear factura del albarán",
-      "description": "Crear factura del albarán"
+      "label": "Crear factura del albar\u00e1n",
+      "description": "Crear factura del albar\u00e1n"
     },
     "Dateexpense": {
       "label": "F.gasto",
@@ -3942,19 +3942,19 @@
     },
     "IsTimeReport": {
       "label": "Informe de tiempo",
-      "description": "La línea es sólamente de un informe del tiempo (no gastos)"
+      "description": "La l\u00ednea es s\u00f3lamente de un informe del tiempo (no gastos)"
     },
     "C_AcctSchema1_ID": {
       "label": "Programa principal de cuentas",
       "description": "Programa principal de cuentas"
     },
     "S_TimeExpenseLine_ID": {
-      "label": "Línea de gasto",
-      "description": "Línea del informe de gasto y tiempo"
+      "label": "L\u00ednea de gasto",
+      "description": "L\u00ednea del informe de gasto y tiempo"
     },
     "S_ResourceAssignment_ID": {
-      "label": "Asignación de recursos",
-      "description": "El ID identifica un único registro"
+      "label": "Asignaci\u00f3n de recursos",
+      "description": "El ID identifica un \u00fanico registro"
     },
     "C_AcctSchema2_ID": {
       "label": "Segundo esquema de contabilidad",
@@ -3981,12 +3981,12 @@
       "description": ""
     },
     "DeliveryStatus": {
-      "label": "Estado del envío",
-      "description": "Estado del envío"
+      "label": "Estado del env\u00edo",
+      "description": "Estado del env\u00edo"
     },
     "DeliveryStatusPurchase": {
-      "label": "Estado del envío",
-      "description": "Estado del envío"
+      "label": "Estado del env\u00edo",
+      "description": "Estado del env\u00edo"
     },
     "C_AcctSchema_Element_ID": {
       "label": "Elementos del esquema de contabilidad",
@@ -3994,19 +3994,19 @@
     },
     "C_AcctSchema_ID": {
       "label": "Esquema contable",
-      "description": "Estructura de contabilidad, incluidos métodos de costo, monedas y calendario."
+      "description": "Estructura de contabilidad, incluidos m\u00e9todos de costo, monedas y calendario."
     },
     "C_Acctschema_ID": {
       "label": "Esquema contable",
-      "description": "Estructura de contabilidad, incluidos métodos de costo, monedas y calendario."
+      "description": "Estructura de contabilidad, incluidos m\u00e9todos de costo, monedas y calendario."
     },
     "UseLifeMonths": {
-      "label": "Vida útil - Meses",
-      "description": "Vida útil en meses de un activo"
+      "label": "Vida \u00fatil - Meses",
+      "description": "Vida \u00fatil en meses de un activo"
     },
     "C_BPartner_Location_ID": {
-      "label": "Dirección",
-      "description": "Ubicación de un tercero seleccionado."
+      "label": "Direcci\u00f3n",
+      "description": "Ubicaci\u00f3n de un tercero seleccionado."
     },
     "InvoicePrice": {
       "label": "Pr. factura",
@@ -4029,8 +4029,8 @@
       "description": "Persona que participa en operaciones diarias de negocios, como cliente, empleado, etc."
     },
     "UseLifeYears": {
-      "label": "Vida útil - Años",
-      "description": "Vida útil en años de un activo"
+      "label": "Vida \u00fatil - A\u00f1os",
+      "description": "Vida \u00fatil en a\u00f1os de un activo"
     },
     "Bpartner_Acctdim_Isenable": {
       "label": "Tercero",
@@ -4045,11 +4045,11 @@
       "description": "Item adquirible e intercambiable por efectivo."
     },
     "C_Bpartner_Location_ID": {
-      "label": "Dirección",
-      "description": "Ubicación de un tercero seleccionado."
+      "label": "Direcci\u00f3n",
+      "description": "Ubicaci\u00f3n de un tercero seleccionado."
     },
     "Birthday": {
-      "label": "Cumpleaños",
+      "label": "Cumplea\u00f1os",
       "description": "Fecha de nacimiento de un tercero."
     },
     "EmailUser": {
@@ -4057,20 +4057,20 @@
       "description": "Nombre de usuario de correo"
     },
     "EmailUserPW": {
-      "label": "Contraseña del email",
-      "description": "Contraseña del Email"
+      "label": "Contrase\u00f1a del email",
+      "description": "Contrase\u00f1a del Email"
     },
     "IsSmtpAuthorization": {
-      "label": "Verificación SMTP ",
-      "description": "Tu servidor de correo necesita verificación"
+      "label": "Verificaci\u00f3n SMTP ",
+      "description": "Tu servidor de correo necesita verificaci\u00f3n"
     },
     "ProductType": {
       "label": "Tipo de producto",
-      "description": "Clasificación importante utilizada para determinar la administración y contabilización de un producto."
+      "description": "Clasificaci\u00f3n importante utilizada para determinar la administraci\u00f3n y contabilizaci\u00f3n de un producto."
     },
     "Ispricerulebased": {
       "label": "Basado en Regla de Precio",
-      "description": "Indica si el servicio tiene un precio fijo o si obtiene el precio basándose en una Regla de Precio de Servicio"
+      "description": "Indica si el servicio tiene un precio fijo o si obtiene el precio bas\u00e1ndose en una Regla de Precio de Servicio"
     },
     "parametervalue": {
       "label": "Valor",
@@ -4078,11 +4078,11 @@
     },
     "C_Calendar_ID": {
       "label": "Calendario",
-      "description": "Tabla que muestra los días de la semana de cada mes del año."
+      "description": "Tabla que muestra los d\u00edas de la semana de cada mes del a\u00f1o."
     },
     "AD_System_ID": {
       "label": "Sistema",
-      "description": "Definición del sistema"
+      "description": "Definici\u00f3n del sistema"
     },
     "Username": {
       "label": "Nombre usuario",
@@ -4093,40 +4093,40 @@
       "description": "Nombre usuario"
     },
     "C_Conversion_Rate_ID": {
-      "label": "Ratio de conversión",
+      "label": "Ratio de conversi\u00f3n",
       "description": "Importe o cantidad en que una unidad de medida cambia por otra."
     },
     "Manufacturer": {
       "label": "Fabricante",
-      "description": "Tercero que elabora un producto específico."
+      "description": "Tercero que elabora un producto espec\u00edfico."
     },
     "DescriptionURL": {
-      "label": "Descripción URL",
-      "description": "Dirección destinada a la descripción de un producto, a la que puede accederse via Internet."
+      "label": "Descripci\u00f3n URL",
+      "description": "Direcci\u00f3n destinada a la descripci\u00f3n de un producto, a la que puede accederse via Internet."
     },
     "A_Asset_Group_ID": {
       "label": "Grupo activo",
-      "description": "Clasificación de los activos basada en características similares."
+      "description": "Clasificaci\u00f3n de los activos basada en caracter\u00edsticas similares."
     },
     "C_Currency_ID": {
       "label": "Moneda",
-      "description": "Medio aceptado de intercambio de moneda que varía según el país."
+      "description": "Medio aceptado de intercambio de moneda que var\u00eda seg\u00fan el pa\u00eds."
     },
     "AD_Process_Access_ID": {
       "label": "AD_Process_Access_ID",
       "description": ""
     },
     "AssetDepreciationDate": {
-      "label": "F.depreciación activo",
-      "description": "Fecha de última depreciación"
+      "label": "F.depreciaci\u00f3n activo",
+      "description": "Fecha de \u00faltima depreciaci\u00f3n"
     },
     "AssetDisposalDate": {
       "label": "F.disponibilidad activo",
       "description": "F.disponibilidad activo"
     },
     "Relateprodcattaxtoservice": {
-      "label": "Modificar Impuesto de la Categoría de Producto",
-      "description": "Proceso para definir la modificación de la configuración de impuesto de los servicios seleccionados"
+      "label": "Modificar Impuesto de la Categor\u00eda de Producto",
+      "description": "Proceso para definir la modificaci\u00f3n de la configuraci\u00f3n de impuesto de los servicios seleccionados"
     },
     "AssetServiceDate": {
       "label": "F.servicio",
@@ -4138,35 +4138,35 @@
     },
     "GuaranteeDate": {
       "label": "F. caducidad",
-      "description": "Fecha de vencimiento de la garantía de calidad de un producto."
+      "description": "Fecha de vencimiento de la garant\u00eda de calidad de un producto."
     },
     "GuaranteeDays": {
-      "label": "Días de garantía",
-      "description": "Número de días en los que el producto tiene garantía o está disponible"
+      "label": "D\u00edas de garant\u00eda",
+      "description": "N\u00famero de d\u00edas en los que el producto tiene garant\u00eda o est\u00e1 disponible"
     },
     "IsDepreciated": {
       "label": "Amortizar",
-      "description": "El activo se usa internamente y será amortizado."
+      "description": "El activo se usa internamente y ser\u00e1 amortizado."
     },
     "IsDisposed": {
       "label": "Dispuesto",
-      "description": "El activo está dispuesto"
+      "description": "El activo est\u00e1 dispuesto"
     },
     "IsInPosession": {
-      "label": "En posesión",
-      "description": "El activo está en posesión de la organización"
+      "label": "En posesi\u00f3n",
+      "description": "El activo est\u00e1 en posesi\u00f3n de la organizaci\u00f3n"
     },
     "IsOwned": {
       "label": "En propiedad",
-      "description": "La organización es propietaria del activo"
+      "description": "La organizaci\u00f3n es propietaria del activo"
     },
     "Isowned": {
       "label": "En propiedad",
-      "description": "La organización es propietaria del activo"
+      "description": "La organizaci\u00f3n es propietaria del activo"
     },
     "LifeUseUnits": {
-      "label": "Vida útil",
-      "description": "Unidad de la vida útil del activo antes de que no sea posible utilizarlo nunca más"
+      "label": "Vida \u00fatil",
+      "description": "Unidad de la vida \u00fatil del activo antes de que no sea posible utilizarlo nunca m\u00e1s"
     },
     "LocationComment": {
       "label": "Comentario ",
@@ -4177,8 +4177,8 @@
       "description": "Unidades comunmente utilizadas para los activos"
     },
     "VersionNo": {
-      "label": "Núm.versión",
-      "description": "Número de versión"
+      "label": "N\u00fam.versi\u00f3n",
+      "description": "N\u00famero de versi\u00f3n"
     },
     "C_Currency_Id_To": {
       "label": "Moneda objetivo",
@@ -4189,8 +4189,8 @@
       "description": "Moneda objeitvo"
     },
     "IsFullyDepreciated": {
-      "label": "Depreciación completa",
-      "description": "El activo está completamente depreciado"
+      "label": "Depreciaci\u00f3n completa",
+      "description": "El activo est\u00e1 completamente depreciado"
     },
     "C_DocType_ID": {
       "label": "Tipo de documento",
@@ -4209,8 +4209,8 @@
       "description": "El servicio puede modificar el impuesto de los productos asociados."
     },
     "C_DocTypeTarget_ID": {
-      "label": "Documento transacción",
-      "description": "Tipo de documento específico que deber utilizarse en una transacción específica."
+      "label": "Documento transacci\u00f3n",
+      "description": "Tipo de documento espec\u00edfico que deber utilizarse en una transacci\u00f3n espec\u00edfica."
     },
     "Sendemail": {
       "label": "Mandar email",
@@ -4218,34 +4218,34 @@
     },
     "C_Elementvalue_ID": {
       "label": "Cuenta Contable",
-      "description": "Código de identificación para un tipo de cuenta."
+      "description": "C\u00f3digo de identificaci\u00f3n para un tipo de cuenta."
     },
     "C_ELEMENTVALUE_ID": {
       "label": "Cuenta Contable",
-      "description": "Código de identificación para un tipo de cuenta."
+      "description": "C\u00f3digo de identificaci\u00f3n para un tipo de cuenta."
     },
     "C_ElementValue_ID": {
       "label": "Cuenta Contable",
-      "description": "Código de identificación para un tipo de cuenta."
+      "description": "C\u00f3digo de identificaci\u00f3n para un tipo de cuenta."
     },
     "A_Country": {
-      "label": "País",
-      "description": "País"
+      "label": "Pa\u00eds",
+      "description": "Pa\u00eds"
     },
     "C_Element_ID": {
-      "label": "Árbol de cuentas ",
-      "description": "Identificador característico de un Árbol de cuentas."
+      "label": "\u00c1rbol de cuentas ",
+      "description": "Identificador caracter\u00edstico de un \u00c1rbol de cuentas."
     },
     "Quantity_Rule": {
       "label": "Regla de Cantidad",
-      "description": "Regla para definir cuántas líneas relacionadas serán creadas cuando se relaciona un servicio con múltiples líneas de un pedido de venta"
+      "description": "Regla para definir cu\u00e1ntas l\u00edneas relacionadas ser\u00e1n creadas cuando se relaciona un servicio con m\u00faltiples l\u00edneas de un pedido de venta"
     },
     "Smtpconnectionsecurity": {
-      "label": "Conexión de seguridad Smtp",
+      "label": "Conexi\u00f3n de seguridad Smtp",
       "description": "Security protocol used for the SMTP connection."
     },
     "AD_Cluster_Instance_ID": {
-      "label": "Instancia del Clúster",
+      "label": "Instancia del Cl\u00faster",
       "description": ""
     },
     "Algorithm": {
@@ -4257,20 +4257,20 @@
       "description": "Campo booleano disponible en productos de tipo servicio que indica si el servicio puede estar relacionado con un producto en un ticket inactivo o no"
     },
     "Deferred_Sell_Max_Days": {
-      "label": "Máximo Días Venta Diferida",
-      "description": "Máximo número de días que pueden pasar desde la fecha de venta de un producto para poder vender un servicio relacionado que permite venta periódica."
+      "label": "M\u00e1ximo D\u00edas Venta Diferida",
+      "description": "M\u00e1ximo n\u00famero de d\u00edas que pueden pasar desde la fecha de venta de un producto para poder vender un servicio relacionado que permite venta peri\u00f3dica."
     },
     "AD_Periodcontrolallowed_Org_ID": {
-      "label": "Organización con control de periodos",
-      "description": "Organización con la casilla de permitir control de periodos activada."
+      "label": "Organizaci\u00f3n con control de periodos",
+      "description": "Organizaci\u00f3n con la casilla de permitir control de periodos activada."
     },
     "Change_Status": {
       "label": "Cambiar Estado",
       "description": ""
     },
     "AdvancedFilterSeqno": {
-      "label": "Número de Secuencia de los Filtros Avanzados",
-      "description": "El número de secuencia indica el orden utilizado en los Filtros Avanzados"
+      "label": "N\u00famero de Secuencia de los Filtros Avanzados",
+      "description": "El n\u00famero de secuencia indica el orden utilizado en los Filtros Avanzados"
     },
     "Startinoddcolumn": {
       "label": "Empezar en columna Impar",
@@ -4278,7 +4278,7 @@
     },
     "Closephase": {
       "label": "Cerrar fase",
-      "description": "Si esta comprobada la fase de trabajo se cerrará cuando el parte de trabajo esté validado"
+      "description": "Si esta comprobada la fase de trabajo se cerrar\u00e1 cuando el parte de trabajo est\u00e9 validado"
     },
     "AllocatedQty": {
       "label": "Cantidad Asignada",
@@ -4289,7 +4289,7 @@
       "description": ""
     },
     "IsExplodeConf": {
-      "label": "Explotar Solapa de Configuración",
+      "label": "Explotar Solapa de Configuraci\u00f3n",
       "description": ""
     },
     "CUR_Inventory_Amount": {
@@ -4301,64 +4301,64 @@
       "description": ""
     },
     "C_LocFrom_ID": {
-      "label": "Ubicación desde",
-      "description": "Ubicación desde donde se envían los ítems."
+      "label": "Ubicaci\u00f3n desde",
+      "description": "Ubicaci\u00f3n desde donde se env\u00edan los \u00edtems."
     },
     "C_Locfrom_ID": {
-      "label": "Ubicación desde",
-      "description": "Ubicación desde donde se envían los ítems."
+      "label": "Ubicaci\u00f3n desde",
+      "description": "Ubicaci\u00f3n desde donde se env\u00edan los \u00edtems."
     },
     "Duedate": {
       "label": "Fecha de vencimiento",
-      "description": "Periodo en que debe satisfacerse una petición específica."
+      "description": "Periodo en que debe satisfacerse una petici\u00f3n espec\u00edfica."
     },
     "DueDate": {
       "label": "Fecha de vencimiento",
-      "description": "Periodo en que debe satisfacerse una petición específica."
+      "description": "Periodo en que debe satisfacerse una petici\u00f3n espec\u00edfica."
     },
     "due_date": {
       "label": "Fecha de vencimiento",
-      "description": "Periodo en que debe satisfacerse una petición específica."
+      "description": "Periodo en que debe satisfacerse una petici\u00f3n espec\u00edfica."
     },
     "NetDay": {
-      "label": "Día de la semana",
-      "description": "Otorgamiento de una nueva fecha de pago sin penalización, posterior a la fecha de pago acordada."
+      "label": "D\u00eda de la semana",
+      "description": "Otorgamiento de una nueva fecha de pago sin penalizaci\u00f3n, posterior a la fecha de pago acordada."
     },
     "Percentage": {
       "label": "Porcentaje",
       "description": "Porcentaje de todo el importe"
     },
     "C_Locto_ID": {
-      "label": "Ubicación a",
-      "description": "Ubicación hacia donde se envían los ítems."
+      "label": "Ubicaci\u00f3n a",
+      "description": "Ubicaci\u00f3n hacia donde se env\u00edan los \u00edtems."
     },
     "C_LocTo_ID": {
-      "label": "Ubicación a",
-      "description": "Ubicación hacia donde se envían los ítems."
+      "label": "Ubicaci\u00f3n a",
+      "description": "Ubicaci\u00f3n hacia donde se env\u00edan los \u00edtems."
     },
     "DropShip_BPartner_ID": {
-      "label": "Entrega de envíos a terceros",
-      "description": "Tercero donde enviar los envíos"
+      "label": "Entrega de env\u00edos a terceros",
+      "description": "Tercero donde enviar los env\u00edos"
     },
     "IsGuaranteeDate": {
       "label": "F. caducidad",
-      "description": "Fecha de vencimiento de la garantía de calidad de un producto."
+      "description": "Fecha de vencimiento de la garant\u00eda de calidad de un producto."
     },
     "IsInstanceAttribute": {
       "label": "Atributo instancia",
-      "description": "El atributo del producto es específico del ejemplo (como el número de serie, lote o fecha garantía)"
+      "description": "El atributo del producto es espec\u00edfico del ejemplo (como el n\u00famero de serie, lote o fecha garant\u00eda)"
     },
     "IsLot": {
       "label": "Lote",
-      "description": "Grupo de ítems idénticos o similares organizados y ubicados en el inventario bajo un número."
+      "description": "Grupo de \u00edtems id\u00e9nticos o similares organizados y ubicados en el inventario bajo un n\u00famero."
     },
     "IsSerNo": {
-      "label": "Número de serie",
-      "description": "Atributo utilizado como identificador único de un producto."
+      "label": "N\u00famero de serie",
+      "description": "Atributo utilizado como identificador \u00fanico de un producto."
     },
     "M_Attribute_ID": {
       "label": "Atributo",
-      "description": "Característica definida de un producto específico."
+      "description": "Caracter\u00edstica definida de un producto espec\u00edfico."
     },
     "M_AttributeSet_ID": {
       "label": "Conjunto atributos",
@@ -4381,8 +4381,8 @@
       "description": "Tarea o emprendimiento definido."
     },
     "C_Location_ID": {
-      "label": "Dirección",
-      "description": "Lugar o residencia específicos."
+      "label": "Direcci\u00f3n",
+      "description": "Lugar o residencia espec\u00edficos."
     },
     "M_AttributeValue_ID": {
       "label": "Valor del atributo",
@@ -4390,71 +4390,71 @@
     },
     "M_Lot_ID": {
       "label": "Lote",
-      "description": "Grupo de ítems idénticos o similares organizados y ubicados en el inventario bajo un número."
+      "description": "Grupo de \u00edtems id\u00e9nticos o similares organizados y ubicados en el inventario bajo un n\u00famero."
     },
     "M_LotCtl_ID": {
       "label": "Control del lote",
       "description": "Control del lote del producto"
     },
     "M_SerNoCtl_ID": {
-      "label": "Control del número de serie",
-      "description": "Control del número de serie del producto"
+      "label": "Control del n\u00famero de serie",
+      "description": "Control del n\u00famero de serie del producto"
     },
     "Included_Tab_ID": {
       "label": "Solapa incluida",
       "description": "Solapa incluida en esta solapa "
     },
     "AD_Session_ID": {
-      "label": "Sesión",
-      "description": "Usuario de la sesión on-line o web"
+      "label": "Sesi\u00f3n",
+      "description": "Usuario de la sesi\u00f3n on-line o web"
     },
     "C_NonBusinessDay_ID": {
-      "label": "Día no laborable",
-      "description": "Día no laborable"
+      "label": "D\u00eda no laborable",
+      "description": "D\u00eda no laborable"
     },
     "BOMType": {
       "label": "Tipos de lista de materiales",
       "description": "Tipos de lista de materiales"
     },
     "C_Phase_ID": {
-      "label": "Fase estándar",
-      "description": "Sección o parte de un proyecto que puede estar compuesta por una o más tareas."
+      "label": "Fase est\u00e1ndar",
+      "description": "Secci\u00f3n o parte de un proyecto que puede estar compuesta por una o m\u00e1s tareas."
     },
     "C_ProjectType_ID": {
       "label": "Tipo de proyecto",
-      "description": "Característica única del proyecto utilizada en los procesos y a veces agrupada dentro de una categoría."
+      "description": "Caracter\u00edstica \u00fanica del proyecto utilizada en los procesos y a veces agrupada dentro de una categor\u00eda."
     },
     "CommittedQty": {
       "label": "Cant.comprometida",
-      "description": "Importe máximo permitido de un proyecto."
+      "description": "Importe m\u00e1ximo permitido de un proyecto."
     },
     "DownloadURL": {
       "label": "URL de descarga",
       "description": "URL donde descargarse los archivos"
     },
     "CopyFrom": {
-      "label": "Copiar líneas",
-      "description": "Acto de añadir declaraciones de documentos preexistentes."
+      "label": "Copiar l\u00edneas",
+      "description": "Acto de a\u00f1adir declaraciones de documentos preexistentes."
     },
     "C_PaymentTerm_ID": {
       "label": "Condiciones de pago",
-      "description": "Plan y fecha de cumplimiento definidos para completar un pago específico."
+      "description": "Plan y fecha de cumplimiento definidos para completar un pago espec\u00edfico."
     },
     "DropShip_Location_ID": {
-      "label": "Lugar de envíos",
-      "description": "Lugar del tercero donde entregar los envíos"
+      "label": "Lugar de env\u00edos",
+      "description": "Lugar del tercero donde entregar los env\u00edos"
     },
     "DropShip_User_ID": {
-      "label": "Contacto de los envíos",
-      "description": "Contacto del tercero para entrega de los envíos"
+      "label": "Contacto de los env\u00edos",
+      "description": "Contacto del tercero para entrega de los env\u00edos"
     },
     "Invoicedamt": {
       "label": "Imp.factura",
-      "description": "Suma que se factura por un ítem o servicio específico."
+      "description": "Suma que se factura por un \u00edtem o servicio espec\u00edfico."
     },
     "InvoicedAmt": {
       "label": "Imp.factura",
-      "description": "Suma que se factura por un ítem o servicio específico."
+      "description": "Suma que se factura por un \u00edtem o servicio espec\u00edfico."
     },
     "GenerateOrder": {
       "label": "Generar pedidos de venta de un proyecto",
@@ -4473,12 +4473,12 @@
       "description": "Balance general del proyecto"
     },
     "WebSession": {
-      "label": "Sesión de la web",
-      "description": "ID de la sesión de la web"
+      "label": "Sesi\u00f3n de la web",
+      "description": "ID de la sesi\u00f3n de la web"
     },
     "C_Period_ID": {
       "label": "Periodo",
-      "description": "Periodo específico de tiempo."
+      "description": "Periodo espec\u00edfico de tiempo."
     },
     "AD_Menu_Trl_ID": {
       "label": "Menu traducido",
@@ -4486,7 +4486,7 @@
     },
     "IsSelfService": {
       "label": "Autoservicio",
-      "description": "El Self-Service permite al usuario introducir datos o actualizar los existentes. Esta opción indica que este registro se introdujo o creo vía Self-Service o que el usuario puede cambiarlo vía la funcionalidad de Self-Service."
+      "description": "El Self-Service permite al usuario introducir datos o actualizar los existentes. Esta opci\u00f3n indica que este registro se introdujo o creo v\u00eda Self-Service o que el usuario puede cambiarlo v\u00eda la funcionalidad de Self-Service."
     },
     "NEW_Value": {
       "label": "Nuevo valor",
@@ -4498,23 +4498,23 @@
     },
     "C_ProjectPhase_ID": {
       "label": "Fase del proyecto",
-      "description": "Sección definida de un proyecto, que puede estar compuesta por una o varias fases."
+      "description": "Secci\u00f3n definida de un proyecto, que puede estar compuesta por una o varias fases."
     },
     "C_ProjectTask_ID": {
       "label": "Tarea del proyecto",
       "description": "Tarea que debe realizarse durante una fase del proyecto."
     },
     "C_Task_ID": {
-      "label": "Tarea estándar",
-      "description": "Tipo de tarea estándar del proyecto"
+      "label": "Tarea est\u00e1ndar",
+      "description": "Tipo de tarea est\u00e1ndar del proyecto"
     },
     "IsCommitCeiling": {
-      "label": "Límite superior",
-      "description": "Indicación de que se está cobrando la suma o importe máximos permitidos por el contrato (puede depender de los requisitios del gobierno)."
+      "label": "L\u00edmite superior",
+      "description": "Indicaci\u00f3n de que se est\u00e1 cobrando la suma o importe m\u00e1ximos permitidos por el contrato (puede depender de los requisitios del gobierno)."
     },
     "IsExclude": {
       "label": "Excluir",
-      "description": "Opción que permite o niega el acceso a datos específicos."
+      "description": "Opci\u00f3n que permite o niega el acceso a datos espec\u00edficos."
     },
     "Project_Acctdim_Isenable": {
       "label": "Proyecto",
@@ -4526,11 +4526,11 @@
     },
     "AD_AlertRule_ID": {
       "label": "Regla alerta",
-      "description": "Definición del elemento alerta"
+      "description": "Definici\u00f3n del elemento alerta"
     },
     "C_Region_ID": {
       "label": "Provincia",
-      "description": "Área de un país específico."
+      "description": "\u00c1rea de un pa\u00eds espec\u00edfico."
     },
     "M_Product_Po_ID": {
       "label": "Proveedor preferido",
@@ -4545,12 +4545,12 @@
       "description": ""
     },
     "C_SalesRegion_ID": {
-      "label": "Región de venta",
-      "description": "Sección definida del mundo donde deben concentrarse las campañas de venta. "
+      "label": "Regi\u00f3n de venta",
+      "description": "Secci\u00f3n definida del mundo donde deben concentrarse las campa\u00f1as de venta. "
     },
     "C_Salesregion_ID": {
-      "label": "Región de venta",
-      "description": "Sección definida del mundo donde deben concentrarse las campañas de venta. "
+      "label": "Regi\u00f3n de venta",
+      "description": "Secci\u00f3n definida del mundo donde deben concentrarse las campa\u00f1as de venta. "
     },
     "AD_Window_Trl_ID": {
       "label": "Ventana traducida",
@@ -4558,43 +4558,43 @@
     },
     "C_Taxcategory_ID": {
       "label": "Grupo de impuesto",
-      "description": "Clasificación de las opciones impositivas basada en atributos o características similares."
+      "description": "Clasificaci\u00f3n de las opciones impositivas basada en atributos o caracter\u00edsticas similares."
     },
     "C_TaxCategory_ID": {
       "label": "Grupo de impuesto",
-      "description": "Clasificación de las opciones impositivas basada en atributos o características similares."
+      "description": "Clasificaci\u00f3n de las opciones impositivas basada en atributos o caracter\u00edsticas similares."
     },
     "M_Freight_ID": {
       "label": "Porte",
       "description": "Rango portes"
     },
     "M_FreightCategory_ID": {
-      "label": "Categoría portes",
-      "description": "Clasificación utilizada para calcular los importes de envíos de la compañía de transporte."
+      "label": "Categor\u00eda portes",
+      "description": "Clasificaci\u00f3n utilizada para calcular los importes de env\u00edos de la compa\u00f1\u00eda de transporte."
     },
     "Memo": {
       "label": "Nota",
       "description": "Texto de la nota"
     },
     "NoPackages": {
-      "label": "Número paquetes",
+      "label": "N\u00famero paquetes",
       "description": "Cantidad de paquetes para enviar."
     },
     "PickDate": {
       "label": "F.recogida",
-      "description": "Fecha/hora cuando se recogió para enviar"
+      "description": "Fecha/hora cuando se recogi\u00f3 para enviar"
     },
     "ReleaseNo": {
-      "label": "Versión nº",
-      "description": "Liberar número interno"
+      "label": "Versi\u00f3n n\u00ba",
+      "description": "Liberar n\u00famero interno"
     },
     "ShipDate": {
-      "label": "F.envío",
-      "description": "Fecha/hora envío"
+      "label": "F.env\u00edo",
+      "description": "Fecha/hora env\u00edo"
     },
     "TrackingNo": {
-      "label": "Número de envío",
-      "description": "Número de la pista del envío"
+      "label": "N\u00famero de env\u00edo",
+      "description": "N\u00famero de la pista del env\u00edo"
     },
     "IsList": {
       "label": "Lista",
@@ -4602,11 +4602,11 @@
     },
     "tax": {
       "label": "Impuesto",
-      "description": "Porcentaje de dinero exigido por el gobierno por un producto o transacción específica."
+      "description": "Porcentaje de dinero exigido por el gobierno por un producto o transacci\u00f3n espec\u00edfica."
     },
     "C_Tax_ID": {
       "label": "Impuesto",
-      "description": "Porcentaje de dinero exigido por el gobierno por un producto o transacción específica."
+      "description": "Porcentaje de dinero exigido por el gobierno por un producto o transacci\u00f3n espec\u00edfica."
     },
     "AD_User_Roles_ID": {
       "label": "Usuario Rol",
@@ -4617,8 +4617,8 @@
       "description": "Ventana de pedido de compras"
     },
     "C_UOM_Conversion_ID": {
-      "label": "Conversión unidades",
-      "description": "Conversión de la unidad de medida"
+      "label": "Conversi\u00f3n unidades",
+      "description": "Conversi\u00f3n de la unidad de medida"
     },
     "C_UOM_ID": {
       "label": "Unidad",
@@ -4645,40 +4645,40 @@
       "description": "Asunto del proyecto (Materiales, trabajo)"
     },
     "ProjectCategory": {
-      "label": "Categoría del proyecto",
-      "description": "Categoría del proyecto"
+      "label": "Categor\u00eda del proyecto",
+      "description": "Categor\u00eda del proyecto"
     },
     "C_UOM_Length_ID": {
       "label": "Unidad de longitud",
-      "description": "Unidad estándar de longitud"
+      "description": "Unidad est\u00e1ndar de longitud"
     },
     "C_OrderPO_ID": {
       "label": "Pedido de compra",
-      "description": "Identificador único de un pedido de compra, que a menudo se genera automáticamente."
+      "description": "Identificador \u00fanico de un pedido de compra, que a menudo se genera autom\u00e1ticamente."
     },
     "IsDescription": {
-      "label": "Sólo descripción",
-      "description": "Si cierto, la línea es sólo una descripción no una operación"
+      "label": "S\u00f3lo descripci\u00f3n",
+      "description": "Si cierto, la l\u00ednea es s\u00f3lo una descripci\u00f3n no una operaci\u00f3n"
     },
     "C_Extbp_Enabled": {
       "label": "Habilitar el Conector con el CRM",
-      "description": "Permite configurar la integración con un sistema CRM externo"
+      "description": "Permite configurar la integraci\u00f3n con un sistema CRM externo"
     },
     "C_UOM_Time_ID": {
       "label": "Unidad de tiempo",
-      "description": "Unidad estándar de tiempo"
+      "description": "Unidad est\u00e1ndar de tiempo"
     },
     "C_UOM_Volume_ID": {
       "label": "Unidad de volumen",
-      "description": "Unidad estándar de volumen"
+      "description": "Unidad est\u00e1ndar de volumen"
     },
     "C_Uom_Weight_ID": {
       "label": "Unidad de peso",
-      "description": "Unidad estándar de peso"
+      "description": "Unidad est\u00e1ndar de peso"
     },
     "C_UOM_Weight_ID": {
       "label": "Unidad de peso",
-      "description": "Unidad estándar de peso"
+      "description": "Unidad est\u00e1ndar de peso"
     },
     "C_Year_ID": {
       "label": "Ejercicio",
@@ -4694,15 +4694,15 @@
     },
     "City": {
       "label": "Ciudad",
-      "description": "Área poblada definida, ubicada en un área más grande, como un estado, provincia o país."
+      "description": "\u00c1rea poblada definida, ubicada en un \u00e1rea m\u00e1s grande, como un estado, provincia o pa\u00eds."
     },
     "Code": {
-      "label": "Código de validación",
-      "description": "Código que se ejecuta para determinar el procedimiento de configuración."
+      "label": "C\u00f3digo de validaci\u00f3n",
+      "description": "C\u00f3digo que se ejecuta para determinar el procedimiento de configuraci\u00f3n."
     },
     "WSC_Calls_Avg": {
       "label": "Media de llamadas conectadas",
-      "description": "Número medio de llamadas conectadas por día en los últimos 30 días"
+      "description": "N\u00famero medio de llamadas conectadas por d\u00eda en los \u00faltimos 30 d\u00edas"
     },
     "Columnname": {
       "label": "Nombre columna BD",
@@ -4714,7 +4714,7 @@
     },
     "Combination": {
       "label": "Conjunto",
-      "description": "Conjunto único de elementos de una cuenta"
+      "description": "Conjunto \u00fanico de elementos de una cuenta"
     },
     "CreatedByAlgorithm": {
       "label": "Creado por algoritmo",
@@ -4726,99 +4726,99 @@
     },
     "Comments": {
       "label": "Comentarios",
-      "description": "Espacio para escribir información adicional relacionada."
+      "description": "Espacio para escribir informaci\u00f3n adicional relacionada."
     },
     "CommitWarning": {
-      "label": "Confirmación al guardar",
-      "description": "Advertencia o información que aparece cuando se guarda un registro."
+      "label": "Confirmaci\u00f3n al guardar",
+      "description": "Advertencia o informaci\u00f3n que aparece cuando se guarda un registro."
     },
     "ControlAmt": {
       "label": "Cant.control",
-      "description": "Si no es cero, el débito del documento debe ser igual a esta cantidad"
+      "description": "Si no es cero, el d\u00e9bito del documento debe ser igual a esta cantidad"
     },
     "ConversionRateType": {
-      "label": "Tipo de rango de conversión",
-      "description": "Tasa de conversión definida que se utiliza en los procesos."
+      "label": "Tipo de rango de conversi\u00f3n",
+      "description": "Tasa de conversi\u00f3n definida que se utiliza en los procesos."
     },
     "PO_Order_Blocking": {
       "label": "Pedido de compra",
       "description": "Permite bloquear pedidos de compra a un proveedor."
     },
     "CostingPrecision": {
-      "label": "Precisión de los  costos",
-      "description": "Redondeo usado en cálculo de costos"
+      "label": "Precisi\u00f3n de los  costos",
+      "description": "Redondeo usado en c\u00e1lculo de costos"
     },
     "Costs": {
       "label": "Costos",
       "description": "Costos en la moneda contable"
     },
     "Created": {
-      "label": "Fecha Creación",
+      "label": "Fecha Creaci\u00f3n",
       "description": "Fecha en que se completa este registro."
     },
     "CountryCode": {
-      "label": "Código ISO país",
-      "description": "Código geográfico de un país basado en el código ISO país."
+      "label": "C\u00f3digo ISO pa\u00eds",
+      "description": "C\u00f3digo geogr\u00e1fico de un pa\u00eds basado en el c\u00f3digo ISO pa\u00eds."
     },
     "created": {
-      "label": "Fecha Creación",
+      "label": "Fecha Creaci\u00f3n",
       "description": "Fecha en que se completa este registro."
     },
     "creationDate": {
-      "label": "Fecha Creación",
+      "label": "Fecha Creaci\u00f3n",
       "description": "Fecha en que se completa este registro."
     },
     "createdBy": {
       "label": "Creado por",
-      "description": "Usuario que creó el registro"
+      "description": "Usuario que cre\u00f3 el registro"
     },
     "Restrictpurchase": {
       "label": "Restringir compras",
-      "description": "Indica si está permitido comprar un producto"
+      "description": "Indica si est\u00e1 permitido comprar un producto"
     },
     "CreditCardNumber": {
-      "label": "Número tarjeta",
-      "description": "Número de la tarjeta de crédito"
+      "label": "N\u00famero tarjeta",
+      "description": "N\u00famero de la tarjeta de cr\u00e9dito"
     },
     "Isvirtual": {
       "label": "Es virtual",
       "description": ""
     },
     "C_Extbp_Config_Filter_Opt_ID": {
-      "label": "Opción de Filtro",
-      "description": "Una opción para seleccionar en un filtro"
+      "label": "Opci\u00f3n de Filtro",
+      "description": "Una opci\u00f3n para seleccionar en un filtro"
     },
     "AD_Process_Group_List_ID": {
       "label": "Lista de Grupo de Procesos",
-      "description": "Proceso dentro de un Grupo de Procesos con un número de sequencia"
+      "description": "Proceso dentro de un Grupo de Procesos con un n\u00famero de sequencia"
     },
     "CurSymbol": {
-      "label": "Símbolo",
-      "description": "Descripción abreviada utilizada para definir una unidad de medida o de moneda."
+      "label": "S\u00edmbolo",
+      "description": "Descripci\u00f3n abreviada utilizada para definir una unidad de medida o de moneda."
     },
     "CurrencyBalancing_Acct": {
       "label": "Cuenta de redondeo de cambio de moneda",
       "description": "Cuenta de redondeo de cambio de moneda"
     },
     "notinvoicedlines": {
-      "label": "LíneasNoFacturadas",
+      "label": "L\u00edneasNoFacturadas",
       "description": ""
     },
     "CurrencyRate": {
-      "label": "Índice",
+      "label": "\u00cdndice",
       "description": "Porcentaje que debe multiplicarse por la cifra original para arribar al impuesto o al tipo de cambio."
     },
     "CurrentNext": {
       "label": "Valor actual",
-      "description": "Número que debe asignarse al ítem siguiente."
+      "description": "N\u00famero que debe asignarse al \u00edtem siguiente."
     },
     "Createfromorders": {
-      "label": "Crear Líneas Desde Pedido",
-      "description": "Acto de añadir declaraciones de pedidos preexistentes."
+      "label": "Crear L\u00edneas Desde Pedido",
+      "description": "Acto de a\u00f1adir declaraciones de pedidos preexistentes."
     },
     "DUNS": {
       "label": "D-U-N-S",
-      "description": "Número Dun & Bradstreet"
+      "description": "N\u00famero Dun & Bradstreet"
     },
     "AD_Field_Trl_ID": {
       "label": "Campo traducido",
@@ -4834,11 +4834,11 @@
     },
     "DateAcct": {
       "label": "Fecha contable",
-      "description": "Fecha de registro de esta transacción en el libro mayor."
+      "description": "Fecha de registro de esta transacci\u00f3n en el libro mayor."
     },
     "DateDelivered": {
       "label": "Datos entregados",
-      "description": "Fecha en la que el producto se entregó"
+      "description": "Fecha en la que el producto se entreg\u00f3"
     },
     "DateDoc": {
       "label": "Fecha del documento",
@@ -4866,39 +4866,39 @@
     },
     "DatePromised": {
       "label": "Fecha comprometida",
-      "description": "Periodo en que debe completarse o enviarse la tarea, el proceso o la acción."
+      "description": "Periodo en que debe completarse o enviarse la tarea, el proceso o la acci\u00f3n."
     },
     "scheduledDeliveryDate": {
       "label": "Fecha comprometida",
-      "description": "Periodo en que debe completarse o enviarse la tarea, el proceso o la acción."
+      "description": "Periodo en que debe completarse o enviarse la tarea, el proceso o la acci\u00f3n."
     },
     "Datepromised": {
       "label": "Fecha comprometida",
-      "description": "Periodo en que debe completarse o enviarse la tarea, el proceso o la acción."
+      "description": "Periodo en que debe completarse o enviarse la tarea, el proceso o la acci\u00f3n."
     },
     "Rundate": {
       "label": "Fecha de proceso",
-      "description": "Fecha de ejecución del proceso"
+      "description": "Fecha de ejecuci\u00f3n del proceso"
     },
     "Nodeidcolumn": {
       "label": "Node ID Column",
       "description": "Para tablas con la referencia al padre: columna que representa el identificador del nodo"
     },
     "DefaultValue": {
-      "label": "Lógica del valor por defecto",
+      "label": "L\u00f3gica del valor por defecto",
       "description": "Primer valor no nulo de un grupo de valores. Se utiliza como valor por defecto de un campo cuando se crea un registro."
     },
     "Defaultvalue": {
-      "label": "Lógica del valor por defecto",
+      "label": "L\u00f3gica del valor por defecto",
       "description": "Primer valor no nulo de un grupo de valores. Se utiliza como valor por defecto de un campo cuando se crea un registro."
     },
     "DeliveryViaRule": {
-      "label": "Medio de envío",
+      "label": "Medio de env\u00edo",
       "description": "Medios ideales para entregar a terceros los productos ordenados."
     },
     "description": {
-      "label": "Descripción",
-      "description": "Espacio para escribir información adicional relacionada."
+      "label": "Descripci\u00f3n",
+      "description": "Espacio para escribir informaci\u00f3n adicional relacionada."
     },
     "Unbox": {
       "label": "Desempaquetar",
@@ -4910,27 +4910,27 @@
     },
     "Discontinued": {
       "label": "Descatalogado",
-      "description": "Declaración de que este producto ya no está disponible en el  mercado."
+      "description": "Declaraci\u00f3n de que este producto ya no est\u00e1 disponible en el  mercado."
     },
     "DiscontinuedBy": {
       "label": "Descatalogado desde",
-      "description": "Nombre de la persona que discontinúa un ítem."
+      "description": "Nombre de la persona que discontin\u00faa un \u00edtem."
     },
     "Discount": {
       "label": "% de descuento",
-      "description": "Descuento proporcional efectuado sobre un ítem, sin relación con otros descuentos anteriores."
+      "description": "Descuento proporcional efectuado sobre un \u00edtem, sin relaci\u00f3n con otros descuentos anteriores."
     },
     "DisplayLength": {
       "label": "Longitud del campo",
-      "description": "Número de caracteres que pueden añadirse a un campo específico."
+      "description": "N\u00famero de caracteres que pueden a\u00f1adirse a un campo espec\u00edfico."
     },
     "Displaylogic": {
-      "label": "Lógica para mostrar",
-      "description": "Unas secuencias específicas que, al ser evaluadas como falsas, se necesitan para esconder un campo."
+      "label": "L\u00f3gica para mostrar",
+      "description": "Unas secuencias espec\u00edficas que, al ser evaluadas como falsas, se necesitan para esconder un campo."
     },
     "DisplayLogic": {
-      "label": "Lógica para mostrar",
-      "description": "Unas secuencias específicas que, al ser evaluadas como falsas, se necesitan para esconder un campo."
+      "label": "L\u00f3gica para mostrar",
+      "description": "Unas secuencias espec\u00edficas que, al ser evaluadas como falsas, se necesitan para esconder un campo."
     },
     "Isnegativestockcorrection": {
       "label": "Permitir Correcciones de Stock Negativo",
@@ -4941,36 +4941,36 @@
       "description": "La columna mostrar valor con la columna mostrar"
     },
     "DisplaySequence": {
-      "label": "Formato impresión dirección",
-      "description": "Formato de impresión de la dirección"
+      "label": "Formato impresi\u00f3n direcci\u00f3n",
+      "description": "Formato de impresi\u00f3n de la direcci\u00f3n"
     },
     "DivideRate": {
       "label": "Dividir por",
-      "description": "Tasa por la que se divide la unidad básica para crear la unidad calculada."
+      "description": "Tasa por la que se divide la unidad b\u00e1sica para crear la unidad calculada."
     },
     "EndDate": {
       "label": "Fecha final",
-      "description": "Parámetro que indica el momento en que finaliza una petición."
+      "description": "Par\u00e1metro que indica el momento en que finaliza una petici\u00f3n."
     },
     "DocAction": {
       "label": "Proceso pedido",
-      "description": "Forma de cambiar el estado de la transacción de un documento."
+      "description": "Forma de cambiar el estado de la transacci\u00f3n de un documento."
     },
     "Process_Goods_Java": {
-      "label": "Procesar albarán java",
-      "description": "Forma de cambiar el estado de la transacción de un documento."
+      "label": "Procesar albar\u00e1n java",
+      "description": "Forma de cambiar el estado de la transacci\u00f3n de un documento."
     },
     "DocNoSequence_ID": {
-      "label": "Sec.doc.(numeración)",
-      "description": "Determina los números del documento"
+      "label": "Sec.doc.(numeraci\u00f3n)",
+      "description": "Determina los n\u00fameros del documento"
     },
     "DocStatus": {
       "label": "Estado doc.",
-      "description": "Posición específica generada por procesos tanto ejecutados como no ejecutados."
+      "description": "Posici\u00f3n espec\u00edfica generada por procesos tanto ejecutados como no ejecutados."
     },
     "Docstatus": {
       "label": "Estado doc.",
-      "description": "Posición específica generada por procesos tanto ejecutados como no ejecutados."
+      "description": "Posici\u00f3n espec\u00edfica generada por procesos tanto ejecutados como no ejecutados."
     },
     "C_Glitem_Acct_ID": {
       "label": "Concepto Contable Contabilidad",
@@ -4981,20 +4981,20 @@
       "description": "Define si este campo debe mostrarse en el popup"
     },
     "documentNo": {
-      "label": "Nº documento",
-      "description": "Identificador de documentos que puede generarse automáticamente."
+      "label": "N\u00ba documento",
+      "description": "Identificador de documentos que puede generarse autom\u00e1ticamente."
     },
     "Documentno": {
-      "label": "Nº documento",
-      "description": "Identificador de documentos que puede generarse automáticamente."
+      "label": "N\u00ba documento",
+      "description": "Identificador de documentos que puede generarse autom\u00e1ticamente."
     },
     "Numericmask": {
-      "label": "Máscara numérica",
+      "label": "M\u00e1scara num\u00e9rica",
       "description": ""
     },
     "ExpressionPhone": {
-      "label": "Formato teléfono",
-      "description": "Formato teléfono"
+      "label": "Formato tel\u00e9fono",
+      "description": "Formato tel\u00e9fono"
     },
     "ExpressionPostal": {
       "label": "Formato CP",
@@ -5005,24 +5005,24 @@
       "description": "Considerar cero"
     },
     "Confprodcatprocess": {
-      "label": "Añadir Categorías de Productos",
+      "label": "A\u00f1adir Categor\u00edas de Productos",
       "description": ""
     },
     "AllowSorting": {
-      "label": "Permitir Ordenación",
-      "description": "Cuando el checkbox está marcado, la columna se puede ordenar."
+      "label": "Permitir Ordenaci\u00f3n",
+      "description": "Cuando el checkbox est\u00e1 marcado, la columna se puede ordenar."
     },
     "Allowsorting": {
-      "label": "Permitir Ordenación",
-      "description": "Cuando el checkbox está marcado, la columna se puede ordenar."
+      "label": "Permitir Ordenaci\u00f3n",
+      "description": "Cuando el checkbox est\u00e1 marcado, la columna se puede ordenar."
     },
     "FreightAmt": {
       "label": "Portes",
-      "description": "Importe de gastos de un envío específico."
+      "description": "Importe de gastos de un env\u00edo espec\u00edfico."
     },
     "docNo": {
-      "label": "Nº documento",
-      "description": "Identificador de documentos que puede generarse automáticamente."
+      "label": "N\u00ba documento",
+      "description": "Identificador de documentos que puede generarse autom\u00e1ticamente."
     },
     "IsDoubleCash": {
       "label": "Critero de caja doble",
@@ -5033,36 +5033,36 @@
       "description": "Usado cuando el gasto de un producto adquirido se periodifica."
     },
     "Imagesizevaluesaction": {
-      "label": "Acción del tamaño de la imagen",
+      "label": "Acci\u00f3n del tama\u00f1o de la imagen",
       "description": ""
     },
     "ImportStatus": {
-      "label": "Estado Importación",
+      "label": "Estado Importaci\u00f3n",
       "description": ""
     },
     "Cancel_Matching": {
-      "label": "Cancelar Asociación",
+      "label": "Cancelar Asociaci\u00f3n",
       "description": ""
     },
     "ElementType": {
       "label": "Tipo",
-      "description": "Característica única de un ítem utilizada en los procesos y a veces agrupada dentro de una categoría."
+      "description": "Caracter\u00edstica \u00fanica de un \u00edtem utilizada en los procesos y a veces agrupada dentro de una categor\u00eda."
     },
     "Enddate": {
       "label": "Fecha final",
-      "description": "Parámetro que indica el momento en que finaliza una petición."
+      "description": "Par\u00e1metro que indica el momento en que finaliza una petici\u00f3n."
     },
     "Isparentselectionallowed": {
-      "label": "Permitir selección de nodos no hoja",
-      "description": "Permite especificar si los nodos no hoja son seleccionables al utilizar la referencia de árbol"
+      "label": "Permitir selecci\u00f3n de nodos no hoja",
+      "description": "Permite especificar si los nodos no hoja son seleccionables al utilizar la referencia de \u00e1rbol"
     },
     "Groupingseparator": {
-      "label": "Separador de la agrupación",
+      "label": "Separador de la agrupaci\u00f3n",
       "description": ""
     },
     "AD_Businessunit_Org_ID": {
-      "label": "Organización unidad de negocio",
-      "description": "Organización unidad de negocio."
+      "label": "Organizaci\u00f3n unidad de negocio",
+      "description": "Organizaci\u00f3n unidad de negocio."
     },
     "Friday": {
       "label": "Viernes",
@@ -5078,18 +5078,18 @@
     },
     "Fax": {
       "label": "Fax",
-      "description": "Número de fax de un tercero específico."
+      "description": "N\u00famero de fax de un tercero espec\u00edfico."
     },
     "FieldLength": {
       "label": "Longitud",
-      "description": "Indicación sobre el largo de la columna, tal como se define en la base de datos."
+      "description": "Indicaci\u00f3n sobre el largo de la columna, tal como se define en la base de datos."
     },
     "Fieldlength": {
       "label": "Longitud",
-      "description": "Indicación sobre el largo de la columna, tal como se define en la base de datos."
+      "description": "Indicaci\u00f3n sobre el largo de la columna, tal como se define en la base de datos."
     },
     "Allowed_Cross_Org_Link": {
-      "label": "Permitir Referencia de Organización Cruzada",
+      "label": "Permitir Referencia de Organizaci\u00f3n Cruzada",
       "description": ""
     },
     "FirstSale": {
@@ -5101,24 +5101,24 @@
       "description": "Norma contable"
     },
     "GL_Category_ID": {
-      "label": "Categoría Libro Mayor",
-      "description": "Clasificación utilizada para agrupar líneas en el Libro Mayor."
+      "label": "Categor\u00eda Libro Mayor",
+      "description": "Clasificaci\u00f3n utilizada para agrupar l\u00edneas en el Libro Mayor."
     },
     "GL_JournalBatch_ID": {
       "label": "Serie de asientos",
       "description": "Serie de asientos"
     },
     "GL_JournalLine_ID": {
-      "label": "Línea de asiento",
-      "description": "Línea de asiento"
+      "label": "L\u00ednea de asiento",
+      "description": "L\u00ednea de asiento"
     },
     "adorgname": {
-      "label": "Organización",
+      "label": "Organizaci\u00f3n",
       "description": ""
     },
     "GL_Journal_ID": {
       "label": "Asiento",
-      "description": "Transacción con un crédito y un débito, asentada en el Libro Mayor."
+      "description": "Transacci\u00f3n con un cr\u00e9dito y un d\u00e9bito, asentada en el Libro Mayor."
     },
     "grandTotalAmount": {
       "label": "Importe total",
@@ -5129,32 +5129,32 @@
       "description": "Importe final (impuestos incluidos) facturado en un documento."
     },
     "Prun_Status": {
-      "label": "Estado Ejecución de Pagos",
+      "label": "Estado Ejecuci\u00f3n de Pagos",
       "description": ""
     },
     "HasPostal_Add": {
-      "label": "Código postal adicional",
-      "description": "Tiene código postal adicional"
+      "label": "C\u00f3digo postal adicional",
+      "description": "Tiene c\u00f3digo postal adicional"
     },
     "HasRegion": {
-      "label": "Tiene región",
-      "description": "El país contiene regiones"
+      "label": "Tiene regi\u00f3n",
+      "description": "El pa\u00eds contiene regiones"
     },
     "HasTree": {
-      "label": "Tiene árbol",
-      "description": "La ventana tiene un árbol gráfico"
+      "label": "Tiene \u00e1rbol",
+      "description": "La ventana tiene un \u00e1rbol gr\u00e1fico"
     },
     "Help": {
       "label": "Ayuda/Comentario",
-      "description": "Comentario que añade información adicional para ayudar a los usuarios a usar los campos."
+      "description": "Comentario que a\u00f1ade informaci\u00f3n adicional para ayudar a los usuarios a usar los campos."
     },
     "Clientclass": {
       "label": "ClaseCliente",
       "description": ""
     },
     "ISO_Code": {
-      "label": "Código ISO",
-      "description": "Código estándar de país"
+      "label": "C\u00f3digo ISO",
+      "description": "C\u00f3digo est\u00e1ndar de pa\u00eds"
     },
     "IncomeSummary_Acct": {
       "label": "Resumen de contabilidad",
@@ -5162,11 +5162,11 @@
     },
     "IncrementNo": {
       "label": "Incrementar",
-      "description": "Adición de un valor específico al número inicial."
+      "description": "Adici\u00f3n de un valor espec\u00edfico al n\u00famero inicial."
     },
     "QtyAum": {
       "label": "Cantidad Unidad Alternativa",
-      "description": "El número de un cierto artículo involucrado en la transacción, según lo definido por la Unidad de Medida Operativa."
+      "description": "El n\u00famero de un cierto art\u00edculo involucrado en la transacci\u00f3n, seg\u00fan lo definido por la Unidad de Medida Operativa."
     },
     "IntercompanyDueFrom_Acct": {
       "label": "Cuenta de cobros Intercompany",
@@ -5174,27 +5174,27 @@
     },
     "IsTaxDeductable": {
       "label": "Impuesto deducible",
-      "description": "Si está activo, este impuesto se tratará como un impuesto deducible sin importar si la organización en la que se utilice sea deducible de impuestos o no."
+      "description": "Si est\u00e1 activo, este impuesto se tratar\u00e1 como un impuesto deducible sin importar si la organizaci\u00f3n en la que se utilice sea deducible de impuestos o no."
     },
     "M_RefInventory_Type_ID": {
       "label": "Tipo de Inventario Referenciado",
       "description": ""
     },
     "InvoiceDay": {
-      "label": "Día de facturación",
-      "description": "Fecha de generación de la factura"
+      "label": "D\u00eda de facturaci\u00f3n",
+      "description": "Fecha de generaci\u00f3n de la factura"
     },
     "InvoiceFrequency": {
       "label": "Periodicidad",
-      "description": "Cuántas veces se va a volver a generar la factura"
+      "description": "Cu\u00e1ntas veces se va a volver a generar la factura"
     },
     "InvoiceWeekDay": {
-      "label": "Día semanal de facturación",
-      "description": "Día de genración  de la factura"
+      "label": "D\u00eda semanal de facturaci\u00f3n",
+      "description": "D\u00eda de genraci\u00f3n  de la factura"
     },
     "IsActive": {
       "label": "Activo",
-      "description": "Cartel que indica si este registro está disponible para utilizar o está desactivado"
+      "description": "Cartel que indica si este registro est\u00e1 disponible para utilizar o est\u00e1 desactivado"
     },
     "IsDelivered": {
       "label": "Repartido-Entregado",
@@ -5209,7 +5209,7 @@
       "description": ""
     },
     "C_Withholding_Acct_ID": {
-      "label": "Retención Contabilidad",
+      "label": "Retenci\u00f3n Contabilidad",
       "description": ""
     },
     "C_Tax_Trl_ID": {
@@ -5241,7 +5241,7 @@
       "description": ""
     },
     "C_BP_Withholding_ID": {
-      "label": "Tercero Retención",
+      "label": "Tercero Retenci\u00f3n",
       "description": ""
     },
     "C_ElementValue_Trl_ID": {
@@ -5253,7 +5253,7 @@
       "description": ""
     },
     "C_Country_Trl_ID": {
-      "label": "País traducido",
+      "label": "Pa\u00eds traducido",
       "description": ""
     },
     "M_Product_Acct_ID": {
@@ -5261,24 +5261,24 @@
       "description": ""
     },
     "IsAmount": {
-      "label": "Imp.mínimo",
-      "description": "Envia facturas sólo si el importe excede el límite"
+      "label": "Imp.m\u00ednimo",
+      "description": "Envia facturas s\u00f3lo si el importe excede el l\u00edmite"
     },
     "IsApproved": {
       "label": "Autorizado",
-      "description": "Indica si el documento requiere autorización"
+      "description": "Indica si el documento requiere autorizaci\u00f3n"
     },
     "Executiondate": {
-      "label": "Fecha Ejecución",
+      "label": "Fecha Ejecuci\u00f3n",
       "description": ""
     },
     "Createfrominouts": {
-      "label": "Crear Líneas Desde Albarán",
-      "description": "Acto de añadir declaraciones de albaranes preexistentes."
+      "label": "Crear L\u00edneas Desde Albar\u00e1n",
+      "description": "Acto de a\u00f1adir declaraciones de albaranes preexistentes."
     },
     "IsAutoSequence": {
-      "label": "Numeración automática",
-      "description": "Asignación automática del siguiente número"
+      "label": "Numeraci\u00f3n autom\u00e1tica",
+      "description": "Asignaci\u00f3n autom\u00e1tica del siguiente n\u00famero"
     },
     "IsBalanced": {
       "label": "Cuadrado",
@@ -5286,7 +5286,7 @@
     },
     "IsBaseLanguage": {
       "label": "Idioma utilizado",
-      "description": "La información del sistema se mantiene en esta lengua"
+      "description": "La informaci\u00f3n del sistema se mantiene en esta lengua"
     },
     "Freight_Currency_ID": {
       "label": "Moneda de los portes",
@@ -5306,7 +5306,7 @@
     },
     "IsCustomer": {
       "label": "Cliente",
-      "description": "Tercero que efectuará las compras."
+      "description": "Tercero que efectuar\u00e1 las compras."
     },
     "IsDeleteable": {
       "label": "Borrar registos",
@@ -5317,36 +5317,36 @@
       "description": "Determina si este registro se puede eliminar"
     },
     "IsDocNoControlled": {
-      "label": "Doc.numéricamente controlado",
-      "description": "El documento tiene un número de secuencia"
+      "label": "Doc.num\u00e9ricamente controlado",
+      "description": "El documento tiene un n\u00famero de secuencia"
     },
     "IsEmployee": {
       "label": "Empleado",
-      "description": "Tercero que trabaja en una organización."
+      "description": "Tercero que trabaja en una organizaci\u00f3n."
     },
     "IsEncrypted": {
-      "label": "Visualización encriptada",
-      "description": "Indicación que señala si el cuadro de entrada presenta un texto completo o sólo asteriscos."
+      "label": "Visualizaci\u00f3n encriptada",
+      "description": "Indicaci\u00f3n que se\u00f1ala si el cuadro de entrada presenta un texto completo o s\u00f3lo asteriscos."
     },
     "C_Extbp_Config_Prop_Opt_ID": {
-      "label": "Opción del la Propiedad del Concector con el CRM",
+      "label": "Opci\u00f3n del la Propiedad del Concector con el CRM",
       "description": "Permite definir los valores aceptados en la Propiedad relacionada del Conector CRM"
     },
     "IsFullyQualified": {
       "label": "Totalmente correcta",
-      "description": "Esta cuenta está correcta"
+      "description": "Esta cuenta est\u00e1 correcta"
     },
     "IsGenerated": {
       "label": "Generada",
-      "description": "Esta línea está generada"
+      "description": "Esta l\u00ednea est\u00e1 generada"
     },
     "Isnettingshipment": {
-      "label": "Es albarán de neteo",
-      "description": "Campo que indica si el albarán es de tipo neteo"
+      "label": "Es albar\u00e1n de neteo",
+      "description": "Campo que indica si el albar\u00e1n es de tipo neteo"
     },
     "WS_Calls_Avg": {
       "label": "Media de llamadas a WS",
-      "description": "Número medio de llamadas a Web Service por día en los últimos 30 días"
+      "description": "N\u00famero medio de llamadas a Web Service por d\u00eda en los \u00faltimos 30 d\u00edas"
     },
     "IsIdentifier": {
       "label": "Identificador",
@@ -5354,11 +5354,11 @@
     },
     "IsInfoTab": {
       "label": "Solapa contabilidad",
-      "description": "Esta solapa contiene información contable"
+      "description": "Esta solapa contiene informaci\u00f3n contable"
     },
     "IsInvoiced": {
       "label": "Facturado",
-      "description": "Indicación de que puede facturarse una transacción a un tercero. "
+      "description": "Indicaci\u00f3n de que puede facturarse una transacci\u00f3n a un tercero. "
     },
     "IsKey": {
       "label": "Columna clave",
@@ -5366,15 +5366,15 @@
     },
     "Ismandatory": {
       "label": "Obligatorio",
-      "description": "Indicación que señala que debe completarse un campo antes de proseguir."
+      "description": "Indicaci\u00f3n que se\u00f1ala que debe completarse un campo antes de proseguir."
     },
     "IsMandatory": {
       "label": "Obligatorio",
-      "description": "Indicación que señala que debe completarse un campo antes de proseguir."
+      "description": "Indicaci\u00f3n que se\u00f1ala que debe completarse un campo antes de proseguir."
     },
     "IsParent": {
       "label": "Columna padre",
-      "description": "Esta columna es un enlaze a su tabla padre (p.e:Cabecera sobre líneas)"
+      "description": "Esta columna es un enlaze a su tabla padre (p.e:Cabecera sobre l\u00edneas)"
     },
     "C_Aum": {
       "label": "Unidad Alternativa",
@@ -5397,7 +5397,7 @@
       "description": ""
     },
     "AD_Tree_Campaign_ID": {
-      "label": "Árbol principal de la campaña",
+      "label": "\u00c1rbol principal de la campa\u00f1a",
       "description": ""
     },
     "Showcompanydata": {
@@ -5405,12 +5405,12 @@
       "description": ""
     },
     "Org_Acctdim_Lines": {
-      "label": "Mostrar en líneas",
-      "description": "Indica si la dimension contable se muestra en la solapa de las líneas del documento."
+      "label": "Mostrar en l\u00edneas",
+      "description": "Indica si la dimension contable se muestra en la solapa de las l\u00edneas del documento."
     },
     "IsManualSettlement": {
-      "label": "Liquidación Manual",
-      "description": "Liquidación Manual de IVA de Caja"
+      "label": "Liquidaci\u00f3n Manual",
+      "description": "Liquidaci\u00f3n Manual de IVA de Caja"
     },
     "IsGlossary": {
       "label": "Glosario",
@@ -5421,7 +5421,7 @@
       "description": "Indica si el producto se puede devolver o no"
     },
     "lastreconbalance": {
-      "label": "Balance última reconciliación",
+      "label": "Balance \u00faltima reconciliaci\u00f3n",
       "description": ""
     },
     "AD_Model_Object_Para_ID": {
@@ -5437,8 +5437,8 @@
       "description": ""
     },
     "Useinproduction": {
-      "label": "Usar en Producción",
-      "description": "Configuración para la precisión estándar que se usará al ejecutar el parte de fabricación."
+      "label": "Usar en Producci\u00f3n",
+      "description": "Configuraci\u00f3n para la precisi\u00f3n est\u00e1ndar que se usar\u00e1 al ejecutar el parte de fabricaci\u00f3n."
     },
     "HqlQuery": {
       "label": "Consulta HQL",
@@ -5449,12 +5449,12 @@
       "description": "Permite bloquear cobros en un cliente."
     },
     "M_Characteristic_Type": {
-      "label": "Tipo de Característica",
-      "description": "Tipo de Característica de Producto"
+      "label": "Tipo de Caracter\u00edstica",
+      "description": "Tipo de Caracter\u00edstica de Producto"
     },
     "FIN_Transitory_Acct": {
       "label": "Cuenta transitoria",
-      "description": "Cuenta Transitoria usada en la contabilización de extractos bancarios"
+      "description": "Cuenta Transitoria usada en la contabilizaci\u00f3n de extractos bancarios"
     },
     "IsProspect": {
       "label": "Cliente potencial",
@@ -5482,11 +5482,11 @@
     },
     "Foreign_Amount": {
       "label": "Importe en Moneda Extranjera",
-      "description": "Importe de la transacción en una moneda extranjera"
+      "description": "Importe de la transacci\u00f3n en una moneda extranjera"
     },
     "Foreign_Currency_ID": {
       "label": "Moneda Extranjera",
-      "description": "La moneda en la que se hizo la transacción si es diferente de la moneda de la cuenta"
+      "description": "La moneda en la que se hizo la transacci\u00f3n si es diferente de la moneda de la cuenta"
     },
     "Foreign_Convert_Rate": {
       "label": "Tipo de cambio",
@@ -5494,27 +5494,27 @@
     },
     "IsPurchased": {
       "label": "Compra",
-      "description": "Indicación de que un ítem puede ser comprado por terceros."
+      "description": "Indicaci\u00f3n de que un \u00edtem puede ser comprado por terceros."
     },
     "IsRange": {
       "label": "Rango",
-      "description": "El parámetro es un rango de valores"
+      "description": "El par\u00e1metro es un rango de valores"
     },
     "IsReadOnly": {
-      "label": "Sólo lectura",
-      "description": "Objeto que sólo puede mostrarse, pero no editarse."
+      "label": "S\u00f3lo lectura",
+      "description": "Objeto que s\u00f3lo puede mostrarse, pero no editarse."
     },
     "Isreadwrite": {
       "label": "Lectura y escritura",
-      "description": "Indicación de que este campo puede mostrarse."
+      "description": "Indicaci\u00f3n de que este campo puede mostrarse."
     },
     "IsreadWrite": {
       "label": "Lectura y escritura",
-      "description": "Indicación de que este campo puede mostrarse."
+      "description": "Indicaci\u00f3n de que este campo puede mostrarse."
     },
     "IsReadWrite": {
       "label": "Lectura y escritura",
-      "description": "Indicación de que este campo puede mostrarse."
+      "description": "Indicaci\u00f3n de que este campo puede mostrarse."
     },
     "Your_It_Service_Login_Image": {
       "label": "Imagen de login por defecto de su servicio de IT",
@@ -5529,36 +5529,36 @@
       "description": "Persona a cargo de cumplir un pedido."
     },
     "Unique_Per_Document": {
-      "label": "Único por Documento",
-      "description": "Este flag indica si el servicio puede ser añadido solo una vez al ticket. Este servicio podría estar relacionado con cero, una o más líneas del ticket."
+      "label": "\u00danico por Documento",
+      "description": "Este flag indica si el servicio puede ser a\u00f1adido solo una vez al ticket. Este servicio podr\u00eda estar relacionado con cero, una o m\u00e1s l\u00edneas del ticket."
     },
     "AD_OrgModule_V_ID": {
-      "label": "Modulo de organización",
-      "description": "Modulos y conjuntos de datos aplicados a la organización"
+      "label": "Modulo de organizaci\u00f3n",
+      "description": "Modulos y conjuntos de datos aplicados a la organizaci\u00f3n"
     },
     "IsSameLine": {
-      "label": "Misma línea",
-      "description": "Indicación de que este campo se muestra en la misma línea que el campo anterior."
+      "label": "Misma l\u00ednea",
+      "description": "Indicaci\u00f3n de que este campo se muestra en la misma l\u00ednea que el campo anterior."
     },
     "IsSingleRow": {
       "label": "Una fila",
-      "description": "El tab se muestra por defecto en modo edición"
+      "description": "El tab se muestra por defecto en modo edici\u00f3n"
     },
     "IsSold": {
       "label": "Venta",
-      "description": "Indicación de que un ítem puede ser vendido por un tercero."
+      "description": "Indicaci\u00f3n de que un \u00edtem puede ser vendido por un tercero."
     },
     "IsStocked": {
       "label": "Almacenado",
-      "description": "La organización almacena este producto"
+      "description": "La organizaci\u00f3n almacena este producto"
     },
     "IsSummary": {
-      "label": "Nivel agrupación",
-      "description": "Método de agrupación de campos para mostrar u ocultar información adicional."
+      "label": "Nivel agrupaci\u00f3n",
+      "description": "M\u00e9todo de agrupaci\u00f3n de campos para mostrar u ocultar informaci\u00f3n adicional."
     },
     "Issummary": {
-      "label": "Nivel agrupación",
-      "description": "Método de agrupación de campos para mostrar u ocultar información adicional."
+      "label": "Nivel agrupaci\u00f3n",
+      "description": "M\u00e9todo de agrupaci\u00f3n de campos para mostrar u ocultar informaci\u00f3n adicional."
     },
     "AD_Window_Access_ID": {
       "label": "AD_Window_Access_ID",
@@ -5570,83 +5570,83 @@
     },
     "IsTableID": {
       "label": "Usado como identificador de registro",
-      "description": "El número de documento será usado como identificador de registro"
+      "description": "El n\u00famero de documento ser\u00e1 usado como identificador de registro"
     },
     "Stock_Valuation": {
-      "label": "Valoración Stock",
+      "label": "Valoraci\u00f3n Stock",
       "description": ""
     },
     "Is_Child_Property_In_Parent": {
       "label": "Propiedad Hija en Entidad Padre",
-      "description": "Indica si la propiedad hija se debería crear en la entidad padre"
+      "description": "Indica si la propiedad hija se deber\u00eda crear en la entidad padre"
     },
     "Istranslated": {
       "label": "Traducido",
-      "description": "Indicación de que un ítem está traducido."
+      "description": "Indicaci\u00f3n de que un \u00edtem est\u00e1 traducido."
     },
     "IsTranslated": {
       "label": "Traducido",
-      "description": "Indicación de que un ítem está traducido."
+      "description": "Indicaci\u00f3n de que un \u00edtem est\u00e1 traducido."
     },
     "IsTranslationTab": {
-      "label": "Solapa de traducción",
-      "description": "Esta solapa contiene información traducida"
+      "label": "Solapa de traducci\u00f3n",
+      "description": "Esta solapa contiene informaci\u00f3n traducida"
     },
     "IsUpdateable": {
       "label": "Actualizable",
-      "description": "Indicación de que un ítem puede ser actualizado por el usuario."
+      "description": "Indicaci\u00f3n de que un \u00edtem puede ser actualizado por el usuario."
     },
     "IsVendor": {
       "label": "Proveedor",
       "description": "Tercero que vende productos o servicios."
     },
     "LastContact": {
-      "label": "Último contacto",
-      "description": "Fecha de último contacto"
+      "label": "\u00daltimo contacto",
+      "description": "Fecha de \u00faltimo contacto"
     },
     "LastResult": {
-      "label": "Último resultado",
-      "description": "Declaración relacionada con el resultado de la última interacción realizada con un tercero."
+      "label": "\u00daltimo resultado",
+      "description": "Declaraci\u00f3n relacionada con el resultado de la \u00faltima interacci\u00f3n realizada con un tercero."
     },
     "processMatching": {
-      "label": "Procesar Asociación",
+      "label": "Procesar Asociaci\u00f3n",
       "description": ""
     },
     "Line": {
-      "label": "Línea",
-      "description": "Línea que indica la posición de esta petición en el documento."
+      "label": "L\u00ednea",
+      "description": "L\u00ednea que indica la posici\u00f3n de esta petici\u00f3n en el documento."
     },
     "SEQ_No_Asset": {
-      "label": "Línea",
-      "description": "Línea que indica la posición de esta petición en el documento."
+      "label": "L\u00ednea",
+      "description": "L\u00ednea que indica la posici\u00f3n de esta petici\u00f3n en el documento."
     },
     "Createworkrequirement": {
       "label": "Crear parte de trabajo",
-      "description": "Crear todos los partes de trabajo para un día específico"
+      "description": "Crear todos los partes de trabajo para un d\u00eda espec\u00edfico"
     },
     "lineNo": {
-      "label": "Línea",
-      "description": "Línea que indica la posición de esta petición en el documento."
+      "label": "L\u00ednea",
+      "description": "L\u00ednea que indica la posici\u00f3n de esta petici\u00f3n en el documento."
     },
     "line": {
-      "label": "Línea",
-      "description": "Línea que indica la posición de esta petición en el documento."
+      "label": "L\u00ednea",
+      "description": "L\u00ednea que indica la posici\u00f3n de esta petici\u00f3n en el documento."
     },
     "M_Shipper_ID": {
       "label": "Transportista",
-      "description": "Nombre de la compañía que hace el envío."
+      "description": "Nombre de la compa\u00f1\u00eda que hace el env\u00edo."
     },
     "T_Credit_Trans_Acct": {
       "label": "Impuesto soportado transitorio",
       "description": "Cuenta de IVA transitorio a reclamar"
     },
     "LineNetAmt": {
-      "label": "Imp. línea",
-      "description": "Suma total de una línea específica, basada sólo en importes y precios."
+      "label": "Imp. l\u00ednea",
+      "description": "Suma total de una l\u00ednea espec\u00edfica, basada s\u00f3lo en importes y precios."
     },
     "M_Locator_ID": {
       "label": "Hueco",
-      "description": "Grupo de coordenadas (x, y, z) que ayudan a ubicar un ítem en el almacén."
+      "description": "Grupo de coordenadas (x, y, z) que ayudan a ubicar un \u00edtem en el almac\u00e9n."
     },
     "HEX_Color": {
       "label": "Color Hexadecimal",
@@ -5654,63 +5654,63 @@
     },
     "Lot": {
       "label": "Lote",
-      "description": "Grupo de ítems idénticos o similares organizados y ubicados en el inventario bajo un número."
+      "description": "Grupo de \u00edtems id\u00e9nticos o similares organizados y ubicados en el inventario bajo un n\u00famero."
     },
     "storageBin": {
       "label": "Hueco",
-      "description": "Grupo de coordenadas (x, y, z) que ayudan a ubicar un ítem en el almacén."
+      "description": "Grupo de coordenadas (x, y, z) que ayudan a ubicar un \u00edtem en el almac\u00e9n."
     },
     "M_PriceList_ID": {
       "label": "Tarifa",
-      "description": "Catálogo de ítems seleccionados que contiene los precios generales o los de un partner específico."
+      "description": "Cat\u00e1logo de \u00edtems seleccionados que contiene los precios generales o los de un partner espec\u00edfico."
     },
     "returnReason": {
-      "label": "Motivos de devolución",
+      "label": "Motivos de devoluci\u00f3n",
       "description": ""
     },
     "M_Pricelist_ID": {
       "label": "Tarifa",
-      "description": "Catálogo de ítems seleccionados que contiene los precios generales o los de un partner específico."
+      "description": "Cat\u00e1logo de \u00edtems seleccionados que contiene los precios generales o los de un partner espec\u00edfico."
     },
     "M_PriceList_Version_ID": {
-      "label": "Versión de tarifa",
-      "description": "Tarifa que tiene un período de validez específico."
+      "label": "Versi\u00f3n de tarifa",
+      "description": "Tarifa que tiene un per\u00edodo de validez espec\u00edfico."
     },
     "M_Product_Category_ID": {
-      "label": "Categoría del producto",
-      "description": "Clasificación de los ítems en base a atributos o características similares."
+      "label": "Categor\u00eda del producto",
+      "description": "Clasificaci\u00f3n de los \u00edtems en base a atributos o caracter\u00edsticas similares."
     },
     "catID": {
-      "label": "Categoría del producto",
-      "description": "Clasificación de los ítems en base a atributos o características similares."
+      "label": "Categor\u00eda del producto",
+      "description": "Clasificaci\u00f3n de los \u00edtems en base a atributos o caracter\u00edsticas similares."
     },
     "M_Product_ID": {
       "label": "Producto",
-      "description": "Ítem producido mediante un proceso."
+      "description": "\u00cdtem producido mediante un proceso."
     },
     "Product_Acctdim_Isenable": {
       "label": "Producto",
-      "description": "Ítem producido mediante un proceso."
+      "description": "\u00cdtem producido mediante un proceso."
     },
     "product": {
       "label": "Producto",
-      "description": "Ítem producido mediante un proceso."
+      "description": "\u00cdtem producido mediante un proceso."
     },
     "Uponpaymentuse": {
       "label": "Cuenta de pago",
       "description": "Cuenta utilizada para el pago"
     },
     "M_Warehouse_ID": {
-      "label": "Almacén",
-      "description": "Ubicación a la que se envían, o de donde proceden, los productos."
+      "label": "Almac\u00e9n",
+      "description": "Ubicaci\u00f3n a la que se env\u00edan, o de donde proceden, los productos."
     },
     "documentLevel": {
       "label": "Nivel",
       "description": ""
     },
     "Line_Gross_Amount": {
-      "label": "Importe bruto de línea",
-      "description": "Importe bruto de una línea"
+      "label": "Importe bruto de l\u00ednea",
+      "description": "Importe bruto de una l\u00ednea"
     },
     "AD_Field_Access_ID": {
       "label": "AD_Field_Access_ID",
@@ -5718,11 +5718,11 @@
     },
     "MsgText": {
       "label": "Mensaje de texto",
-      "description": "Texto o contenido del mensaje de inicio de la aplicación."
+      "description": "Texto o contenido del mensaje de inicio de la aplicaci\u00f3n."
     },
     "MsgTip": {
       "label": "Consejo",
-      "description": "Ayuda o asesoramiento provisto en relación con el mensaje de inicio de la aplicación."
+      "description": "Ayuda o asesoramiento provisto en relaci\u00f3n con el mensaje de inicio de la aplicaci\u00f3n."
     },
     "MsgType": {
       "label": "Tipo de mensaje",
@@ -5734,27 +5734,27 @@
     },
     "MultiplyRate": {
       "label": "Multiplicar por",
-      "description": "Tasa por la que se multiplica la unidad básica para obtener la unidad convertida."
+      "description": "Tasa por la que se multiplica la unidad b\u00e1sica para obtener la unidad convertida."
     },
     "NAICS": {
       "label": "NAICS/SIC",
-      "description": "Código SIC o NAIC - http://www.osha.gov/oshstats/sicser.html"
+      "description": "C\u00f3digo SIC o NAIC - http://www.osha.gov/oshstats/sicser.html"
     },
     "DaysTillDue": {
-      "label": "Días para siguiente vto",
-      "description": "Días para siguiente vto"
+      "label": "D\u00edas para siguiente vto",
+      "description": "D\u00edas para siguiente vto"
     },
     "NetDays": {
-      "label": "Días de plazo",
-      "description": "Otorgamiento de varios días de pago sin penalización, posterior a la fecha de pago acordada."
+      "label": "D\u00edas de plazo",
+      "description": "Otorgamiento de varios d\u00edas de pago sin penalizaci\u00f3n, posterior a la fecha de pago acordada."
     },
     "NumberEmployees": {
-      "label": "Nº empleados",
-      "description": "Número de empleados"
+      "label": "N\u00ba empleados",
+      "description": "N\u00famero de empleados"
     },
     "OrderByClause": {
-      "label": "Cláusula SQL Order by",
-      "description": "Especificación de la cláusula SQL \"ORDER BY\" utilizada para mostrar registros clasificados por defaut."
+      "label": "Cl\u00e1usula SQL Order by",
+      "description": "Especificaci\u00f3n de la cl\u00e1usula SQL \"ORDER BY\" utilizada para mostrar registros clasificados por defaut."
     },
     "BadDebtExpense_Acct": {
       "label": "Cuenta de gastos de dudoso cobro",
@@ -5765,16 +5765,16 @@
       "description": "Cuenta utilizada para registrar los gastos relacionados al dudoso cobro."
     },
     "Org_ID": {
-      "label": "Organización de la transacción",
-      "description": "Organización dentro del cliente"
+      "label": "Organizaci\u00f3n de la transacci\u00f3n",
+      "description": "Organizaci\u00f3n dentro del cliente"
     },
     "Key_Seqno": {
-      "label": "Número de Secuencia Clave",
+      "label": "N\u00famero de Secuencia Clave",
       "description": "Permite especificar el orden de secuencia correcto cuando varias propiedades son parte de la clave"
     },
     "PO_PriceList_ID": {
       "label": "Tarifa de compra",
-      "description": "Catálogo de productos seleccionados para la venta, cada uno con su precio específico."
+      "description": "Cat\u00e1logo de productos seleccionados para la venta, cada uno con su precio espec\u00edfico."
     },
     "Isdataset": {
       "label": "Esdataset",
@@ -5782,59 +5782,59 @@
     },
     "IsTransient": {
       "label": "Transitorio",
-      "description": "Marcar si la columna es transitoria y se ignorará cuando se compare los datos"
+      "description": "Marcar si la columna es transitoria y se ignorar\u00e1 cuando se compare los datos"
     },
     "isTransientCondition": {
-      "label": "Condición Transitoria",
-      "description": "Expresión Java que será evaluada y si resulta falsa, se marcará la columna como transitoria"
+      "label": "Condici\u00f3n Transitoria",
+      "description": "Expresi\u00f3n Java que ser\u00e1 evaluada y si resulta falsa, se marcar\u00e1 la columna como transitoria"
     },
     "C_Doctypesimpinvoice_ID": {
       "label": "Tipo de Documento para Factura Simplificada",
       "description": "Tipo de Documento utilizado en las Facturas Simplificadas generadas desde este Documento de Venta"
     },
     "Smtpserversenderaddress": {
-      "label": "Dirección de envío del servidor SMTP",
-      "description": "Dirección usada para enviar correo electrónico"
+      "label": "Direcci\u00f3n de env\u00edo del servidor SMTP",
+      "description": "Direcci\u00f3n usada para enviar correo electr\u00f3nico"
     },
     "Parent_ID": {
       "label": "Padre",
-      "description": "Método para agrupar informes que permite mostrar e imprimir información individual  o agrupada."
+      "description": "M\u00e9todo para agrupar informes que permite mostrar e imprimir informaci\u00f3n individual  o agrupada."
     },
     "Parent_Tax_ID": {
       "label": "Impuesto padre",
-      "description": "Indica un impuesto del que se han hecho muchos más"
+      "description": "Indica un impuesto del que se han hecho muchos m\u00e1s"
     },
     "Password": {
-      "label": "Contraseña",
-      "description": "Código secreto utilizado para permitir el acceso a una ventana o solapa específica."
+      "label": "Contrase\u00f1a",
+      "description": "C\u00f3digo secreto utilizado para permitir el acceso a una ventana o solapa espec\u00edfica."
     },
     "PriceActual": {
       "label": "Precio unitario",
-      "description": "Precio que se paga por un ítem específico."
+      "description": "Precio que se paga por un \u00edtem espec\u00edfico."
     },
     "PeriodAction": {
-      "label": "Periodo de actuación",
-      "description": "Actuación para este periodo"
+      "label": "Periodo de actuaci\u00f3n",
+      "description": "Actuaci\u00f3n para este periodo"
     },
     "Periodaction": {
-      "label": "Periodo de actuación",
-      "description": "Actuación para este periodo"
+      "label": "Periodo de actuaci\u00f3n",
+      "description": "Actuaci\u00f3n para este periodo"
     },
     "Cancel": {
       "label": "Cancelar Ajuste de Costes",
       "description": "Cancelar Ajuste de Costes"
     },
     "Responseinfo": {
-      "label": "Información de la Respuesta",
+      "label": "Informaci\u00f3n de la Respuesta",
       "description": ""
     },
     "AllowFiltering": {
       "label": "Permitir Filtrado",
-      "description": "Cuando el checkbox está marcado, la columna se puede filtrar."
+      "description": "Cuando el checkbox est\u00e1 marcado, la columna se puede filtrar."
     },
     "Upondeposituse": {
-      "label": "Cuenta de depósito",
-      "description": "Cuenta utilizada para el depósito"
+      "label": "Cuenta de dep\u00f3sito",
+      "description": "Cuenta utilizada para el dep\u00f3sito"
     },
     "Quotation_ID": {
       "label": "Presupuesto",
@@ -5849,52 +5849,52 @@
       "description": "Atributo de producto"
     },
     "Apply_Next": {
-      "label": "Aplicar próximo descuento/promoción",
+      "label": "Aplicar pr\u00f3ximo descuento/promoci\u00f3n",
       "description": ""
     },
     "WS_Rejected_Max": {
-      "label": "Máximo rechazado de WS",
-      "description": "Número máximo de llamadas a Web Service rechazadas por día en los últimos 30 días"
+      "label": "M\u00e1ximo rechazado de WS",
+      "description": "N\u00famero m\u00e1ximo de llamadas a Web Service rechazadas por d\u00eda en los \u00faltimos 30 d\u00edas"
     },
     "Imageheight": {
       "label": "Altura de imagen",
       "description": ""
     },
     "PeriodNo": {
-      "label": "Número de periodo",
-      "description": "Número único para el periodo"
+      "label": "N\u00famero de periodo",
+      "description": "N\u00famero \u00fanico para el periodo"
     },
     "PeriodStatus": {
-      "label": "Situación del periodo",
-      "description": "Situación del periodo"
+      "label": "Situaci\u00f3n del periodo",
+      "description": "Situaci\u00f3n del periodo"
     },
     "Periodstatus": {
-      "label": "Situación del periodo",
-      "description": "Situación del periodo"
+      "label": "Situaci\u00f3n del periodo",
+      "description": "Situaci\u00f3n del periodo"
     },
     "PeriodType": {
       "label": "Tipo de periodo",
       "description": "Tipo de periodo"
     },
     "M_Relatedproductcategory_ID": {
-      "label": "Categoría de Producto Relacionada",
+      "label": "Categor\u00eda de Producto Relacionada",
       "description": ""
     },
     "Phone": {
-      "label": "Teléfono",
-      "description": "Número de teléfono de un tercero específico."
+      "label": "Tel\u00e9fono",
+      "description": "N\u00famero de tel\u00e9fono de un tercero espec\u00edfico."
     },
     "InitialBalance": {
       "label": "Saldo Inicial",
       "description": "Saldo Inicial de la cuenta financiera. El saldo de la cuenta en el momento de registrar la cuenta financiera."
     },
     "Phone2": {
-      "label": "Teléfono alternativo",
-      "description": "Teléfono alternativo de contacto de un tercero."
+      "label": "Tel\u00e9fono alternativo",
+      "description": "Tel\u00e9fono alternativo de contacto de un tercero."
     },
     "AD_Tree_User1_ID": {
-      "label": "Dimensión primaria de usuario 1",
-      "description": "Dimensión primaria de usuario 1"
+      "label": "Dimensi\u00f3n primaria de usuario 1",
+      "description": "Dimensi\u00f3n primaria de usuario 1"
     },
     "DisplayedTotalAmt": {
       "label": "Importe total mostrado",
@@ -5902,19 +5902,19 @@
     },
     "Postal": {
       "label": "C.P.",
-      "description": "Código de identificación utilizado para mover los ítems a una ubicación específica."
+      "description": "C\u00f3digo de identificaci\u00f3n utilizado para mover los \u00edtems a una ubicaci\u00f3n espec\u00edfica."
     },
     "Postal_Add": {
-      "label": "Información adicional del C.P.",
-      "description": "Código postal adicional"
+      "label": "Informaci\u00f3n adicional del C.P.",
+      "description": "C\u00f3digo postal adicional"
     },
     "Postingtype": {
       "label": "Tipo de contabilizado",
-      "description": "Tipo de contabilidad utilizada en determinados procesos y a veces agrupada dentro de una categoría."
+      "description": "Tipo de contabilidad utilizada en determinados procesos y a veces agrupada dentro de una categor\u00eda."
     },
     "PostingType": {
       "label": "Tipo de contabilizado",
-      "description": "Tipo de contabilidad utilizada en determinados procesos y a veces agrupada dentro de una categoría."
+      "description": "Tipo de contabilidad utilizada en determinados procesos y a veces agrupada dentro de una categor\u00eda."
     },
     "PotentialLifeTimeValue": {
       "label": "Valor potencial",
@@ -5922,15 +5922,15 @@
     },
     "Prefix": {
       "label": "Prefijo",
-      "description": "Caracteres que se añaden al comienzo de un comentario o número."
+      "description": "Caracteres que se a\u00f1aden al comienzo de un comentario o n\u00famero."
     },
     "Conforgprocess": {
-      "label": "Añadir Organizaciones",
+      "label": "A\u00f1adir Organizaciones",
       "description": ""
     },
     "PriceList": {
       "label": "Precio tarifa",
-      "description": "Precio oficial de un producto en una moneda específica."
+      "description": "Precio oficial de un producto en una moneda espec\u00edfica."
     },
     "AD_Table_Access_ID": {
       "label": "Acceso tabla",
@@ -5961,7 +5961,7 @@
       "description": ""
     },
     "AD_Process_Para_Trl_ID": {
-      "label": "Parámetros de proceso traducido",
+      "label": "Par\u00e1metros de proceso traducido",
       "description": ""
     },
     "C_Tax_Acct_ID": {
@@ -5993,7 +5993,7 @@
       "description": ""
     },
     "M_Warehouse_Acct_ID": {
-      "label": "Almacén Contabilidad",
+      "label": "Almac\u00e9n Contabilidad",
       "description": ""
     },
     "AD_Form_Access_ID": {
@@ -6009,7 +6009,7 @@
       "description": ""
     },
     "C_PaymentTerm_Trl_ID": {
-      "label": "Condición de pago traducida",
+      "label": "Condici\u00f3n de pago traducida",
       "description": ""
     },
     "C_BP_Employee_Acct_ID": {
@@ -6025,11 +6025,11 @@
       "description": ""
     },
     "AD_Role_OrgAccess_ID": {
-      "label": "Acceso Rol Organización",
+      "label": "Acceso Rol Organizaci\u00f3n",
       "description": ""
     },
     "C_TaxCategory_Trl_ID": {
-      "label": "Categoría de impuesto traducida",
+      "label": "Categor\u00eda de impuesto traducida",
       "description": ""
     },
     "C_OrderTax_ID": {
@@ -6042,15 +6042,15 @@
     },
     "Processing": {
       "label": "Procesar ahora",
-      "description": "Petición para que se procese el documento o la tarea pertinente."
+      "description": "Petici\u00f3n para que se procese el documento o la tarea pertinente."
     },
     "Qty": {
       "label": "Cantidad",
-      "description": "Número de un ítem determinado."
+      "description": "N\u00famero de un \u00edtem determinado."
     },
     "orderedQuantity": {
       "label": "Cantidad",
-      "description": "Número de un ítem determinado."
+      "description": "N\u00famero de un \u00edtem determinado."
     },
     "QtyDelivered": {
       "label": "Cant.entregada",
@@ -6065,8 +6065,8 @@
       "description": "Cant.entregada"
     },
     "Financial_Invoice_Line": {
-      "label": "Línea de factura financiera",
-      "description": "Indica si se trata de una línea de factura financiera y, por lo tanto, se contabiliza directamente contra la cuenta del LM o no."
+      "label": "L\u00ednea de factura financiera",
+      "description": "Indica si se trata de una l\u00ednea de factura financiera y, por lo tanto, se contabiliza directamente contra la cuenta del LM o no."
     },
     "Qtyinvoiced": {
       "label": "Cant.facturada",
@@ -6094,27 +6094,27 @@
     },
     "originalOrderedQuantity": {
       "label": "Cant. pedido",
-      "description": "Cantidad de un ítem involucrado en una transacción, expresada en unidades estándares. Se utiliza para calcular el precio por unidad."
+      "description": "Cantidad de un \u00edtem involucrado en una transacci\u00f3n, expresada en unidades est\u00e1ndares. Se utiliza para calcular el precio por unidad."
     },
     "QtyOrdered": {
       "label": "Cant. pedido",
-      "description": "Cantidad de un ítem involucrado en una transacción, expresada en unidades estándares. Se utiliza para calcular el precio por unidad."
+      "description": "Cantidad de un \u00edtem involucrado en una transacci\u00f3n, expresada en unidades est\u00e1ndares. Se utiliza para calcular el precio por unidad."
     },
     "Qtyordered": {
       "label": "Cant. pedido",
-      "description": "Cantidad de un ítem involucrado en una transacción, expresada en unidades estándares. Se utiliza para calcular el precio por unidad."
+      "description": "Cantidad de un \u00edtem involucrado en una transacci\u00f3n, expresada en unidades est\u00e1ndares. Se utiliza para calcular el precio por unidad."
     },
     "QtyReserved": {
       "label": "Cant.reservada",
       "description": "Cant.reservada"
     },
     "Rate": {
-      "label": "Índice",
+      "label": "\u00cdndice",
       "description": "Porcentaje que debe multiplicarse por la cifra original para arribar al impuesto o al tipo de cambio."
     },
     "RealizedLoss_Acct": {
-      "label": "Cuenta de pérdidas realizada",
-      "description": "Cuenta de Pérdidas Realizada"
+      "label": "Cuenta de p\u00e9rdidas realizada",
+      "description": "Cuenta de P\u00e9rdidas Realizada"
     },
     "Record_ID": {
       "label": "Id. registro",
@@ -6133,68 +6133,68 @@
       "description": ""
     },
     "Referenceno": {
-      "label": "Nº de referencia",
-      "description": "Número de una referencia específica."
+      "label": "N\u00ba de referencia",
+      "description": "N\u00famero de una referencia espec\u00edfica."
     },
     "referenceNo": {
-      "label": "Nº de referencia",
-      "description": "Número de una referencia específica."
+      "label": "N\u00ba de referencia",
+      "description": "N\u00famero de una referencia espec\u00edfica."
     },
     "ReferenceNo": {
-      "label": "Nº de referencia",
-      "description": "Número de una referencia específica."
+      "label": "N\u00ba de referencia",
+      "description": "N\u00famero de una referencia espec\u00edfica."
     },
     "RegionName": {
       "label": "Provincia",
-      "description": "Nombre de un área en un país específico."
+      "description": "Nombre de un \u00e1rea en un pa\u00eds espec\u00edfico."
     },
     "Result": {
       "label": "Resultado",
-      "description": "Indica el resultado obtenido como consecuencia de cualquier acción tomada."
+      "description": "Indica el resultado obtenido como consecuencia de cualquier acci\u00f3n tomada."
     },
     "RetainedEarning_Acct": {
       "label": "Reservas",
       "description": "Cuenta de reservas"
     },
     "SKU": {
-      "label": "Referencia de almacén",
-      "description": "\"Unidad de mantenimiento de stock\" utilizada para rastrear los ítems vendidos por terceros."
+      "label": "Referencia de almac\u00e9n",
+      "description": "\"Unidad de mantenimiento de stock\" utilizada para rastrear los \u00edtems vendidos por terceros."
     },
     "User1_ID": {
-      "label": "Dimensión 1",
-      "description": "Elementos opcionales que previamente se definen para esta combinación contable."
+      "label": "Dimensi\u00f3n 1",
+      "description": "Elementos opcionales que previamente se definen para esta combinaci\u00f3n contable."
     },
     "User1_Acctdim_Isenable": {
-      "label": "Dimensión 1",
-      "description": "Elementos opcionales que previamente se definen para esta combinación contable."
+      "label": "Dimensi\u00f3n 1",
+      "description": "Elementos opcionales que previamente se definen para esta combinaci\u00f3n contable."
     },
     "AD_Module_ID": {
-      "label": "Módulo",
-      "description": "Módulo"
+      "label": "M\u00f3dulo",
+      "description": "M\u00f3dulo"
     },
     "C_Campaign_ID": {
-      "label": "Campaña",
-      "description": "Campaña publicitaria destinada a aumentar las ventas."
+      "label": "Campa\u00f1a",
+      "description": "Campa\u00f1a publicitaria destinada a aumentar las ventas."
     },
     "C_Order_ID": {
       "label": "Pedido de compra",
-      "description": "Identificador único, a menudo generado automáticamente, para un pedido de venta."
+      "description": "Identificador \u00fanico, a menudo generado autom\u00e1ticamente, para un pedido de venta."
     },
     "C_Channel_ID": {
       "label": "Canal",
-      "description": "Canal a través del cual se genera la venta."
+      "description": "Canal a trav\u00e9s del cual se genera la venta."
     },
     "SO_CreditLimit": {
-      "label": "Crédito límite",
+      "label": "Cr\u00e9dito l\u00edmite",
       "description": "Importe total sin pagar permitido para una factura"
     },
     "SO_CreditUsed": {
-      "label": "Crédito usado",
-      "description": "Crédito usado"
+      "label": "Cr\u00e9dito usado",
+      "description": "Cr\u00e9dito usado"
     },
     "DeliveryRule": {
-      "label": "Preparación",
-      "description": "Especificación del momento en que debe realizarse un envío específico."
+      "label": "Preparaci\u00f3n",
+      "description": "Especificaci\u00f3n del momento en que debe realizarse un env\u00edo espec\u00edfico."
     },
     "PreventConcurrent": {
       "label": "Prevenir ejecuciones concurrentes",
@@ -6206,43 +6206,43 @@
     },
     "c_order_id": {
       "label": "Pedido de compra",
-      "description": "Identificador único, a menudo generado automáticamente, para un pedido de venta."
+      "description": "Identificador \u00fanico, a menudo generado autom\u00e1ticamente, para un pedido de venta."
     },
     "InvoiceRule": {
-      "label": "Facturación",
-      "description": "Tipo y frecuencia de facturación"
+      "label": "Facturaci\u00f3n",
+      "description": "Tipo y frecuencia de facturaci\u00f3n"
     },
     "TermName": {
-      "label": "Facturación",
-      "description": "Tipo y frecuencia de facturación"
+      "label": "Facturaci\u00f3n",
+      "description": "Tipo y frecuencia de facturaci\u00f3n"
     },
     "List_Seqno": {
-      "label": "Número de Secuencia de la Lista",
+      "label": "N\u00famero de Secuencia de la Lista",
       "description": "Secuencia para mostrar la propiedad en los resultados de la vista de lista"
     },
     "Applywhereclausetochildnodes": {
-      "label": "Aplicar cláusula HQL where a los nodos hijo",
-      "description": "Permite especificar si la cláusula where clause del tab será utilizada al obtener los nodos no raíz"
+      "label": "Aplicar cl\u00e1usula HQL where a los nodos hijo",
+      "description": "Permite especificar si la cl\u00e1usula where clause del tab ser\u00e1 utilizada al obtener los nodos no ra\u00edz"
     },
     "C_InvoiceSchedule_ID": {
-      "label": "Calendario de facturación",
-      "description": "Calendario de facturación"
+      "label": "Calendario de facturaci\u00f3n",
+      "description": "Calendario de facturaci\u00f3n"
     },
     "Issymbolrightside": {
-      "label": "Símbolo de moneda a la derecha",
-      "description": "Indica si el símbolo de moneda aparece a la derecha de la cantidad"
+      "label": "S\u00edmbolo de moneda a la derecha",
+      "description": "Indica si el s\u00edmbolo de moneda aparece a la derecha de la cantidad"
     },
     "C_OrderLine_ID": {
-      "label": "Línea pedido de venta",
-      "description": "Identificador único, a menudo generado automáticamente, para una línea de pedidos de venta."
+      "label": "L\u00ednea pedido de venta",
+      "description": "Identificador \u00fanico, a menudo generado autom\u00e1ticamente, para una l\u00ednea de pedidos de venta."
     },
     "C_Orderline_ID": {
-      "label": "Línea pedido de venta",
-      "description": "Identificador único, a menudo generado automáticamente, para una línea de pedidos de venta."
+      "label": "L\u00ednea pedido de venta",
+      "description": "Identificador \u00fanico, a menudo generado autom\u00e1ticamente, para una l\u00ednea de pedidos de venta."
     },
     "salesOrderLine": {
-      "label": "Línea pedido de venta",
-      "description": "Identificador único, a menudo generado automáticamente, para una línea de pedidos de venta."
+      "label": "L\u00ednea pedido de venta",
+      "description": "Identificador \u00fanico, a menudo generado autom\u00e1ticamente, para una l\u00ednea de pedidos de venta."
     },
     "SalesVolume": {
       "label": "Volumen de ventas",
@@ -6254,67 +6254,67 @@
     },
     "IsInDevelopment": {
       "label": "En Desarrollo",
-      "description": "Determina si el módulo está en proceso de desarrollo actualmente."
+      "description": "Determina si el m\u00f3dulo est\u00e1 en proceso de desarrollo actualmente."
     },
     "License": {
       "label": "Texto de la licencia",
-      "description": "Texto de la licencia del módulo"
+      "description": "Texto de la licencia del m\u00f3dulo"
     },
     "SeqNo": {
       "label": "Secuencia",
-      "description": "Orden de los registros en un documento específico."
+      "description": "Orden de los registros en un documento espec\u00edfico."
     },
     "JavaPackage": {
       "label": "Paquete Java",
-      "description": "Paquete Java para el módulo"
+      "description": "Paquete Java para el m\u00f3dulo"
     },
     "Author": {
       "label": "Autor",
-      "description": "Autor del módulo"
+      "description": "Autor del m\u00f3dulo"
     },
     "Prop_Opt_Seqno": {
       "label": "Secuencia",
-      "description": "Orden de los registros en un documento específico."
+      "description": "Orden de los registros en un documento espec\u00edfico."
     },
     "EndVersion": {
-      "label": "Última versión",
-      "description": "Última versión compatible"
+      "label": "\u00daltima versi\u00f3n",
+      "description": "\u00daltima versi\u00f3n compatible"
     },
     "SerNo": {
-      "label": "Nº de serie",
-      "description": "Atributo utilizado como identificador único de un producto."
+      "label": "N\u00ba de serie",
+      "description": "Atributo utilizado como identificador \u00fanico de un producto."
     },
     "ShareOfCustomer": {
       "label": "Cuota de mercado",
-      "description": "Cuota de participación del cliente"
+      "description": "Cuota de participaci\u00f3n del cliente"
     },
     "Isused": {
       "label": "Es Usado",
       "description": ""
     },
     "Restrictmanufacture": {
-      "label": "Restringir fabricación",
-      "description": "Indica si está permitido fabricar un producto"
+      "label": "Restringir fabricaci\u00f3n",
+      "description": "Indica si est\u00e1 permitido fabricar un producto"
     },
     "LicenseType": {
       "label": "Tipo de Licencia",
       "description": "Tipo de licencia"
     },
     "AD_Module_Dependency_ID": {
-      "label": "Dependencia entre Módulos",
-      "description": "Define las dependencias entre módulos"
+      "label": "Dependencia entre M\u00f3dulos",
+      "description": "Define las dependencias entre m\u00f3dulos"
     },
     "IsIncluded": {
-      "label": "Está Incluido",
-      "description": "Define si se incluye o si es sólo dependiente"
+      "label": "Est\u00e1 Incluido",
+      "description": "Define si se incluye o si es s\u00f3lo dependiente"
     },
     "StartVersion": {
-      "label": "Primera versión",
-      "description": "Primera versión compatible"
+      "label": "Primera versi\u00f3n",
+      "description": "Primera versi\u00f3n compatible"
     },
     "AD_Dependent_Module_ID": {
       "label": "Modulo dependiente",
-      "description": "Módulo Dependiente"
+      "description": "M\u00f3dulo Dependiente"
     },
     "ShelfDepth": {
       "label": "Profundidad balda",
@@ -6326,23 +6326,23 @@
     },
     "IsOrgBalanced": {
       "label": "Saldado",
-      "description": "Indica se el informe será balanceado o no."
+      "description": "Indica se el informe ser\u00e1 balanceado o no."
     },
     "Start_Date": {
       "label": "Fecha inicio",
-      "description": "La fecha en la que está programado el inicio."
+      "description": "La fecha en la que est\u00e1 programado el inicio."
     },
     "Secondly_Interval": {
       "label": "Intervalo en segundos",
-      "description": "Intervalo en horas entre un evento (como la ejecución de un proceso)."
+      "description": "Intervalo en horas entre un evento (como la ejecuci\u00f3n de un proceso)."
     },
     "Finishes_Time": {
-      "label": "Hora de finalización",
-      "description": "La hora en la que terminará este elemento."
+      "label": "Hora de finalizaci\u00f3n",
+      "description": "La hora en la que terminar\u00e1 este elemento."
     },
     "Monthly_Option": {
-      "label": "Opción Mensual",
-      "description": "Opción por la que se programa un Proceso de forma mensual."
+      "label": "Opci\u00f3n Mensual",
+      "description": "Opci\u00f3n por la que se programa un Proceso de forma mensual."
     },
     "Start_Time": {
       "label": "Comienzo",
@@ -6350,19 +6350,19 @@
     },
     "Minutely_Interval": {
       "label": "Intervalo en Minutos",
-      "description": "Intervalo en minutos entre un evento (como la ejecución de un proceso)."
+      "description": "Intervalo en minutos entre un evento (como la ejecuci\u00f3n de un proceso)."
     },
     "Finishes": {
       "label": "Finaliza",
-      "description": "Especifica que este elemento debería finalizar."
+      "description": "Especifica que este elemento deber\u00eda finalizar."
     },
     "Finishes_Date": {
-      "label": "Fecha finalización",
-      "description": "La fecha en la que este elemento finalizará."
+      "label": "Fecha finalizaci\u00f3n",
+      "description": "La fecha en la que este elemento finalizar\u00e1."
     },
     "Monthly_Day_Of_Week": {
-      "label": "Día de la semana",
-      "description": "Un día de la semana."
+      "label": "D\u00eda de la semana",
+      "description": "Un d\u00eda de la semana."
     },
     "Daily_Interval": {
       "label": "Intervalo_Diario",
@@ -6370,11 +6370,11 @@
     },
     "Hourly_Interval": {
       "label": "Intervalo en Horas",
-      "description": "Intervalo en horas entre un evento (como la ejecución de un proceso)."
+      "description": "Intervalo en horas entre un evento (como la ejecuci\u00f3n de un proceso)."
     },
     "Monthly_Specific_Day": {
-      "label": "Día del Mes",
-      "description": "La fecha específica dentro de cada mes."
+      "label": "D\u00eda del Mes",
+      "description": "La fecha espec\u00edfica dentro de cada mes."
     },
     "ShelfWidth": {
       "label": "Anchura balda",
@@ -6382,47 +6382,47 @@
     },
     "IsTransactionsAllowed": {
       "label": "Transacciones Permitidas",
-      "description": "Define si se permiten transacciones en este tipo de organización"
+      "description": "Define si se permiten transacciones en este tipo de organizaci\u00f3n"
     },
     "DAY_Fri": {
       "label": "Viernes",
-      "description": "El día de la semana viernes."
+      "description": "El d\u00eda de la semana viernes."
     },
     "DAY_Thu": {
       "label": "Jueves",
-      "description": "Día de la semana jueves."
+      "description": "D\u00eda de la semana jueves."
     },
     "DAY_Sun": {
       "label": "Domingo",
-      "description": "Día de la semana domingo."
+      "description": "D\u00eda de la semana domingo."
     },
     "DAY_Mon": {
       "label": "Lunes",
-      "description": "Día de la semana lunes."
+      "description": "D\u00eda de la semana lunes."
     },
     "DAY_Sat": {
-      "label": "Sábado",
-      "description": "Día de la semana sábado."
+      "label": "S\u00e1bado",
+      "description": "D\u00eda de la semana s\u00e1bado."
     },
     "DAY_Tue": {
       "label": "Martes",
-      "description": "Día de la semana martes."
+      "description": "D\u00eda de la semana martes."
     },
     "DAY_Wed": {
-      "label": "Miércoles",
-      "description": "Día de la semana miércoles."
+      "label": "Mi\u00e9rcoles",
+      "description": "D\u00eda de la semana mi\u00e9rcoles."
     },
     "Sortno": {
       "label": "Orden para mostrar",
-      "description": "Método para clasificar y ordenar registros en una ventana."
+      "description": "M\u00e9todo para clasificar y ordenar registros en una ventana."
     },
     "SortNo": {
       "label": "Orden para mostrar",
-      "description": "Método para clasificar y ordenar registros en una ventana."
+      "description": "M\u00e9todo para clasificar y ordenar registros en una ventana."
     },
     "Channel": {
       "label": "Canal",
-      "description": "El método por el que este Procesamiento de peticiones fue ejecutado/programado."
+      "description": "El m\u00e9todo por el que este Procesamiento de peticiones fue ejecutado/programado."
     },
     "Isrolesecurity": {
       "label": "Seguridad basada en el Rol",
@@ -6430,67 +6430,67 @@
     },
     "AD_Process_Request_ID": {
       "label": "AD_Process_Request_ID",
-      "description": "Petición para ejecutar un Proceso."
+      "description": "Petici\u00f3n para ejecutar un Proceso."
     },
     "AD_Process_Set_ID": {
       "label": "AD_Process_Set_ID",
-      "description": "Identificador único para un conjunto de Procesos (una colección de Procesamientos de Peticiones)."
+      "description": "Identificador \u00fanico para un conjunto de Procesos (una colecci\u00f3n de Procesamientos de Peticiones)."
     },
     "Timing_Option": {
       "label": "Programado",
-      "description": "Cuando se debe ejecutar un Procesamiento de Peticiones - bien inmediatamente, otro día o siguiendo un patrón de repetición."
+      "description": "Cuando se debe ejecutar un Procesamiento de Peticiones - bien inmediatamente, otro d\u00eda o siguiendo un patr\u00f3n de repetici\u00f3n."
     },
     "Startdate": {
       "label": "Fecha de inicio",
-      "description": "Parámetro que indica cuándo comienza una petición específica."
+      "description": "Par\u00e1metro que indica cu\u00e1ndo comienza una petici\u00f3n espec\u00edfica."
     },
     "StartDate": {
       "label": "Fecha de inicio",
-      "description": "Parámetro que indica cuándo comienza una petición específica."
+      "description": "Par\u00e1metro que indica cu\u00e1ndo comienza una petici\u00f3n espec\u00edfica."
     },
     "Paymentexec_Message": {
-      "label": "Mensaje de ejecución de un cobro",
+      "label": "Mensaje de ejecuci\u00f3n de un cobro",
       "description": ""
     },
     "StartNo": {
-      "label": "Nº inicial",
-      "description": "Primer número que se utiliza en una secuencia de control o estándar."
+      "label": "N\u00ba inicial",
+      "description": "Primer n\u00famero que se utiliza en una secuencia de control o est\u00e1ndar."
     },
     "Startno": {
-      "label": "Nº inicial",
-      "description": "Primer número que se utiliza en una secuencia de control o estándar."
+      "label": "N\u00ba inicial",
+      "description": "Primer n\u00famero que se utiliza en una secuencia de control o est\u00e1ndar."
     },
     "Schedule": {
       "label": "Programar Proceso",
-      "description": "Programar la ejecución de un Proceso, bien inmediatamente ,otro día o siguiendo un patrón de repetición."
+      "description": "Programar la ejecuci\u00f3n de un Proceso, bien inmediatamente ,otro d\u00eda o siguiendo un patr\u00f3n de repetici\u00f3n."
     },
     "StdPrecision": {
-      "label": "Precisión estándar",
-      "description": "Regla de redondeo para el cálculo  importes"
+      "label": "Precisi\u00f3n est\u00e1ndar",
+      "description": "Regla de redondeo para el c\u00e1lculo  importes"
     },
     "Substitute_ID": {
       "label": "Sustituto",
       "description": "Producto susceptible de ser utilizado en lugar de otro"
     },
     "Cron": {
-      "label": "Expresión Cron",
-      "description": "Una expresión cron de Quartz para programar este Procesamiento de Peticiones."
+      "label": "Expresi\u00f3n Cron",
+      "description": "Una expresi\u00f3n cron de Quartz para programar este Procesamiento de Peticiones."
     },
     "Daily_Option": {
-      "label": "Opción Diaria",
-      "description": "Opción para ejecutar un Procesamiento de Peticiones diariamente."
+      "label": "Opci\u00f3n Diaria",
+      "description": "Opci\u00f3n para ejecutar un Procesamiento de Peticiones diariamente."
     },
     "Suffix": {
       "label": "Sufijo",
-      "description": "Uno o varios caracteres que se añaden al final de una declaración o un número."
+      "description": "Uno o varios caracteres que se a\u00f1aden al final de una declaraci\u00f3n o un n\u00famero."
     },
     "Scheduled_Finish": {
       "label": "Finaliza",
-      "description": "La fecha y hora en la que un Procesamiento de Peticiones está programado para finalizar (repetidamente)."
+      "description": "La fecha y hora en la que un Procesamiento de Peticiones est\u00e1 programado para finalizar (repetidamente)."
     },
     "Next_Fire_Time": {
-      "label": "Siguiente Ejecución",
-      "description": "La siguiente vez que se ejecutará el proceso."
+      "label": "Siguiente Ejecuci\u00f3n",
+      "description": "La siguiente vez que se ejecutar\u00e1 el proceso."
     },
     "AD_Dataset_ID": {
       "label": "Conjunto de Datos",
@@ -6513,32 +6513,32 @@
       "description": "Tabla del Conjunto de Datos"
     },
     "Log": {
-      "label": "Histórico del Proceso",
-      "description": "El histórico de la ejecución del Proceso."
+      "label": "Hist\u00f3rico del Proceso",
+      "description": "El hist\u00f3rico de la ejecuci\u00f3n del Proceso."
     },
     "Runtime": {
-      "label": "Duración",
-      "description": "Tiempo transcurrido desde que el Proceso comenzó hasta que finalizó su ejecución."
+      "label": "Duraci\u00f3n",
+      "description": "Tiempo transcurrido desde que el Proceso comenz\u00f3 hasta que finaliz\u00f3 su ejecuci\u00f3n."
     },
     "AD_Process_Run_ID": {
-      "label": "Ejecución del Proceso",
-      "description": "Ejecución individual de un Proceso."
+      "label": "Ejecuci\u00f3n del Proceso",
+      "description": "Ejecuci\u00f3n individual de un Proceso."
     },
     "UpdateInfo": {
-      "label": "Información de la Actualización",
-      "description": "Información sobre la actualización"
+      "label": "Informaci\u00f3n de la Actualizaci\u00f3n",
+      "description": "Informaci\u00f3n sobre la actualizaci\u00f3n"
     },
     "Updateinfo": {
-      "label": "Información de la Actualización",
-      "description": "Información sobre la actualización"
+      "label": "Informaci\u00f3n de la Actualizaci\u00f3n",
+      "description": "Informaci\u00f3n sobre la actualizaci\u00f3n"
     },
     "AD_Module_Trl_ID": {
-      "label": "Traducción del Módulo",
-      "description": "Traducción para los módulos"
+      "label": "Traducci\u00f3n del M\u00f3dulo",
+      "description": "Traducci\u00f3n para los m\u00f3dulos"
     },
     "Update_Available": {
-      "label": "Actualización Disponible",
-      "description": "Nueva versión para actualizar el módulo actual"
+      "label": "Actualizaci\u00f3n Disponible",
+      "description": "Nueva versi\u00f3n para actualizar el m\u00f3dulo actual"
     },
     "SuspenseBalancing_Acct": {
       "label": "Cuenta de asiento no cuadrado",
@@ -6550,11 +6550,11 @@
     },
     "AD_Org_Acctschema_ID": {
       "label": "AD_Org_Acctschema_ID",
-      "description": "Se refiere al Esquema Contable de la organización"
+      "description": "Se refiere al Esquema Contable de la organizaci\u00f3n"
     },
     "IsPeriodControlAllowed": {
       "label": "Permitir Control de Periodos",
-      "description": "Especifica si la organización puede abrir o cerrar periodos"
+      "description": "Especifica si la organizaci\u00f3n puede abrir o cerrar periodos"
     },
     "Fact_Acct_Group_ID": {
       "label": "ID Grupo",
@@ -6570,19 +6570,19 @@
     },
     "Record_ID2": {
       "label": "Registro ID 2",
-      "description": "Efecto al que hace referencia esta línea de la tabla Fact_Acct."
+      "description": "Efecto al que hace referencia esta l\u00ednea de la tabla Fact_Acct."
     },
     "FactAcctType": {
       "label": "Tipo",
-      "description": "Tipo de asiento (Normal, Cierre, Apertura, Regularización)"
+      "description": "Tipo de asiento (Normal, Cierre, Apertura, Regularizaci\u00f3n)"
     },
     "Factaccttype": {
       "label": "Tipo",
-      "description": "Tipo de asiento (Normal, Cierre, Apertura, Regularización)"
+      "description": "Tipo de asiento (Normal, Cierre, Apertura, Regularizaci\u00f3n)"
     },
     "Reg_Fact_Acct_Group_ID": {
-      "label": "Regularización Fact_Acct_Group_ID",
-      "description": "Se refiere al Fact_Acct_Group_ID del asiento de regularización"
+      "label": "Regularizaci\u00f3n Fact_Acct_Group_ID",
+      "description": "Se refiere al Fact_Acct_Group_ID del asiento de regularizaci\u00f3n"
     },
     "Divideup_Fact_Acct_Group_ID": {
       "label": "RepartoReservas Fact_Acct_Group_ID",
@@ -6597,12 +6597,12 @@
       "description": "Indica si es un asiento de apertura"
     },
     "Previous_Fire_Time": {
-      "label": "Ejecución Anterior",
-      "description": "La última vez que el Procesamiento de Peticiones fue ejecutado."
+      "label": "Ejecuci\u00f3n Anterior",
+      "description": "La \u00faltima vez que el Procesamiento de Peticiones fue ejecutado."
     },
     "Position": {
       "label": "Cargo",
-      "description": "Determina la posición física de la columna"
+      "description": "Determina la posici\u00f3n f\u00edsica de la columna"
     },
     "TableName": {
       "label": "Nombre tabla BD",
@@ -6613,28 +6613,28 @@
       "description": "El contexto en el que un Procesamiento de Peticiones fue programado o ejecutado."
     },
     "Hourly_Repetitions": {
-      "label": "Número de Repeticiones",
-      "description": "El número de veces que se repetirá un procesamiento de peticiones después de su primera ejecución."
+      "label": "N\u00famero de Repeticiones",
+      "description": "El n\u00famero de veces que se repetir\u00e1 un procesamiento de peticiones despu\u00e9s de su primera ejecuci\u00f3n."
     },
     "Minutely_Repetitions": {
-      "label": "Núm de Repeticiones",
-      "description": "El número de veces que se repetirá un procesamiento de peticiones después de su primera ejecución."
+      "label": "N\u00fam de Repeticiones",
+      "description": "El n\u00famero de veces que se repetir\u00e1 un procesamiento de peticiones despu\u00e9s de su primera ejecuci\u00f3n."
     },
     "Secondly_Repetitions": {
       "label": "Repeticiones",
-      "description": "El número de veces que se repetirá un procesamiento de peticiones después de su primera ejecución."
+      "description": "El n\u00famero de veces que se repetir\u00e1 un procesamiento de peticiones despu\u00e9s de su primera ejecuci\u00f3n."
     },
     "IsRecursive": {
       "label": "En cascada",
-      "description": "Si está marcado, el proceso también abrirá o cerrará los documentos de todas las organizaciones que dependan de la organización seleccionada."
+      "description": "Si est\u00e1 marcado, el proceso tambi\u00e9n abrir\u00e1 o cerrar\u00e1 los documentos de todas las organizaciones que dependan de la organizaci\u00f3n seleccionada."
     },
     "C_Periodcontrol_Log_ID": {
       "label": "Registro de Control de Periodos",
       "description": "Registro de Control de Periodos"
     },
     "IsTranslationRequired": {
-      "label": "Traducción Requerida",
-      "description": "Este módulo requiere traducción"
+      "label": "Traducci\u00f3n Requerida",
+      "description": "Este m\u00f3dulo requiere traducci\u00f3n"
     },
     "AD_Module_Dbprefix_ID": {
       "label": "Prefijo de Base de Datos",
@@ -6642,11 +6642,11 @@
     },
     "TaxID": {
       "label": "CIF/NIF",
-      "description": "Número único definido por el gobierno para asignar y pagar impuestos."
+      "description": "N\u00famero \u00fanico definido por el gobierno para asignar y pagar impuestos."
     },
     "Restrictdistriborderreceipt": {
-      "label": "Restringir pedidos de distribución (recibir)",
-      "description": "Indica si está permitido realizar un pedido de distribución (recibir) con un producto"
+      "label": "Restringir pedidos de distribuci\u00f3n (recibir)",
+      "description": "Indica si est\u00e1 permitido realizar un pedido de distribuci\u00f3n (recibir) con un producto"
     },
     "Isrtl": {
       "label": "Lenguaje RTL",
@@ -6654,15 +6654,15 @@
     },
     "Text": {
       "label": "Texto",
-      "description": "Lugar para añadir observaciones relacionadas con un control específico."
+      "description": "Lugar para a\u00f1adir observaciones relacionadas con un control espec\u00edfico."
     },
     "To_Country_ID": {
-      "label": "País destino",
-      "description": "País al que se destina el envío."
+      "label": "Pa\u00eds destino",
+      "description": "Pa\u00eds al que se destina el env\u00edo."
     },
     "To_Region_ID": {
       "label": "Provincia destino",
-      "description": "Estado o provincia de un país al que se destina el envío."
+      "description": "Estado o provincia de un pa\u00eds al que se destina el env\u00edo."
     },
     "TotalCr": {
       "label": "Saldo total acreedor",
@@ -6673,43 +6673,43 @@
       "description": "Saldo total deudor en la moneda del documento"
     },
     "TotalLines": {
-      "label": "Imp. total líneas",
-      "description": "Suma final de los totales de todas las líneas de un documento o transacción específica (no incluyen los impuestos)."
+      "label": "Imp. total l\u00edneas",
+      "description": "Suma final de los totales de todas las l\u00edneas de un documento o transacci\u00f3n espec\u00edfica (no incluyen los impuestos)."
     },
     "Treetype": {
       "label": "Tipo  Area",
-      "description": "Elemento del árbol en el que se ha construido(producto, tercero)"
+      "description": "Elemento del \u00e1rbol en el que se ha construido(producto, tercero)"
     },
     "TreeType": {
       "label": "Tipo  Area",
-      "description": "Elemento del árbol en el que se ha construido(producto, tercero)"
+      "description": "Elemento del \u00e1rbol en el que se ha construido(producto, tercero)"
     },
     "IsTranslationModule": {
-      "label": "Es un módulo de traducción",
-      "description": "Este es un módulo de traducción"
+      "label": "Es un m\u00f3dulo de traducci\u00f3n",
+      "description": "Este es un m\u00f3dulo de traducci\u00f3n"
     },
     "HasReferenceData": {
       "label": "Tiene datos de referencia",
-      "description": "El módulo contiene datos de referencia"
+      "description": "El m\u00f3dulo contiene datos de referencia"
     },
     "HasChartOfAccounts": {
       "label": "Tiene fichero de cuentas",
-      "description": "El módulo contiene un fichero de cuentas"
+      "description": "El m\u00f3dulo contiene un fichero de cuentas"
     },
     "Restrictdistriborderissue": {
-      "label": "Restringir pedidos de distribución (enviar)",
-      "description": "Indica si está permitido realizar un pedido de distribución (enviar) con un producto"
+      "label": "Restringir pedidos de distribuci\u00f3n (enviar)",
+      "description": "Indica si est\u00e1 permitido realizar un pedido de distribuci\u00f3n (enviar) con un producto"
     },
     "IsRegistered": {
-      "label": "Registrar Módulo",
-      "description": "Indica si el módulo está registrado en el Repositorio Central"
+      "label": "Registrar M\u00f3dulo",
+      "description": "Indica si el m\u00f3dulo est\u00e1 registrado en el Repositorio Central"
     },
     "IsBusinessObject": {
       "label": "Es Objeto de Negocio",
       "description": "Incluir Objetos de Negocio"
     },
     "Params": {
-      "label": "Parámetros",
+      "label": "Par\u00e1metros",
       "description": ""
     },
     "Report": {
@@ -6722,27 +6722,27 @@
     },
     "Cancelandreplace": {
       "label": "Cancelar y Reemplazar",
-      "description": "Botón que crea un pedido temporal duplicado"
+      "description": "Bot\u00f3n que crea un pedido temporal duplicado"
     },
     "P_Def_Revenue_Acct": {
       "label": "Ingreso de producto a periodificar",
       "description": "Usado para periodificar un ingreso para un producto vendido."
     },
     "Update_Ver_ID": {
-      "label": "Versión Actualizada",
-      "description": "Versión Actualizada"
+      "label": "Versi\u00f3n Actualizada",
+      "description": "Versi\u00f3n Actualizada"
     },
     "End_Time": {
       "label": "Fin",
-      "description": "La fecha en la que finalizó la ejecución del proceso."
+      "description": "La fecha en la que finaliz\u00f3 la ejecuci\u00f3n del proceso."
     },
     "END_Time": {
       "label": "Fin",
-      "description": "La fecha en la que finalizó la ejecución del proceso."
+      "description": "La fecha en la que finaliz\u00f3 la ejecuci\u00f3n del proceso."
     },
     "Estimatedtime": {
       "label": "Tiempo estimado",
-      "description": "Tiempo estimado para la operación"
+      "description": "Tiempo estimado para la operaci\u00f3n"
     },
     "Iscancelled": {
       "label": "Cancelado",
@@ -6750,7 +6750,7 @@
     },
     "Customization_Allowed": {
       "label": "Personalizaciones Permitidas",
-      "description": "Permitir personalizaciones en el módulo CORE."
+      "description": "Permitir personalizaciones en el m\u00f3dulo CORE."
     },
     "Open_Fact_Acct_Group_ID": {
       "label": "Open_Fact_Acct_Group_ID",
@@ -6766,59 +6766,59 @@
     },
     "Valuefield_ID": {
       "label": "Campo de Valor",
-      "description": "El valor de este campo se colocará en la columna clave extranjera"
+      "description": "El valor de este campo se colocar\u00e1 en la columna clave extranjera"
     },
     "Isrfc": {
-      "label": "Devolución a cliente",
+      "label": "Devoluci\u00f3n a cliente",
       "description": ""
     },
     "ReferenceDataInfo": {
-      "label": "Descripción de los Datos de Referencia",
-      "description": "Descripción de los datos de referencia contenidos en el módulo"
+      "label": "Descripci\u00f3n de los Datos de Referencia",
+      "description": "Descripci\u00f3n de los datos de referencia contenidos en el m\u00f3dulo"
     },
     "Referencedatainfo": {
-      "label": "Descripción de los Datos de Referencia",
-      "description": "Descripción de los datos de referencia contenidos en el módulo"
+      "label": "Descripci\u00f3n de los Datos de Referencia",
+      "description": "Descripci\u00f3n de los datos de referencia contenidos en el m\u00f3dulo"
     },
     "Type": {
       "label": "Tipo",
-      "description": "Característica única de un ítem utilizada en los procesos y a veces agrupada dentro de una categoría."
+      "description": "Caracter\u00edstica \u00fanica de un \u00edtem utilizada en los procesos y a veces agrupada dentro de una categor\u00eda."
     },
     "ValidTo": {
-      "label": "Válido hasta",
-      "description": "Parámetro que establece el momento de finalización de una petición específica."
+      "label": "V\u00e1lido hasta",
+      "description": "Par\u00e1metro que establece el momento de finalizaci\u00f3n de una petici\u00f3n espec\u00edfica."
     },
     "PayInAdvance": {
       "label": "Crear Efecto por Adelantado",
       "description": "Crear un efecto por adelantado"
     },
     "UOMSymbol": {
-      "label": "Símbolo",
-      "description": "Descripción abreviada utilizada para definir una unidad de medida o de moneda."
+      "label": "S\u00edmbolo",
+      "description": "Descripci\u00f3n abreviada utilizada para definir una unidad de medida o de moneda."
     },
     "UPC": {
       "label": "UPC/EAN",
-      "description": "Código de barra y número que identifica un producto."
+      "description": "C\u00f3digo de barra y n\u00famero que identifica un producto."
     },
     "UnitsPerPallet": {
       "label": "Unds./Pale",
       "description": "Unds./Pale"
     },
     "UnrealizedLoss_Acct": {
-      "label": "Cuenta de pérdidas no realizadas",
-      "description": "Cuenta de pérdidas no realizadas"
+      "label": "Cuenta de p\u00e9rdidas no realizadas",
+      "description": "Cuenta de p\u00e9rdidas no realizadas"
     },
     "SO_Goods_Blocking": {
-      "label": "Albarán (Cliente)",
+      "label": "Albar\u00e1n (Cliente)",
       "description": "Permite bloquear albaranes de cliente para un cliente"
     },
     "updated": {
       "label": "Actualizado",
-      "description": "<P>Indica la fecha en la que está petición fue actualizada por última vez.</P>"
+      "description": "<P>Indica la fecha en la que est\u00e1 petici\u00f3n fue actualizada por \u00faltima vez.</P>"
     },
     "updatedBy": {
       "label": "Actualizado por",
-      "description": "Usuario que actualizó el registro"
+      "description": "Usuario que actualiz\u00f3 el registro"
     },
     "UseCurrencyBalancing": {
       "label": "Utilizar cuenta de redondeo de cambio de moneda",
@@ -6842,67 +6842,67 @@
     },
     "User2_ID": {
       "label": "Usuario2",
-      "description": "Despliegue de elementos opcionales que son definidos previamente para esta combinación contable."
+      "description": "Despliegue de elementos opcionales que son definidos previamente para esta combinaci\u00f3n contable."
     },
     "User2_Acctdim_Isenable": {
       "label": "Usuario2",
-      "description": "Despliegue de elementos opcionales que son definidos previamente para esta combinación contable."
+      "description": "Despliegue de elementos opcionales que son definidos previamente para esta combinaci\u00f3n contable."
     },
     "Vendor_Blocking": {
       "label": "Bloqueo de proveedor",
-      "description": "Permite bloquear el proveedor. Al marcarlo, aparece una sección llamada bloqueo de tercero con las posibles opciones de bloqueo."
+      "description": "Permite bloquear el proveedor. Al marcarlo, aparece una secci\u00f3n llamada bloqueo de tercero con las posibles opciones de bloqueo."
     },
     "UserLevel": {
       "label": "Nivel de usuario",
-      "description": "Al sistema, al cliente, a la organización"
+      "description": "Al sistema, al cliente, a la organizaci\u00f3n"
     },
     "VFormat": {
       "label": "Formato",
-      "description": "Formato es el formato con el que se mostrará."
+      "description": "Formato es el formato con el que se mostrar\u00e1."
     },
     "ValidFrom": {
-      "label": "Válido desde",
-      "description": "Parámetro que establece el momento de iniciación de una petición específica."
+      "label": "V\u00e1lido desde",
+      "description": "Par\u00e1metro que establece el momento de iniciaci\u00f3n de una petici\u00f3n espec\u00edfica."
     },
     "Validfrom": {
-      "label": "Válido desde",
-      "description": "Parámetro que establece el momento de iniciación de una petición específica."
+      "label": "V\u00e1lido desde",
+      "description": "Par\u00e1metro que establece el momento de iniciaci\u00f3n de una petici\u00f3n espec\u00edfica."
     },
     "Isinitialbalance": {
-      "label": "Balance Inicial del Año",
-      "description": "Si está marcada, el sistema calculará automáticamente el balance de apertura para el año fiscal (independientemente de si el periodo es mensual o trimestral)."
+      "label": "Balance Inicial del A\u00f1o",
+      "description": "Si est\u00e1 marcada, el sistema calcular\u00e1 autom\u00e1ticamente el balance de apertura para el a\u00f1o fiscal (independientemente de si el periodo es mensual o trimestral)."
     },
     "Year": {
       "label": "Ejercicio",
-      "description": "Ejercicio del año"
+      "description": "Ejercicio del a\u00f1o"
     },
     "ValidationType": {
-      "label": "Tipo de validación",
-      "description": "Diferentes métodos de validar un dato"
+      "label": "Tipo de validaci\u00f3n",
+      "description": "Diferentes m\u00e9todos de validar un dato"
     },
     "Last_Build": {
-      "label": "Última Compilación",
-      "description": "Última vez que se compiló el sistema"
+      "label": "\u00daltima Compilaci\u00f3n",
+      "description": "\u00daltima vez que se compil\u00f3 el sistema"
     },
     "Last_DBUpdate": {
-      "label": "Última Actualización de la Base de Datos",
-      "description": "Última actualización de la base de datos"
+      "label": "\u00daltima Actualizaci\u00f3n de la Base de Datos",
+      "description": "\u00daltima actualizaci\u00f3n de la base de datos"
     },
     "searchKey": {
       "label": "Identificador",
-      "description": "Método rápido para hallar un registro particular."
+      "description": "M\u00e9todo r\u00e1pido para hallar un registro particular."
     },
     "value": {
       "label": "Identificador",
-      "description": "Método rápido para hallar un registro particular."
+      "description": "M\u00e9todo r\u00e1pido para hallar un registro particular."
     },
     "Z": {
       "label": "Altura (Z)",
-      "description": "Dimensión Z"
+      "description": "Dimensi\u00f3n Z"
     },
     "LastCalculatedOnDate": {
-      "label": "Fecha del Último Cálculo",
-      "description": "Fecha del Último Cálculo"
+      "label": "Fecha del \u00daltimo C\u00e1lculo",
+      "description": "Fecha del \u00daltimo C\u00e1lculo"
     },
     "Reversed_C_Invoice_ID": {
       "label": "Factura Rectificativa",
@@ -6913,11 +6913,11 @@
       "description": "Es un checksum de la base de datos al completo"
     },
     "VendorCategory": {
-      "label": "Categoría proveedor",
-      "description": "Clasificación de los proveedores basada en atributos o características similares."
+      "label": "Categor\u00eda proveedor",
+      "description": "Clasificaci\u00f3n de los proveedores basada en atributos o caracter\u00edsticas similares."
     },
     "VendorProductNo": {
-      "label": "Código proveedor",
+      "label": "C\u00f3digo proveedor",
       "description": "Identificador utilizado por un proveedor para identificar un producto vendido por sus terceros."
     },
     "IsAcctLegalEntity": {
@@ -6933,24 +6933,24 @@
       "description": "Peso del producto"
     },
     "WhereClause": {
-      "label": "Cláusula SQL Where",
-      "description": "Especificación de la cláusula SQL \"WHERE\" utilizada para mostrar datos filtrados permanentemente."
+      "label": "Cl\u00e1usula SQL Where",
+      "description": "Especificaci\u00f3n de la cl\u00e1usula SQL \"WHERE\" utilizada para mostrar datos filtrados permanentemente."
     },
     "Enableinfininvoices": {
       "label": "Disponible en Facturas Financieras",
-      "description": "Las cuentas que tengan esta casilla marcada se podrán seleccionar al crear una línea de factura financiera."
+      "description": "Las cuentas que tengan esta casilla marcada se podr\u00e1n seleccionar al crear una l\u00ednea de factura financiera."
     },
     "WindowType": {
       "label": "Tipo de ventana",
-      "description": "Tipo o clasificación de la ventana"
+      "description": "Tipo o clasificaci\u00f3n de la ventana"
     },
     "X": {
-      "label": "Estantería (X)",
-      "description": "Dimensión X, e.j:Pasillo"
+      "label": "Estanter\u00eda (X)",
+      "description": "Dimensi\u00f3n X, e.j:Pasillo"
     },
     "X12DE355": {
-      "label": "Código EDI",
-      "description": "Código EDI unidad"
+      "label": "C\u00f3digo EDI",
+      "description": "C\u00f3digo EDI unidad"
     },
     "Pendingaumqty": {
       "label": "Cantidad Pendiente en Unidad Alternativa",
@@ -6958,14 +6958,14 @@
     },
     "Y": {
       "label": "Columna (Y)",
-      "description": "Dimensión Y"
+      "description": "Dimensi\u00f3n Y"
     },
     "Timeout": {
-      "label": "Tiempo de Expiración",
-      "description": "El Tiempo de Expiración es el valor en segundos asignado por el usuario para la petición al servicio definido"
+      "label": "Tiempo de Expiraci\u00f3n",
+      "description": "El Tiempo de Expiraci\u00f3n es el valor en segundos asignado por el usuario para la petici\u00f3n al servicio definido"
     },
     "LastPaymentDate": {
-      "label": "Fecha último pago",
+      "label": "Fecha \u00faltimo pago",
       "description": ""
     },
     "Isdefaultemail": {
@@ -6977,19 +6977,19 @@
       "description": ""
     },
     "Isordered": {
-      "label": "Está ordenado",
-      "description": "Permite especificar si los el orden de los nodos en el árbol es relevante"
+      "label": "Est\u00e1 ordenado",
+      "description": "Permite especificar si los el orden de los nodos en el \u00e1rbol es relevante"
     },
     "Errorinfo": {
-      "label": "Información Error",
-      "description": "Información Error"
+      "label": "Informaci\u00f3n Error",
+      "description": "Informaci\u00f3n Error"
     },
     "Startingtimesaturday": {
-      "label": "Hora inicio Sábado",
+      "label": "Hora inicio S\u00e1bado",
       "description": ""
     },
     "Endingtimewednesday": {
-      "label": "Hora fin Miércoles",
+      "label": "Hora fin Mi\u00e9rcoles",
       "description": ""
     },
     "FIN_Doubtful_Debt_Run_ID": {
@@ -6997,7 +6997,7 @@
       "description": ""
     },
     "validuntil": {
-      "label": "Válido hasta",
+      "label": "V\u00e1lido hasta",
       "description": ""
     },
     "Datetimeformat": {
@@ -7006,27 +7006,27 @@
     },
     "C_Extbp_Config_Filter_ID": {
       "label": "Filtro del Concetor CRM",
-      "description": "Filtros para la integración con el Conector CRM"
+      "description": "Filtros para la integraci\u00f3n con el Conector CRM"
     },
     "AD_Orgtype_ID": {
-      "label": "Tipo de Organización",
-      "description": "Define el tipo de organización"
+      "label": "Tipo de Organizaci\u00f3n",
+      "description": "Define el tipo de organizaci\u00f3n"
     },
     "IsBusinessUnit": {
       "label": "Unidad de Negocio",
-      "description": "Una organización con sus cuentas independientes. Pertenece, junto con otras unidades de negocio, a una entidad legal."
+      "description": "Una organizaci\u00f3n con sus cuentas independientes. Pertenece, junto con otras unidades de negocio, a una entidad legal."
     },
     "IsLegalEntity": {
       "label": "Entidad Legal",
-      "description": "Una organización que es una entidad legal"
+      "description": "Una organizaci\u00f3n que es una entidad legal"
     },
     "Characteristics_Selection": {
-      "label": "Características Incluidas",
-      "description": "Modo selección para las Características del Producto"
+      "label": "Caracter\u00edsticas Incluidas",
+      "description": "Modo selecci\u00f3n para las Caracter\u00edsticas del Producto"
     },
     "IsCategoryKey": {
-      "label": "Clave de Categoría",
-      "description": "Si está marcada, la propiedad será usada como Clave de Categoría"
+      "label": "Clave de Categor\u00eda",
+      "description": "Si est\u00e1 marcada, la propiedad ser\u00e1 usada como Clave de Categor\u00eda"
     },
     "AD_Tab_Access_ID": {
       "label": "AD_Tab_Access_ID",
@@ -7037,23 +7037,23 @@
       "description": "Establece la prioridad de los planes de pago generados al procesar la factura o el pedido."
     },
     "CANCELPRICEAD": {
-      "label": "Cancelar Modificación de Precio",
-      "description": "Se usa para activar o desactivar la modificación de precios en cada línea"
+      "label": "Cancelar Modificaci\u00f3n de Precio",
+      "description": "Se usa para activar o desactivar la modificaci\u00f3n de precios en cada l\u00ednea"
     },
     "Stopwhenfail": {
-      "label": "Parar la ejecución del grupo cuando un proceso falle",
-      "description": "Parar la ejecución del grupo cuando un proceso falle"
+      "label": "Parar la ejecuci\u00f3n del grupo cuando un proceso falle",
+      "description": "Parar la ejecuci\u00f3n del grupo cuando un proceso falle"
     },
     "Isincludecharacteristics": {
-      "label": "Incluir Características",
+      "label": "Incluir Caracter\u00edsticas",
       "description": ""
     },
     "IsStatic": {
-      "label": "Estático",
-      "description": "Impide añadir el registro al árbol."
+      "label": "Est\u00e1tico",
+      "description": "Impide a\u00f1adir el registro al \u00e1rbol."
     },
     "Onchangefunction": {
-      "label": "Función 'On Change'",
+      "label": "Funci\u00f3n 'On Change'",
       "description": ""
     },
     "Filtericon": {
@@ -7069,72 +7069,72 @@
       "description": "Factura Rectificativa"
     },
     "Divisiongroupqty": {
-      "label": "División de la cantidad de grupo",
-      "description": "Indica la cantidad en la que los productos P+ serán agrupados"
+      "label": "Divisi\u00f3n de la cantidad de grupo",
+      "description": "Indica la cantidad en la que los productos P+ ser\u00e1n agrupados"
     },
     "AD_Process_Run_Group_ID": {
-      "label": "Lanzado por la Ejecución del Grupo",
+      "label": "Lanzado por la Ejecuci\u00f3n del Grupo",
       "description": ""
     },
     "M_InventoryStatus_ID": {
       "label": "Estado de Inventario",
-      "description": "Condición de un inventario específico"
+      "description": "Condici\u00f3n de un inventario espec\u00edfico"
     },
     "M_Inventorystatus_ID": {
       "label": "Estado de Inventario",
-      "description": "Condición de un inventario específico"
+      "description": "Condici\u00f3n de un inventario espec\u00edfico"
     },
     "Servoutcost": {
-      "label": "Coste de externalización",
+      "label": "Coste de externalizaci\u00f3n",
       "description": ""
     },
     "IsEditable": {
       "label": "Editable",
-      "description": "Si está marcada, la propiedad podrá ser editada"
+      "description": "Si est\u00e1 marcada, la propiedad podr\u00e1 ser editada"
     },
     "Your_Company_Menu_Image": {
-      "label": "Imagen de Menú por Defecto de su Compañía",
+      "label": "Imagen de Men\u00fa por Defecto de su Compa\u00f1\u00eda",
       "description": ""
     },
     "ReportType": {
       "label": "Tipo de Informe",
-      "description": "Indica si el informe es de tipo \"Punto en el tiempo\" (necesita calcular el balance de apertura si no existe) o de tipo \"Periódico\" (en este caso no se necesita el cálculo)"
+      "description": "Indica si el informe es de tipo \"Punto en el tiempo\" (necesita calcular el balance de apertura si no existe) o de tipo \"Peri\u00f3dico\" (en este caso no se necesita el c\u00e1lculo)"
     },
     "M_Servicepricerule_ID": {
       "label": "Regla de Precio de Servicio",
       "description": "Reglas para establecer el precio del servicio."
     },
     "Session_Active": {
-      "label": "Matar Sesión",
-      "description": "Sesión Activa"
+      "label": "Matar Sesi\u00f3n",
+      "description": "Sesi\u00f3n Activa"
     },
     "Payin_Invoicepaidstatus": {
       "label": "Estado de la factura pagada",
-      "description": "Estado en el que una factura se considera pagada. Este estado puede configurarse para cada método de pago y cuenta financiera."
+      "description": "Estado en el que una factura se considera pagada. Este estado puede configurarse para cada m\u00e9todo de pago y cuenta financiera."
     },
     "Confprodprocess": {
-      "label": "Añadir Productos",
+      "label": "A\u00f1adir Productos",
       "description": ""
     },
     "Istree": {
-      "label": "Es árbol",
-      "description": "Define si se quiere mostrar la información de esta table jerárquicamente."
+      "label": "Es \u00e1rbol",
+      "description": "Define si se quiere mostrar la informaci\u00f3n de esta table jer\u00e1rquicamente."
     },
     "Update_Currency": {
       "label": "Establecer nueva moneda",
       "description": ""
     },
     "Version_Label": {
-      "label": "Etiqueta Versión",
-      "description": "Indentificador de versión en formato entendible por humanos"
+      "label": "Etiqueta Versi\u00f3n",
+      "description": "Indentificador de versi\u00f3n en formato entendible por humanos"
     },
     "AD_Tree_Costcenter_ID": {
-      "label": "Arbol primario de categoría de recursos",
+      "label": "Arbol primario de categor\u00eda de recursos",
       "description": ""
     },
     "Characteristics_Excl_Selection": {
-      "label": "Excluir Características",
-      "description": "Modo de selección de Características del Producto"
+      "label": "Excluir Caracter\u00edsticas",
+      "description": "Modo de selecci\u00f3n de Caracter\u00edsticas del Producto"
     },
     "IsExpensePositive": {
       "label": "Balance de gasto al debe en positivo ",
@@ -7149,7 +7149,7 @@
       "description": ""
     },
     "AD_Extension_Points_ID": {
-      "label": "Puntos de Extensión",
+      "label": "Puntos de Extensi\u00f3n",
       "description": ""
     },
     "C_Acctschema_Process_ID": {
@@ -7166,14 +7166,14 @@
     },
     "IsCommercial": {
       "label": "EsComercial",
-      "description": "Módulo Comercial"
+      "description": "M\u00f3dulo Comercial"
     },
     "Dateformat": {
       "label": "Formato de fecha",
       "description": ""
     },
     "LocatorOrg": {
-      "label": "Organización del Hueco",
+      "label": "Organizaci\u00f3n del Hueco",
       "description": ""
     },
     "Tuesday": {
@@ -7181,8 +7181,8 @@
       "description": ""
     },
     "CategoryKey_Seqno": {
-      "label": "Número de Secuencia de la Clave de la Categoría",
-      "description": "Secuencia en la Clave de la Categoría"
+      "label": "N\u00famero de Secuencia de la Clave de la Categor\u00eda",
+      "description": "Secuencia en la Clave de la Categor\u00eda"
     },
     "Sunday": {
       "label": "Domingo",
@@ -7198,11 +7198,11 @@
     },
     "Server_Url": {
       "label": "URL del Servidor",
-      "description": "URL del contexto en el que se encuentra la sesión"
+      "description": "URL del contexto en el que se encuentra la sesi\u00f3n"
     },
     "Bpartner_Extref_Selection": {
-      "label": "Referencias Externas al Tercero Incluídas",
-      "description": "Modo de selección de la Referencia Externa al Tercero"
+      "label": "Referencias Externas al Tercero Inclu\u00eddas",
+      "description": "Modo de selecci\u00f3n de la Referencia Externa al Tercero"
     },
     "Support_Contact": {
       "label": "Contacto de Soporte",
@@ -7218,7 +7218,7 @@
     },
     "IsFullyAudited": {
       "label": "Completamente auditado",
-      "description": "Mantener histórico de auditoría para esta tabla"
+      "description": "Mantener hist\u00f3rico de auditor\u00eda para esta tabla"
     },
     "Process_ID": {
       "label": "Proceso",
@@ -7241,16 +7241,16 @@
       "description": "Nuevo valor caracter"
     },
     "NEW_Number": {
-      "label": "Nuevo numérico",
-      "description": "Nuevo valor numérico"
+      "label": "Nuevo num\u00e9rico",
+      "description": "Nuevo valor num\u00e9rico"
     },
     "OLD_Nchar": {
       "label": "NChar anterior",
       "description": "Valor Nchar anterior"
     },
     "OLD_Number": {
-      "label": "Numérico anterior",
-      "description": "Valor Numérico anterior"
+      "label": "Num\u00e9rico anterior",
+      "description": "Valor Num\u00e9rico anterior"
     },
     "NEW_Date": {
       "label": "Nueva fecha",
@@ -7265,12 +7265,12 @@
       "description": "Valor Char anterior"
     },
     "Record_Revision": {
-      "label": "Revisión de registro",
-      "description": "Revisión del registro"
+      "label": "Revisi\u00f3n de registro",
+      "description": "Revisi\u00f3n del registro"
     },
     "Barcode": {
-      "label": "Código de barras",
-      "description": "Código de barras que identifica a este artículo"
+      "label": "C\u00f3digo de barras",
+      "description": "C\u00f3digo de barras que identifica a este art\u00edculo"
     },
     "Endingtimetuesday": {
       "label": "Hora fin Martes",
@@ -7282,7 +7282,7 @@
     },
     "BP_Currency_ID": {
       "label": "Moneda",
-      "description": "Medio aceptado de intercambio de moneda que varía según el país."
+      "description": "Medio aceptado de intercambio de moneda que var\u00eda seg\u00fan el pa\u00eds."
     },
     "FIN_Payment_Schedule_ID": {
       "label": "Fin_Payment_Schedule_ID",
@@ -7309,15 +7309,15 @@
       "description": "Cuenta financiera usada para depositar / retirar dinero tales como cuentas bancarias o gastos menores de caja"
     },
     "Fin_Finacc_Transaction_ID": {
-      "label": "ID de transacción",
+      "label": "ID de transacci\u00f3n",
       "description": ""
     },
     "FIN_Finacc_Transaction_ID": {
-      "label": "ID de transacción",
+      "label": "ID de transacci\u00f3n",
       "description": ""
     },
     "FIN_FinAcc_Transaction_ID": {
-      "label": "ID de transacción",
+      "label": "ID de transacci\u00f3n",
       "description": ""
     },
     "Paymentamt": {
@@ -7325,19 +7325,19 @@
       "description": ""
     },
     "depositAmount": {
-      "label": "Importe del depósito",
+      "label": "Importe del dep\u00f3sito",
       "description": ""
     },
     "Depositamt": {
-      "label": "Importe del depósito",
+      "label": "Importe del dep\u00f3sito",
       "description": ""
     },
     "Numberofpayments": {
-      "label": "Número de cobros",
+      "label": "N\u00famero de cobros",
       "description": ""
     },
     "NumberOfPayments": {
-      "label": "Número de cobros",
+      "label": "N\u00famero de cobros",
       "description": ""
     },
     "Outstanding": {
@@ -7349,7 +7349,7 @@
       "description": "Conjunto de efectos de una factura previstos de ser cobrados/pagados"
     },
     "Lastpayment": {
-      "label": "Último pago",
+      "label": "\u00daltimo pago",
       "description": "Last Payment In Date"
     },
     "Fin_Payment_Detail_V_ID": {
@@ -7357,11 +7357,11 @@
       "description": ""
     },
     "AD_Application_ID": {
-      "label": "Aplicación",
-      "description": "Define la aplicación que usa Openbravo como base"
+      "label": "Aplicaci\u00f3n",
+      "description": "Define la aplicaci\u00f3n que usa Openbravo como base"
     },
     "UI_Impl": {
-      "label": "Implementación de la UI en tiempo de ejecución",
+      "label": "Implementaci\u00f3n de la UI en tiempo de ejecuci\u00f3n",
       "description": "Clase Java que implementa la Interfaz de usuario."
     },
     "IsBaseReference": {
@@ -7373,15 +7373,15 @@
       "description": "Referencia padre de la subreferencia"
     },
     "Model_Impl": {
-      "label": "Implementación de Modelo",
+      "label": "Implementaci\u00f3n de Modelo",
       "description": "Clase Java que implementa el Modelo."
     },
     "P_Revenue_Return_Acct": {
-      "label": "Devolución de Ingresos por el Producto",
-      "description": "Número de cuenta en la contabilida general para marcar las devoluciones de este producto."
+      "label": "Devoluci\u00f3n de Ingresos por el Producto",
+      "description": "N\u00famero de cuenta en la contabilida general para marcar las devoluciones de este producto."
     },
     "Your_Company_Login_Image": {
-      "label": "Imagen de Login por Defecto de su Compañía",
+      "label": "Imagen de Login por Defecto de su Compa\u00f1\u00eda",
       "description": ""
     },
     "PO_C_Incoterms_ID": {
@@ -7393,11 +7393,11 @@
       "description": "Vista del IVA de caja de la factura"
     },
     "Isexpiredpassword": {
-      "label": "Contraseña Caducada",
-      "description": "Cuando se marque, la contraseña del usuario quedará caducada y el usuario tendrá que cambiarla."
+      "label": "Contrase\u00f1a Caducada",
+      "description": "Cuando se marque, la contrase\u00f1a del usuario quedar\u00e1 caducada y el usuario tendr\u00e1 que cambiarla."
     },
     "Paymentexec_Result": {
-      "label": "Resultado de la Ejecución de Pagos",
+      "label": "Resultado de la Ejecuci\u00f3n de Pagos",
       "description": ""
     },
     "Startingtimethursday": {
@@ -7405,91 +7405,91 @@
       "description": ""
     },
     "FIN_Paymentmethod_ID": {
-      "label": "Método de pago",
+      "label": "M\u00e9todo de pago",
       "description": "Es la forma en la que se espera hacer o recibir el efecto."
     },
     "Fin_Paymentmethod_ID": {
-      "label": "Método de pago",
+      "label": "M\u00e9todo de pago",
       "description": "Es la forma en la que se espera hacer o recibir el efecto."
     },
     "Paymentno": {
-      "label": "Nº Pago",
-      "description": "Número de Cobro"
+      "label": "N\u00ba Pago",
+      "description": "N\u00famero de Cobro"
     },
     "Iseditlinenetamt": {
-      "label": "Editar importe neto de línea",
-      "description": "Check que permite al usuario editar el campo Importe neto de línea."
+      "label": "Editar importe neto de l\u00ednea",
+      "description": "Check que permite al usuario editar el campo Importe neto de l\u00ednea."
     },
     "Todatesend": {
       "label": "Hasta",
       "description": "Fecha fin"
     },
     "Translation_Strategy": {
-      "label": "Estrategia de Traducción",
-      "description": "Si se deja vacío entonces las Ventanas, Procesos... relacionados con la entrada de menú estarán disponibles también en la versión reducida de la traducción"
+      "label": "Estrategia de Traducci\u00f3n",
+      "description": "Si se deja vac\u00edo entonces las Ventanas, Procesos... relacionados con la entrada de men\u00fa estar\u00e1n disponibles tambi\u00e9n en la versi\u00f3n reducida de la traducci\u00f3n"
     },
     "P_Cogs_Return_Acct": {
-      "label": "Devolución del Costo del Producto",
-      "description": "El coste del material devuelto para un producto específico."
+      "label": "Devoluci\u00f3n del Costo del Producto",
+      "description": "El coste del material devuelto para un producto espec\u00edfico."
     },
     "Project_Acctdim_Header": {
       "label": "Mostrar en cabecera",
-      "description": "Indica si la dimensión contable se muestra en la cabecera del documento."
+      "description": "Indica si la dimensi\u00f3n contable se muestra en la cabecera del documento."
     },
     "Costcenter_Acctdim_Header": {
       "label": "Mostrar en cabecera",
-      "description": "Indica si la dimensión contable se muestra en la cabecera del documento."
+      "description": "Indica si la dimensi\u00f3n contable se muestra en la cabecera del documento."
     },
     "User1_Acctdim_Header": {
       "label": "Mostrar en cabecera",
-      "description": "Indica si la dimensión contable se muestra en la cabecera del documento."
+      "description": "Indica si la dimensi\u00f3n contable se muestra en la cabecera del documento."
     },
     "Product_Acctdim_Header": {
       "label": "Mostrar en cabecera",
-      "description": "Indica si la dimensión contable se muestra en la cabecera del documento."
+      "description": "Indica si la dimensi\u00f3n contable se muestra en la cabecera del documento."
     },
     "Bpartner_Acctdim_Header": {
       "label": "Mostrar en cabecera",
-      "description": "Indica si la dimensión contable se muestra en la cabecera del documento."
+      "description": "Indica si la dimensi\u00f3n contable se muestra en la cabecera del documento."
     },
     "User2_Acctdim_Header": {
       "label": "Mostrar en cabecera",
-      "description": "Indica si la dimensión contable se muestra en la cabecera del documento."
+      "description": "Indica si la dimensi\u00f3n contable se muestra en la cabecera del documento."
     },
     "Show_In_Header": {
       "label": "Mostrar en cabecera",
-      "description": "Indica si la dimensión contable se muestra en la cabecera del documento."
+      "description": "Indica si la dimensi\u00f3n contable se muestra en la cabecera del documento."
     },
     "BaseAmount": {
       "label": "Base Imponible",
-      "description": "Base imponible usada para el cálculo de importes de impuestos."
+      "description": "Base imponible usada para el c\u00e1lculo de importes de impuestos."
     },
     "Attrsetvaluetype": {
       "label": "Usar conjunto de atributos como",
-      "description": "Una carecterística distintiva del conjunto de atributos."
+      "description": "Una carecter\u00edstica distintiva del conjunto de atributos."
     },
     "C_TaxBase_ID": {
       "label": "Base Impuesto",
-      "description": "Índice de impuesto usado como base para el cálculo del importe de los impuestos."
+      "description": "\u00cdndice de impuesto usado como base para el c\u00e1lculo del importe de los impuestos."
     },
     "C_Orderlinetax_ID": {
-      "label": "Impuesto de línea de pedido",
-      "description": "Un único identificador generado automáticamente la mayoría de las veces para una línea de pedido de venta"
+      "label": "Impuesto de l\u00ednea de pedido",
+      "description": "Un \u00fanico identificador generado autom\u00e1ticamente la mayor\u00eda de las veces para una l\u00ednea de pedido de venta"
     },
     "C_InvoiceLineTax_ID": {
-      "label": "Impuesto de línea de factura",
-      "description": "Impuesto de línea de factura"
+      "label": "Impuesto de l\u00ednea de factura",
+      "description": "Impuesto de l\u00ednea de factura"
     },
     "DocTaxAmount": {
-      "label": "Cálculo del importe de impuestos del documento",
-      "description": "Criterio para el cálculo de impuestos del documento"
+      "label": "C\u00e1lculo del importe de impuestos del documento",
+      "description": "Criterio para el c\u00e1lculo de impuestos del documento"
     },
     "Event_Time": {
       "label": "Hora",
       "description": "Fecha y hora para el evento"
     },
     "Process_Desc": {
-      "label": "Descripción de Proceso",
+      "label": "Descripci\u00f3n de Proceso",
       "description": ""
     },
     "Isoneattrsetvalrequired": {
@@ -7505,8 +7505,8 @@
       "description": ""
     },
     "Last_Session_Ping": {
-      "label": "Último ping",
-      "description": "Hora de la última vez en la que la sesión envió ping"
+      "label": "\u00daltimo ping",
+      "description": "Hora de la \u00faltima vez en la que la sesi\u00f3n envi\u00f3 ping"
     },
     "FIN_Payment_Schedule_Order": {
       "label": "Programar pago de pedido",
@@ -7526,14 +7526,14 @@
     },
     "orderNo": {
       "label": "No. Pedido",
-      "description": "Número de pedido"
+      "description": "N\u00famero de pedido"
     },
     "Orderno": {
       "label": "No. Pedido",
-      "description": "Número de pedido"
+      "description": "N\u00famero de pedido"
     },
     "FIN_Payment_Scheduledetail_ID": {
-      "label": "Detalle de programación de pagos",
+      "label": "Detalle de programaci\u00f3n de pagos",
       "description": ""
     },
     "FIN_Withdrawal_Acct": {
@@ -7541,16 +7541,16 @@
       "description": "Cuenta de reintegro usada por la cuenta financiera"
     },
     "FIN_Debit_Acct": {
-      "label": "Cuenta de débito",
-      "description": "Cuenta de débito usada por la cuenta financiera"
+      "label": "Cuenta de d\u00e9bito",
+      "description": "Cuenta de d\u00e9bito usada por la cuenta financiera"
     },
     "FIN_Makepayment_Acct": {
       "label": "Cuenta de pago",
       "description": "Cuenta de pago usada por la cuenta financiera"
     },
     "FIN_Credit_Acct": {
-      "label": "Cuenta de crédito",
-      "description": "Cuenta de crédito usada por la cuenta financiera"
+      "label": "Cuenta de cr\u00e9dito",
+      "description": "Cuenta de cr\u00e9dito usada por la cuenta financiera"
     },
     "FIN_Receivepayment_Acct": {
       "label": "Cuenta de cobro",
@@ -7561,8 +7561,8 @@
       "description": "Cuentas financiera"
     },
     "FIN_Deposit_Acct": {
-      "label": "Cuenta de depósito",
-      "description": "Cuenta de depósito usada por la cuenta financiera"
+      "label": "Cuenta de dep\u00f3sito",
+      "description": "Cuenta de dep\u00f3sito usada por la cuenta financiera"
     },
     "IsSecondaryKey": {
       "label": "Clave secundaria",
@@ -7570,15 +7570,15 @@
     },
     "Breakdown": {
       "label": "Separar",
-      "description": "Para separar las líneas de un pedido en el albarán"
+      "description": "Para separar las l\u00edneas de un pedido en el albar\u00e1n"
     },
     "QuantityOrder": {
       "label": "Cant. pedido",
-      "description": "Número de un ítem involucrado en la transacción, expresado en unidades no estándares."
+      "description": "N\u00famero de un \u00edtem involucrado en la transacci\u00f3n, expresado en unidades no est\u00e1ndares."
     },
     "orderQuantity": {
       "label": "Cant. pedido",
-      "description": "Número de un ítem involucrado en la transacción, expresado en unidades no estándares."
+      "description": "N\u00famero de un \u00edtem involucrado en la transacci\u00f3n, expresado en unidades no est\u00e1ndares."
     },
     "GLItemAmt": {
       "label": "Importe conceptos",
@@ -7586,19 +7586,19 @@
     },
     "M_Product_Uom_Id": {
       "label": "Unidad del pedido",
-      "description": "Unidad de medida que se utiliza en la petición."
+      "description": "Unidad de medida que se utiliza en la petici\u00f3n."
     },
     "Ad_Auxiliarinput_Id": {
       "label": "Input auxiliar",
       "description": ""
     },
     "IsSessionAttr": {
-      "label": "Atributo sesión",
-      "description": "Es un atributo de la sesión"
+      "label": "Atributo sesi\u00f3n",
+      "description": "Es un atributo de la sesi\u00f3n"
     },
     "ShowInRelation": {
-      "label": "Mostrar en la relación",
-      "description": "Mostrar en la relación"
+      "label": "Mostrar en la relaci\u00f3n",
+      "description": "Mostrar en la relaci\u00f3n"
     },
     "C_Incoterms_ID": {
       "label": "Incoterms",
@@ -7613,7 +7613,7 @@
       "description": ""
     },
     "C_Projectproposalline_ID": {
-      "label": "Identificador de línea de presupuesto",
+      "label": "Identificador de l\u00ednea de presupuesto",
       "description": ""
     },
     "C_Projectproposaltask_ID": {
@@ -7621,11 +7621,11 @@
       "description": ""
     },
     "Datesend": {
-      "label": "Fecha envío",
+      "label": "Fecha env\u00edo",
       "description": ""
     },
     "Incoterms_Description": {
-      "label": "Descripción INCOTERM",
+      "label": "Descripci\u00f3n INCOTERM",
       "description": ""
     },
     "Isdelivery": {
@@ -7633,19 +7633,19 @@
       "description": ""
     },
     "Lineno": {
-      "label": "Línea",
+      "label": "L\u00ednea",
       "description": ""
     },
     "Projectkind": {
       "label": "Tipo de obra",
-      "description": "Característica única de trabajo utilizada en los procesos."
+      "description": "Caracter\u00edstica \u00fanica de trabajo utilizada en los procesos."
     },
     "Projectphase": {
       "label": "Fase",
       "description": ""
     },
     "Projectstatus": {
-      "label": "Situación proyecto",
+      "label": "Situaci\u00f3n proyecto",
       "description": "Indica el estado actual del proyecto."
     },
     "Publicprivate": {
@@ -7653,7 +7653,7 @@
       "description": ""
     },
     "Requiresdescription": {
-      "label": "Descripción requerida",
+      "label": "Descripci\u00f3n requerida",
       "description": ""
     },
     "Deliverynotes": {
@@ -7665,7 +7665,7 @@
       "description": ""
     },
     "Incotermsdescription": {
-      "label": "Descripción INCOTERMS",
+      "label": "Descripci\u00f3n INCOTERMS",
       "description": ""
     },
     "FilterClause": {
@@ -7673,11 +7673,11 @@
       "description": "Filtro"
     },
     "QuantityOrderBook": {
-      "label": "Cantidad pedido teórico",
-      "description": "Cantidad pedido teórico"
+      "label": "Cantidad pedido te\u00f3rico",
+      "description": "Cantidad pedido te\u00f3rico"
     },
     "FootNote": {
-      "label": "Pie de página",
+      "label": "Pie de p\u00e1gina",
       "description": ""
     },
     "HeaderNote": {
@@ -7689,20 +7689,20 @@
       "description": ""
     },
     "Codebank": {
-      "label": "Código banco",
-      "description": "Código del banco"
+      "label": "C\u00f3digo banco",
+      "description": "C\u00f3digo del banco"
     },
     "Codebranch": {
-      "label": "Código sucursal",
-      "description": "Código de la sucursal"
+      "label": "C\u00f3digo sucursal",
+      "description": "C\u00f3digo de la sucursal"
     },
     "Digitcontrol": {
-      "label": "Dígito de control",
-      "description": "Dígito de control"
+      "label": "D\u00edgito de control",
+      "description": "D\u00edgito de control"
     },
     "Codeaccount": {
-      "label": "Código cuenta",
-      "description": "Número de cuenta"
+      "label": "C\u00f3digo cuenta",
+      "description": "N\u00famero de cuenta"
     },
     "Firstname": {
       "label": "Nombre",
@@ -7713,8 +7713,8 @@
       "description": "Apellido del contacto"
     },
     "FixMonthDay2": {
-      "label": "2ndo día de vencimiento",
-      "description": "Día del mes en que vencen las facturas. Pueden definirse 3 fechas de vencimiento."
+      "label": "2ndo d\u00eda de vencimiento",
+      "description": "D\u00eda del mes en que vencen las facturas. Pueden definirse 3 fechas de vencimiento."
     },
     "Invoice_ToProject": {
       "label": "Factura a origen",
@@ -7730,11 +7730,11 @@
     },
     "M_Warehouse_Shipper_ID": {
       "label": "Rutero",
-      "description": "Almacén de transporte"
+      "description": "Almac\u00e9n de transporte"
     },
     "Shippercode": {
-      "label": "Código terminal",
-      "description": "Código terminal"
+      "label": "C\u00f3digo terminal",
+      "description": "C\u00f3digo terminal"
     },
     "M_Rappel_Bpartner_ID": {
       "label": "Rappel tercero",
@@ -7742,19 +7742,19 @@
     },
     "M_Rappel_ID": {
       "label": "Rappel",
-      "description": "Promoción ofrecida en un momento específico del año, basada en las cantidades vendidas."
+      "description": "Promoci\u00f3n ofrecida en un momento espec\u00edfico del a\u00f1o, basada en las cantidades vendidas."
     },
     "M_Rappel_Invoice_ID": {
       "label": "Factura rappel",
       "description": ""
     },
     "M_Rappel_Productcategory_ID": {
-      "label": "Categoría de producto rappel",
+      "label": "Categor\u00eda de producto rappel",
       "description": ""
     },
     "PricePrecision": {
-      "label": "Precisión de precio",
-      "description": "Precisión de precio"
+      "label": "Precisi\u00f3n de precio",
+      "description": "Precisi\u00f3n de precio"
     },
     "FromDocumentNo": {
       "label": "Desde No Documento",
@@ -7782,31 +7782,31 @@
     },
     "Dateplanned": {
       "label": "Fecha prevista",
-      "description": "Periodo en que debe satisfacerse una petición específica."
+      "description": "Periodo en que debe satisfacerse una petici\u00f3n espec\u00edfica."
     },
     "INE_Number": {
-      "label": "Código INE",
-      "description": "Código INE."
+      "label": "C\u00f3digo INE",
+      "description": "C\u00f3digo INE."
     },
     "C_Debt_Payment_ID": {
       "label": "Efecto",
-      "description": "Obligación a pagar o derecho a cobrar por un ítem o servicio específico."
+      "description": "Obligaci\u00f3n a pagar o derecho a cobrar por un \u00edtem o servicio espec\u00edfico."
     },
     "C_Settlement_Cancel_ID": {
-      "label": "Liquidación de cancelación",
-      "description": "Declaración utilizada para cancelar el pago correspondiente."
+      "label": "Liquidaci\u00f3n de cancelaci\u00f3n",
+      "description": "Declaraci\u00f3n utilizada para cancelar el pago correspondiente."
     },
     "C_Settlement_Generate_ID": {
       "label": "Efecto generado",
       "description": "Efecto generado"
     },
     "C_Settlement_ID": {
-      "label": "Liquidación",
-      "description": "Proceso de intercambio o realización de un pago una vez que finaliza una transacción."
+      "label": "Liquidaci\u00f3n",
+      "description": "Proceso de intercambio o realizaci\u00f3n de un pago una vez que finaliza una transacci\u00f3n."
     },
     "Cancel_Processed": {
-      "label": "Cancelación procesada",
-      "description": "Cancelación procesada"
+      "label": "Cancelaci\u00f3n procesada",
+      "description": "Cancelaci\u00f3n procesada"
     },
     "ChangeSettlementCancel": {
       "label": "Modificar Efecto",
@@ -7817,8 +7817,8 @@
       "description": "Actualiza los campos C_SETTLEMENT_ID, ISPAID, WRITEOFF a null, 'N' y 0 respectivamente"
     },
     "Generate_Processed": {
-      "label": "Generación procesada",
-      "description": "Generación procesada"
+      "label": "Generaci\u00f3n procesada",
+      "description": "Generaci\u00f3n procesada"
     },
     "Cancelednotchargeamt": {
       "label": "Cancelado no aplicado",
@@ -7837,12 +7837,12 @@
       "description": "Crear archivo"
     },
     "Amountcredit": {
-      "label": "Importe crédito",
-      "description": "Importe crédito"
+      "label": "Importe cr\u00e9dito",
+      "description": "Importe cr\u00e9dito"
     },
     "Amountdebit": {
-      "label": "Importe débito",
-      "description": "Importe débito"
+      "label": "Importe d\u00e9bito",
+      "description": "Importe d\u00e9bito"
     },
     "C_Debt_Payment_Balancing_ID": {
       "label": "Cuadrado de efectos",
@@ -7850,27 +7850,27 @@
     },
     "C_Glitem_ID": {
       "label": "Concepto contable",
-      "description": "Alias de una combinación contable que puede usarse habitualmente en las operaciones diarias."
+      "description": "Alias de una combinaci\u00f3n contable que puede usarse habitualmente en las operaciones diarias."
     },
     "c_glitem_id": {
       "label": "Concepto contable",
-      "description": "Alias de una combinación contable que puede usarse habitualmente en las operaciones diarias."
+      "description": "Alias de una combinaci\u00f3n contable que puede usarse habitualmente en las operaciones diarias."
     },
     "Orgfiltered": {
-      "label": "Filtrar organización",
-      "description": "Filtra por organización para calcular el número de documento segun el tipo documento."
+      "label": "Filtrar organizaci\u00f3n",
+      "description": "Filtra por organizaci\u00f3n para calcular el n\u00famero de documento segun el tipo documento."
     },
     "Glitem_Credit_Acct": {
-      "label": "Cuenta crédito",
-      "description": "Cuenta crédito"
+      "label": "Cuenta cr\u00e9dito",
+      "description": "Cuenta cr\u00e9dito"
     },
     "Glitem_Debit_Acct": {
-      "label": "Cuenta débito",
-      "description": "Cuenta débito"
+      "label": "Cuenta d\u00e9bito",
+      "description": "Cuenta d\u00e9bito"
     },
     "Settlementtype": {
-      "label": "Tipo liquidación",
-      "description": "Tipo liquidación"
+      "label": "Tipo liquidaci\u00f3n",
+      "description": "Tipo liquidaci\u00f3n"
     },
     "C_Acctschema_Table_ID": {
       "label": "Tabla de esquema contable",
@@ -7889,7 +7889,7 @@
       "description": ""
     },
     "Islogistic": {
-      "label": "Es logístico",
+      "label": "Es log\u00edstico",
       "description": ""
     },
     "PreQtyOnHand": {
@@ -7905,16 +7905,16 @@
       "description": ""
     },
     "WeekDay": {
-      "label": "Día de la semana",
-      "description": "Cualquier día de la semana, excepto sábado y domingo."
+      "label": "D\u00eda de la semana",
+      "description": "Cualquier d\u00eda de la semana, excepto s\u00e1bado y domingo."
     },
     "Create_Reg_Fact_Acct": {
-      "label": "Crear asiento de regularización",
-      "description": "Crear asiento de regularización."
+      "label": "Crear asiento de regularizaci\u00f3n",
+      "description": "Crear asiento de regularizaci\u00f3n."
     },
     "Drop_Reg_Fact_Acct": {
-      "label": "Borrar asiento de regularización",
-      "description": "Borrar asiento de regularización"
+      "label": "Borrar asiento de regularizaci\u00f3n",
+      "description": "Borrar asiento de regularizaci\u00f3n"
     },
     "Move_FromTo_Locator": {
       "label": "Mover un hueco entero",
@@ -7941,16 +7941,16 @@
       "description": "Contabilidad directa"
     },
     "Fixmonthday3": {
-      "label": "3er día de vencimiento",
-      "description": "Día del mes en que vencen las facturas. Pueden definirse 3 fechas de vencimiento."
+      "label": "3er d\u00eda de vencimiento",
+      "description": "D\u00eda del mes en que vencen las facturas. Pueden definirse 3 fechas de vencimiento."
     },
     "Checkinoutorg": {
-      "label": "Comprobar organización albarán",
-      "description": "Comprueba la organización del albarán y la organización del tercero."
+      "label": "Comprobar organizaci\u00f3n albar\u00e1n",
+      "description": "Comprueba la organizaci\u00f3n del albar\u00e1n y la organizaci\u00f3n del tercero."
     },
     "Checkorderorg": {
-      "label": "Comprobar organización pedido",
-      "description": "Comprueba la organización del pedido y la organización del tercero"
+      "label": "Comprobar organizaci\u00f3n pedido",
+      "description": "Comprueba la organizaci\u00f3n del pedido y la organizaci\u00f3n del tercero"
     },
     "TimeFrom": {
       "label": "Hora Desde",
@@ -7969,8 +7969,8 @@
       "description": ""
     },
     "Groupacctinvlines": {
-      "label": "Agrupar líneas de factura en contabilidad",
-      "description": "Agrupar líneas de factura en contabilidad"
+      "label": "Agrupar l\u00edneas de factura en contabilidad",
+      "description": "Agrupar l\u00edneas de factura en contabilidad"
     },
     "C_Debt_Payment_Bal_Replace_ID": {
       "label": "C_Debt_Payment_Bal_Replace_ID",
@@ -7982,7 +7982,7 @@
     },
     "M_Product_Customer_ID": {
       "label": "Producto Cliente",
-      "description": "Asignación de producto a cliente"
+      "description": "Asignaci\u00f3n de producto a cliente"
     },
     "Ispriceprinted": {
       "label": "Imprimir precio",
@@ -7990,7 +7990,7 @@
     },
     "C_Discount_ID": {
       "label": "Descuento",
-      "description": "Porcentaje de reducción de un precio basado en el precio de la tarifa."
+      "description": "Porcentaje de reducci\u00f3n de un precio basado en el precio de la tarifa."
     },
     "Cost": {
       "label": "Costo",
@@ -8005,7 +8005,7 @@
       "description": ""
     },
     "M_Pricelist_Version_Generate": {
-      "label": "Generar versión de tarifas",
+      "label": "Generar versi\u00f3n de tarifas",
       "description": ""
     },
     "Replacing": {
@@ -8061,7 +8061,7 @@
       "description": "Identificador de registro SQL"
     },
     "LastPlannedProposalDate": {
-      "label": "Fecha último seguimiento",
+      "label": "Fecha \u00faltimo seguimiento",
       "description": ""
     },
     "PlannedPOAmt": {
@@ -8069,20 +8069,20 @@
       "description": ""
     },
     "Invoicegrouping": {
-      "label": "Agrupación en factura",
+      "label": "Agrupaci\u00f3n en factura",
       "description": ""
     },
     "AD_Month_ID": {
       "label": "ID AD_Month",
-      "description": "Un mes del año"
+      "description": "Un mes del a\u00f1o"
     },
     "Quarter": {
       "label": "Trimestre",
-      "description": "Un trimestre del año"
+      "description": "Un trimestre del a\u00f1o"
     },
     "AD_Dimension_ID": {
-      "label": "ID de dimensión",
-      "description": "ID de dimensión"
+      "label": "ID de dimensi\u00f3n",
+      "description": "ID de dimensi\u00f3n"
     },
     "Join_Group1": {
       "label": "Grupo 1",
@@ -8101,8 +8101,8 @@
       "description": ""
     },
     "UpdateLines": {
-      "label": "Actualiza los atributos de los artículos del albarán",
-      "description": "Actualizar los atributos de las líneas del albarán"
+      "label": "Actualiza los atributos de los art\u00edculos del albar\u00e1n",
+      "description": "Actualizar los atributos de las l\u00edneas del albar\u00e1n"
     },
     "Isbackground": {
       "label": "Es en segundo plano",
@@ -8117,7 +8117,7 @@
       "description": ""
     },
     "C_Paymenttermline_ID": {
-      "label": "Condición de pago",
+      "label": "Condici\u00f3n de pago",
       "description": ""
     },
     "Excludetax": {
@@ -8129,20 +8129,20 @@
       "description": ""
     },
     "C_Invoiceline_Acctdimension_ID": {
-      "label": "Dimensión contable de línea de factura",
+      "label": "Dimensi\u00f3n contable de l\u00ednea de factura",
       "description": ""
     },
     "A_Amortization_ID": {
-      "label": "Amortización",
-      "description": "Amortización o reducción del valor de un producto con el tiempo."
+      "label": "Amortizaci\u00f3n",
+      "description": "Amortizaci\u00f3n o reducci\u00f3n del valor de un producto con el tiempo."
     },
     "A_Amortizationline_ID": {
-      "label": "Línea de amortización",
-      "description": "Línea de amortización"
+      "label": "L\u00ednea de amortizaci\u00f3n",
+      "description": "L\u00ednea de amortizaci\u00f3n"
     },
     "Amortization_Percentage": {
-      "label": "% Amortización",
-      "description": "% Amortización"
+      "label": "% Amortizaci\u00f3n",
+      "description": "% Amortizaci\u00f3n"
     },
     "Amortizationamt": {
       "label": "Importe a amortizar",
@@ -8157,8 +8157,8 @@
       "description": "Fecha inicio"
     },
     "Annualamortizationpercentage": {
-      "label": "% anual amortización",
-      "description": "% anual amortización"
+      "label": "% anual amortizaci\u00f3n",
+      "description": "% anual amortizaci\u00f3n"
     },
     "Datecancelled": {
       "label": "Fecha baja",
@@ -8177,12 +8177,12 @@
       "description": "Importe fijo de descuento"
     },
     "BP_Group_Selection": {
-      "label": "Modo selección Grupo Terceros",
-      "description": "Modo selección Grupo Terceros"
+      "label": "Modo selecci\u00f3n Grupo Terceros",
+      "description": "Modo selecci\u00f3n Grupo Terceros"
     },
     "BPartner_Selection": {
-      "label": "Modo selección terceros",
-      "description": "Modo selección terceros"
+      "label": "Modo selecci\u00f3n terceros",
+      "description": "Modo selecci\u00f3n terceros"
     },
     "Fixed": {
       "label": "Precio Fijo",
@@ -8209,24 +8209,24 @@
       "description": ""
     },
     "Prod_Cat_Selection": {
-      "label": "Modo selección Categoría de producto",
-      "description": "Modo selección Categoría de producto"
+      "label": "Modo selecci\u00f3n Categor\u00eda de producto",
+      "description": "Modo selecci\u00f3n Categor\u00eda de producto"
     },
     "Product_Selection": {
-      "label": "Modo selección de producto",
-      "description": "Modo selección de producto"
+      "label": "Modo selecci\u00f3n de producto",
+      "description": "Modo selecci\u00f3n de producto"
     },
     "Document_Copies": {
       "label": "Copias documentos",
-      "description": "Número de copias de cada documento a imprimir."
+      "description": "N\u00famero de copias de cada documento a imprimir."
     },
     "Acctvalueamt": {
       "label": "Valor contable",
       "description": "Importe del valor contable"
     },
     "Amortizationtype": {
-      "label": "Tipo de amortización",
-      "description": "Tipo de amortización"
+      "label": "Tipo de amortizaci\u00f3n",
+      "description": "Tipo de amortizaci\u00f3n"
     },
     "Amortizationvalueamt": {
       "label": "Valor a amortizar",
@@ -8241,15 +8241,15 @@
       "description": ""
     },
     "MA_Section_ID": {
-      "label": "Sección",
-      "description": "Sección"
+      "label": "Secci\u00f3n",
+      "description": "Secci\u00f3n"
     },
     "MA_Machine_ID": {
-      "label": "Máquina",
+      "label": "M\u00e1quina",
       "description": "Herramienta utilizada para ayudar a realizar o completar una tarea."
     },
     "Purchaseyear": {
-      "label": "Año de compra",
+      "label": "A\u00f1o de compra",
       "description": ""
     },
     "Usecycle": {
@@ -8257,8 +8257,8 @@
       "description": ""
     },
     "MA_Machinestation_ID": {
-      "label": "Máquina Puesto",
-      "description": "Máquina Puesto"
+      "label": "M\u00e1quina Puesto",
+      "description": "M\u00e1quina Puesto"
     },
     "MA_Process_ID": {
       "label": "Proceso",
@@ -8266,7 +8266,7 @@
     },
     "MA_Workstation_ID": {
       "label": "Puesto de trabajo",
-      "description": "Área definida de producción compuesta por recursos tales como las máquinas y la mano de obra."
+      "description": "\u00c1rea definida de producci\u00f3n compuesta por recursos tales como las m\u00e1quinas y la mano de obra."
     },
     "Discarded": {
       "label": "Rechazado",
@@ -8285,7 +8285,7 @@
       "description": "Proceso de utillaje."
     },
     "Numberuses": {
-      "label": "Número de usos",
+      "label": "N\u00famero de usos",
       "description": ""
     },
     "Usecoef": {
@@ -8297,7 +8297,7 @@
       "description": ""
     },
     "Preptime": {
-      "label": "Tiempo Preparación",
+      "label": "Tiempo Preparaci\u00f3n",
       "description": ""
     },
     "Rejected": {
@@ -8306,11 +8306,11 @@
     },
     "Quantity": {
       "label": "Cantidad",
-      "description": "Número de un ítem determinado."
+      "description": "N\u00famero de un \u00edtem determinado."
     },
     "quantity": {
       "label": "Cantidad",
-      "description": "Número de un ítem determinado."
+      "description": "N\u00famero de un \u00edtem determinado."
     },
     "MA_Incidence_ID": {
       "label": "Incidencia",
@@ -8321,20 +8321,20 @@
       "description": ""
     },
     "MA_Processplan_ID": {
-      "label": "Plan de producción",
-      "description": "Guía para mover un ítem determinado a través de un proceso de transformación."
+      "label": "Plan de producci\u00f3n",
+      "description": "Gu\u00eda para mover un \u00edtem determinado a trav\u00e9s de un proceso de transformaci\u00f3n."
     },
     "MA_Sequence_ID": {
       "label": "Secuencia",
-      "description": "Orden de los registros en un documento específico."
+      "description": "Orden de los registros en un documento espec\u00edfico."
     },
     "MA_Sequenceproduct_ID": {
       "label": "Producto de secuencia",
       "description": ""
     },
     "Productiontype": {
-      "label": "Tipo de producción",
-      "description": "Clasificación que indica si se ha creado o utilizado algo en la secuencia."
+      "label": "Tipo de producci\u00f3n",
+      "description": "Clasificaci\u00f3n que indica si se ha creado o utilizado algo en la secuencia."
     },
     "Donequantity": {
       "label": "Cantidad Realizada",
@@ -8345,11 +8345,11 @@
       "description": ""
     },
     "MA_Workrequirement_ID": {
-      "label": "Orden de fabricación",
-      "description": "Orden que autoriza la producción de un producto específico y de la cantidad producida."
+      "label": "Orden de fabricaci\u00f3n",
+      "description": "Orden que autoriza la producci\u00f3n de un producto espec\u00edfico y de la cantidad producida."
     },
     "MA_Wrphase_ID": {
-      "label": "Fase de Orden de Fabricación",
+      "label": "Fase de Orden de Fabricaci\u00f3n",
       "description": ""
     },
     "MA_Wrphaseproduct_ID": {
@@ -8361,7 +8361,7 @@
       "description": ""
     },
     "MA_Weemployee_ID": {
-      "label": "Empleado producción",
+      "label": "Empleado producci\u00f3n",
       "description": ""
     },
     "MA_Weincidence_ID": {
@@ -8413,19 +8413,19 @@
       "description": ""
     },
     "Production": {
-      "label": "Producción",
-      "description": "Indicación de que un ítem se utiliza en producción."
+      "label": "Producci\u00f3n",
+      "description": "Indicaci\u00f3n de que un \u00edtem se utiliza en producci\u00f3n."
     },
     "AD_Sequence_Pr_ID": {
       "label": "Secuencia para Producto",
-      "description": "La secuencia se usará para generar el número de subcuenta del Producto"
+      "description": "La secuencia se usar\u00e1 para generar el n\u00famero de subcuenta del Producto"
     },
     "Groupuse": {
       "label": "Consumo conjunto",
       "description": ""
     },
     "Noqty": {
-      "label": "Cantidad vacía",
+      "label": "Cantidad vac\u00eda",
       "description": ""
     },
     "Explodephases": {
@@ -8433,7 +8433,7 @@
       "description": ""
     },
     "MA_Processplan_Version_ID": {
-      "label": "Versión de plan de producción",
+      "label": "Versi\u00f3n de plan de producci\u00f3n",
       "description": ""
     },
     "CostCenterUse": {
@@ -8453,28 +8453,28 @@
       "description": "Uso de CC"
     },
     "Conversionrate": {
-      "label": "Ratio de conversión",
+      "label": "Ratio de conversi\u00f3n",
       "description": "Importe o cantidad en que una unidad de medida cambia por otra."
     },
     "Secondaryqty": {
       "label": "Cantidad Secundaria",
-      "description": "Número de unidades de proceso que necesitan ser producidas."
+      "description": "N\u00famero de unidades de proceso que necesitan ser producidas."
     },
     "Secondaryunit": {
       "label": "Unidad proceso",
-      "description": "El número de unidades de proceso obtenidas ejecutando una vez un plan de proceso."
+      "description": "El n\u00famero de unidades de proceso obtenidas ejecutando una vez un plan de proceso."
     },
     "Critical": {
-      "label": "Crítico",
+      "label": "Cr\u00edtico",
       "description": ""
     },
     "Frecuency": {
       "label": "Frecuencia",
-      "description": "Cantidad de veces que algo ocurre durante un período específico de tiempo."
+      "description": "Cantidad de veces que algo ocurre durante un per\u00edodo espec\u00edfico de tiempo."
     },
     "MA_CCP_Group_ID": {
       "label": "Grupo de puntos de control",
-      "description": "Conjunto de puntos que deben chequearse en un período específico de tiempo."
+      "description": "Conjunto de puntos que deben chequearse en un per\u00edodo espec\u00edfico de tiempo."
     },
     "MA_Measure_Group_ID": {
       "label": "Grupo de toma de datos",
@@ -8498,10 +8498,10 @@
     },
     "Shift": {
       "label": "Turno",
-      "description": "División del día de trabajo en intervalos."
+      "description": "Divisi\u00f3n del d\u00eda de trabajo en intervalos."
     },
     "Valuenumber": {
-      "label": "Número de tomas",
+      "label": "N\u00famero de tomas",
       "description": ""
     },
     "Valuetype": {
@@ -8513,7 +8513,7 @@
       "description": ""
     },
     "Copyversion": {
-      "label": "Copiar versión",
+      "label": "Copiar versi\u00f3n",
       "description": ""
     },
     "MA_Measure_Shift_ID": {
@@ -8521,7 +8521,7 @@
       "description": ""
     },
     "V_Char": {
-      "label": "Comprobación",
+      "label": "Comprobaci\u00f3n",
       "description": ""
     },
     "Datadate": {
@@ -8529,23 +8529,23 @@
       "description": ""
     },
     "Days": {
-      "label": "Días",
+      "label": "D\u00edas",
       "description": ""
     },
     "MA_Pc_Case_ID": {
-      "label": "Caso de control periódico",
+      "label": "Caso de control peri\u00f3dico",
       "description": ""
     },
     "MA_Pc_Test_ID": {
-      "label": "Prueba de Control Periódico",
+      "label": "Prueba de Control Peri\u00f3dico",
       "description": ""
     },
     "MA_Pc_Value_ID": {
-      "label": "Valor de control periódico",
+      "label": "Valor de control peri\u00f3dico",
       "description": ""
     },
     "MA_Periodic_Control_ID": {
-      "label": "Control Periódico",
+      "label": "Control Peri\u00f3dico",
       "description": ""
     },
     "TestResult": {
@@ -8554,7 +8554,7 @@
     },
     "Observation": {
       "label": "Observaciones",
-      "description": "Espacio para escribir información adicional relacionada."
+      "description": "Espacio para escribir informaci\u00f3n adicional relacionada."
     },
     "MA_Globaluse_ID": {
       "label": "Uso global",
@@ -8566,7 +8566,7 @@
     },
     "AD_Model_Object_ID": {
       "label": "Objeto Modelo",
-      "description": "Identificación de un objeto en el diccionario."
+      "description": "Identificaci\u00f3n de un objeto en el diccionario."
     },
     "AD_Model_Object_Mapping_ID": {
       "label": "Mapeo objeto modelo",
@@ -8574,18 +8574,18 @@
     },
     "MappingName": {
       "label": "Nombre de mapeo",
-      "description": "Instrucción o guía utilizada para requerir este objeto mediante un buscador."
+      "description": "Instrucci\u00f3n o gu\u00eda utilizada para requerir este objeto mediante un buscador."
     },
     "C_Tax_Zone_ID": {
       "label": "Zona impuesto",
       "description": "Identificador de la zona del impuesto"
     },
     "From_Country_ID": {
-      "label": "País desde",
+      "label": "Pa\u00eds desde",
       "description": ""
     },
     "From_Region_ID": {
-      "label": "Región desde",
+      "label": "Regi\u00f3n desde",
       "description": ""
     },
     "IsPrNewAccount": {
@@ -8593,19 +8593,19 @@
       "description": "Crear Nueva Cuenta para el Producto"
     },
     "PO_Fixmonthday": {
-      "label": "Día de vencimiento",
-      "description": "Día del mes en que vencen las facturas. Pueden definirse 3 fechas de vencimiento."
+      "label": "D\u00eda de vencimiento",
+      "description": "D\u00eda del mes en que vencen las facturas. Pueden definirse 3 fechas de vencimiento."
     },
     "PO_Fixmonthday2": {
-      "label": "Día de vencimiento 2",
-      "description": "Día del mes de la fecha de vencimiento"
+      "label": "D\u00eda de vencimiento 2",
+      "description": "D\u00eda del mes de la fecha de vencimiento"
     },
     "PO_Fixmonthday3": {
-      "label": "Día de vencimiento 3",
-      "description": "Día del mes de la fecha de vencimiento"
+      "label": "D\u00eda de vencimiento 3",
+      "description": "D\u00eda del mes de la fecha de vencimiento"
     },
     "Fontdaytoday": {
-      "label": "Fuente día hoy",
+      "label": "Fuente d\u00eda hoy",
       "description": ""
     },
     "C_Debt_Payment_Create": {
@@ -8613,16 +8613,16 @@
       "description": "Efecto creado"
     },
     "Delivery_Location_ID": {
-      "label": "Dirección de entrega",
-      "description": "Lugar o dirección específica a la que debe enviarse o de la que debe retirarse un pedido."
+      "label": "Direcci\u00f3n de entrega",
+      "description": "Lugar o direcci\u00f3n espec\u00edfica a la que debe enviarse o de la que debe retirarse un pedido."
     },
     "PO_Bankaccount_ID": {
-      "label": "Nº Cuenta Proveedor",
-      "description": "Nº Cuenta por defecto del proveedor"
+      "label": "N\u00ba Cuenta Proveedor",
+      "description": "N\u00ba Cuenta por defecto del proveedor"
     },
     "SO_Bankaccount_ID": {
-      "label": "Nº Cuenta Cliente",
-      "description": "Nº Cuenta por defecto para Cliente"
+      "label": "N\u00ba Cuenta Cliente",
+      "description": "N\u00ba Cuenta por defecto para Cliente"
     },
     "MA_Ccp_Shift_ID": {
       "label": "Turno de puntos de control",
@@ -8637,7 +8637,7 @@
       "description": ""
     },
     "C_Promissoryformat_ID": {
-      "label": "Formato pagaré",
+      "label": "Formato pagar\u00e9",
       "description": ""
     },
     "Fontamount": {
@@ -8649,7 +8649,7 @@
       "description": ""
     },
     "Fontdayplanned": {
-      "label": "Fuente día previsto",
+      "label": "Fuente d\u00eda previsto",
       "description": ""
     },
     "Edit": {
@@ -8669,43 +8669,43 @@
       "description": ""
     },
     "Fontyearplanned": {
-      "label": "Fuente año previsto",
+      "label": "Fuente a\u00f1o previsto",
       "description": ""
     },
     "Fontyeartoday": {
-      "label": "Fuente año hoy",
+      "label": "Fuente a\u00f1o hoy",
       "description": ""
     },
     "Line1left": {
-      "label": "Mar. izq. línea 1",
+      "label": "Mar. izq. l\u00ednea 1",
       "description": ""
     },
     "Line1top": {
-      "label": "Mar. sup. línea 1",
+      "label": "Mar. sup. l\u00ednea 1",
       "description": ""
     },
     "Line2left": {
-      "label": "Mar. izq. línea 2",
-      "description": "Distancia a la parte izquierda para la segunda línea."
+      "label": "Mar. izq. l\u00ednea 2",
+      "description": "Distancia a la parte izquierda para la segunda l\u00ednea."
     },
     "Line2top": {
-      "label": "Mar. sup. línea 2",
+      "label": "Mar. sup. l\u00ednea 2",
       "description": ""
     },
     "Line3left": {
-      "label": "Mar. izq. línea 3",
-      "description": "Distancia a la parte izquierda para la tercera línea."
+      "label": "Mar. izq. l\u00ednea 3",
+      "description": "Distancia a la parte izquierda para la tercera l\u00ednea."
     },
     "Line3top": {
-      "label": "Mar. sup. línea 3",
+      "label": "Mar. sup. l\u00ednea 3",
       "description": ""
     },
     "Line4left": {
-      "label": "Mar. izq. línea 4",
-      "description": "Distancia a la parte izquierda para la cuarta línea."
+      "label": "Mar. izq. l\u00ednea 4",
+      "description": "Distancia a la parte izquierda para la cuarta l\u00ednea."
     },
     "Line4top": {
-      "label": "Mar. sup. línea 4",
+      "label": "Mar. sup. l\u00ednea 4",
       "description": ""
     },
     "Param11": {
@@ -8741,24 +8741,24 @@
       "description": ""
     },
     "Printbankloc": {
-      "label": "Imp. Localización",
+      "label": "Imp. Localizaci\u00f3n",
       "description": ""
     },
     "Confirmed": {
       "label": "Confirmado",
-      "description": "Indicación  de que una acción está aceptada y que se completa según lo esperado."
+      "description": "Indicaci\u00f3n  de que una acci\u00f3n est\u00e1 aceptada y que se completa seg\u00fan lo esperado."
     },
     "MA_Machine_Type_ID": {
-      "label": "Tipo de máquina",
-      "description": "Característica de un tipo de máquina utilizada en los procesos."
+      "label": "Tipo de m\u00e1quina",
+      "description": "Caracter\u00edstica de un tipo de m\u00e1quina utilizada en los procesos."
     },
     "MA_Maint_Operation_ID": {
-      "label": "Operación de mantenimiento",
-      "description": "Descripción que explica una tarea de mantenimiento específica."
+      "label": "Operaci\u00f3n de mantenimiento",
+      "description": "Descripci\u00f3n que explica una tarea de mantenimiento espec\u00edfica."
     },
     "MA_Maint_Part_ID": {
       "label": "Orden de mantenimiento",
-      "description": "Característica única de una máquina utilizada en los procesos y a veces agrupada en una categoría."
+      "description": "Caracter\u00edstica \u00fanica de una m\u00e1quina utilizada en los procesos y a veces agrupada en una categor\u00eda."
     },
     "Amtoffer": {
       "label": "Tipo de importe",
@@ -8778,14 +8778,14 @@
     },
     "MA_Maintenance_ID": {
       "label": "Mantenimiento",
-      "description": "Acto de asegurar que la orden de trabajo de un ítem específico es correcta."
+      "description": "Acto de asegurar que la orden de trabajo de un \u00edtem espec\u00edfico es correcta."
     },
     "Maintenance_Type": {
       "label": "Tipo de mantenimiento",
-      "description": "Grupo de tareas de mantenimiento que pueden realizarse en una máquina."
+      "description": "Grupo de tareas de mantenimiento que pueden realizarse en una m\u00e1quina."
     },
     "Monthday": {
-      "label": "Día del mes",
+      "label": "D\u00eda del mes",
       "description": ""
     },
     "Partdate": {
@@ -8845,12 +8845,12 @@
       "description": "Incluir producto"
     },
     "Include_Product_Category": {
-      "label": "Incluir Categoría de Productos",
-      "description": "Incluir Categoría de Productos"
+      "label": "Incluir Categor\u00eda de Productos",
+      "description": "Incluir Categor\u00eda de Productos"
     },
     "M_Internal_Consumption_ID": {
       "label": "Consumo Interno",
-      "description": "Indicación de que un ítem es de uso interno y no será vendido."
+      "description": "Indicaci\u00f3n de que un \u00edtem es de uso interno y no ser\u00e1 vendido."
     },
     "M_Internal_Consumptionline_ID": {
       "label": "M_Internal_Consumptionline_ID",
@@ -8858,27 +8858,27 @@
     },
     "Column_Suffix": {
       "label": "Sufijo",
-      "description": "Uno o varios caracteres que se añaden al final de una declaración o un número."
+      "description": "Uno o varios caracteres que se a\u00f1aden al final de una declaraci\u00f3n o un n\u00famero."
     },
     "Totalamortization": {
-      "label": "Amortización total",
-      "description": "Amortización total"
+      "label": "Amortizaci\u00f3n total",
+      "description": "Amortizaci\u00f3n total"
     },
     "A_Accumdepreciation_Acct": {
-      "label": "Amortización acumulada",
-      "description": "Amortización acumulada"
+      "label": "Amortizaci\u00f3n acumulada",
+      "description": "Amortizaci\u00f3n acumulada"
     },
     "A_Depreciation_Acct": {
-      "label": "Amortización",
-      "description": "Cuenta de amortización"
+      "label": "Amortizaci\u00f3n",
+      "description": "Cuenta de amortizaci\u00f3n"
     },
     "A_Disposal_Gain": {
       "label": "Beneficio del traspaso",
       "description": "Beneficio del traspaso"
     },
     "A_Disposal_Loss": {
-      "label": "Pérdida del traspaso",
-      "description": "Pérdida del traspaso"
+      "label": "P\u00e9rdida del traspaso",
+      "description": "P\u00e9rdida del traspaso"
     },
     "Depreciatedplan": {
       "label": "Amortizado planificado",
@@ -8889,32 +8889,32 @@
       "description": "Amortizado real"
     },
     "depreciation": {
-      "label": "Amortización",
-      "description": "Estado y progreso de la amortización"
+      "label": "Amortizaci\u00f3n",
+      "description": "Estado y progreso de la amortizaci\u00f3n"
     },
     "C_Budget_ID": {
       "label": "Presupuesto",
       "description": "Grupo de gastos esperados para una tarea."
     },
     "C_Budgetline_ID": {
-      "label": "Línea de presupuesto",
+      "label": "L\u00ednea de presupuesto",
       "description": ""
     },
     "Amortizationcalctype": {
-      "label": "Tipo de cálculo",
-      "description": "Tipo de cálculo"
+      "label": "Tipo de c\u00e1lculo",
+      "description": "Tipo de c\u00e1lculo"
     },
     "Depreciatedpreviousamt": {
       "label": "Amortizado anterior",
       "description": ""
     },
     "C_Dp_Management_ID": {
-      "label": "Gestión efectos",
-      "description": "Gestión de efectos"
+      "label": "Gesti\u00f3n efectos",
+      "description": "Gesti\u00f3n de efectos"
     },
     "C_Dp_Managementline_ID": {
       "label": "C_Dp_Managementline_ID",
-      "description": "Gestión de línea de efectos"
+      "description": "Gesti\u00f3n de l\u00ednea de efectos"
     },
     "Status_From": {
       "label": "Estado Origen",
@@ -8933,8 +8933,8 @@
       "description": "Costo o valor de un bien o servicio."
     },
     "Line_Round": {
-      "label": "Redondeo línea",
-      "description": "Redondeo línea"
+      "label": "Redondeo l\u00ednea",
+      "description": "Redondeo l\u00ednea"
     },
     "Qtyfrom": {
       "label": "Cantidad desde",
@@ -8942,7 +8942,7 @@
     },
     "Qtyto": {
       "label": "Cantidad hasta",
-      "description": "Parámetro que indica la máxima cantidad posible de una petición específica."
+      "description": "Par\u00e1metro que indica la m\u00e1xima cantidad posible de una petici\u00f3n espec\u00edfica."
     },
     "Total_Round": {
       "label": "Redondeo total",
@@ -8957,15 +8957,15 @@
       "description": "Consolidar"
     },
     "Paymentruleconsolidated": {
-      "label": "Forma de pago consolidación",
-      "description": "Forma de pago consolidación"
+      "label": "Forma de pago consolidaci\u00f3n",
+      "description": "Forma de pago consolidaci\u00f3n"
     },
     "AD_Accountingrpt_Element_ID": {
       "label": "AD_Accountingrpt_Element_ID",
       "description": "Elemento de informe contable"
     },
     "Filteredbyorganization": {
-      "label": "Filtro por organización",
+      "label": "Filtro por organizaci\u00f3n",
       "description": ""
     },
     "Isshown": {
@@ -8985,12 +8985,12 @@
       "description": "Crear Archivo para banco"
     },
     "C_Debt_Payment_Cancelled": {
-      "label": "Efecto cancelación",
-      "description": "Efecto cancelación"
+      "label": "Efecto cancelaci\u00f3n",
+      "description": "Efecto cancelaci\u00f3n"
     },
     "C_Remittanceline_ID": {
       "label": "C_Remittanceline_ID",
-      "description": "Línea de remesa"
+      "description": "L\u00ednea de remesa"
     },
     "returned": {
       "label": "Devuelto",
@@ -9025,7 +9025,7 @@
       "description": "Estado devuelto"
     },
     "C_Externalpos_Category_ID": {
-      "label": "Categoría Producto TPV",
+      "label": "Categor\u00eda Producto TPV",
       "description": ""
     },
     "C_Externalpos_Product_ID": {
@@ -9034,35 +9034,35 @@
     },
     "C_Remittance_Parameter_ID": {
       "label": "C_Remittance_Parameter_ID",
-      "description": "Parámetro"
+      "description": "Par\u00e1metro"
     },
     "Content": {
       "label": "Contenido",
       "description": "Contenido"
     },
     "Last_Days": {
-      "label": "Días consumo",
-      "description": "Días consumo"
+      "label": "D\u00edas consumo",
+      "description": "D\u00edas consumo"
     },
     "Reference_Order": {
       "label": "Referencia pedido",
-      "description": "Usa Nº pedido como Nº de albarán"
+      "description": "Usa N\u00ba pedido como N\u00ba de albar\u00e1n"
     },
     "Status_Initial": {
       "label": "Estado inicial",
       "description": "Estado inicial."
     },
     "IsAutomaticGenerated": {
-      "label": "Generado automáticamente",
-      "description": "Se genera automáticamente"
+      "label": "Generado autom\u00e1ticamente",
+      "description": "Se genera autom\u00e1ticamente"
     },
     "Report_Type": {
       "label": "Tipo informe",
       "description": "Tipo informe"
     },
     "C_Invoiceline_Offer_ID": {
-      "label": "Oferta Línea de Factura",
-      "description": "Ofertas aplicadas a la línea de factura."
+      "label": "Oferta L\u00ednea de Factura",
+      "description": "Ofertas aplicadas a la l\u00ednea de factura."
     },
     "C_Orderline_Offer_ID": {
       "label": "ID C_Orderline_Offer",
@@ -9077,8 +9077,8 @@
       "description": ""
     },
     "C_Salary_Category_ID": {
-      "label": "Categoría salarial",
-      "description": "Clasificación de salarios basada en atributos o características similares."
+      "label": "Categor\u00eda salarial",
+      "description": "Clasificaci\u00f3n de salarios basada en atributos o caracter\u00edsticas similares."
     },
     "Cost_Type": {
       "label": "Tipo de costo",
@@ -9093,8 +9093,8 @@
       "description": "Unidad de medida asociada al costo localizado en el campo adyacente."
     },
     "Isproduction": {
-      "label": "Producción",
-      "description": "Indicación de que un ítem se utiliza en producción."
+      "label": "Producci\u00f3n",
+      "description": "Indicaci\u00f3n de que un \u00edtem se utiliza en producci\u00f3n."
     },
     "Calculate": {
       "label": "Calcular costo indirecto",
@@ -9110,7 +9110,7 @@
     },
     "MA_Indirect_Cost_ID": {
       "label": "Costo indirecto",
-      "description": "Gasto comercial que no puede asignarse a la producción."
+      "description": "Gasto comercial que no puede asignarse a la producci\u00f3n."
     },
     "MA_Indirect_Cost_Value_ID": {
       "label": "MA_Indirect_Cost_Value_ID",
@@ -9121,8 +9121,8 @@
       "description": ""
     },
     "PO_BP_TaxCategory_ID": {
-      "label": "Categoría Imp. Tercero",
-      "description": "Categoría Impuestos para Terceros"
+      "label": "Categor\u00eda Imp. Tercero",
+      "description": "Categor\u00eda Impuestos para Terceros"
     },
     "Responsible_ID": {
       "label": "Responsable",
@@ -9149,8 +9149,8 @@
       "description": "Cantidad hasta"
     },
     "Pricelist_Selection": {
-      "label": "Modo selección Tarifas",
-      "description": "Modo selección Tarifas"
+      "label": "Modo selecci\u00f3n Tarifas",
+      "description": "Modo selecci\u00f3n Tarifas"
     },
     "M_Offer_Pricelist_ID": {
       "label": "M_Offer_Pricelist_ID",
@@ -9158,7 +9158,7 @@
     },
     "Outsourced": {
       "label": "Subcontratado",
-      "description": "Decisión de que la tarea o la fase sea completada por un tercero externo."
+      "description": "Decisi\u00f3n de que la tarea o la fase sea completada por un tercero externo."
     },
     "MA_Pl_Invoiceline_ID": {
       "label": "MA_Pl_Invoiceline_ID",
@@ -9169,8 +9169,8 @@
       "description": ""
     },
     "MA_Costcenter_Version_ID": {
-      "label": "Versión del centro de costo",
-      "description": "Centro de costo utilizado durante un período específico de tiempo."
+      "label": "Versi\u00f3n del centro de costo",
+      "description": "Centro de costo utilizado durante un per\u00edodo espec\u00edfico de tiempo."
     },
     "ConvertChargeAmt": {
       "label": "Imp. gastos conv.",
@@ -9201,19 +9201,19 @@
       "description": ""
     },
     "Outsourcingcost": {
-      "label": "Costo Subcontratación",
+      "label": "Costo Subcontrataci\u00f3n",
       "description": ""
     },
     "Improductivehoursyear": {
-      "label": "Horas improductivas año",
+      "label": "Horas improductivas a\u00f1o",
       "description": ""
     },
     "Dayhours": {
-      "label": "Horas/día",
+      "label": "Horas/d\u00eda",
       "description": ""
     },
     "Yearvalue": {
-      "label": "Valor/año",
+      "label": "Valor/a\u00f1o",
       "description": ""
     },
     "Purchaseamt": {
@@ -9221,8 +9221,8 @@
       "description": ""
     },
     "Amortization": {
-      "label": "Amortización",
-      "description": "Amortización o reducción del valor de un producto con el tiempo."
+      "label": "Amortizaci\u00f3n",
+      "description": "Amortizaci\u00f3n o reducci\u00f3n del valor de un producto con el tiempo."
     },
     "Costuomyear": {
       "label": "Unidades de costo anuales",
@@ -9233,11 +9233,11 @@
       "description": ""
     },
     "Daysyear": {
-      "label": "Días/año",
+      "label": "D\u00edas/a\u00f1o",
       "description": ""
     },
     "M_Product_Org_ID": {
-      "label": "Producto Organización",
+      "label": "Producto Organizaci\u00f3n",
       "description": "Detalles para un producto en distintas organizaciones."
     },
     "MA_Sequence_Ic_ID": {
@@ -9250,7 +9250,7 @@
     },
     "Calccost": {
       "label": "Costo calculado",
-      "description": "Costo calculado teóricamente, asociado a esta solapa específica."
+      "description": "Costo calculado te\u00f3ricamente, asociado a esta solapa espec\u00edfica."
     },
     "MA_Sequence_Employee_ID": {
       "label": "MA_Sequence_Employee_ID",
@@ -9261,11 +9261,11 @@
       "description": "Persona encargada de elaborar el plan de MRP."
     },
     "MRP_Salesforecast_ID": {
-      "label": "Previsión de ventas",
+      "label": "Previsi\u00f3n de ventas",
       "description": ""
     },
     "MRP_Salesforecastline_ID": {
-      "label": "Línea de Previsión de ventas",
+      "label": "L\u00ednea de Previsi\u00f3n de ventas",
       "description": ""
     },
     "M_Requisition_ID": {
@@ -9273,23 +9273,23 @@
       "description": ""
     },
     "M_Requisitionline_ID": {
-      "label": "Línea de necesidad de material",
+      "label": "L\u00ednea de necesidad de material",
       "description": ""
     },
     "MRP_Planningmethod_ID": {
-      "label": "Método planificación",
+      "label": "M\u00e9todo planificaci\u00f3n",
       "description": ""
     },
     "Inouttrxtype": {
-      "label": "Tipo de transacción",
-      "description": "Grupo especial de características o procesos."
+      "label": "Tipo de transacci\u00f3n",
+      "description": "Grupo especial de caracter\u00edsticas o procesos."
     },
     "MRP_Planningmethodline_ID": {
-      "label": "Línea de Método planificación",
+      "label": "L\u00ednea de M\u00e9todo planificaci\u00f3n",
       "description": ""
     },
     "Daysto": {
-      "label": "Días hasta",
+      "label": "D\u00edas hasta",
       "description": ""
     },
     "Weighting": {
@@ -9297,35 +9297,35 @@
       "description": ""
     },
     "Daysfrom": {
-      "label": "Días desde",
+      "label": "D\u00edas desde",
       "description": ""
     },
     "Qtystd": {
       "label": "Cantidad Std.",
-      "description": "Cantidad Estándar"
+      "description": "Cantidad Est\u00e1ndar"
     },
     "Stockmin": {
-      "label": "Stock Mín.",
+      "label": "Stock M\u00edn.",
       "description": ""
     },
     "Qtymax": {
-      "label": "Cantidad Máx.",
-      "description": "Cantidad Máxima"
+      "label": "Cantidad M\u00e1x.",
+      "description": "Cantidad M\u00e1xima"
     },
     "Delaymin": {
-      "label": "Retraso Mínimo",
-      "description": "Retraso mínimo"
+      "label": "Retraso M\u00ednimo",
+      "description": "Retraso m\u00ednimo"
     },
     "Qtytype": {
       "label": "Tipo Cantidad",
       "description": "Tipo Cantidad"
     },
     "Qtymin": {
-      "label": "Cantidad Mín.",
-      "description": "Cantidad Mínima"
+      "label": "Cantidad M\u00edn.",
+      "description": "Cantidad M\u00ednima"
     },
     "Launchwr": {
-      "label": "Lanzar Orden de Producción",
+      "label": "Lanzar Orden de Producci\u00f3n",
       "description": ""
     },
     "Timehorizon": {
@@ -9337,35 +9337,35 @@
       "description": ""
     },
     "Planneddate": {
-      "label": "Día planificado",
-      "description": "Fecha en que ocurre la transacción."
+      "label": "D\u00eda planificado",
+      "description": "Fecha en que ocurre la transacci\u00f3n."
     },
     "Securitymargin": {
-      "label": "Días de holgura",
+      "label": "D\u00edas de holgura",
       "description": ""
     },
     "MRP_Run_Production_ID": {
-      "label": "Planificación de producción",
+      "label": "Planificaci\u00f3n de producci\u00f3n",
       "description": ""
     },
     "MRP_Run_Productionline_ID": {
-      "label": "Línea de planificación de la producción",
+      "label": "L\u00ednea de planificaci\u00f3n de la producci\u00f3n",
       "description": ""
     },
     "Isfixed": {
       "label": "Fija",
-      "description": "Forma de bloquear la solapa de cabecera para evitar que resulte afectada si un proceso específico comienza a ejecutarse nuevamente."
+      "description": "Forma de bloquear la solapa de cabecera para evitar que resulte afectada si un proceso espec\u00edfico comienza a ejecutarse nuevamente."
     },
     "MRP_Run_Purchaseline_ID": {
-      "label": "Línea del plan de compras",
+      "label": "L\u00ednea del plan de compras",
       "description": ""
     },
     "MRP_Run_Purchase_ID": {
-      "label": "Planificación de compras",
+      "label": "Planificaci\u00f3n de compras",
       "description": ""
     },
     "Simulate": {
-      "label": "Proceso Plan Producción",
+      "label": "Proceso Plan Producci\u00f3n",
       "description": ""
     },
     "Launchmr": {
@@ -9381,7 +9381,7 @@
       "description": ""
     },
     "Isplanned": {
-      "label": "Está planificado",
+      "label": "Est\u00e1 planificado",
       "description": ""
     },
     "Isexploded": {
@@ -9389,7 +9389,7 @@
       "description": ""
     },
     "Plannedorderdate": {
-      "label": "Día de pedido planificado",
+      "label": "D\u00eda de pedido planificado",
       "description": ""
     },
     "Iscompleted": {
@@ -9397,7 +9397,7 @@
       "description": ""
     },
     "Pixelsize": {
-      "label": "Tamaño de píxel",
+      "label": "Tama\u00f1o de p\u00edxel",
       "description": ""
     },
     "Translatedby": {
@@ -9438,19 +9438,19 @@
     },
     "Referencekey_ID": {
       "label": "Referencia Clave",
-      "description": "Especificación exacta de una referencia para una lista o tabla."
+      "description": "Especificaci\u00f3n exacta de una referencia para una lista o tabla."
     },
     "Developmentstatus": {
       "label": "Estado de desarrollo",
       "description": "Estado de desarrollo"
     },
     "SO_Bp_Taxcategory_ID": {
-      "label": "Categoría Imp. Tercero",
-      "description": "Categoría Imp. Tercero"
+      "label": "Categor\u00eda Imp. Tercero",
+      "description": "Categor\u00eda Imp. Tercero"
     },
     "C_BP_TaxCategory_ID": {
-      "label": "Categoría de impuestos de proveedor",
-      "description": "Categoría de impuestos de proveedor"
+      "label": "Categor\u00eda de impuestos de proveedor",
+      "description": "Categor\u00eda de impuestos de proveedor"
     },
     "IsJasper": {
       "label": "Informe Jasper",
@@ -9473,16 +9473,16 @@
       "description": "Rol por Defecto"
     },
     "Default_M_Warehouse_ID": {
-      "label": "Almacén por Defecto",
-      "description": "Almacén por Defecto"
+      "label": "Almac\u00e9n por Defecto",
+      "description": "Almac\u00e9n por Defecto"
     },
     "Default_Ad_Org_ID": {
-      "label": "Organización por Defecto",
-      "description": "Organización por Defecto"
+      "label": "Organizaci\u00f3n por Defecto",
+      "description": "Organizaci\u00f3n por Defecto"
     },
     "CopyFromPO": {
       "label": "Copiar desde pedidos",
-      "description": "Copiar líneas desde pedidos"
+      "description": "Copiar l\u00edneas desde pedidos"
     },
     "Bank_Name": {
       "label": "Nombre",
@@ -9501,8 +9501,8 @@
       "description": "Conjunto de pagos de un pedido previstos para su cobro/pago"
     },
     "FIN_Reconciliation_ID": {
-      "label": "Conciliación",
-      "description": "Conciliación relacionada con una cuenta financiera"
+      "label": "Conciliaci\u00f3n",
+      "description": "Conciliaci\u00f3n relacionada con una cuenta financiera"
     },
     "Acct_Length": {
       "label": "Longitud Cuenta",
@@ -9510,7 +9510,7 @@
     },
     "SubAcct_Length": {
       "label": "Longitud Subcuenta",
-      "description": "Este campo indica la longitud del número de la subcuenta."
+      "description": "Este campo indica la longitud del n\u00famero de la subcuenta."
     },
     "Login_Status": {
       "label": "Estado de Login",
@@ -9518,11 +9518,11 @@
     },
     "IsLocked": {
       "label": "Bloqueado",
-      "description": "El usuario está bloqueado y no puede acceder a la aplicación"
+      "description": "El usuario est\u00e1 bloqueado y no puede acceder a la aplicaci\u00f3n"
     },
     "Grid_Seqno": {
-      "label": "Posición en grid",
-      "description": "Posición en grid"
+      "label": "Posici\u00f3n en grid",
+      "description": "Posici\u00f3n en grid"
     },
     "FIN_Payment_Prop_Detail_V_ID": {
       "label": "FIN_Payment_Prop_Detail_V_ID",
@@ -9534,35 +9534,35 @@
     },
     "AD_Sequence_Bp_ID": {
       "label": "Secuencia para Tercero",
-      "description": "La secuencia se usará para generar el número de subcuenta del Tercero"
+      "description": "La secuencia se usar\u00e1 para generar el n\u00famero de subcuenta del Tercero"
     },
     "IsBpNewAccount": {
       "label": "Crear Nueva Cuenta para Tercero",
       "description": "Crea una nueva cuenta para el Tercero"
     },
     "Dramount": {
-      "label": "Importe Débito",
-      "description": "Importe Débito"
+      "label": "Importe D\u00e9bito",
+      "description": "Importe D\u00e9bito"
     },
     "Cramount": {
-      "label": "Importe Crédito",
-      "description": "Importe Crédito"
+      "label": "Importe Cr\u00e9dito",
+      "description": "Importe Cr\u00e9dito"
     },
     "FIN_Bankstatementline_ID": {
-      "label": "Línea de extracto bancario",
-      "description": "Línea de extracto bancario"
+      "label": "L\u00ednea de extracto bancario",
+      "description": "L\u00ednea de extracto bancario"
     },
     "matchingtype": {
-      "label": "Tipo de relación",
-      "description": "Tipo de relación para una determinada línea"
+      "label": "Tipo de relaci\u00f3n",
+      "description": "Tipo de relaci\u00f3n para una determinada l\u00ednea"
     },
     "Matchingtype": {
-      "label": "Tipo de relación",
-      "description": "Tipo de relación para una determinada línea"
+      "label": "Tipo de relaci\u00f3n",
+      "description": "Tipo de relaci\u00f3n para una determinada l\u00ednea"
     },
     "Printdetailed": {
-      "label": "Impresión detallada",
-      "description": "Impresión detallada"
+      "label": "Impresi\u00f3n detallada",
+      "description": "Impresi\u00f3n detallada"
     },
     "Startingbalance": {
       "label": "Balance Inicial",
@@ -9577,19 +9577,19 @@
       "description": "Extracto Bancario relacionado con una cuenta financiera"
     },
     "Automatic_Withdrawn": {
-      "label": "Reintegro automático en cuenta",
+      "label": "Reintegro autom\u00e1tico en cuenta",
       "description": ""
     },
     "Importdate": {
-      "label": "Fecha de importación",
-      "description": "Fecha de importación del fichero del banco"
+      "label": "Fecha de importaci\u00f3n",
+      "description": "Fecha de importaci\u00f3n del fichero del banco"
     },
     "Notes": {
       "label": "Notas",
       "description": ""
     },
     "SKCode": {
-      "label": "Código",
+      "label": "C\u00f3digo",
       "description": ""
     },
     "Endingtimemonday": {
@@ -9597,27 +9597,27 @@
       "description": ""
     },
     "IsAuditInserts": {
-      "label": "Inserciones en auditoría",
-      "description": "Si esta opción está activada, cuando se inserte un registro en una tabla auditada, el valor inicial de sus columnas se almacenará en la tabla de auditoria"
+      "label": "Inserciones en auditor\u00eda",
+      "description": "Si esta opci\u00f3n est\u00e1 activada, cuando se inserte un registro en una tabla auditada, el valor inicial de sus columnas se almacenar\u00e1 en la tabla de auditoria"
     },
     "Gtin": {
       "label": "Gtin",
-      "description": "El GTIN es un número de 14 dígitos usado para identificar de manera única y global artículos comerciales, productos o servicios"
+      "description": "El GTIN es un n\u00famero de 14 d\u00edgitos usado para identificar de manera \u00fanica y global art\u00edculos comerciales, productos o servicios"
     },
     "FIN_Matching_Algorithm_ID": {
-      "label": "Algoritmo de reconciliación",
-      "description": "Algoritmo de reconciliación utilizado para relacionar las líneas del extracto bancario."
+      "label": "Algoritmo de reconciliaci\u00f3n",
+      "description": "Algoritmo de reconciliaci\u00f3n utilizado para relacionar las l\u00edneas del extracto bancario."
     },
     "FIN_Bankfile_Format_ID": {
       "label": "Formato de Fichero del Banco",
       "description": "Identifica cada uno de los formatos de fichero soportados"
     },
     "Automatic_Deposit": {
-      "label": "Depósito automático en cuenta",
+      "label": "Dep\u00f3sito autom\u00e1tico en cuenta",
       "description": ""
     },
     "Automatic_Receipt": {
-      "label": "Cobro automático",
+      "label": "Cobro autom\u00e1tico",
       "description": ""
     },
     "FIN_Finacc_Paymentmethod_ID": {
@@ -9625,23 +9625,23 @@
       "description": ""
     },
     "Automatic_Payment": {
-      "label": "Pago Automático",
+      "label": "Pago Autom\u00e1tico",
       "description": ""
     },
     "FIN_Bankrevaluationloss_Acct": {
-      "label": "Cuenta de pérdidas por devaluación",
-      "description": "Cuenta para contabilizar las pérdidas por devaluación"
+      "label": "Cuenta de p\u00e9rdidas por devaluaci\u00f3n",
+      "description": "Cuenta para contabilizar las p\u00e9rdidas por devaluaci\u00f3n"
     },
     "FIN_Bankfee_Acct": {
       "label": "Cuenta de gastos bancarios",
       "description": "Cuenta para contabilizar gastos bancarios"
     },
     "FIN_Bankrevaluationgain_Acct": {
-      "label": "Cuenta de ganancias por revalorización",
-      "description": "Cuenta para contabilizar ganancias por revalorización"
+      "label": "Cuenta de ganancias por revalorizaci\u00f3n",
+      "description": "Cuenta para contabilizar ganancias por revalorizaci\u00f3n"
     },
     "PO_Paymentmethod_ID": {
-      "label": "Método de pago",
+      "label": "M\u00e9todo de pago",
       "description": ""
     },
     "PO_Financial_Account_ID": {
@@ -9649,23 +9649,23 @@
       "description": "Cuenta financiera usada para depositar / retirar dinero tales como cuentas bancarias o gastos menores de caja"
     },
     "Automatic_Writeoff_Amt": {
-      "label": "Importe descuento automático",
+      "label": "Importe descuento autom\u00e1tico",
       "description": ""
     },
     "Bank_Digitcontrol": {
-      "label": "Dígito de control del Banco",
+      "label": "D\u00edgito de control del Banco",
       "description": ""
     },
     "Account_Digitcontrol": {
-      "label": "Dígito de control de cuenta",
+      "label": "D\u00edgito de control de cuenta",
       "description": ""
     },
     "C_Orderline_Related_ID": {
-      "label": "Línea de Pedido de Venta",
-      "description": "Línea de pedido de venta relacionada con otra línea de pedido de venta de tipo servicio"
+      "label": "L\u00ednea de Pedido de Venta",
+      "description": "L\u00ednea de pedido de venta relacionada con otra l\u00ednea de pedido de venta de tipo servicio"
     },
     "Hqlorderbyclause": {
-      "label": "Cláusula Order By de HQL",
+      "label": "Cl\u00e1usula Order By de HQL",
       "description": ""
     },
     "C_Bank_ID": {
@@ -9674,15 +9674,15 @@
     },
     "C_BankAccount_ID": {
       "label": "Cuenta bancaria",
-      "description": "Cuenta bancaria de una institución bancaria reconocida."
+      "description": "Cuenta bancaria de una instituci\u00f3n bancaria reconocida."
     },
     "C_BP_BankAccount_ID": {
       "label": "Cuenta bancaria de terceros",
       "description": "Cuenta bancaria de terceros"
     },
     "C_Withholding_ID": {
-      "label": "Retención",
-      "description": "Retención"
+      "label": "Retenci\u00f3n",
+      "description": "Retenci\u00f3n"
     },
     "Selected": {
       "label": "Seleccionado",
@@ -9694,7 +9694,7 @@
     },
     "Org_Acctdim_Breakdown": {
       "label": "Mostrar en desglose",
-      "description": "Indica si la dimensión contable se muestra en la solapa de desglose del documento."
+      "description": "Indica si la dimensi\u00f3n contable se muestra en la solapa de desglose del documento."
     },
     "Beneficiary": {
       "label": "Beneficiario",
@@ -9725,20 +9725,20 @@
       "description": "Mostrar sindicato de propietario en cantidades positivas."
     },
     "Classification": {
-      "label": "Clasificación",
-      "description": "La clasificación puede (opcionalmente) usarse para agrupar productos."
+      "label": "Clasificaci\u00f3n",
+      "description": "La clasificaci\u00f3n puede (opcionalmente) usarse para agrupar productos."
     },
     "IsPropertyList": {
       "label": "Lista de Propiedades",
       "description": "Determina la forma de definir la preferencia: por Propiedad o por Atributo."
     },
     "Visibleat_Org_ID": {
-      "label": "Visible a la Organización",
-      "description": "Define la visibilidad de la Organización."
+      "label": "Visible a la Organizaci\u00f3n",
+      "description": "Define la visibilidad de la Organizaci\u00f3n."
     },
     "VisibleAt_Org_ID": {
-      "label": "Visible a la Organización",
-      "description": "Define la visibilidad de la Organización."
+      "label": "Visible a la Organizaci\u00f3n",
+      "description": "Define la visibilidad de la Organizaci\u00f3n."
     },
     "VisibleAt_Role_ID": {
       "label": "Visible al Rol",
@@ -9757,11 +9757,11 @@
       "description": "Define la visibilidad del Cliente."
     },
     "Creditlimit": {
-      "label": "Límite de crédito",
+      "label": "L\u00edmite de cr\u00e9dito",
       "description": "Importe permitido"
     },
     "CreditLimit": {
-      "label": "Límite de crédito",
+      "label": "L\u00edmite de cr\u00e9dito",
       "description": "Importe permitido"
     },
     "Detail_Colspan": {
@@ -9778,23 +9778,23 @@
     },
     "Isquantityvariable": {
       "label": "Es Cantidad Variable",
-      "description": "Si esta marcada, las líneas de albarán y las líneas de las facturas de venta con cantidad mayor que la cantidad pedida son permitidas para este producto."
+      "description": "Si esta marcada, las l\u00edneas de albar\u00e1n y las l\u00edneas de las facturas de venta con cantidad mayor que la cantidad pedida son permitidas para este producto."
     },
     "DirectShip": {
-      "label": "Envío directo",
-      "description": "Envío directo del proveedor al cliente"
+      "label": "Env\u00edo directo",
+      "description": "Env\u00edo directo del proveedor al cliente"
     },
     "AD_Calendarowner_Org_ID": {
-      "label": "Organización propietaria del calendario",
-      "description": "Organización propietaria del calendario."
+      "label": "Organizaci\u00f3n propietaria del calendario",
+      "description": "Organizaci\u00f3n propietaria del calendario."
     },
     "Docbasetype": {
       "label": "Tipo doc. base",
-      "description": "Clasificación del tipo de documentos que aparecen y se procesan en la misma ventana."
+      "description": "Clasificaci\u00f3n del tipo de documentos que aparecen y se procesan en la misma ventana."
     },
     "DocBaseType": {
       "label": "Tipo doc. base",
-      "description": "Clasificación del tipo de documentos que aparecen y se procesan en la misma ventana."
+      "description": "Clasificaci\u00f3n del tipo de documentos que aparecen y se procesan en la misma ventana."
     },
     "Payout_Deferred": {
       "label": "En espera",
@@ -9805,43 +9805,43 @@
       "description": ""
     },
     "DocumentCopies": {
-      "label": "Nº de copias",
-      "description": "Número de copias de cada documento a imprimir."
+      "label": "N\u00ba de copias",
+      "description": "N\u00famero de copias de cada documento a imprimir."
     },
     "DocumentNote": {
       "label": "Nota del doc.",
-      "description": "Espacio para escribir información adicional relacionada."
+      "description": "Espacio para escribir informaci\u00f3n adicional relacionada."
     },
     "ValidateOnNew": {
       "label": "Validar en Nuevo",
-      "description": "Se ejecutarán validaciones y callouts al crear un nuevo registro."
+      "description": "Se ejecutar\u00e1n validaciones y callouts al crear un nuevo registro."
     },
     "IsUsedSequence": {
-      "label": "Usar Secuencia Automática",
-      "description": "Usar Secuencia Automática"
+      "label": "Usar Secuencia Autom\u00e1tica",
+      "description": "Usar Secuencia Autom\u00e1tica"
     },
     "Valuetext": {
-      "label": "Valor del parámetro de tipo texto",
+      "label": "Valor del par\u00e1metro de tipo texto",
       "description": ""
     },
     "FIN_Payment_Run_Para_ID": {
-      "label": "Parámetro Ejecución de Pagos",
+      "label": "Par\u00e1metro Ejecuci\u00f3n de Pagos",
       "description": ""
     },
     "Valuecheck": {
-      "label": "Valor del parámetro",
+      "label": "Valor del par\u00e1metro",
       "description": ""
     },
     "FIN_Payment_Run_Payment_ID": {
-      "label": "Pago dentro de la Ejecución de Pagos",
+      "label": "Pago dentro de la Ejecuci\u00f3n de Pagos",
       "description": ""
     },
     "FIN_Pay_Exec_Process_ID": {
-      "label": "Proceso de Ejecución de Pagos",
+      "label": "Proceso de Ejecuci\u00f3n de Pagos",
       "description": ""
     },
     "FIN_Pay_Exec_Process_Para_ID": {
-      "label": "Parámetro de Proceso de Ejecución de Pagos",
+      "label": "Par\u00e1metro de Proceso de Ejecuci\u00f3n de Pagos",
       "description": ""
     },
     "Defaultcheck": {
@@ -9853,27 +9853,27 @@
       "description": ""
     },
     "Parametertype": {
-      "label": "Tipo de Parámetro",
+      "label": "Tipo de Par\u00e1metro",
       "description": ""
     },
     "FIN_Payment_Run_ID": {
-      "label": "Ejecución de Pagos",
+      "label": "Ejecuci\u00f3n de Pagos",
       "description": ""
     },
     "Prun_Source": {
-      "label": "Forma de Ejecución",
+      "label": "Forma de Ejecuci\u00f3n",
       "description": ""
     },
     "Run_Source": {
-      "label": "Forma de Ejecución",
+      "label": "Forma de Ejecuci\u00f3n",
       "description": ""
     },
     "Payout_Execution_Type": {
-      "label": "Tipo de Ejecución",
+      "label": "Tipo de Ejecuci\u00f3n",
       "description": ""
     },
     "Payin_Execution_Process_ID": {
-      "label": "Proceso de Ejecución",
+      "label": "Proceso de Ejecuci\u00f3n",
       "description": ""
     },
     "Payin_Allow": {
@@ -9881,7 +9881,7 @@
       "description": ""
     },
     "Payout_Execution_Process_ID": {
-      "label": "Proceso de Ejecución",
+      "label": "Proceso de Ejecuci\u00f3n",
       "description": ""
     },
     "Payin_Deferred": {
@@ -9889,12 +9889,12 @@
       "description": ""
     },
     "Payin_Execution_Type": {
-      "label": "Tipo de Ejecución",
+      "label": "Tipo de Ejecuci\u00f3n",
       "description": ""
     },
     "Afterdiscounts": {
-      "label": "Después de Descuentos",
-      "description": "Porcentaje que será aplicado después de los descuentos y promociones para calcular el precio."
+      "label": "Despu\u00e9s de Descuentos",
+      "description": "Porcentaje que ser\u00e1 aplicado despu\u00e9s de los descuentos y promociones para calcular el precio."
     },
     "Print_Name": {
       "label": "Nombre impreso",
@@ -9913,64 +9913,64 @@
       "description": "Impuesto de IVA de caja"
     },
     "Email": {
-      "label": "Correo electrónico",
-      "description": "Dirección de correo electrónico de un tercero específico."
+      "label": "Correo electr\u00f3nico",
+      "description": "Direcci\u00f3n de correo electr\u00f3nico de un tercero espec\u00edfico."
     },
     "EMail": {
-      "label": "Correo electrónico",
-      "description": "Dirección de correo electrónico"
+      "label": "Correo electr\u00f3nico",
+      "description": "Direcci\u00f3n de correo electr\u00f3nico"
     },
     "EnforcePriceLimit": {
-      "label": "Forzar pr.límite",
-      "description": "No permitir precios por debajo del precio límite"
+      "label": "Forzar pr.l\u00edmite",
+      "description": "No permitir precios por debajo del precio l\u00edmite"
     },
     "Basisstatus": {
       "label": "Estado base",
-      "description": "Documentos que se tendrán en cuenta para el calculo de comisiones: todos los documentos o documentos totalmente pagados"
+      "description": "Documentos que se tendr\u00e1n en cuenta para el calculo de comisiones: todos los documentos o documentos totalmente pagados"
     },
     "FixAmt": {
       "label": "Fijar importe",
       "description": "Fijar importe para ser recaudado o pagado"
     },
     "FixMonthCutoff": {
-      "label": "Día de corte",
-      "description": "Último día a incluir para la siguiente fecha de vencimiento"
+      "label": "D\u00eda de corte",
+      "description": "\u00daltimo d\u00eda a incluir para la siguiente fecha de vencimiento"
     },
     "FixMonthDay": {
-      "label": "Día de vencimiento",
-      "description": "Día del mes en que vencen las facturas. Pueden definirse 3 fechas de vencimiento."
+      "label": "D\u00eda de vencimiento",
+      "description": "D\u00eda del mes en que vencen las facturas. Pueden definirse 3 fechas de vencimiento."
     },
     "FixMonthOffset": {
       "label": "Meses de plazo",
-      "description": "Número de meses.(0 el mismo, 1 siguiente)"
+      "description": "N\u00famero de meses.(0 el mismo, 1 siguiente)"
     },
     "IsWebServiceEnabled": {
       "label": "Web Services habilitados",
-      "description": "Si esta marcada, los web services podrán obtener datos para usuarios con este rol"
+      "description": "Si esta marcada, los web services podr\u00e1n obtener datos para usuarios con este rol"
     },
     "warehouse": {
-      "label": "Almacén",
+      "label": "Almac\u00e9n",
       "description": ""
     },
     "Proxy_Password": {
       "label": "Password de Proxy",
-      "description": "Password para la autenticación del proxy"
+      "description": "Password para la autenticaci\u00f3n del proxy"
     },
     "Payout_Invoicepaidstatus": {
       "label": "Estado de la factura pagada",
-      "description": "Estado en el que una factura se considera pagada. Este estado puede configurarse para cada método de pago y cuenta financiera."
+      "description": "Estado en el que una factura se considera pagada. Este estado puede configurarse para cada m\u00e9todo de pago y cuenta financiera."
     },
     "Bpartner_ExtCat": {
-      "label": "Categoría del Tercero Externo",
-      "description": "Este campo contiene la Categoría del Tercero de un sistema externo"
+      "label": "Categor\u00eda del Tercero Externo",
+      "description": "Este campo contiene la Categor\u00eda del Tercero de un sistema externo"
     },
     "Maturity_Update": {
-      "label": "Nivel de Madurez para Actualización",
-      "description": "Nivel Mínimo de Madurez en módulos para actualización"
+      "label": "Nivel de Madurez para Actualizaci\u00f3n",
+      "description": "Nivel M\u00ednimo de Madurez en m\u00f3dulos para actualizaci\u00f3n"
     },
     "Maturity_Search": {
-      "label": "Nivel de Madurez para Búsqueda",
-      "description": "Nivel Mínimo de Madurez en módulos para búsqueda"
+      "label": "Nivel de Madurez para B\u00fasqueda",
+      "description": "Nivel M\u00ednimo de Madurez en m\u00f3dulos para b\u00fasqueda"
     },
     "Ischeckonsave": {
       "label": "Comprobar al Guardar",
@@ -9981,32 +9981,32 @@
       "description": ""
     },
     "Dependency_Enforcement": {
-      "label": "Obligación de dependencia",
-      "description": "La obligación de dependencia define qué versiones del módulo dependiente son compatibles con el módulo padre."
+      "label": "Obligaci\u00f3n de dependencia",
+      "description": "La obligaci\u00f3n de dependencia define qu\u00e9 versiones del m\u00f3dulo dependiente son compatibles con el m\u00f3dulo padre."
     },
     "User_Editable_Enforcement": {
-      "label": "Obligación editable",
-      "description": "Define si la obligación puede ser sobreescrita por el usuario"
+      "label": "Obligaci\u00f3n editable",
+      "description": "Define si la obligaci\u00f3n puede ser sobreescrita por el usuario"
     },
     "Instance_Enforcement": {
       "label": "Instancia Obligada",
-      "description": "Instancia específica de obligación de dependencia"
+      "description": "Instancia espec\u00edfica de obligaci\u00f3n de dependencia"
     },
     "Org_Acctdim_Isenable": {
-      "label": "Organización",
+      "label": "Organizaci\u00f3n",
       "description": ""
     },
     "Isbackdatedtrx": {
-      "label": "Transacción Retroactiva",
+      "label": "Transacci\u00f3n Retroactiva",
       "description": ""
     },
     "Proxy_User": {
       "label": "Usuario de Proxy",
-      "description": "Usuario para la autenticación del proxy"
+      "description": "Usuario para la autenticaci\u00f3n del proxy"
     },
     "IsProxy_Authenticated": {
-      "label": "Autenticación requerida",
-      "description": "Se requiere autenticación para el uso del proxy"
+      "label": "Autenticaci\u00f3n requerida",
+      "description": "Se requiere autenticaci\u00f3n para el uso del proxy"
     },
     "C_Invoicetax_Cashvat_ID": {
       "label": "Invoice Cash VAT",
@@ -10018,22 +10018,22 @@
     },
     "Enabled": {
       "label": "Habilitado",
-      "description": "Módulo habilitado"
+      "description": "M\u00f3dulo habilitado"
     },
     "Org_Acctdim_Header": {
       "label": "Mostrar en cabecera",
-      "description": "Indica si la dimensión contable se muestra en la cabecera del documento."
+      "description": "Indica si la dimensi\u00f3n contable se muestra en la cabecera del documento."
     },
     "Asbom": {
       "label": "As per BOM",
-      "description": "Categoría Virtual de Impuestos que indica que los impuestos se definen por los productos de la Lista de Materiales"
+      "description": "Categor\u00eda Virtual de Impuestos que indica que los impuestos se definen por los productos de la Lista de Materiales"
     },
     "Generated_Credit": {
-      "label": "Crédito generado",
+      "label": "Cr\u00e9dito generado",
       "description": ""
     },
     "Used_Credit": {
-      "label": "Crédito usado",
+      "label": "Cr\u00e9dito usado",
       "description": ""
     },
     "Amountupto": {
@@ -10041,8 +10041,8 @@
       "description": ""
     },
     "AD_Tree_User2_ID": {
-      "label": "Dimensión primaria de usuario 2",
-      "description": "Dimensión primaria de usuario 2"
+      "label": "Dimensi\u00f3n primaria de usuario 2",
+      "description": "Dimensi\u00f3n primaria de usuario 2"
     },
     "AD_Package_ID": {
       "label": "Paquete de Datos",
@@ -10050,7 +10050,7 @@
     },
     "IsDisplayedInList": {
       "label": "Mostrar en la lista",
-      "description": "Si está marcada, la propiedad se mostrará en los resultados de la vista de lista"
+      "description": "Si est\u00e1 marcada, la propiedad se mostrar\u00e1 en los resultados de la vista de lista"
     },
     "CUR_Unitcost": {
       "label": "Coste Unitario actual",
@@ -10058,66 +10058,66 @@
     },
     "DB_Identifier": {
       "label": "Identificador de la Base de Datos",
-      "description": "Identificador Único de la base de datos de la instancia"
+      "description": "Identificador \u00danico de la base de datos de la instancia"
     },
     "MAC_Identifier": {
       "label": "Identificador MAC",
-      "description": "Identificador de la Dirección MAC"
+      "description": "Identificador de la Direcci\u00f3n MAC"
     },
     "Installed_Modules": {
-      "label": "Módulos Instalados",
-      "description": "Lista de módulos instalados en la instancia"
+      "label": "M\u00f3dulos Instalados",
+      "description": "Lista de m\u00f3dulos instalados en la instancia"
     },
     "Obps_Identifier": {
-      "label": "Identificador de la Clave de Activación",
-      "description": "Identificador de la Clave de Activación"
+      "label": "Identificador de la Clave de Activaci\u00f3n",
+      "description": "Identificador de la Clave de Activaci\u00f3n"
     },
     "First_Login": {
       "label": "Primer Acceso",
-      "description": "Fecha del Primer Acceso a la aplicación"
+      "description": "Fecha del Primer Acceso a la aplicaci\u00f3n"
     },
     "Last_Login": {
-      "label": "Último Acceso",
-      "description": "Fecha del Último Acceso a la aplicación"
+      "label": "\u00daltimo Acceso",
+      "description": "Fecha del \u00daltimo Acceso a la aplicaci\u00f3n"
     },
     "Total_Logins": {
-      "label": "Número total de accesos",
-      "description": "Número total de accesos"
+      "label": "N\u00famero total de accesos",
+      "description": "N\u00famero total de accesos"
     },
     "Usage_Percentage": {
       "label": "Porcentaje de uso",
-      "description": "Porcentaje de tiempo en el que la aplicación ha estado en uso (al menos una sesión activa) durante los últimos 30 días."
+      "description": "Porcentaje de tiempo en el que la aplicaci\u00f3n ha estado en uso (al menos una sesi\u00f3n activa) durante los \u00faltimos 30 d\u00edas."
     },
     "Avg_Concurrent_Usr": {
       "label": "Media de Usuarios Concurrentes",
-      "description": "Media de Usuarios Concurrentes durante los últimos 30 días"
+      "description": "Media de Usuarios Concurrentes durante los \u00faltimos 30 d\u00edas"
     },
     "Total_Logins_Month": {
-      "label": "Total Accesos Último Mes",
-      "description": "Número total de accesos durante los últimos 30 días"
+      "label": "Total Accesos \u00daltimo Mes",
+      "description": "N\u00famero total de accesos durante los \u00faltimos 30 d\u00edas"
     },
     "MAX_Concurrent_Users": {
-      "label": "Máximo Usuarios Concurrentes",
-      "description": "Máximo número de usuarios concurrentes durante los últimos 30 días"
+      "label": "M\u00e1ximo Usuarios Concurrentes",
+      "description": "M\u00e1ximo n\u00famero de usuarios concurrentes durante los \u00faltimos 30 d\u00edas"
     },
     "Client_Number": {
-      "label": "Número de Entidades",
-      "description": "Número total de entidades en la instancia."
+      "label": "N\u00famero de Entidades",
+      "description": "N\u00famero total de entidades en la instancia."
     },
     "Org_Number": {
-      "label": "Número de Organizaciones",
-      "description": "Número total de organizaciones en la instancia."
+      "label": "N\u00famero de Organizaciones",
+      "description": "N\u00famero total de organizaciones en la instancia."
     },
     "Instance_Purpose": {
-      "label": "Propósito de la Instancia",
+      "label": "Prop\u00f3sito de la Instancia",
       "description": "Purpose defines the intended use or role of the active system instance, indicating whether it is used for testing, evaluation, development, or production."
     },
     "IsBillTo": {
       "label": "Dir.factura",
-      "description": "Indica si esta es la dirección de facturación"
+      "description": "Indica si esta es la direcci\u00f3n de facturaci\u00f3n"
     },
     "AD_Session_Usage_Audit_ID": {
-      "label": "Auditoría de Uso",
+      "label": "Auditor\u00eda de Uso",
       "description": ""
     },
     "Command": {
@@ -10137,24 +10137,24 @@
       "description": "Los balances con moneda extranjera son guardados en la moneda propuesta"
     },
     "IsUsageAuditEnabled": {
-      "label": "Activada la Auditoría de Uso",
+      "label": "Activada la Auditor\u00eda de Uso",
       "description": ""
     },
     "Is_Usage_Audit_Enabled": {
-      "label": "Activada la Auditoría de Uso",
-      "description": "¿Está la Auditoría de Uso Activada?"
+      "label": "Activada la Auditor\u00eda de Uso",
+      "description": "\u00bfEst\u00e1 la Auditor\u00eda de Uso Activada?"
     },
     "Show_Community_Branding": {
       "label": "Mostrar Community Branding",
       "description": ""
     },
     "IsOneTime": {
-      "label": "*Operación antigua",
+      "label": "*Operaci\u00f3n antigua",
       "description": ""
     },
     "Social_Name": {
       "label": "Nombre social",
-      "description": "Nombre social de la organización"
+      "description": "Nombre social de la organizaci\u00f3n"
     },
     "IsPaidTo3Party": {
       "label": "Pagado a una tercera persona",
@@ -10162,7 +10162,7 @@
     },
     "IsPayFrom": {
       "label": "Dir. pago del cliente",
-      "description": "Dirección desde donde paga el tercero y a donde mandaremos las cartas de apremio"
+      "description": "Direcci\u00f3n desde donde paga el tercero y a donde mandaremos las cartas de apremio"
     },
     "IsPercentWithholding": {
       "label": "Porcentaje retenido",
@@ -10170,11 +10170,11 @@
     },
     "IsRemitTo": {
       "label": "Dir. cobro proveedor",
-      "description": "Dirección a la que se hacen los pagos"
+      "description": "Direcci\u00f3n a la que se hacen los pagos"
     },
     "IsShipTo": {
-      "label": "Dir.envíos",
-      "description": "Dirección de terceros donde enviar las cosas"
+      "label": "Dir.env\u00edos",
+      "description": "Direcci\u00f3n de terceros donde enviar las cosas"
     },
     "Production_Banner_Image_ID": {
       "label": "Imagen Productivo",
@@ -10190,70 +10190,70 @@
     },
     "IsTaxExempt": {
       "label": "Exento de impuestos",
-      "description": "Condición que establece que no corresponde aplicar impuestos a un caso específco."
+      "description": "Condici\u00f3n que establece que no corresponde aplicar impuestos a un caso espec\u00edfco."
     },
     "IsTaxProrated": {
       "label": "Impuesto prorrateado",
       "description": "Impuesto prorrateado."
     },
     "IsTaxWithholding": {
-      "label": "Retención Fiscal",
-      "description": "Impuesto de retención fiscal"
+      "label": "Retenci\u00f3n Fiscal",
+      "description": "Impuesto de retenci\u00f3n fiscal"
     },
     "MaxAmt": {
-      "label": "Imp.máximo",
-      "description": "Importe máximo en la moneda de la factura"
+      "label": "Imp.m\u00e1ximo",
+      "description": "Importe m\u00e1ximo en la moneda de la factura"
     },
     "MinAmt": {
-      "label": "Imp.mínimo",
-      "description": "Importe mínimo en la moneda de la factura"
+      "label": "Imp.m\u00ednimo",
+      "description": "Importe m\u00ednimo en la moneda de la factura"
     },
     "Merged_Module_Uuid": {
-      "label": "UUID del módulo fusionado",
-      "description": "UUID (Identificador Único) del módulo fusionado"
+      "label": "UUID del m\u00f3dulo fusionado",
+      "description": "UUID (Identificador \u00danico) del m\u00f3dulo fusionado"
     },
     "Merged_Module_Name": {
-      "label": "Nombre del Módulo Fusionado",
-      "description": "Nombre del módulo fusionado"
+      "label": "Nombre del M\u00f3dulo Fusionado",
+      "description": "Nombre del m\u00f3dulo fusionado"
     },
     "Rejected_Logins_Due_Conc_Users": {
-      "label": "Accesos rechazados debido al límite de usuarios concurrentes",
+      "label": "Accesos rechazados debido al l\u00edmite de usuarios concurrentes",
       "description": ""
     },
     "M_AttributeSetInstanceTo_ID": {
       "label": "Nuevo Valor atributos",
-      "description": "El valor de atributos que se asociará al inventario al procesar la transacción"
+      "description": "El valor de atributos que se asociar\u00e1 al inventario al procesar la transacci\u00f3n"
     },
     "C_Charge_ID": {
       "label": "Gastos",
       "description": "Costo o gasto incurrido durante una actividad comercial."
     },
     "Isconversionmatching": {
-      "label": "Coincidencias en la conversión",
+      "label": "Coincidencias en la conversi\u00f3n",
       "description": ""
     },
     "Order_Min": {
-      "label": "Cant. pedido mín.",
-      "description": "Cantidad mínima de un ítem que debe adquirirse por vez a un proveedor."
+      "label": "Cant. pedido m\u00edn.",
+      "description": "Cantidad m\u00ednima de un \u00edtem que debe adquirirse por vez a un proveedor."
     },
     "Order_Pack": {
       "label": "Cant. paquetes pedido",
-      "description": "Cantidad de un ítem específico que contiene un paquete."
+      "description": "Cantidad de un \u00edtem espec\u00edfico que contiene un paquete."
     },
     "AD_Process_Request_Group_ID": {
       "label": "Lanzado por el Grupo",
       "description": ""
     },
     "YourCompanyURL": {
-      "label": "URL de su Compañía",
-      "description": "URL de su Compañía"
+      "label": "URL de su Compa\u00f1\u00eda",
+      "description": "URL de su Compa\u00f1\u00eda"
     },
     "IS_Client_Admin": {
       "label": "Administrador de la Entidad",
       "description": ""
     },
     "Is_Org_Admin": {
-      "label": "Administrador de la Organización",
+      "label": "Administrador de la Organizaci\u00f3n",
       "description": ""
     },
     "Is_Role_Admin": {
@@ -10262,42 +10262,42 @@
     },
     "PaymentRulePO": {
       "label": "Forma de pago",
-      "description": "Método utilizado para pagar la petición."
+      "description": "M\u00e9todo utilizado para pagar la petici\u00f3n."
     },
     "Percent": {
       "label": "Porcentaje",
       "description": "Porcentaje retenido"
     },
     "ReturnOrderNo": {
-      "label": "Nº Orden devolución de material",
+      "label": "N\u00ba Orden devoluci\u00f3n de material",
       "description": ""
     },
     "POReference": {
-      "label": "Nº de referencia",
-      "description": "Número de referencia o de documento, según consta en la aplicación de un tercero"
+      "label": "N\u00ba de referencia",
+      "description": "N\u00famero de referencia o de documento, seg\u00fan consta en la aplicaci\u00f3n de un tercero"
     },
     "PrintName": {
-      "label": "Etiqueta de impresión",
+      "label": "Etiqueta de impresi\u00f3n",
       "description": "Texto desplegado de un elemento ."
     },
     "Viaemail": {
-      "label": "Correo electrónico",
-      "description": "Este campo define el valor por defecto del campo Via Mail en la creación de clientes desde el punto de venta"
+      "label": "Correo electr\u00f3nico",
+      "description": "Este campo define el valor por defecto del campo Via Mail en la creaci\u00f3n de clientes desde el punto de venta"
     },
     "PriceLastPO": {
-      "label": "Último pr. de compra",
-      "description": "Último precio pagado por este producto, como consta en el pedido de compra."
+      "label": "\u00daltimo pr. de compra",
+      "description": "\u00daltimo precio pagado por este producto, como consta en el pedido de compra."
     },
     "PriceLimit": {
-      "label": "Pr. límite",
-      "description": "Precio más bajo al que puede venderse un ítem."
+      "label": "Pr. l\u00edmite",
+      "description": "Precio m\u00e1s bajo al que puede venderse un \u00edtem."
     },
     "C_Attachment_Conf_ID": {
-      "label": "Configuración de Adjuntos",
+      "label": "Configuraci\u00f3n de Adjuntos",
       "description": ""
     },
     "PriceStd": {
-      "label": "Pr. estándar",
+      "label": "Pr. est\u00e1ndar",
       "description": "Precio regular o normal de un producto en la lista de precios respectiva."
     },
     "Convertquotation": {
@@ -10305,8 +10305,8 @@
       "description": ""
     },
     "Rating": {
-      "label": "Valoración",
-      "description": "Estimación o evaluación cuyo objetivo es definir un valor."
+      "label": "Valoraci\u00f3n",
+      "description": "Estimaci\u00f3n o evaluaci\u00f3n cuyo objetivo es definir un valor."
     },
     "Bpartner_Extref": {
       "label": "Referencia CRM",
@@ -10317,12 +10317,12 @@
       "description": "Este campo almacena la referencia a un Tercero de un sistema CRM externo"
     },
     "Routingno": {
-      "label": "Cuenta electrónica",
-      "description": "Número de cuenta"
+      "label": "Cuenta electr\u00f3nica",
+      "description": "N\u00famero de cuenta"
     },
     "RoutingNo": {
-      "label": "Cuenta electrónica",
-      "description": "Número de cuenta"
+      "label": "Cuenta electr\u00f3nica",
+      "description": "N\u00famero de cuenta"
     },
     "IsAdvancedFilter": {
       "label": "Filtro Avanzado",
@@ -10334,35 +10334,35 @@
     },
     "IsShared": {
       "label": "Compartido",
-      "description": "Referencias Compartidas o Únicas"
+      "description": "Referencias Compartidas o \u00danicas"
     },
     "Filter_Opt_Seqno": {
-      "label": "Número de Secuencia de la Opción en el Filtro",
-      "description": "Número de Secuencia de la Opción en el Filtro"
+      "label": "N\u00famero de Secuencia de la Opci\u00f3n en el Filtro",
+      "description": "N\u00famero de Secuencia de la Opci\u00f3n en el Filtro"
     },
     "SwiftCode": {
-      "label": "Código Swift",
-      "description": "Código Swift (Society of Worldwide Interbank Financial Telecommunications)"
+      "label": "C\u00f3digo Swift",
+      "description": "C\u00f3digo Swift (Society of Worldwide Interbank Financial Telecommunications)"
     },
     "Swiftcode": {
-      "label": "Código Swift",
-      "description": "Código Swift (Society of Worldwide Interbank Financial Telecommunications)"
+      "label": "C\u00f3digo Swift",
+      "description": "C\u00f3digo Swift (Society of Worldwide Interbank Financial Telecommunications)"
     },
     "ThresholdMax": {
-      "label": "Imp.máximo",
-      "description": "Máximo importe bruto para el cálculo de retenciones"
+      "label": "Imp.m\u00e1ximo",
+      "description": "M\u00e1ximo importe bruto para el c\u00e1lculo de retenciones"
     },
     "Thresholdmin": {
-      "label": "Imp.mínimo",
-      "description": "Mínimo importe bruto para el cálculo de retenciones"
+      "label": "Imp.m\u00ednimo",
+      "description": "M\u00ednimo importe bruto para el c\u00e1lculo de retenciones"
     },
     "Url": {
       "label": "URL",
-      "description": "Dirección a la que se puede acceder vía Internet."
+      "description": "Direcci\u00f3n a la que se puede acceder v\u00eda Internet."
     },
     "URL": {
       "label": "URL",
-      "description": "Dirección a la que se puede acceder vía Internet."
+      "description": "Direcci\u00f3n a la que se puede acceder v\u00eda Internet."
     },
     "Procedurename": {
       "label": "Procedimiento",
@@ -10373,20 +10373,20 @@
       "description": "Nombre del procedemiento"
     },
     "IsConfigScriptApplied": {
-      "label": "Aplicar Script de Configuración",
-      "description": "Aplica el script de configuración al compilar la aplicación"
+      "label": "Aplicar Script de Configuraci\u00f3n",
+      "description": "Aplica el script de configuraci\u00f3n al compilar la aplicaci\u00f3n"
     },
     "IsCustomQueryEnabled": {
       "label": "Habilitar Consultas Personalizadas",
-      "description": "Envía Consultas Personalizadas al Heartbeat"
+      "description": "Env\u00eda Consultas Personalizadas al Heartbeat"
     },
     "Aumqty": {
       "label": "Cantidad Operativa",
-      "description": "El número de un cierto artículo envuelto en la transacción, según la Unidad de Medida Operativa."
+      "description": "El n\u00famero de un cierto art\u00edculo envuelto en la transacci\u00f3n, seg\u00fan la Unidad de Medida Operativa."
     },
     "operativeQuantity": {
       "label": "Cantidad Operativa",
-      "description": "El número de un cierto artículo envuelto en la transacción, según la Unidad de Medida Operativa."
+      "description": "El n\u00famero de un cierto art\u00edculo envuelto en la transacci\u00f3n, seg\u00fan la Unidad de Medida Operativa."
     },
     "Received": {
       "label": "Recibido",
@@ -10394,7 +10394,7 @@
     },
     "aumqty": {
       "label": "Cantidad Operativa",
-      "description": "El número de un cierto artículo envuelto en la transacción, según la Unidad de Medida Operativa."
+      "description": "El n\u00famero de un cierto art\u00edculo envuelto en la transacci\u00f3n, seg\u00fan la Unidad de Medida Operativa."
     },
     "Imported": {
       "label": "Importado",
@@ -10402,15 +10402,15 @@
     },
     "Isrestrictbackend": {
       "label": "Restringir acceso al backend",
-      "description": "Si se marca, este rol no tendrá acceso al backend (ERP). Tendrá acceso a otras aplicaciones (como WebPOS)"
+      "description": "Si se marca, este rol no tendr\u00e1 acceso al backend (ERP). Tendr\u00e1 acceso a otras aplicaciones (como WebPOS)"
     },
     "AD_Inheritedcalendar_ID": {
       "label": "Calendario heredado",
-      "description": "Calendario heredado de la organización propietaria del calendario."
+      "description": "Calendario heredado de la organizaci\u00f3n propietaria del calendario."
     },
     "Isalwaysshown": {
-      "label": "Nodo de Título",
-      "description": "Los nodos que tengan el check \"Nodo de Título\", siempre se mostrarán en el informe, aunque el balance sea 0 y tenga el check \"Mostrar sólo cuentas con valor\"."
+      "label": "Nodo de T\u00edtulo",
+      "description": "Los nodos que tengan el check \"Nodo de T\u00edtulo\", siempre se mostrar\u00e1n en el informe, aunque el balance sea 0 y tenga el check \"Mostrar s\u00f3lo cuentas con valor\"."
     },
     "Startingtime": {
       "label": "Hora inicio",
@@ -10418,26 +10418,26 @@
     },
     "unitPrice": {
       "label": "Precio unitario",
-      "description": "Precio que será pagado por un ítem específico"
+      "description": "Precio que ser\u00e1 pagado por un \u00edtem espec\u00edfico"
     },
     "Dimension": {
-      "label": "Dimensión de contabilidad",
+      "label": "Dimensi\u00f3n de contabilidad",
       "description": "Dimensiones de contabilidad"
     },
     "IsDisplayedInDetail": {
       "label": "Mostrar en Detalle",
-      "description": "Si está marcada la propiedad se mostrará en la vista de detalle"
+      "description": "Si est\u00e1 marcada la propiedad se mostrar\u00e1 en la vista de detalle"
     },
     "WS_Calls_Max": {
-      "label": "Máximas llamadas a WS",
-      "description": "Número máximo de llamadas a Web Service por día en los últimos 30 días"
+      "label": "M\u00e1ximas llamadas a WS",
+      "description": "N\u00famero m\u00e1ximo de llamadas a Web Service por d\u00eda en los \u00faltimos 30 d\u00edas"
     },
     "Overdue_Return_Days": {
-      "label": "Días de Retraso en Devolución",
-      "description": "Indica cuántos días dispone el cliente para devolver un servicio después de adquirirlo"
+      "label": "D\u00edas de Retraso en Devoluci\u00f3n",
+      "description": "Indica cu\u00e1ntos d\u00edas dispone el cliente para devolver un servicio despu\u00e9s de adquirirlo"
     },
     "Endingtimesaturday": {
-      "label": "Hora fin Sábado",
+      "label": "Hora fin S\u00e1bado",
       "description": ""
     },
     "Reactivate": {
@@ -10469,12 +10469,12 @@
       "description": "Mostrar botones de procesos de la solapa padre"
     },
     "HqlLogic": {
-      "label": "Lógica HQL",
-      "description": "Cláusula where de HQL que la fila de destino debe cumplir para abrir la solapa definida en la regla"
+      "label": "L\u00f3gica HQL",
+      "description": "Cl\u00e1usula where de HQL que la fila de destino debe cumplir para abrir la solapa definida en la regla"
     },
     "Disable_Parent_Key_Property": {
       "label": "Deshabilitar la propiedad parentKey",
-      "description": "Indica si se necesita utilizar la propiedad padre al calcular la cláusula where de la solapa"
+      "description": "Indica si se necesita utilizar la propiedad padre al calcular la cl\u00e1usula where de la solapa"
     },
     "C_Bp_Set_ID": {
       "label": "Conjunto de Terceros",
@@ -10494,15 +10494,15 @@
     },
     "Isautosave": {
       "label": "Lanza el autoguardado",
-      "description": "Define si un botón lanza el autoguardado o no."
+      "description": "Define si un bot\u00f3n lanza el autoguardado o no."
     },
     "IsDefaultValuesDataSet": {
       "label": "Valores por defecto del Dataset",
-      "description": "Importar datos como valores por defecto, actualizaciones posteriores no modificarán los datos ya importados."
+      "description": "Importar datos como valores por defecto, actualizaciones posteriores no modificar\u00e1n los datos ya importados."
     },
     "IsPortalAdmin": {
       "label": "Administrador del portal",
-      "description": "Si está marcado, el rol del portal tendrá permisos de administrador de portal"
+      "description": "Si est\u00e1 marcado, el rol del portal tendr\u00e1 permisos de administrador de portal"
     },
     "TotalDebtAmount": {
       "label": "Importe de dudoso cobro",
@@ -10517,12 +10517,12 @@
       "description": "Importe de dudoso cobro"
     },
     "SmtpTimeout": {
-      "label": "Timeout conexión Smtp",
-      "description": "Tiempo de expiración usado en la comunicación con un servidor SMTP"
+      "label": "Timeout conexi\u00f3n Smtp",
+      "description": "Tiempo de expiraci\u00f3n usado en la comunicaci\u00f3n con un servidor SMTP"
     },
     "Dependant_Module_Name": {
-      "label": "Nombre del Módulo Dependiente",
-      "description": "Nombre del módulo dependiente"
+      "label": "Nombre del M\u00f3dulo Dependiente",
+      "description": "Nombre del m\u00f3dulo dependiente"
     },
     "InvoiceStatus": {
       "label": "Estado de factura",
@@ -10533,27 +10533,27 @@
       "description": ""
     },
     "Uipattern": {
-      "label": "Patrón de la Interfaz de Usuario",
-      "description": "Define el patrón de la Interfaz de Usuario"
+      "label": "Patr\u00f3n de la Interfaz de Usuario",
+      "description": "Define el patr\u00f3n de la Interfaz de Usuario"
     },
     "UIPattern": {
-      "label": "Patrón de la Interfaz de Usuario",
-      "description": "Define el patrón de la Interfaz de Usuario"
+      "label": "Patr\u00f3n de la Interfaz de Usuario",
+      "description": "Define el patr\u00f3n de la Interfaz de Usuario"
     },
     "M_Servicepricerule_Range_ID": {
       "label": "Rango de la Regla de Precio de Servicio",
       "description": ""
     },
     "FIN_Payment_Credit_ID": {
-      "label": "Crédito de pago financiero",
-      "description": "Único identificador para un crédito de pago financiero"
+      "label": "Cr\u00e9dito de pago financiero",
+      "description": "\u00danico identificador para un cr\u00e9dito de pago financiero"
     },
     "FIN_Payment_Id_Used": {
-      "label": "Crédito de pago usado",
-      "description": "Representa el crédito de pago que ha sido utilizado"
+      "label": "Cr\u00e9dito de pago usado",
+      "description": "Representa el cr\u00e9dito de pago que ha sido utilizado"
     },
     "Displaylogicgrid": {
-      "label": "Lógica para mostrar para columna de grid",
+      "label": "L\u00f3gica para mostrar para columna de grid",
       "description": ""
     },
     "Availableaumqty": {
@@ -10569,20 +10569,20 @@
       "description": ""
     },
     "excludeAuditInfo": {
-      "label": "Excluir Información de Auditoría",
-      "description": "Define si la tabla del Conjunto de Datos debe excluir la información de auditoría al comparar los datos"
+      "label": "Excluir Informaci\u00f3n de Auditor\u00eda",
+      "description": "Define si la tabla del Conjunto de Datos debe excluir la informaci\u00f3n de auditor\u00eda al comparar los datos"
     },
     "M_Costadjustment_Cancel": {
       "label": "Cancelar Ajuste de Coste",
       "description": ""
     },
     "shipmentNumber": {
-      "label": "Número de envío",
+      "label": "N\u00famero de env\u00edo",
       "description": ""
     },
     "IsReturn": {
-      "label": "Devolución",
-      "description": "Identifica un documento de devolución"
+      "label": "Devoluci\u00f3n",
+      "description": "Identifica un documento de devoluci\u00f3n"
     },
     "PendingQty": {
       "label": "Pendiente",
@@ -10602,10 +10602,10 @@
     },
     "Color": {
       "label": "Color",
-      "description": "Código del color en hexadecimal precedido por el símbolo #"
+      "description": "C\u00f3digo del color en hexadecimal precedido por el s\u00edmbolo #"
     },
     "Returnorderno": {
-      "label": "Nº Orden devolución de material",
+      "label": "N\u00ba Orden devoluci\u00f3n de material",
       "description": ""
     },
     "Availableqty": {
@@ -10617,32 +10617,32 @@
       "description": ""
     },
     "Writeofflimit": {
-      "label": "Límite de cancelación",
-      "description": "Límite de cancelación en un pago."
+      "label": "L\u00edmite de cancelaci\u00f3n",
+      "description": "L\u00edmite de cancelaci\u00f3n en un pago."
     },
     "returnQtyOtherRM": {
       "label": "Cantidad devuelta en otras devoluciones",
       "description": ""
     },
     "Wednesday": {
-      "label": "Miércoles",
+      "label": "Mi\u00e9rcoles",
       "description": ""
     },
     "AD_Table_Tree_ID": {
-      "label": "Categoría de árbol",
-      "description": "Estructura de árbol que se va a utilizar en esta solapa"
+      "label": "Categor\u00eda de \u00e1rbol",
+      "description": "Estructura de \u00e1rbol que se va a utilizar en esta solapa"
     },
     "Allowancefordoubtful_Acct": {
-      "label": "Cuenta de provisión para dudoso cobro",
+      "label": "Cuenta de provisi\u00f3n para dudoso cobro",
       "description": "Cuenta utilizada para el aprovisionamiento de deudas de dudoso cobro. Este importe reduce el importe de la cuenta de cobro en el balance de sumas y saldos."
     },
     "AllowanceForDoubtful_Acct": {
-      "label": "Cuenta de provisión para dudoso cobro",
+      "label": "Cuenta de provisi\u00f3n para dudoso cobro",
       "description": "Cuenta utilizada para el aprovisionamiento de deudas de dudoso cobro. Este importe reduce el importe de la cuenta de cobro en el balance de sumas y saldos."
     },
     "Periodnumber_Exp": {
-      "label": "Número de periodo",
-      "description": "Número de periodos en los que se periodifica el gasto."
+      "label": "N\u00famero de periodo",
+      "description": "N\u00famero de periodos en los que se periodifica el gasto."
     },
     "Columnsdetailview": {
       "label": "Columas para Vista Detalle",
@@ -10653,15 +10653,15 @@
       "description": ""
     },
     "Awaiting_Execution": {
-      "label": "Importe Pendiente de Ejecución",
+      "label": "Importe Pendiente de Ejecuci\u00f3n",
       "description": ""
     },
     "daysOverDue": {
-      "label": "Días Retraso",
+      "label": "D\u00edas Retraso",
       "description": ""
     },
     "Daysoverdue": {
-      "label": "Días Retraso",
+      "label": "D\u00edas Retraso",
       "description": ""
     },
     "IsLiabilityPositive": {
@@ -10673,15 +10673,15 @@
       "description": ""
     },
     "Your_Company_Document_Image": {
-      "label": "Imagen por Defecto de Documento de su Compañía",
+      "label": "Imagen por Defecto de Documento de su Compa\u00f1\u00eda",
       "description": ""
     },
     "TransactionCost": {
-      "label": "Coste de la transacción",
+      "label": "Coste de la transacci\u00f3n",
       "description": ""
     },
     "transactionCost": {
-      "label": "Coste de la transacción",
+      "label": "Coste de la transacci\u00f3n",
       "description": ""
     },
     "C_Doctypeaggrinvoice_ID": {
@@ -10693,7 +10693,7 @@
       "description": ""
     },
     "M_Costing_Algorithm_ID": {
-      "label": "Algoritmo de cálculo de costes",
+      "label": "Algoritmo de c\u00e1lculo de costes",
       "description": ""
     },
     "cumCost": {
@@ -10709,11 +10709,11 @@
       "description": ""
     },
     "trxProcessDate": {
-      "label": "Fecha del proceso de transacción",
+      "label": "Fecha del proceso de transacci\u00f3n",
       "description": ""
     },
     "TrxProcessDate": {
-      "label": "Fecha del proceso de transacción",
+      "label": "Fecha del proceso de transacci\u00f3n",
       "description": ""
     },
     "AD_Color_ID": {
@@ -10722,10 +10722,10 @@
     },
     "Bookusingpoprice": {
       "label": "Registrar con precio de compra",
-      "description": "Al estar marcado, la contabilización del Pedido de Compra se realizara con el precio de compra en vez de con el coste del producto."
+      "description": "Al estar marcado, la contabilizaci\u00f3n del Pedido de Compra se realizara con el precio de compra en vez de con el coste del producto."
     },
     "Void_Intconsumption_Line_ID": {
-      "label": "Línea de consumo interno anulada",
+      "label": "L\u00ednea de consumo interno anulada",
       "description": ""
     },
     "Purchase": {
@@ -10733,32 +10733,32 @@
       "description": "Representa la prioridad de esta Unidad Alternativa en los flujos de Compra."
     },
     "M_Costing_Rule_ID": {
-      "label": "Regla de cálculo de costes",
+      "label": "Regla de c\u00e1lculo de costes",
       "description": ""
     },
     "Warehouse_Dimension": {
-      "label": "Dimensión de almacén",
+      "label": "Dimensi\u00f3n de almac\u00e9n",
       "description": ""
     },
     "Relate_Orderline": {
-      "label": "Seleccionar Línea de Pedido",
+      "label": "Seleccionar L\u00ednea de Pedido",
       "description": "Asocia un producto relacionado con este servicio"
     },
     "C_Costcenter_ID": {
       "label": "Centro de costos",
-      "description": "División que se añade a la estructura interna de asignación de costes de una organización. "
+      "description": "Divisi\u00f3n que se a\u00f1ade a la estructura interna de asignaci\u00f3n de costes de una organizaci\u00f3n. "
     },
     "Sqllogic": {
-      "label": "Lógica sql",
-      "description": "Este campo se utiliza para definir una columna calculada. Una columna calculada es una columna de una tabla cuyos valores se obtienen utilizando una expresión sql y que no existe explícitamente en el esquema de base de datos."
+      "label": "L\u00f3gica sql",
+      "description": "Este campo se utiliza para definir una columna calculada. Una columna calculada es una columna de una tabla cuyos valores se obtienen utilizando una expresi\u00f3n sql y que no existe expl\u00edcitamente en el esquema de base de datos."
     },
     "IsAdvanced": {
       "label": "Avanzado",
-      "description": "Roles automáticos avanzados son concedidos con características avanzadas"
+      "description": "Roles autom\u00e1ticos avanzados son concedidos con caracter\u00edsticas avanzadas"
     },
     "Isdeferredexpense": {
       "label": "Gasto postpuesto",
-      "description": "Al estar marcado los gastos del producto se periodificarán según el plan y el número de periodos"
+      "description": "Al estar marcado los gastos del producto se periodificar\u00e1n seg\u00fan el plan y el n\u00famero de periodos"
     },
     "IsValidated": {
       "label": "Validado",
@@ -10777,11 +10777,11 @@
       "description": "No permitir pagos a proveedor."
     },
     "PO_Goods_Blocking": {
-      "label": "Albarán (Proveedor)",
+      "label": "Albar\u00e1n (Proveedor)",
       "description": "No permitir albaranes a proveedor."
     },
     "M_Costing_Rule_Product_V_ID": {
-      "label": "Regla de cálculo de costes del producto",
+      "label": "Regla de c\u00e1lculo de costes del producto",
       "description": ""
     },
     "IsCostCalculated": {
@@ -10794,7 +10794,7 @@
     },
     "C_CostCenter_ID": {
       "label": "Centro de costos",
-      "description": "División que se añade a la estructura interna de asignación de costes de una organización. "
+      "description": "Divisi\u00f3n que se a\u00f1ade a la estructura interna de asignaci\u00f3n de costes de una organizaci\u00f3n. "
     },
     "System_Status": {
       "label": "Estado_Sistema",
@@ -10805,12 +10805,12 @@
       "description": ""
     },
     "amountlines": {
-      "label": "ImporteLíneas",
+      "label": "ImporteL\u00edneas",
       "description": ""
     },
     "Costcenter_Acctdim_Isenable": {
       "label": "Centro de costos",
-      "description": "División que se añade a la estructura interna de asignación de costes de una organización. "
+      "description": "Divisi\u00f3n que se a\u00f1ade a la estructura interna de asignaci\u00f3n de costes de una organizaci\u00f3n. "
     },
     "Init_Inventory_ID": {
       "label": "Iniciar inventario",
@@ -10821,7 +10821,7 @@
       "description": ""
     },
     "M_Costing_Rule_Init_ID": {
-      "label": "Inicialización de la regla de cálculo de costes",
+      "label": "Inicializaci\u00f3n de la regla de c\u00e1lculo de costes",
       "description": ""
     },
     "M_Relatedproduct_ID": {
@@ -10833,47 +10833,47 @@
       "description": ""
     },
     "Periodnumber": {
-      "label": "Número de periodo",
-      "description": "Número de periodos en los que se divide un pago."
+      "label": "N\u00famero de periodo",
+      "description": "N\u00famero de periodos en los que se divide un pago."
     },
     "Credit": {
-      "label": "Crédito",
+      "label": "Cr\u00e9dito",
       "description": ""
     },
     "aumConversionRate": {
-      "label": "Conversión Unidad Alternativa",
+      "label": "Conversi\u00f3n Unidad Alternativa",
       "description": ""
     },
     "Secondarywhereclause": {
-      "label": "Cláusula SQL Where Secundaria",
-      "description": "Es una cláusula de SQL \"where\" secundaria usada por \"dbsourcemanager\" para filtrar datos dentro de una tabla"
+      "label": "Cl\u00e1usula SQL Where Secundaria",
+      "description": "Es una cl\u00e1usula de SQL \"where\" secundaria usada por \"dbsourcemanager\" para filtrar datos dentro de una tabla"
     },
     "BankFormat": {
       "label": "Formato cuenta bancaria",
-      "description": "Formato de cuenta bancaria que genera el nº de cuenta mostrada"
+      "description": "Formato de cuenta bancaria que genera el n\u00ba de cuenta mostrada"
     },
     "Sectionmessage_ID": {
-      "label": "Sección",
-      "description": "Sección de Configuración del Tercero Externo"
+      "label": "Secci\u00f3n",
+      "description": "Secci\u00f3n de Configuraci\u00f3n del Tercero Externo"
     },
     "grosspricestd": {
       "label": "Precio unitario bruto base",
       "description": ""
     },
     "Replacedorderline_id": {
-      "label": "Línea de Pedido Reemplazada",
-      "description": "Enlace a la línea de pedido que ha sido reemplazada"
+      "label": "L\u00ednea de Pedido Reemplazada",
+      "description": "Enlace a la l\u00ednea de pedido que ha sido reemplazada"
     },
     "Killprocess": {
       "label": "Cancelar Proceso",
-      "description": "Cancelar el proceso de background si éste implementa un método de cancelación."
+      "description": "Cancelar el proceso de background si \u00e9ste implementa un m\u00e9todo de cancelaci\u00f3n."
     },
     "Aum": {
       "label": "Unidad Alternativa",
       "description": ""
     },
     "Manualcostadjustment": {
-      "label": "Corrección Manual del Coste",
+      "label": "Correcci\u00f3n Manual del Coste",
       "description": ""
     },
     "Headermargin": {
@@ -10882,15 +10882,15 @@
     },
     "ExpectedDate": {
       "label": "Fecha esperada",
-      "description": "Periodo en que debe satisfacerse una petición específica."
+      "description": "Periodo en que debe satisfacerse una petici\u00f3n espec\u00edfica."
     },
     "expectedDate": {
       "label": "Fecha esperada",
-      "description": "Periodo en que debe satisfacerse una petición específica."
+      "description": "Periodo en que debe satisfacerse una petici\u00f3n espec\u00edfica."
     },
     "Expecteddate": {
       "label": "Fecha esperada",
-      "description": "Periodo en que debe satisfacerse una petición específica."
+      "description": "Periodo en que debe satisfacerse una petici\u00f3n espec\u00edfica."
     },
     "FIN_Rev_Payment_ID": {
       "label": "Pago revertido",
@@ -10910,7 +10910,7 @@
     },
     "IsPortal": {
       "label": "Para usuarios del portal",
-      "description": "Si está marcado, este  rol tendrá un interfaz simplificado (al portal), donde solo puede acceder a los widgets del espacio de trabajo."
+      "description": "Si est\u00e1 marcado, este  rol tendr\u00e1 un interfaz simplificado (al portal), donde solo puede acceder a los widgets del espacio de trabajo."
     },
     "Startingtimemonday": {
       "label": "Hora inicio Lunes",
@@ -10918,18 +10918,18 @@
     },
     "Ishandlenodesmanually": {
       "label": "Gestionar nodos manualmente",
-      "description": "Si esta opción esta activada, la creación y el borrado de los nodos del árbol se gestionará manualmente."
+      "description": "Si esta opci\u00f3n esta activada, la creaci\u00f3n y el borrado de los nodos del \u00e1rbol se gestionar\u00e1 manualmente."
     },
     "Returneduom": {
-      "label": "Unidad de Devolución",
+      "label": "Unidad de Devoluci\u00f3n",
       "description": ""
     },
     "Identifier_Seqno": {
-      "label": "Número de Secuencia del Identificador",
+      "label": "N\u00famero de Secuencia del Identificador",
       "description": "La secuencia indica el orden de las propiedades del Identificador"
     },
     "Limit_Margin": {
-      "label": "% Margen Precio Límite",
+      "label": "% Margen Precio L\u00edmite",
       "description": ""
     },
     "Costbased": {
@@ -10946,14 +10946,14 @@
     },
     "IsScanIdentifier": {
       "label": "Filtro usado para escanear",
-      "description": "Cuando se ejecute un escaneo el conector CRM usará este filtro"
+      "description": "Cuando se ejecute un escaneo el conector CRM usar\u00e1 este filtro"
     },
     "OutstandingDoubtfulDebtAmount": {
       "label": "Importe pendiente de dudoso cobro",
       "description": "Importe pendiente de dudoso cobro"
     },
     "Paidamtatinvoicing": {
-      "label": "Importe Pagado en la Facturación",
+      "label": "Importe Pagado en la Facturaci\u00f3n",
       "description": ""
     },
     "Grosspricelist": {
@@ -10966,35 +10966,35 @@
     },
     "AD_Process_Group_ID": {
       "label": "Grupo de Procesos",
-      "description": "Grupo de Procesos que se ejecutarán en series desde la ventana de Procesamiento de Peticiones"
+      "description": "Grupo de Procesos que se ejecutar\u00e1n en series desde la ventana de Procesamiento de Peticiones"
     },
     "pendinglines": {
-      "label": "LíneasPendientes",
+      "label": "L\u00edneasPendientes",
       "description": ""
     },
     "Print_Description": {
-      "label": "Descripción de Impresión",
-      "description": "Si se selecciona, la descripción del servicio se muestra en el ticket"
+      "label": "Descripci\u00f3n de Impresi\u00f3n",
+      "description": "Si se selecciona, la descripci\u00f3n del servicio se muestra en el ticket"
     },
     "Exclude": {
       "label": "Excluir",
-      "description": "Si excluir esta seleccionado, serán excluidas para el calculo de la comisión las líneas que satisfacen las condiciones especificadas en la línea actual. El campo cascade tiene que estar seleccionado para poder excluir lineas."
+      "description": "Si excluir esta seleccionado, ser\u00e1n excluidas para el calculo de la comisi\u00f3n las l\u00edneas que satisfacen las condiciones especificadas en la l\u00ednea actual. El campo cascade tiene que estar seleccionado para poder excluir lineas."
     },
     "Costing_Status": {
       "label": "Costing Status",
-      "description": "Status del cálculo de costes"
+      "description": "Status del c\u00e1lculo de costes"
     },
     "AD_Cluster_Service_Settings_ID": {
       "label": "AD_Cluster_Service_Settings_ID",
-      "description": "Tabla usada para la configuración de un servicio particular de cluster."
+      "description": "Tabla usada para la configuraci\u00f3n de un servicio particular de cluster."
     },
     "IsExcludeAudit": {
-      "label": "Excluir Auditoría",
-      "description": "Excluir columna de auditoría"
+      "label": "Excluir Auditor\u00eda",
+      "description": "Excluir columna de auditor\u00eda"
     },
     "relatedQuantity": {
       "label": "Cantidad Relacionada",
-      "description": "El número de un elemento involucrado en una transacción, dado en unidades estándar. Se usa para determinar el precio por unidad."
+      "description": "El n\u00famero de un elemento involucrado en una transacci\u00f3n, dado en unidades est\u00e1ndar. Se usa para determinar el precio por unidad."
     },
     "Gross_Amt": {
       "label": "Importe bruto",
@@ -11005,12 +11005,12 @@
       "description": "Tiempo de Proceso"
     },
     "returnedUOM": {
-      "label": "Unidad de Devolución",
-      "description": "Unidad de Devolución"
+      "label": "Unidad de Devoluci\u00f3n",
+      "description": "Unidad de Devoluci\u00f3n"
     },
     "Uniqueattconsum": {
-      "label": "Conjunto de atributos único de consumo",
-      "description": "Indica si el producto tiene que ser consumido desde un grupo de atributos único"
+      "label": "Conjunto de atributos \u00fanico de consumo",
+      "description": "Indica si el producto tiene que ser consumido desde un grupo de atributos \u00fanico"
     },
     "Isallocated": {
       "label": "Asignado",
@@ -11049,7 +11049,7 @@
       "description": "Cuenta de IVA transitorio a pagar"
     },
     "AD_Org_Warehouse_ID": {
-      "label": "Almacén de la organización",
+      "label": "Almac\u00e9n de la organizaci\u00f3n",
       "description": ""
     },
     "IsBackgroundDisabled": {
@@ -11057,36 +11057,36 @@
       "description": "Desactiva la tabla seleccionada para el proceso de background de contabilidad"
     },
     "M_Warehouse_Rule_ID": {
-      "label": "Regla de almacén",
+      "label": "Regla de almac\u00e9n",
       "description": ""
     },
     "Bpartner_Acctdim_Breakdown": {
       "label": "Mostrar en desglose",
-      "description": "Indica si la dimensión contable se muestra en la solapa de desglose del documento."
+      "description": "Indica si la dimensi\u00f3n contable se muestra en la solapa de desglose del documento."
     },
     "User2_Acctdim_Breakdown": {
       "label": "Mostrar en desglose",
-      "description": "Indica si la dimensión contable se muestra en la solapa de desglose del documento."
+      "description": "Indica si la dimensi\u00f3n contable se muestra en la solapa de desglose del documento."
     },
     "Project_Acctdim_Breakdown": {
       "label": "Mostrar en desglose",
-      "description": "Indica si la dimensión contable se muestra en la solapa de desglose del documento."
+      "description": "Indica si la dimensi\u00f3n contable se muestra en la solapa de desglose del documento."
     },
     "Costcenter_Acctdim_Breakdown": {
       "label": "Mostrar en desglose",
-      "description": "Indica si la dimensión contable se muestra en la solapa de desglose del documento."
+      "description": "Indica si la dimensi\u00f3n contable se muestra en la solapa de desglose del documento."
     },
     "Product_Acctdim_Breakdown": {
       "label": "Mostrar en desglose",
-      "description": "Indica si la dimensión contable se muestra en la solapa de desglose del documento."
+      "description": "Indica si la dimensi\u00f3n contable se muestra en la solapa de desglose del documento."
     },
     "Show_In_Breakdown": {
       "label": "Mostrar en desglose",
-      "description": "Indica si la dimensión contable se muestra en la solapa de desglose del documento."
+      "description": "Indica si la dimensi\u00f3n contable se muestra en la solapa de desglose del documento."
     },
     "User1_Acctdim_Breakdown": {
       "label": "Mostrar en desglose",
-      "description": "Indica si la dimensión contable se muestra en la solapa de desglose del documento."
+      "description": "Indica si la dimensi\u00f3n contable se muestra en la solapa de desglose del documento."
     },
     "RES_Status": {
       "label": "Estado",
@@ -11121,20 +11121,20 @@
       "description": ""
     },
     "Pricestd": {
-      "label": "Precio estándar",
+      "label": "Precio est\u00e1ndar",
       "description": "El precio normal de un producto en su respectiva tarifa."
     },
     "Hqltreewhereclause": {
-      "label": "Clásula HQL Where para nodos raíz",
-      "description": "Cláusula where que define cuales son los nodos raíz para esta tabla"
+      "label": "Cl\u00e1sula HQL Where para nodos ra\u00edz",
+      "description": "Cl\u00e1usula where que define cuales son los nodos ra\u00edz para esta tabla"
     },
     "Isdeferredrevenue": {
       "label": "Ingreso postpuesto",
-      "description": "Al marcarlo el ingreso del producto se periodificará utilizando el plan y el número de periodos"
+      "description": "Al marcarlo el ingreso del producto se periodificar\u00e1 utilizando el plan y el n\u00famero de periodos"
     },
     "IsDeferred": {
       "label": "Ingreso postpuesto",
-      "description": "Al marcarlo el ingreso del producto se periodificará utilizando el plan y el número de periodos"
+      "description": "Al marcarlo el ingreso del producto se periodificar\u00e1 utilizando el plan y el n\u00famero de periodos"
     },
     "RES_Process": {
       "label": "Proceso de reservas",
@@ -11149,7 +11149,7 @@
       "description": ""
     },
     "Sales_Orderline_ID": {
-      "label": "Línea de pedido de venta",
+      "label": "L\u00ednea de pedido de venta",
       "description": ""
     },
     "Manage_Prereservation": {
@@ -11157,7 +11157,7 @@
       "description": ""
     },
     "Purchase_Orderline_ID": {
-      "label": "Línea del pedido de compra",
+      "label": "L\u00ednea del pedido de compra",
       "description": ""
     },
     "Manage_Reservation": {
@@ -11173,12 +11173,12 @@
       "description": ""
     },
     "InstanceNo": {
-      "label": "Número de Instancia",
-      "description": "Número de Instancia de Professional Edition"
+      "label": "N\u00famero de Instancia",
+      "description": "N\u00famero de Instancia de Professional Edition"
     },
     "Logistics": {
-      "label": "Logística",
-      "description": "Representa la prioridad de esta Unidad Alternativa en los flujos logísticos."
+      "label": "Log\u00edstica",
+      "description": "Representa la prioridad de esta Unidad Alternativa en los flujos log\u00edsticos."
     },
     "Typeofdata": {
       "label": "Tipo de Dato",
@@ -11186,43 +11186,43 @@
     },
     "Is_Customer_Consent": {
       "label": "Consentimiento para el Procesamiento de Datos del Cliente",
-      "description": "Está marcado cuando el Cliente consiente el procesamiento de su información"
+      "description": "Est\u00e1 marcado cuando el Cliente consiente el procesamiento de su informaci\u00f3n"
     },
     "Ismultiple": {
-      "label": "Es múltiple",
-      "description": "El descuento solo se aplicará si la cantidad pedida se ajusta a la cantidad especificada en el paquete o a un múltiplo."
+      "label": "Es m\u00faltiple",
+      "description": "El descuento solo se aplicar\u00e1 si la cantidad pedida se ajusta a la cantidad especificada en el paquete o a un m\u00faltiplo."
     },
     "C_Extbp_Config_Property_ID": {
       "label": "Propiedad del Conector CRM",
       "description": "Propiedad del Conector CRM"
     },
     "Outuponclearinguse": {
-      "label": "Cuenta de reconciliación Pago",
-      "description": "Cuenta utilizada tras la reconciliación"
+      "label": "Cuenta de reconciliaci\u00f3n Pago",
+      "description": "Cuenta utilizada tras la reconciliaci\u00f3n"
     },
     "Decimalseparator": {
       "label": "Separador decimal",
       "description": ""
     },
     "Iscollapsed": {
-      "label": "Está contraido",
-      "description": "Establece el tipo de agrupación de campos para que se contraiga por defecto"
+      "label": "Est\u00e1 contraido",
+      "description": "Establece el tipo de agrupaci\u00f3n de campos para que se contraiga por defecto"
     },
     "Create_Reservations": {
       "label": "Crear reservas",
       "description": ""
     },
     "Is_Explicit_Access": {
-      "label": "Requiere permiso explícito de acceso",
-      "description": "Requiere permiso explícito de acceso"
+      "label": "Requiere permiso expl\u00edcito de acceso",
+      "description": "Requiere permiso expl\u00edcito de acceso"
     },
     "RM_Pickfromreceipt": {
-      "label": "Elegir/Editar líneas",
+      "label": "Elegir/Editar l\u00edneas",
       "description": ""
     },
     "Restrictsalefrompos": {
       "label": "Restringir ventas desde TPV",
-      "description": "Indica si está permitido vender un producto desde el punto de venta"
+      "description": "Indica si est\u00e1 permitido vender un producto desde el punto de venta"
     },
     "Isspecialatt": {
       "label": "Es atributo especial",
@@ -11233,8 +11233,8 @@
       "description": "Unidad Alternativa Operativa"
     },
     "Commercialauth": {
-      "label": "Autorización comercial",
-      "description": "Este campo indica si el cliente desea recibir o no información comercial por parte de la organización"
+      "label": "Autorizaci\u00f3n comercial",
+      "description": "Este campo indica si el cliente desea recibir o no informaci\u00f3n comercial por parte de la organizaci\u00f3n"
     },
     "Multiple": {
       "label": "Unidades por paquete",
@@ -11254,11 +11254,11 @@
     },
     "iscascade": {
       "label": "En cascada",
-      "description": "Si esta seleccionado la comisión será calculada en cascada"
+      "description": "Si esta seleccionado la comisi\u00f3n ser\u00e1 calculada en cascada"
     },
     "Isthreadsafe": {
       "label": "Seguro en Hilos",
-      "description": "Si está seleccionado indica que la ventana se puede abrir en más de una solapa de forma segura."
+      "description": "Si est\u00e1 seleccionado indica que la ventana se puede abrir en m\u00e1s de una solapa de forma segura."
     },
     "Totalpaid": {
       "label": "Total pagado",
@@ -11269,23 +11269,23 @@
       "description": "Permite bloquear facturas a clientes"
     },
     "LastPasswordUpdate": {
-      "label": "Último Cambio de Contraseña",
-      "description": "Fecha del último cambio de la contraseña de usuario"
+      "label": "\u00daltimo Cambio de Contrase\u00f1a",
+      "description": "Fecha del \u00faltimo cambio de la contrase\u00f1a de usuario"
     },
     "Thursday": {
       "label": "Jueves",
       "description": ""
     },
     "WSC_Calls_Max": {
-      "label": "Máximas llamadas conectadas",
-      "description": "Número máximo de llamadas conectadas al día en los últimos 30 días"
+      "label": "M\u00e1ximas llamadas conectadas",
+      "description": "N\u00famero m\u00e1ximo de llamadas conectadas al d\u00eda en los \u00faltimos 30 d\u00edas"
     },
     "M_Characteristic_ID": {
-      "label": "Característica",
+      "label": "Caracter\u00edstica",
       "description": ""
     },
     "M_Offer_Characteristic_ID": {
-      "label": "Característica",
+      "label": "Caracter\u00edstica",
       "description": ""
     },
     "M_Ch_Subset_Value_ID": {
@@ -11293,15 +11293,15 @@
       "description": ""
     },
     "M_Ch_Value_ID": {
-      "label": "Valor de característica",
+      "label": "Valor de caracter\u00edstica",
       "description": ""
     },
     "M_Ch_Subset_ID": {
-      "label": "Subconjunto de característica",
+      "label": "Subconjunto de caracter\u00edstica",
       "description": ""
     },
     "Prun_Message": {
-      "label": "Mensaje de Ejecución de Pagos",
+      "label": "Mensaje de Ejecuci\u00f3n de Pagos",
       "description": ""
     },
     "M_Brand_ID": {
@@ -11309,7 +11309,7 @@
       "description": ""
     },
     "M_Product_Ch_ID": {
-      "label": "Característica de producto",
+      "label": "Caracter\u00edstica de producto",
       "description": ""
     },
     "Prepaymentamt": {
@@ -11317,15 +11317,15 @@
       "description": ""
     },
     "Isgeneric": {
-      "label": "Es genérico",
+      "label": "Es gen\u00e9rico",
       "description": ""
     },
     "IsGeneric": {
-      "label": "Es genérico",
+      "label": "Es gen\u00e9rico",
       "description": ""
     },
     "Generic_Product_ID": {
-      "label": "Producto genérico",
+      "label": "Producto gen\u00e9rico",
       "description": ""
     },
     "Isvariant": {
@@ -11337,35 +11337,35 @@
       "description": ""
     },
     "Detail_Seqno": {
-      "label": "Número de Secuencia del Detalle",
+      "label": "N\u00famero de Secuencia del Detalle",
       "description": "Secuencia para mostrar la propiedad en la vista de detalle"
     },
     "Is30DayMonth": {
-      "label": "Un mes son 30 días",
-      "description": "Al calcular el plan de amortización, se considera que los meses tienen 30 días."
+      "label": "Un mes son 30 d\u00edas",
+      "description": "Al calcular el plan de amortizaci\u00f3n, se considera que los meses tienen 30 d\u00edas."
     },
     "InvoiceAmount": {
       "label": "Importe Factura",
       "description": ""
     },
     "Quotationline_ID": {
-      "label": "Línea de presupuesto",
+      "label": "L\u00ednea de presupuesto",
       "description": ""
     },
     "Basisamt": {
       "label": "Cantidad base",
-      "description": "Cantidad que se tendrá en cuenta para el cálculo de la comisión: neto o margen. Si es seleccionado el margen, solo se tendrán en cuenta las facturas que tengan albaranes asociados."
+      "description": "Cantidad que se tendr\u00e1 en cuenta para el c\u00e1lculo de la comisi\u00f3n: neto o margen. Si es seleccionado el margen, solo se tendr\u00e1n en cuenta las facturas que tengan albaranes asociados."
     },
     "IsIncludeInI18N": {
       "label": "Forzar disponibilidad en cliente",
-      "description": "Columna para forzar la inclusión de mensajes de Core en el objeto OB.I18N"
+      "description": "Columna para forzar la inclusi\u00f3n de mensajes de Core en el objeto OB.I18N"
     },
     "Filter": {
       "label": "Filtro",
       "description": "Define si este campo se puede filtrar en el popup"
     },
     "M_Product_Ch_Conf_ID": {
-      "label": "Configuración de característica de producto",
+      "label": "Configuraci\u00f3n de caracter\u00edstica de producto",
       "description": ""
     },
     "Define_Price": {
@@ -11374,14 +11374,14 @@
     },
     "M_Product_Status_ID": {
       "label": "Estado Ciclo de Vida",
-      "description": "Estado de gestión del ciclo de vida del producto"
+      "description": "Estado de gesti\u00f3n del ciclo de vida del producto"
     },
     "CreateVariants": {
       "label": "Crear variantes",
       "description": ""
     },
     "Characteristic_Desc": {
-      "label": "Descripción de característica",
+      "label": "Descripci\u00f3n de caracter\u00edstica",
       "description": ""
     },
     "SO_C_Incoterms_ID": {
@@ -11393,15 +11393,15 @@
       "description": "Representa la prioridad de esta Unidad Alternativa en los flujos de Venta"
     },
     "Displaylogic_Server": {
-      "label": "Mostrar Lógica Evaluada en el Servidor",
-      "description": "Una especificación de sentencias que, al ser evaluadas como falsas en el Servidor, hace que el campo no se muestre en la Ventana generada."
+      "label": "Mostrar L\u00f3gica Evaluada en el Servidor",
+      "description": "Una especificaci\u00f3n de sentencias que, al ser evaluadas como falsas en el Servidor, hace que el campo no se muestre en la Ventana generada."
     },
     "Fixbackdatedfrom": {
       "label": "Ajuste Retroactivo de Transacciones Desde",
-      "description": "Fecha de inicio en la regla de cálculo de costes para el ajuste retroactivo de transacciones"
+      "description": "Fecha de inicio en la regla de c\u00e1lculo de costes para el ajuste retroactivo de transacciones"
     },
     "Add_Products": {
-      "label": "Añadir Productos",
+      "label": "A\u00f1adir Productos",
       "description": ""
     },
     "AD_Role_Inheritance_ID": {
@@ -11409,8 +11409,8 @@
       "description": "Herencia de Roles"
     },
     "IsReadOnlyTree": {
-      "label": "Árbol de solo lectura",
-      "description": "Permite especificar que el árbol de esta solapa sea de sólo lectura"
+      "label": "\u00c1rbol de solo lectura",
+      "description": "Permite especificar que el \u00e1rbol de esta solapa sea de s\u00f3lo lectura"
     },
     "Recalculatepermissions": {
       "label": "Recalcular Permisos",
@@ -11425,7 +11425,7 @@
       "description": ""
     },
     "Updateinvariants": {
-      "label": "Actualizar características",
+      "label": "Actualizar caracter\u00edsticas",
       "description": ""
     },
     "outstandingAmount": {
@@ -11441,15 +11441,15 @@
       "description": ""
     },
     "RM_AddOrphanLine": {
-      "label": "Insertar líneas sin albarán",
+      "label": "Insertar l\u00edneas sin albar\u00e1n",
       "description": ""
     },
     "C_Extbp_Config_ID": {
-      "label": "Configuración del Conector CRM",
-      "description": "Configuración para las integraciones con sistemas CRM"
+      "label": "Configuraci\u00f3n del Conector CRM",
+      "description": "Configuraci\u00f3n para las integraciones con sistemas CRM"
     },
     "Create_POLines": {
-      "label": "Crear líneas",
+      "label": "Crear l\u00edneas",
       "description": ""
     },
     "isVariantCreated": {
@@ -11466,7 +11466,7 @@
     },
     "Beat_Type": {
       "label": "Tipo",
-      "description": "Tipo de pulsación"
+      "description": "Tipo de pulsaci\u00f3n"
     },
     "M_RefInventory_ID": {
       "label": "Inventario Referenciado",
@@ -11477,11 +11477,11 @@
       "description": ""
     },
     "NodeDeletionPolicy": {
-      "label": "Política de borrado de nodos",
+      "label": "Pol\u00edtica de borrado de nodos",
       "description": "Define el comportamiento cuando se elimina un nodo"
     },
     "Email_Process_ID": {
-      "label": "Proceso de correo Electrónico",
+      "label": "Proceso de correo Electr\u00f3nico",
       "description": ""
     },
     "BadDebtRevenue_Acct": {
@@ -11493,16 +11493,16 @@
       "description": "Cuenta utilizada para registrar el ingreso relacionado con el cobro de una deuda de dudoso cobro"
     },
     "DirectNavigation": {
-      "label": "Navegación Directa",
-      "description": "La regla no require cumplir la Lógica HQL"
+      "label": "Navegaci\u00f3n Directa",
+      "description": "La regla no require cumplir la L\u00f3gica HQL"
     },
     "IsExpense": {
       "label": "Gasto",
       "description": "Flag que indica si el tipo de documento es para gastos o no."
     },
     "Backdatedtrxsfixed": {
-      "label": "Transacción Ajustada Retroactivamente",
-      "description": "Si está marcado significa que el ajuste retroactivo de transacciones se ha ejecutado para esta regla de cálculo de costes."
+      "label": "Transacci\u00f3n Ajustada Retroactivamente",
+      "description": "Si est\u00e1 marcado significa que el ajuste retroactivo de transacciones se ha ejecutado para esta regla de c\u00e1lculo de costes."
     },
     "Onhandqty": {
       "label": "Cant. Disponible",
@@ -11521,36 +11521,36 @@
       "description": "Indica si el link tiene que abrirse en una solapa del navegador."
     },
     "User1_Acctdim_Lines": {
-      "label": "Mostrar en líneas",
-      "description": "Indica si la dimension contable se muestra en la solapa de las líneas del documento."
+      "label": "Mostrar en l\u00edneas",
+      "description": "Indica si la dimension contable se muestra en la solapa de las l\u00edneas del documento."
     },
     "Costcenter_Acctdim_Lines": {
-      "label": "Mostrar en líneas",
-      "description": "Indica si la dimension contable se muestra en la solapa de las líneas del documento."
+      "label": "Mostrar en l\u00edneas",
+      "description": "Indica si la dimension contable se muestra en la solapa de las l\u00edneas del documento."
     },
     "Product_Acctdim_Lines": {
-      "label": "Mostrar en líneas",
-      "description": "Indica si la dimension contable se muestra en la solapa de las líneas del documento."
+      "label": "Mostrar en l\u00edneas",
+      "description": "Indica si la dimension contable se muestra en la solapa de las l\u00edneas del documento."
     },
     "Bpartner_Acctdim_Lines": {
-      "label": "Mostrar en líneas",
-      "description": "Indica si la dimension contable se muestra en la solapa de las líneas del documento."
+      "label": "Mostrar en l\u00edneas",
+      "description": "Indica si la dimension contable se muestra en la solapa de las l\u00edneas del documento."
     },
     "Show_In_Lines": {
-      "label": "Mostrar en líneas",
-      "description": "Indica si la dimension contable se muestra en la solapa de las líneas del documento."
+      "label": "Mostrar en l\u00edneas",
+      "description": "Indica si la dimension contable se muestra en la solapa de las l\u00edneas del documento."
     },
     "User2_Acctdim_Lines": {
-      "label": "Mostrar en líneas",
-      "description": "Indica si la dimension contable se muestra en la solapa de las líneas del documento."
+      "label": "Mostrar en l\u00edneas",
+      "description": "Indica si la dimension contable se muestra en la solapa de las l\u00edneas del documento."
     },
     "Project_Acctdim_Lines": {
-      "label": "Mostrar en líneas",
-      "description": "Indica si la dimension contable se muestra en la solapa de las líneas del documento."
+      "label": "Mostrar en l\u00edneas",
+      "description": "Indica si la dimension contable se muestra en la solapa de las l\u00edneas del documento."
     },
     "Typewriteoff": {
-      "label": "Tipo de límite de cancelación",
-      "description": "Límite de cancelación de un pago para la cuenta financiera."
+      "label": "Tipo de l\u00edmite de cancelaci\u00f3n",
+      "description": "L\u00edmite de cancelaci\u00f3n de un pago para la cuenta financiera."
     },
     "Expected": {
       "label": "A liquidar",
@@ -11573,11 +11573,11 @@
       "description": ""
     },
     "Relateprodcattoservice": {
-      "label": "Relacionar Categorías de Producto",
-      "description": "P&E para incluir/excluir categorías de productos en la solapa de productos e indicar si un servicio puede ser aplicado sobre ellos."
+      "label": "Relacionar Categor\u00edas de Producto",
+      "description": "P&E para incluir/excluir categor\u00edas de productos en la solapa de productos e indicar si un servicio puede ser aplicado sobre ellos."
     },
     "M_Returnlocator_ID": {
-      "label": "Hueco de devolución",
+      "label": "Hueco de devoluci\u00f3n",
       "description": "Hueco para devoluciones."
     },
     "Cancelledorder_id": {
@@ -11586,22 +11586,22 @@
     },
     "Istranslatable": {
       "label": "Traducible",
-      "description": "Indica si una opción para la configuración de una propiedad del Tercero Externo es traducible"
+      "description": "Indica si una opci\u00f3n para la configuraci\u00f3n de una propiedad del Tercero Externo es traducible"
     },
     "Whereclauserootnodes": {
-      "label": "Clásula HQL Where para nodos raíz",
-      "description": "Cláusula where que define cuales son los nodos raíz para esta referencia de árbol"
+      "label": "Cl\u00e1sula HQL Where para nodos ra\u00edz",
+      "description": "Cl\u00e1usula where que define cuales son los nodos ra\u00edz para esta referencia de \u00e1rbol"
     },
     "Jsoninfo": {
-      "label": "Información JSON",
+      "label": "Informaci\u00f3n JSON",
       "description": ""
     },
     "Restrictsaleoutofstock": {
       "label": "Restringir ventas si no hay stock",
-      "description": "Indica si está permitido vender un producto sin stock"
+      "description": "Indica si est\u00e1 permitido vender un producto sin stock"
     },
     "Startingtimewednesday": {
-      "label": "Hora inicio Miércoles",
+      "label": "Hora inicio Mi\u00e9rcoles",
       "description": ""
     },
     "Doubtfuldebt_Acct": {
@@ -11609,15 +11609,15 @@
       "description": "Cuenta utilizada para reclasificar la deuda una vez que se ha reconocido como dudoso cobro"
     },
     "AcctDescription": {
-      "label": "Descripción del asiento",
-      "description": "Descripción del apunte contable"
+      "label": "Descripci\u00f3n del asiento",
+      "description": "Descripci\u00f3n del apunte contable"
     },
     "AD_Cluster_Service_ID": {
       "label": "AD_Cluster_Service_ID",
       "description": "Tabla usada para identificar el nodo del cluster responsable de manejar un servicio en particular."
     },
     "C_Attachment_Method_ID": {
-      "label": "Método de Adjuntos",
+      "label": "M\u00e9todo de Adjuntos",
       "description": ""
     },
     "Specialatt": {
@@ -11641,12 +11641,12 @@
       "description": ""
     },
     "M_Offer_Type_ID": {
-      "label": "Tipo de descuento/promoción",
+      "label": "Tipo de descuento/promoci\u00f3n",
       "description": ""
     },
     "Whereclause": {
-      "label": "Cláusula Where HQL/SQL",
-      "description": "La cláusula Where indica el WHERE de HQL/SQL  usado para el filtrado de los datos"
+      "label": "Cl\u00e1usula Where HQL/SQL",
+      "description": "La cl\u00e1usula Where indica el WHERE de HQL/SQL  usado para el filtrado de los datos"
     },
     "Inherit_From": {
       "label": "Hereda De",
@@ -11661,20 +11661,20 @@
       "description": "Cuenta utilizada para reclasificar la deuda una vez que se ha reconocido como dudoso cobro"
     },
     "categoryName": {
-      "label": "Categoría de Producto",
-      "description": "Identificador no unívoco de un registro/documento que puede utilizarse habitualmente como herramienta de búsqueda."
+      "label": "Categor\u00eda de Producto",
+      "description": "Identificador no un\u00edvoco de un registro/documento que puede utilizarse habitualmente como herramienta de b\u00fasqueda."
     },
     "Saturday": {
-      "label": "Sábado",
+      "label": "S\u00e1bado",
       "description": ""
     },
     "Hqlfilterclause": {
-      "label": "Cláusula Filter HQL",
+      "label": "Cl\u00e1usula Filter HQL",
       "description": "By using this HQL clause, initially the user will not be able to see  data that does not fit the criteria. Once the user clears the filter, this hql clause will not be applied."
     },
     "DataOriginType": {
       "label": "Origen de datos",
-      "description": "Campo para especificar el tipo del origen de datos: tabla/vista física o fuente de datos"
+      "description": "Campo para especificar el tipo del origen de datos: tabla/vista f\u00edsica o fuente de datos"
     },
     "Showlogo": {
       "label": "Mostrar Logo",
@@ -11682,7 +11682,7 @@
     },
     "Customer_Blocking": {
       "label": "Bloqueo de cliente",
-      "description": "Permite bloquear terceros. Al estar marcado, aparece una nueva sección llamada Bloqueo de Terceros con las opciones de bloqueo."
+      "description": "Permite bloquear terceros. Al estar marcado, aparece una nueva secci\u00f3n llamada Bloqueo de Terceros con las opciones de bloqueo."
     },
     "Uponreceiptuse": {
       "label": "Cuenta del cobro",
@@ -11690,7 +11690,7 @@
     },
     "C_Acctschema_Gl_ID": {
       "label": "Esquema contable del Libro Mayor",
-      "description": "Contabilidad general define la forma de manejar los errores y el balance, así como las cuentas necesarias para contabilizar la contabilidad general."
+      "description": "Contabilidad general define la forma de manejar los errores y el balance, as\u00ed como las cuentas necesarias para contabilizar la contabilidad general."
     },
     "adjustmentAmt": {
       "label": "Imp. Ajuste",
@@ -11701,8 +11701,8 @@
       "description": ""
     },
     "EnableBankStatement": {
-      "label": "Contabilización del extracto bancario",
-      "description": "Activar Contabilización de Extractos Bancarios"
+      "label": "Contabilizaci\u00f3n del extracto bancario",
+      "description": "Activar Contabilizaci\u00f3n de Extractos Bancarios"
     },
     "M_StockReservationPEDataSource_ID": {
       "label": "Elegir Editar reservas manual",
@@ -11710,7 +11710,7 @@
     },
     "Viasms": {
       "label": "Sms",
-      "description": "Este campo define el valor por defecto del campo Via SMS en la creación de clientes desde el punto de venta"
+      "description": "Este campo define el valor por defecto del campo Via SMS en la creaci\u00f3n de clientes desde el punto de venta"
     },
     "Gross_Unit_Price": {
       "label": "Precio unitario bruto",
@@ -11737,16 +11737,16 @@
       "description": ""
     },
     "Cumcost": {
-      "label": "Valoración acumulada",
+      "label": "Valoraci\u00f3n acumulada",
       "description": ""
     },
     "Treestructure": {
-      "label": "Estructura de árbol",
-      "description": "Estructura interna del árbol"
+      "label": "Estructura de \u00e1rbol",
+      "description": "Estructura interna del \u00e1rbol"
     },
     "Maximumqty": {
-      "label": "Máximo stock no reservado",
-      "description": "No se ha reservado la cantidad máxima del producto en stock."
+      "label": "M\u00e1ximo stock no reservado",
+      "description": "No se ha reservado la cantidad m\u00e1xima del producto en stock."
     },
     "ReferenceDate": {
       "label": "Fecha de Referencia",
@@ -11769,11 +11769,11 @@
       "description": ""
     },
     "M_Costadjustmentline_ID": {
-      "label": "Línea de Ajuste de Coste",
+      "label": "L\u00ednea de Ajuste de Coste",
       "description": ""
     },
     "M_CostAdjustmentLine_ID": {
-      "label": "Línea de Ajuste de Coste",
+      "label": "L\u00ednea de Ajuste de Coste",
       "description": ""
     },
     "IsSource": {
@@ -11781,7 +11781,7 @@
       "description": ""
     },
     "NeedsPosting": {
-      "label": "Necesita contabilización",
+      "label": "Necesita contabilizaci\u00f3n",
       "description": ""
     },
     "Adjustment_Amount": {
@@ -11789,8 +11789,8 @@
       "description": ""
     },
     "IsShowTreeNodeIcons": {
-      "label": "Mostrar iconos de los nodos del árbol",
-      "description": "Define si se deben mostrar los iconos de los nodos del árbol"
+      "label": "Mostrar iconos de los nodos del \u00e1rbol",
+      "description": "Define si se deben mostrar los iconos de los nodos del \u00e1rbol"
     },
     "M_Inventorystatus_Trl_ID": {
       "label": "Estado de Inventario Traducido",
@@ -11801,7 +11801,7 @@
       "description": ""
     },
     "Debit": {
-      "label": "Débito",
+      "label": "D\u00e9bito",
       "description": ""
     },
     "Isselectorfilter": {
@@ -11813,28 +11813,28 @@
       "description": "Proceso de Ajuste Retroactivo de Transacciones"
     },
     "Isreversal": {
-      "label": "Nota de crédito",
-      "description": "El checkbox de Nota de crédito aplica solo a tipos de documento de Facturas. Este tipo de facturas se comportarán como Notas de crédito. Esto quiere decir que el importe total de la factura debe ser positivo. El plan de pago será negativo."
+      "label": "Nota de cr\u00e9dito",
+      "description": "El checkbox de Nota de cr\u00e9dito aplica solo a tipos de documento de Facturas. Este tipo de facturas se comportar\u00e1n como Notas de cr\u00e9dito. Esto quiere decir que el importe total de la factura debe ser positivo. El plan de pago ser\u00e1 negativo."
     },
     "Priceoffer": {
       "label": "Precio Base Neto Unitario",
       "description": ""
     },
     "Committedamt": {
-      "label": "Cuantía del acuerdo",
-      "description": "Suma máxima facturable de un proyecto."
+      "label": "Cuant\u00eda del acuerdo",
+      "description": "Suma m\u00e1xima facturable de un proyecto."
     },
     "DueAmt": {
       "label": "Importe Actualmente Vencido",
       "description": "Importe Vencido"
     },
     "Iscommitceiling": {
-      "label": "Límite superior",
-      "description": "Indicación de que se está cobrando la suma o importe máximos permitidos por el contrato (puede depender de los requisitios del gobierno)."
+      "label": "L\u00edmite superior",
+      "description": "Indicaci\u00f3n de que se est\u00e1 cobrando la suma o importe m\u00e1ximos permitidos por el contrato (puede depender de los requisitios del gobierno)."
     },
     "Iscomplete": {
       "label": "Tarea completa",
-      "description": "Está completo"
+      "description": "Est\u00e1 completo"
     },
     "Expreinvoicing": {
       "label": "Gastos refacturables",
@@ -11849,16 +11849,16 @@
       "description": "Importe Pendiente"
     },
     "FIN_In_Intransit_Acct": {
-      "label": "Cuenta de pagos en tránsito",
-      "description": "Cuenta utilizada para el estado en tránsito de los cobros"
+      "label": "Cuenta de pagos en tr\u00e1nsito",
+      "description": "Cuenta utilizada para el estado en tr\u00e1nsito de los cobros"
     },
     "IsDirectPrint": {
-      "label": "Impresión directa",
-      "description": "Impresión directa"
+      "label": "Impresi\u00f3n directa",
+      "description": "Impresi\u00f3n directa"
     },
     "M_Pricelist_Version_Base_ID": {
       "label": "Origen tarifa",
-      "description": "Origen de cálculo de la lista de precios "
+      "description": "Origen de c\u00e1lculo de la lista de precios "
     },
     "ImportTable": {
       "label": "Crear columnas de la base de datos",
@@ -11882,23 +11882,23 @@
     },
     "Periodno": {
       "label": "Hasta el Periodo",
-      "description": "Número único para el periodo"
+      "description": "N\u00famero \u00fanico para el periodo"
     },
     "FIN_In_Clear_Acct": {
-      "label": "Cuenta de reconciliación",
-      "description": "Cuenta utilizada para cobros tras la reconciliación "
+      "label": "Cuenta de reconciliaci\u00f3n",
+      "description": "Cuenta utilizada para cobros tras la reconciliaci\u00f3n "
     },
     "Name1": {
       "label": "Nombre del Objeto",
       "description": ""
     },
     "StandardQty": {
-      "label": "Cantidad estándar",
-      "description": "Cant.estándar"
+      "label": "Cantidad est\u00e1ndar",
+      "description": "Cant.est\u00e1ndar"
     },
     "IsComplete": {
       "label": "Fase completa",
-      "description": "Está completo"
+      "description": "Est\u00e1 completo"
     },
     "Plannedpoprice": {
       "label": "Precio de compra previsto",
@@ -11906,10 +11906,10 @@
     },
     "PlannedPrice": {
       "label": "Precio previsto",
-      "description": "Precio previsto para esta línea del proyecto"
+      "description": "Precio previsto para esta l\u00ednea del proyecto"
     },
     "AD_Forced_Org_ID": {
-      "label": "Organización forzada",
+      "label": "Organizaci\u00f3n forzada",
       "description": ""
     },
     "Product_Value": {
@@ -11918,11 +11918,11 @@
     },
     "Product_Name": {
       "label": "Nombre del producto",
-      "description": "Identificador de un documento que puede utilizarse como herramienta de búsqueda."
+      "description": "Identificador de un documento que puede utilizarse como herramienta de b\u00fasqueda."
     },
     "Product_Description": {
-      "label": "Descripción del producto",
-      "description": "Espacio para escribir información adicional relacionada."
+      "label": "Descripci\u00f3n del producto",
+      "description": "Espacio para escribir informaci\u00f3n adicional relacionada."
     },
     "Explote": {
       "label": "Explotar Fases",
@@ -11934,15 +11934,15 @@
     },
     "Attribute": {
       "label": "Atributo",
-      "description": "Característica definida de un producto específico."
+      "description": "Caracter\u00edstica definida de un producto espec\u00edfico."
     },
     "FIN_Out_Intransit_Acct": {
-      "label": "Cuenta de pagos en tránsito",
-      "description": "Cuenta utilizada para el estado en tránsito de los pagos"
+      "label": "Cuenta de pagos en tr\u00e1nsito",
+      "description": "Cuenta utilizada para el estado en tr\u00e1nsito de los pagos"
     },
     "Updated": {
-      "label": "Último Ping",
-      "description": "<P>Indica la fecha en la que está petición fue actualizada por última vez.</P>"
+      "label": "\u00daltimo Ping",
+      "description": "<P>Indica la fecha en la que est\u00e1 petici\u00f3n fue actualizada por \u00faltima vez.</P>"
     },
     "CreateClosing": {
       "label": "Revertir Balance de Cuentas Permanentes",
@@ -11953,7 +11953,7 @@
       "description": ""
     },
     "RM_CreateInvoice": {
-      "label": "Crear crédito",
+      "label": "Crear cr\u00e9dito",
       "description": ""
     },
     "paymentAmount": {
@@ -11965,7 +11965,7 @@
       "description": ""
     },
     "Daysoutstanding": {
-      "label": "Días hasta Pago en Fecha",
+      "label": "D\u00edas hasta Pago en Fecha",
       "description": ""
     },
     "Percentageoverdue": {
@@ -11985,19 +11985,19 @@
       "description": "Texto a excluir al intentar hacer coincidir con el nombre del tercero."
     },
     "FIN_Out_Clear_Acct": {
-      "label": "Cuenta de reconciliación",
-      "description": "Cuenta utilizada tras la reconciliación de pagos"
+      "label": "Cuenta de reconciliaci\u00f3n",
+      "description": "Cuenta utilizada tras la reconciliaci\u00f3n de pagos"
     },
     "Testproxy": {
       "label": "Probar Heartbeat",
-      "description": "Probar la configuración de Heartbeat"
+      "description": "Probar la configuraci\u00f3n de Heartbeat"
     },
     "GenerateList": {
       "label": "Crear lista de conteo de inventario",
       "description": "Generar lista"
     },
     "EM_APRM_MatchTransactions": {
-      "label": "Conciliación",
+      "label": "Conciliaci\u00f3n",
       "description": ""
     },
     "Reschedule": {
@@ -12006,7 +12006,7 @@
     },
     "IsReady": {
       "label": "Validar",
-      "description": "Indica si la organización está lista para ser usada"
+      "description": "Indica si la organizaci\u00f3n est\u00e1 lista para ser usada"
     },
     "Unschedule": {
       "label": "Desprogramar Proceso",
@@ -12021,7 +12021,7 @@
       "description": "Adjudicar un proyecto"
     },
     "Launched": {
-      "label": "Ejecutar control periódico",
+      "label": "Ejecutar control peri\u00f3dico",
       "description": ""
     },
     "Copybudget": {
@@ -12037,24 +12037,24 @@
       "description": "Exporta los Datos de Referencia a un fichero XML"
     },
     "Change_Instance_Purpose": {
-      "label": "Configuración del Propósito de la Instancia",
+      "label": "Configuraci\u00f3n del Prop\u00f3sito de la Instancia",
       "description": ""
     },
     "Copyproduct": {
       "label": "Crear copia de producto",
-      "description": "Crea un nuevo producto copiado de P- e inserta una nueva línea en la secuencia de uso del nuevo producto creado"
+      "description": "Crea un nuevo producto copiado de P- e inserta una nueva l\u00ednea en la secuencia de uso del nuevo producto creado"
     },
     "Template": {
       "label": "Plantilla",
-      "description": "El código fuente de la plantilla"
+      "description": "El c\u00f3digo fuente de la plantilla"
     },
     "Obclker_Template_ID": {
       "label": "Plantilla",
-      "description": "La plantilla usada para generar la visualización del componente."
+      "description": "La plantilla usada para generar la visualizaci\u00f3n del componente."
     },
     "TemplateClasspathLocation": {
-      "label": "Localización de la plantilla",
-      "description": "Define la localización del fichero de la plantilla en el classpath"
+      "label": "Localizaci\u00f3n de la plantilla",
+      "description": "Define la localizaci\u00f3n del fichero de la plantilla en el classpath"
     },
     "Dependson_Template_ID": {
       "label": "Depende de la plantilla ",
@@ -12094,11 +12094,11 @@
     },
     "EM_APRM_Displayed_Acc_ID": {
       "label": "Cuenta Financiera",
-      "description": "Cuenta Financiera mostrada en la solapa Detalles de Cobro del Pedido de Venta. Para cobros de neteo su valor estará vacío."
+      "description": "Cuenta Financiera mostrada en la solapa Detalles de Cobro del Pedido de Venta. Para cobros de neteo su valor estar\u00e1 vac\u00edo."
     },
     "EM_APRM_PaymentMethod": {
-      "label": "Método de Pago",
-      "description": "Método de Pago en Factura de Venta"
+      "label": "M\u00e9todo de Pago",
+      "description": "M\u00e9todo de Pago en Factura de Venta"
     },
     "paid_out": {
       "label": "Pagado",
@@ -12113,7 +12113,7 @@
       "description": "El algoritmo trata de hacer coincidir la referencia"
     },
     "paymentMethodName": {
-      "label": "Método de pago",
+      "label": "M\u00e9todo de pago",
       "description": "Es la forma en la que se espera hacer o recibir el efecto."
     },
     "Payment": {
@@ -12121,7 +12121,7 @@
       "description": ""
     },
     "Invoice_Documentno": {
-      "label": "Nº documento",
+      "label": "N\u00ba documento",
       "description": ""
     },
     "Difference": {
@@ -12137,11 +12137,11 @@
       "description": "Transferencia de Fondos entre Cuentas Financieras"
     },
     "Order_Documentno": {
-      "label": "Nº documento",
+      "label": "N\u00ba documento",
       "description": ""
     },
     "transactionGLItemName": {
-      "label": "Transacción Concepto Contable",
+      "label": "Transacci\u00f3n Concepto Contable",
       "description": ""
     },
     "EM_APRM_Process_Proposal": {
@@ -12149,20 +12149,20 @@
       "description": ""
     },
     "EM_Aprm_Processed": {
-      "label": "Proceso de Transacción",
-      "description": "Botón Proceso"
+      "label": "Proceso de Transacci\u00f3n",
+      "description": "Bot\u00f3n Proceso"
     },
     "EM_APRM_Addpayment": {
-      "label": "Añadir Cobro",
-      "description": "Botón para añadir un cobro."
+      "label": "A\u00f1adir Cobro",
+      "description": "Bot\u00f3n para a\u00f1adir un cobro."
     },
     "EM_APRM_AddPayment": {
-      "label": "Añadir Cobro",
-      "description": "Botón para añadir un cobro."
+      "label": "A\u00f1adir Cobro",
+      "description": "Bot\u00f3n para a\u00f1adir un cobro."
     },
     "invoicedAmount": {
       "label": "Importe factura",
-      "description": "Suma que se factura por un ítem o servicio específico."
+      "description": "Suma que se factura por un \u00edtem o servicio espec\u00edfico."
     },
     "received_in": {
       "label": "Recibido",
@@ -12173,7 +12173,7 @@
       "description": ""
     },
     "EM_Aprm_Add_Scheduledpayments": {
-      "label": "Añadir Detalles de Pago",
+      "label": "A\u00f1adir Detalles de Pago",
       "description": ""
     },
     "EM_APRM_ReconciledItemAmount": {
@@ -12189,15 +12189,15 @@
       "description": ""
     },
     "Unrec_No": {
-      "label": "Nº partidas no reconciliadas",
+      "label": "N\u00ba partidas no reconciliadas",
       "description": ""
     },
     "Deposit_No": {
-      "label": "Depósitos Pendientes",
+      "label": "Dep\u00f3sitos Pendientes",
       "description": ""
     },
     "Item_No": {
-      "label": "Nº partidas reconciliadas",
+      "label": "N\u00ba partidas reconciliadas",
       "description": ""
     },
     "Item_Amt": {
@@ -12209,7 +12209,7 @@
       "description": ""
     },
     "Deposit_Amt": {
-      "label": "Importe de Depósitos Pendientes",
+      "label": "Importe de Dep\u00f3sitos Pendientes",
       "description": ""
     },
     "Payment_No": {
@@ -12233,11 +12233,11 @@
       "description": "Diferencia de Concepto Contable"
     },
     "EM_APRM_OutstandingPaymentsItemNo": {
-      "label": "Reintegro Pendiente nº",
+      "label": "Reintegro Pendiente n\u00ba",
       "description": ""
     },
     "EM_APRM_UnReconciledItemNo": {
-      "label": "Elemento sin reconciliar nº",
+      "label": "Elemento sin reconciliar n\u00ba",
       "description": ""
     },
     "expectedAmount": {
@@ -12245,8 +12245,8 @@
       "description": "A liquidar"
     },
     "type": {
-      "label": "Tipo de Línea de extracto bancario",
-      "description": "Tipo de Línea de extracto bancario"
+      "label": "Tipo de L\u00ednea de extracto bancario",
+      "description": "Tipo de L\u00ednea de extracto bancario"
     },
     "EM_Aprm_Executepayment": {
       "label": "Ejecutar Pago",
@@ -12257,11 +12257,11 @@
       "description": "El algoritmo trata de hacer coincidir el nombre del tercero"
     },
     "aprm_finacc_transaction_v_id": {
-      "label": "Transacción Cuenta Financiera",
+      "label": "Transacci\u00f3n Cuenta Financiera",
       "description": ""
     },
     "Aprm_Finacc_Transaction_V_ID": {
-      "label": "Transacción Cuenta Financiera",
+      "label": "Transacci\u00f3n Cuenta Financiera",
       "description": ""
     },
     "EM_APRM_Glitem_ID": {
@@ -12273,11 +12273,11 @@
       "description": ""
     },
     "EM_Aprm_Addtransactionpd": {
-      "label": "Definición del Proceso Añadir Transacción",
-      "description": "Definición del Proceso Añadir Transacción"
+      "label": "Definici\u00f3n del Proceso A\u00f1adir Transacci\u00f3n",
+      "description": "Definici\u00f3n del Proceso A\u00f1adir Transacci\u00f3n"
     },
     "EM_APRM_OutstandingDepositsItemNo": {
-      "label": "Depositos Pendientes nº",
+      "label": "Depositos Pendientes n\u00ba",
       "description": ""
     },
     "matchedDocument": {
@@ -12285,12 +12285,12 @@
       "description": ""
     },
     "EM_APRM_Displayed_Paymmeth_ID": {
-      "label": "Método de Pago",
-      "description": "Método de pago mostrado en la solapa Detalles de Cobro del Pedido de Venta. Para cobros de neteo su valor estará vacío."
+      "label": "M\u00e9todo de Pago",
+      "description": "M\u00e9todo de pago mostrado en la solapa Detalles de Cobro del Pedido de Venta. Para cobros de neteo su valor estar\u00e1 vac\u00edo."
     },
     "EM_Aprm_Payment_Desc": {
-      "label": "Referencia de la factura para la descripción del pago",
-      "description": "Referencia a la factura que se incluirá automáticamente en la Descripción del Pago"
+      "label": "Referencia de la factura para la descripci\u00f3n del pago",
+      "description": "Referencia a la factura que se incluir\u00e1 autom\u00e1ticamente en la Descripci\u00f3n del Pago"
     },
     "EM_APRM_OutstandingPaymentsItemsAmount": {
       "label": "Importe de Reintegros Pendientes",
@@ -12306,15 +12306,15 @@
     },
     "gLItem": {
       "label": "Concepto contable",
-      "description": "Conceptos contables añadidos como parte de un pago dado"
+      "description": "Conceptos contables a\u00f1adidos como parte de un pago dado"
     },
     "businessPartnerName": {
       "label": "Tercero",
       "description": "Nombre del Tercero"
     },
     "Matchtransactiondate": {
-      "label": "Asociar fecha de transacción",
-      "description": "El algoritmo trata de hacer coincidir la fecha de transacción"
+      "label": "Asociar fecha de transacci\u00f3n",
+      "description": "El algoritmo trata de hacer coincidir la fecha de transacci\u00f3n"
     },
     "EM_APRM_ReversePayment": {
       "label": "Revertir pago",
@@ -12325,8 +12325,8 @@
       "description": ""
     },
     "EM_APRM_PrintDetailed": {
-      "label": "Imprimir informe de reconciliación detallado",
-      "description": "Imprimir informe de reconciliación detallado"
+      "label": "Imprimir informe de reconciliaci\u00f3n detallado",
+      "description": "Imprimir informe de reconciliaci\u00f3n detallado"
     },
     "EM_APRM_Process_BS": {
       "label": "Proceso de Extracto Bancario",
@@ -12337,40 +12337,40 @@
       "description": ""
     },
     "EM_APRM_ReconciledItemNo": {
-      "label": "Registro Reconciliado nº",
+      "label": "Registro Reconciliado n\u00ba",
       "description": ""
     },
     "salesOrderNo": {
-      "label": "Nº Pedido",
-      "description": "Número de pedido"
+      "label": "N\u00ba Pedido",
+      "description": "N\u00famero de pedido"
     },
     "EM_APRM_MatchTrans_Force": {
-      "label": "Forzar Conciliación",
+      "label": "Forzar Conciliaci\u00f3n",
       "description": ""
     },
     "EM_Aprm_AddMultiplePayments": {
-      "label": "Añadir Múltiples Pagos",
-      "description": "El Usuario puede seleccionar varios pagos al mismo tiempo. El sistema creará un transacción individual asociada a cada pago seleccionado"
+      "label": "A\u00f1adir M\u00faltiples Pagos",
+      "description": "El Usuario puede seleccionar varios pagos al mismo tiempo. El sistema crear\u00e1 un transacci\u00f3n individual asociada a cada pago seleccionado"
     },
     "EM_APRM_ImportBankFile": {
       "label": "Importar extracto bancario",
       "description": "Importar Extracto Bancario"
     },
     "EM_APRM_PrintSummary": {
-      "label": "Imprimir informe de reconciliación resumido",
-      "description": "Imprimir informe de reconciliación resumido"
+      "label": "Imprimir informe de reconciliaci\u00f3n resumido",
+      "description": "Imprimir informe de reconciliaci\u00f3n resumido"
     },
     "EM_APRM_Process_Reconciliation": {
-      "label": "Proceso de Reconciliación",
-      "description": "Procesar Documento de Reconciliación"
+      "label": "Proceso de Reconciliaci\u00f3n",
+      "description": "Procesar Documento de Reconciliaci\u00f3n"
     },
     "Process_Reconciliation": {
-      "label": "Proceso de Reconciliación",
-      "description": "Procesar Documento de Reconciliación"
+      "label": "Proceso de Reconciliaci\u00f3n",
+      "description": "Procesar Documento de Reconciliaci\u00f3n"
     },
     "EM_Aprm_Process_Rec": {
-      "label": "Proceso de Reconciliación",
-      "description": "Procesar Documento de Reconciliación"
+      "label": "Proceso de Reconciliaci\u00f3n",
+      "description": "Procesar Documento de Reconciliaci\u00f3n"
     },
     "Width": {
       "label": "Anchura",
@@ -12381,7 +12381,7 @@
       "description": ""
     },
     "Summarize_Type": {
-      "label": "Tipo de Sumarización",
+      "label": "Tipo de Sumarizaci\u00f3n",
       "description": ""
     },
     "Link_Expression": {
@@ -12390,18 +12390,18 @@
     },
     "Display_Expression": {
       "label": "Alias Mostrado de la Columna",
-      "description": "Alias de la Columna que será mostrado"
+      "description": "Alias de la Columna que ser\u00e1 mostrado"
     },
     "OBCQL_Widget_Query_ID": {
       "label": "Consulta del Widget",
-      "description": "Identificador de una definición de consulta HQL de una clase de widget que implementa la superclase Query/List"
+      "description": "Identificador de una definici\u00f3n de consulta HQL de una clase de widget que implementa la superclase Query/List"
     },
     "Include_In": {
-      "label": "Incluír en",
+      "label": "Inclu\u00edr en",
       "description": ""
     },
     "OBCQL_Query_Column_Trl_ID": {
-      "label": "Traducción de Columna de Consulta",
+      "label": "Traducci\u00f3n de Columna de Consulta",
       "description": ""
     },
     "Has_Link": {
@@ -12413,7 +12413,7 @@
       "description": ""
     },
     "Whereclause_Left_Part": {
-      "label": "Parte Izquierda de la Cláusula Where",
+      "label": "Parte Izquierda de la Cl\u00e1usula Where",
       "description": ""
     },
     "USE_Pdf_As_Xls_Template": {
@@ -12421,76 +12421,76 @@
       "description": ""
     },
     "Obuiapp_Navbar_Role_Access_ID": {
-      "label": "Permisos de Roles para Componentes de la Barra de Navegación",
-      "description": "Define qué roles tienen acceso a qué componentes de la barra de navegación."
+      "label": "Permisos de Roles para Componentes de la Barra de Navegaci\u00f3n",
+      "description": "Define qu\u00e9 roles tienen acceso a qu\u00e9 componentes de la barra de navegaci\u00f3n."
     },
     "USE_Pdf_As_Html_Template": {
       "label": "Usar PDF como plantilla HTML",
-      "description": "Determina si se debe utilizar la plantilla PDF para generar el informe en formato HTML en lugar de definir una plantilla específica para dicho formato."
+      "description": "Determina si se debe utilizar la plantilla PDF para generar el informe en formato HTML en lugar de definir una plantilla espec\u00edfica para dicho formato."
     },
     "IsLazyFiltering": {
       "label": "Filtrado bajo demanda en el grid",
-      "description": "Si se establece, el grid no realizará la acción de filtrado o/y ordenado hasta que se presione el botón de 'Aplicar Filtros'. Del mismo modo, las funciones de resumen presentes en el grid no se recalcularán hasta que se presione este botón."
+      "description": "Si se establece, el grid no realizar\u00e1 la acci\u00f3n de filtrado o/y ordenado hasta que se presione el bot\u00f3n de 'Aplicar Filtros'. Del mismo modo, las funciones de resumen presentes en el grid no se recalcular\u00e1n hasta que se presione este bot\u00f3n."
     },
     "Disablefkcombo": {
-      "label": "Deshabilitar el Combo de Filtro por Clave Foránea",
-      "description": "Si la casilla está marcada, el combo de clave foránea se deshabilitará y se filtrará la columna como si fuese un columna estándar de texto"
+      "label": "Deshabilitar el Combo de Filtro por Clave For\u00e1nea",
+      "description": "Si la casilla est\u00e1 marcada, el combo de clave for\u00e1nea se deshabilitar\u00e1 y se filtrar\u00e1 la columna como si fuese un columna est\u00e1ndar de texto"
     },
     "Isgridlegacy": {
-      "label": "Compatibilidad con parámetros de grid antiguos",
-      "description": "Se utiliza para especificar si este proceso debe ser compatible con las ventanas de parámetros antiguas."
+      "label": "Compatibilidad con par\u00e1metros de grid antiguos",
+      "description": "Se utiliza para especificar si este proceso debe ser compatible con las ventanas de par\u00e1metros antiguas."
     },
     "Isfkdropdownunfiltered": {
-      "label": "Combo de Clave Foránea sin filtrar",
+      "label": "Combo de Clave For\u00e1nea sin filtrar",
       "description": "If this flag if checked, the filter drop down will show the rows from the referenced table unfiltered by specific rows being referenced in the referencing table."
     },
     "Startinnewline": {
-      "label": "Empezar en nueva línea",
+      "label": "Empezar en nueva l\u00ednea",
       "description": ""
     },
     "Ongridloadfunction": {
-      "label": "Función 'On Grid Load'",
-      "description": "Esta función se invoca cuando el parámetro de tipo grid se carga la primera vez."
+      "label": "Funci\u00f3n 'On Grid Load'",
+      "description": "Esta funci\u00f3n se invoca cuando el par\u00e1metro de tipo grid se carga la primera vez."
     },
     "Obuiapp_Data_Pool_Sel_ID": {
       "label": "Obuiapp_Data_Pool_Sel_ID",
-      "description": "Selección de pool de datos para informes"
+      "description": "Selecci\u00f3n de pool de datos para informes"
     },
     "EM_Obuiapp_Summaryfn": {
-      "label": "Función de Resumen",
+      "label": "Funci\u00f3n de Resumen",
       "description": ""
     },
     "EM_Obuiapp_Newfn": {
-      "label": "Nueva Función",
+      "label": "Nueva Funci\u00f3n",
       "description": ""
     },
     "displayedRows": {
-      "label": "Número de filas mostradas",
-      "description": "La altura del grid se ajustará para mostrar el número de filas especificadas en este campo."
+      "label": "N\u00famero de filas mostradas",
+      "description": "La altura del grid se ajustar\u00e1 para mostrar el n\u00famero de filas especificadas en este campo."
     },
     "EM_Obuiapp_Validator": {
-      "label": "Función de Validación",
-      "description": "Define la función a usar como parte de los validadores de campos"
+      "label": "Funci\u00f3n de Validaci\u00f3n",
+      "description": "Define la funci\u00f3n a usar como parte de los validadores de campos"
     },
     "Sortable": {
-      "label": "Permitir ordenación",
+      "label": "Permitir ordenaci\u00f3n",
       "description": "Define si se permite ordenar"
     },
     "IsMultiRecord": {
-      "label": "Registros múltiples",
-      "description": "Permite ejecutar múltiples registros al mismo tiempo"
+      "label": "Registros m\u00faltiples",
+      "description": "Permite ejecutar m\u00faltiples registros al mismo tiempo"
     },
     "Allroles": {
       "label": "Disponible para todos los roles",
-      "description": "Define que este componente de barra de navegación está disponible para todos los roles."
+      "description": "Define que este componente de barra de navegaci\u00f3n est\u00e1 disponible para todos los roles."
     },
     "NumColumn": {
-      "label": "Número de columna",
-      "description": "Número de columna en el cual se establece el campo actual (valores permitidos entre 1 y 4)"
+      "label": "N\u00famero de columna",
+      "description": "N\u00famero de columna en el cual se establece el campo actual (valores permitidos entre 1 y 4)"
     },
     "EM_Obuiapp_Removefn": {
-      "label": "Eliminar Función",
-      "description": "Función que se ejecuta al eliminar una fila del grid"
+      "label": "Eliminar Funci\u00f3n",
+      "description": "Funci\u00f3n que se ejecuta al eliminar una fila del grid"
     },
     "logger": {
       "label": "Logger",
@@ -12498,15 +12498,15 @@
     },
     "ATT_Propertypath": {
       "label": "Ruta de Propiedad",
-      "description": "Define la ruta de la propiedad tomada para este parámetro."
+      "description": "Define la ruta de la propiedad tomada para este par\u00e1metro."
     },
     "Obuiapp_Process_ID": {
       "label": "Obuiapp_Process_ID",
-      "description": "Definición de proceso"
+      "description": "Definici\u00f3n de proceso"
     },
     "EM_Obuiapp_Can_Delete": {
       "label": "Puede eliminar",
-      "description": "Define si el usuario puede borrar líneas"
+      "description": "Define si el usuario puede borrar l\u00edneas"
     },
     "EvaluateFixedValue": {
       "label": "Evaluar Valor Fijo",
@@ -12514,42 +12514,42 @@
     },
     "AllowSummaryFunctions": {
       "label": "Permitir Funciones de Resumen",
-      "description": "Si se habilita el usuario puede añadir funciones de resumen al grid mediante el menú contextual a nivel de cabecera de columna. Cuando se deshabilita, el menú de funciones resumen no estará disponible."
+      "description": "Si se habilita el usuario puede a\u00f1adir funciones de resumen al grid mediante el men\u00fa contextual a nivel de cabecera de columna. Cuando se deshabilita, el men\u00fa de funciones resumen no estar\u00e1 disponible."
     },
     "HTML_Template": {
       "label": "Plantilla HTML",
-      "description": "Plantilla JRXML que se usará para exportar el informe en formato HTML"
+      "description": "Plantilla JRXML que se usar\u00e1 para exportar el informe en formato HTML"
     },
     "EM_Obuiapp_Clone_Children": {
       "label": "Solicitar clonar hijos",
       "description": ""
     },
     "Obuiapp_Navbar_Component_ID": {
-      "label": "Componente de Barra de Navegación",
-      "description": "Un componente mostrado en al barra de navegación, en la parte superior del interfaz de usuario"
+      "label": "Componente de Barra de Navegaci\u00f3n",
+      "description": "Un componente mostrado en al barra de navegaci\u00f3n, en la parte superior del interfaz de usuario"
     },
     "ATT_Showindescription": {
-      "label": "Mostrar en Descripción",
-      "description": "Define si este parámetro es relevante en la columna Text de la tabla C_File."
+      "label": "Mostrar en Descripci\u00f3n",
+      "description": "Define si este par\u00e1metro es relevante en la columna Text de la tabla C_File."
     },
     "Obuiapp_Process_Trl_ID": {
-      "label": "Proceso Traducción",
+      "label": "Proceso Traducci\u00f3n",
       "description": ""
     },
     "AllowTransactionalFilters": {
       "label": "Permitir Filtros Transaccionales",
-      "description": "Al marcar la casilla se activan los filtros transaccionales. Si no está marcada, los filtros transaccionales estarán deshabilitados."
+      "description": "Al marcar la casilla se activan los filtros transaccionales. Si no est\u00e1 marcada, los filtros transaccionales estar\u00e1n deshabilitados."
     },
     "Fixedvalue": {
       "label": "Valor fijo",
       "description": ""
     },
     "Obuiapp_Parameter_ID": {
-      "label": "Parámetro",
+      "label": "Par\u00e1metro",
       "description": ""
     },
     "Value_Number": {
-      "label": "Valor tipo número",
+      "label": "Valor tipo n\u00famero",
       "description": ""
     },
     "Value_Date": {
@@ -12561,12 +12561,12 @@
       "description": ""
     },
     "EM_OBUIAPP_VIEW_IMPL_ID": {
-      "label": "Implementación de la Vista",
-      "description": "La implementación de la vista que se muestra en la solapa de una interfaz multi-documento"
+      "label": "Implementaci\u00f3n de la Vista",
+      "description": "La implementaci\u00f3n de la vista que se muestra en la solapa de una interfaz multi-documento"
     },
     "EM_Obuiapp_Can_Add": {
-      "label": "Puede Añadir",
-      "description": "Define si el usuario puede añadir nuevas líneas"
+      "label": "Puede A\u00f1adir",
+      "description": "Define si el usuario puede a\u00f1adir nuevas l\u00edneas"
     },
     "Total_Amt": {
       "label": "Importe Total",
@@ -12581,103 +12581,103 @@
       "description": ""
     },
     "EM_OBUIAPP_Selection": {
-      "label": "Función de Selección",
-      "description": "Función de Javascript personalizada que se ejecutará cuando la selección en el grid cambia"
+      "label": "Funci\u00f3n de Selecci\u00f3n",
+      "description": "Funci\u00f3n de Javascript personalizada que se ejecutar\u00e1 cuando la selecci\u00f3n en el grid cambia"
     },
     "Obuiapp_Pool_Report_V_ID": {
       "label": "Informe",
-      "description": "Hace referencia a un informe independientemente del lugar en el que está definido"
+      "description": "Hace referencia a un informe independientemente del lugar en el que est\u00e1 definido"
     },
     "ON_Refresh_Function": {
-      "label": "Función On Refresh",
-      "description": "En este campo se puede definir una función javascript. Esta función se ejecutará cuando se refresque la ventana de parámetros."
+      "label": "Funci\u00f3n On Refresh",
+      "description": "En este campo se puede definir una funci\u00f3n javascript. Esta funci\u00f3n se ejecutar\u00e1 cuando se refresque la ventana de par\u00e1metros."
     },
     "EM_Obuiapp_Process_ID": {
-      "label": "Definición de proceso",
-      "description": "Proceso para ser ejecutado por el botón"
+      "label": "Definici\u00f3n de proceso",
+      "description": "Proceso para ser ejecutado por el bot\u00f3n"
     },
     "EM_OBUIAPP_Process_ID": {
-      "label": "Definición de proceso",
-      "description": "Proceso para ser ejecutado por el botón"
+      "label": "Definici\u00f3n de proceso",
+      "description": "Proceso para ser ejecutado por el bot\u00f3n"
     },
     "Filterable": {
       "label": "Permitir filtrado",
       "description": "Define si se permite el filtro"
     },
     "EM_Obuiapp_Show_Clone_Button": {
-      "label": "Mostrar botón Clonar",
+      "label": "Mostrar bot\u00f3n Clonar",
       "description": ""
     },
     "EM_Obuiapp_Selection_Type": {
-      "label": "Tipo de Selección",
-      "description": "Especifica el tipo de selección disponible en un grid"
+      "label": "Tipo de Selecci\u00f3n",
+      "description": "Especifica el tipo de selecci\u00f3n disponible en un grid"
     },
     "Threshold_To_Filter": {
       "label": "Umbral para lanzar el filtrado en un campo de texto (en ms)",
       "description": "Umbral en ms para lanzar el filtrado en los campos de texto"
     },
     "EM_Obuiapp_Colspan": {
-      "label": "Número de columnas ocupadas",
-      "description": "Número de columnas que ocupa este campo en el formulario"
+      "label": "N\u00famero de columnas ocupadas",
+      "description": "N\u00famero de columnas que ocupa este campo en el formulario"
     },
     "Data_Pool": {
       "label": "Pool de Datos",
       "description": "Enumera todos los posibles pools de base de datos que OBDal puede usar para recuperar datos."
     },
     "IsSortable": {
-      "label": "Por defecto permitir ordenación",
+      "label": "Por defecto permitir ordenaci\u00f3n",
       "description": "Define si se permite ordenar"
     },
     "Isstaticcomponent": {
-      "label": "Componente Estático",
-      "description": "Define si un componente de la barra de navegación es estático o no."
+      "label": "Componente Est\u00e1tico",
+      "description": "Define si un componente de la barra de navegaci\u00f3n es est\u00e1tico o no."
     },
     "EM_Obuiapp_Show_Select": {
-      "label": "Mostrar Columna de Selección",
-      "description": "Define si la columna de selección se debe mostrar"
+      "label": "Mostrar Columna de Selecci\u00f3n",
+      "description": "Define si la columna de selecci\u00f3n se debe mostrar"
     },
     "level": {
       "label": "Nivel de Log",
       "description": "Nivel de log del Logger"
     },
     "ON_Load_Function": {
-      "label": "Función 'On Load'",
-      "description": "En este campo se puede definir una función javascript. Este función se ejecutará cuando la venta de parámetros se cargue, justo después de que se establezcan los valores por defecto."
+      "label": "Funci\u00f3n 'On Load'",
+      "description": "En este campo se puede definir una funci\u00f3n javascript. Este funci\u00f3n se ejecutar\u00e1 cuando la venta de par\u00e1metros se cargue, justo despu\u00e9s de que se establezcan los valores por defecto."
     },
     "displayTitle": {
-      "label": "Mostrar título",
-      "description": "Este campo se utiliza para especificar si debe mostrarse el título de un parámetro de tipo grid"
+      "label": "Mostrar t\u00edtulo",
+      "description": "Este campo se utiliza para especificar si debe mostrarse el t\u00edtulo de un par\u00e1metro de tipo grid"
     },
     "Clientsidevalidation": {
-      "label": "Validación de lado del cliente",
-      "description": "Función javascript a ejecutar antes de invocar el Handler del servidor."
+      "label": "Validaci\u00f3n de lado del cliente",
+      "description": "Funci\u00f3n javascript a ejecutar antes de invocar el Handler del servidor."
     },
     "Text_Filter_Behavior": {
       "label": "Comportamiento filtro de campo de texto",
-      "description": "Define el tipo de filtro que se aplicará a este elemento. Solo funciona para los campos de texto."
+      "description": "Define el tipo de filtro que se aplicar\u00e1 a este elemento. Solo funciona para los campos de texto."
     },
     "Filteronchange": {
       "label": "Filtrar al modificar el texto",
-      "description": "Si está seleccionado, las columnas de texto lanzarán el filtrado al cambiar su contenido"
+      "description": "Si est\u00e1 seleccionado, las columnas de texto lanzar\u00e1n el filtrado al cambiar su contenido"
     },
     "EM_Obuiapp_Rowspan": {
-      "label": "Número de Filas Ocupadas",
-      "description": "Número de filas que debería ocupar este campo en el formulario"
+      "label": "N\u00famero de Filas Ocupadas",
+      "description": "N\u00famero de filas que deber\u00eda ocupar este campo en el formulario"
     },
     "IsCanAddRecordsToSelector": {
-      "label": "Puede añadir registros al Selector",
-      "description": "Al seleccionar esta casilla, el proceso estará disponible en la ventana de 'Selector Definido'"
+      "label": "Puede a\u00f1adir registros al Selector",
+      "description": "Al seleccionar esta casilla, el proceso estar\u00e1 disponible en la ventana de 'Selector Definido'"
     },
     "EM_Obuiapp_Default_Expression": {
-      "label": "Expresión de filtrado por defecto",
-      "description": "Define una expresión utilizada para filtrar la propiedad"
+      "label": "Expresi\u00f3n de filtrado por defecto",
+      "description": "Define una expresi\u00f3n utilizada para filtrar la propiedad"
     },
     "Port": {
       "label": "Puerto/Aeropuerto",
       "description": ""
     },
     "Limitamt": {
-      "label": "Importe Límite",
+      "label": "Importe L\u00edmite",
       "description": ""
     },
     "Intr_Header_ID": {
@@ -12693,7 +12693,7 @@
       "description": ""
     },
     "Ytdreported_Amt": {
-      "label": "Importe Acumulado del año",
+      "label": "Importe Acumulado del a\u00f1o",
       "description": ""
     },
     "Intr_C_Orderline_ID": {
@@ -12709,7 +12709,7 @@
       "description": ""
     },
     "Invoice_Date": {
-      "label": "Día de Factura",
+      "label": "D\u00eda de Factura",
       "description": ""
     },
     "Intr_C_Uom_ID": {
@@ -12717,23 +12717,23 @@
       "description": "Unidad de medida suplementaria"
     },
     "Declaration_Type": {
-      "label": "Declaración de Intrastat",
+      "label": "Declaraci\u00f3n de Intrastat",
       "description": ""
     },
     "Statistical_Amt_Percent_Po": {
-      "label": "Valor Estadístico %",
-      "description": "Porcentaje valor estadístico"
+      "label": "Valor Estad\u00edstico %",
+      "description": "Porcentaje valor estad\u00edstico"
     },
     "Statistical_Amt_Percent": {
-      "label": "Valor Estadístico %",
-      "description": "Porcentaje valor estadístico"
+      "label": "Valor Estad\u00edstico %",
+      "description": "Porcentaje valor estad\u00edstico"
     },
     "Statistical_Amt_Percent_So": {
-      "label": "Valor Estadístico %",
-      "description": "Porcentaje valor estadístico"
+      "label": "Valor Estad\u00edstico %",
+      "description": "Porcentaje valor estad\u00edstico"
     },
     "NC8_Code": {
-      "label": "Código de Mercancía",
+      "label": "C\u00f3digo de Mercanc\u00eda",
       "description": ""
     },
     "Intr_C_Bpartner_ID": {
@@ -12741,7 +12741,7 @@
       "description": ""
     },
     "EM_Intr_Transaction_Type": {
-      "label": "Tipo de Transacción",
+      "label": "Tipo de Transacci\u00f3n",
       "description": ""
     },
     "SO_Port": {
@@ -12753,7 +12753,7 @@
       "description": "Calendario usado para las declaraciones de Intrastat"
     },
     "Invoiceline_Amt": {
-      "label": "Importe Línea de Factura",
+      "label": "Importe L\u00ednea de Factura",
       "description": ""
     },
     "Transportation_Type": {
@@ -12769,11 +12769,11 @@
       "description": ""
     },
     "Statical_Amt": {
-      "label": "Valor estadístico",
+      "label": "Valor estad\u00edstico",
       "description": ""
     },
     "Statistical_Regime": {
-      "label": "Régimen estadístico",
+      "label": "R\u00e9gimen estad\u00edstico",
       "description": ""
     },
     "Intr_C_Invoiceline_ID": {
@@ -12782,11 +12782,11 @@
     },
     "EM_OBSPTI_Declaration": {
       "label": "Tipo de Libro",
-      "description": "Define en qué tipo de Libro de Facturas se declarará el impuesto "
+      "description": "Define en qu\u00e9 tipo de Libro de Facturas se declarar\u00e1 el impuesto "
     },
     "EM_Obspti_Isimplicitcharge": {
-      "label": "Carga Implícita",
-      "description": "Define el impuesto hijo que será incorporado a SII-IGIC cuando la factura pertenece a RECM."
+      "label": "Carga Impl\u00edcita",
+      "description": "Define el impuesto hijo que ser\u00e1 incorporado a SII-IGIC cuando la factura pertenece a RECM."
     },
     "EM_Aeat347_County": {
       "label": "Municipio",
@@ -12813,8 +12813,8 @@
       "description": "Planta"
     },
     "EM_Aeat347_Situation": {
-      "label": "Situación",
-      "description": "Situación"
+      "label": "Situaci\u00f3n",
+      "description": "Situaci\u00f3n"
     },
     "EM_Aeat347_Referenceid": {
       "label": "Referencia catastral",
@@ -12822,15 +12822,15 @@
     },
     "EM_Aeat347_Complement": {
       "label": "Complemento",
-      "description": "Complemento de la dirección"
+      "description": "Complemento de la direcci\u00f3n"
     },
     "EM_Aeat347_Countycode": {
-      "label": "Código de municipio",
-      "description": "Código de municipio"
+      "label": "C\u00f3digo de municipio",
+      "description": "C\u00f3digo de municipio"
     },
     "POS_Sequence": {
       "label": "Secuencia en la columna",
-      "description": "Posición dentro de la columna en la que se muestra el widget"
+      "description": "Posici\u00f3n dentro de la columna en la que se muestra el widget"
     },
     "Copied_From": {
       "label": "Copiado de",
@@ -12882,59 +12882,59 @@
     },
     "Sequence": {
       "label": "Secuencia",
-      "description": "Define el orden en el que se mostrarán las opciones de menú"
+      "description": "Define el orden en el que se mostrar\u00e1n las opciones de men\u00fa"
     },
     "Idfkfiltering": {
-      "label": "Soporte para filtrado de columnas de Clave Foránea por su ID",
-      "description": "Si esta casilla está marcada, cuando una clave foránea se filtra seleccionando un valor desde el desplegable, la clave foránea se filtrará usando su id."
+      "label": "Soporte para filtrado de columnas de Clave For\u00e1nea por su ID",
+      "description": "Si esta casilla est\u00e1 marcada, cuando una clave for\u00e1nea se filtra seleccionando un valor desde el desplegable, la clave for\u00e1nea se filtrar\u00e1 usando su id."
     },
     "Useastabledataorigin": {
       "label": "Utilizar como origen de datos de tabla",
       "description": "Indica si esta fuente de datos se utiliza como un origen de datos en la ventana Tabla"
     },
     "OBTL_Withholding_Parameter_ID": {
-      "label": "Parámetro de declaración",
-      "description": "Relación entre un tipo de retención y el paramétro de Declaración de Impuestos asociado."
+      "label": "Par\u00e1metro de declaraci\u00f3n",
+      "description": "Relaci\u00f3n entre un tipo de retenci\u00f3n y el param\u00e9tro de Declaraci\u00f3n de Impuestos asociado."
     },
     "From_C_Period_ID": {
       "label": "Desde Periodo",
       "description": "Periodo inicial del Libro de Facturas"
     },
     "TAX_Id_Key": {
-      "label": "Clave NIF País Residencia",
-      "description": "Clave NIF País Residencia"
+      "label": "Clave NIF Pa\u00eds Residencia",
+      "description": "Clave NIF Pa\u00eds Residencia"
     },
     "Filter_Expression": {
-      "label": "Expresión de Filtro",
-      "description": "Define una expresion Javascript que devuelve una cláusula HQL 'where'"
+      "label": "Expresi\u00f3n de Filtro",
+      "description": "Define una expresion Javascript que devuelve una cl\u00e1usula HQL 'where'"
     },
     "Custom_Query": {
       "label": "Consulta Customizada",
       "description": ""
     },
     "Clause_Left_Part": {
-      "label": "Parte Izquierda de la Cláusula",
+      "label": "Parte Izquierda de la Cl\u00e1usula",
       "description": ""
     },
     "Popuptextmatchstyle": {
       "label": "Estilo de Emparejamiento de Texto en Popup",
-      "description": "Define la lógica de emparejamiento de texto usada en los filtros del grid del popup"
+      "description": "Define la l\u00f3gica de emparejamiento de texto usada en los filtros del grid del popup"
     },
     "Obuisel_Selector_Field_ID": {
       "label": "Campo de Selector",
-      "description": "Clave de identificación del selector."
+      "description": "Clave de identificaci\u00f3n del selector."
     },
     "Isoutfield": {
       "label": "Campo de salida",
-      "description": "El valor de este campo será enviado a la ventana que ha abierto el selector"
+      "description": "El valor de este campo ser\u00e1 enviado a la ventana que ha abierto el selector"
     },
     "Obuisel_Selector_ID": {
       "label": "Selector",
-      "description": "Clave de identificación del selector."
+      "description": "Clave de identificaci\u00f3n del selector."
     },
     "Suggestiontextmatchstyle": {
       "label": "Estilo de Emparejamiento en Sugerencia",
-      "description": "Define la lógica de emparejamiento de texto usada en el cuadro de sugerencia."
+      "description": "Define la l\u00f3gica de emparejamiento de texto usada en el cuadro de sugerencia."
     },
     "EM_Etvfac_Nif": {
       "label": "NIF Entidad Productora",
@@ -12945,12 +12945,12 @@
       "description": "Nombre y Apellido del Emisor de Certificado"
     },
     "EM_Etvfac_Invoice_Status": {
-      "label": "Estado de Envío a Verifactu",
-      "description": "Muestra el estado de envío a Verifactu de la factura."
+      "label": "Estado de Env\u00edo a Verifactu",
+      "description": "Muestra el estado de env\u00edo a Verifactu de la factura."
     },
     "Descripcion": {
-      "label": "Descripción",
-      "description": "Breve descripción o detalles adicionales sobre la factura."
+      "label": "Descripci\u00f3n",
+      "description": "Breve descripci\u00f3n o detalles adicionales sobre la factura."
     },
     "EM_AEAT349_Period": {
       "label": "Periodo",
@@ -12958,11 +12958,11 @@
     },
     "Tbai_Destiny_Config_ID": {
       "label": "Destino",
-      "description": "Destino de la configuración de TicketBAI."
+      "description": "Destino de la configuraci\u00f3n de TicketBAI."
     },
     "Issubsanation": {
-      "label": "Es Subsanación",
-      "description": "Especifica que se trata de una subsanación de un registro de facturación de alta previamente generado."
+      "label": "Es Subsanaci\u00f3n",
+      "description": "Especifica que se trata de una subsanaci\u00f3n de un registro de facturaci\u00f3n de alta previamente generado."
     },
     "EM_Etvfac_Inv_Type": {
       "label": "Tipo de Factura",
@@ -12970,7 +12970,7 @@
     },
     "EM_Etvfac_Entity_ID": {
       "label": "ID Entidad Productora",
-      "description": "Número de identificación de la persona o entidad productora."
+      "description": "N\u00famero de identificaci\u00f3n de la persona o entidad productora."
     },
     "EM_Esreg_Region_Code": {
       "label": "Spanish Region Code",
@@ -12978,23 +12978,23 @@
     },
     "Tbai_Config_ID": {
       "label": "Tbai_Config_ID",
-      "description": "Identificador de configuración del sistema TBAI."
+      "description": "Identificador de configuraci\u00f3n del sistema TBAI."
     },
     "EM_AEAT349_C_Year_ID": {
-      "label": "Año",
-      "description": "Seleccionar el año en caso de que la factura rectificada haya sido declarada anteriormente en el modelo 349"
+      "label": "A\u00f1o",
+      "description": "Seleccionar el a\u00f1o en caso de que la factura rectificada haya sido declarada anteriormente en el modelo 349"
     },
     "URL_Qr_Base_Test": {
       "label": "Url base para QR Test",
-      "description": "URL base para generar el código QR en un entorno de pruebas."
+      "description": "URL base para generar el c\u00f3digo QR en un entorno de pruebas."
     },
     "Java_Qualifier": {
       "label": "Java Qualifier",
       "description": "Java Qualifier"
     },
     "Etaf_Audit_Discrepancy_ID": {
-      "label": "Discrepancia de Auditoría",
-      "description": "Discrepancia en la cadena de registros de la auditoría."
+      "label": "Discrepancia de Auditor\u00eda",
+      "description": "Discrepancia en la cadena de registros de la auditor\u00eda."
     },
     "Tbai_Syncinvoice_ID": {
       "label": "Syncronized Invoice ID",
@@ -13002,22 +13002,22 @@
     },
     "CreatedBy": {
       "label": "CreatedBy",
-      "description": "Usuario que creó el registro"
+      "description": "Usuario que cre\u00f3 el registro"
     },
     "EM_Aeat390_Rep_Nif": {
       "label": "NIF del Representante Legal",
       "description": ""
     },
     "Code_Error": {
-      "label": "Código de Error",
-      "description": "Código de Error."
+      "label": "C\u00f3digo de Error",
+      "description": "C\u00f3digo de Error."
     },
     "Schema_Uri_Void": {
-      "label": "Uri del esquema de anulación para Factura (Cliente)",
+      "label": "Uri del esquema de anulaci\u00f3n para Factura (Cliente)",
       "description": "URI del esquema utilizado para anular facturas en el sistema."
     },
     "Error_Reason": {
-      "label": "Descripción Error Registro",
+      "label": "Descripci\u00f3n Error Registro",
       "description": "Error recibido al enviar la factura."
     },
     "Schema_Uri": {
@@ -13025,12 +13025,12 @@
       "description": "URI del esquema utilizado para registrar facturas en el sistema."
     },
     "Type_Operation": {
-      "label": "Tipo de Operación",
+      "label": "Tipo de Operaci\u00f3n",
       "description": "Operaciones de Alta o Baja."
     },
     "EM_Etvfac_Issue_Description": {
       "label": "Detalle de la Incidencia",
-      "description": "Información acerca del problema técnico que ocurrió."
+      "description": "Informaci\u00f3n acerca del problema t\u00e9cnico que ocurri\u00f3."
     },
     "EM_AEAT349_BP_BaseAmount_S": {
       "label": "Base Imponible del 349 Servicios",
@@ -13038,7 +13038,7 @@
     },
     "EM_AEAT349_IsCorrective": {
       "label": "Correctiva del 349",
-      "description": "Indica si será necesario realizar una corrección en el modelo oficial 349"
+      "description": "Indica si ser\u00e1 necesario realizar una correcci\u00f3n en el modelo oficial 349"
     },
     "EM_Aeat390_Surname2": {
       "label": "Segundo Apellido",
@@ -13061,20 +13061,20 @@
       "description": "El Modelo 390 debe expresar las cantidades agrupadas por el porcentaje de los impuestos (ejemplo: al 4%, al 18%, etc.)"
     },
     "EM_Etsg_Add_Certificate": {
-      "label": "Añadir Certificado Digital",
-      "description": "Cargar un certificado digital a esta organización."
+      "label": "A\u00f1adir Certificado Digital",
+      "description": "Cargar un certificado digital a esta organizaci\u00f3n."
     },
     "EM_Aeat390_Surname1": {
       "label": "Primer Apellido",
       "description": ""
     },
     "EM_Tbai_Voidxmlgenerator": {
-      "label": "Enviar anulación a TIcketbai",
-      "description": "Permite el envío de la anulación de una factura al sistema TicketBAI."
+      "label": "Enviar anulaci\u00f3n a TIcketbai",
+      "description": "Permite el env\u00edo de la anulaci\u00f3n de una factura al sistema TicketBAI."
     },
     "TAX_Type": {
-      "label": "Impuesto de Aplicación",
-      "description": "Impuestos indirectos sobre el consumo en España."
+      "label": "Impuesto de Aplicaci\u00f3n",
+      "description": "Impuestos indirectos sobre el consumo en Espa\u00f1a."
     },
     "EM_Aeat390_Is_BI_And_Cuota": {
       "label": "Modelo 390: Separar Base Imponible y Cuota",
@@ -13085,48 +13085,48 @@
       "description": ""
     },
     "Epigraph": {
-      "label": "Epígrafe",
-      "description": "Número del Epígrafe del IAE"
+      "label": "Ep\u00edgrafe",
+      "description": "N\u00famero del Ep\u00edgrafe del IAE"
     },
     "Production_Env": {
-      "label": "Entorno de Producción",
-      "description": "Indica si el sistema está en un entorno de producción o de prueba."
+      "label": "Entorno de Producci\u00f3n",
+      "description": "Indica si el sistema est\u00e1 en un entorno de producci\u00f3n o de prueba."
     },
     "EM_Etvfac_Id_Type": {
       "label": "Tipo ID Entidad Productora",
       "description": "Tipo de ID de la entidad productora del software."
     },
     "EM_Etvfac_Ipsi_Regime": {
-      "label": "Régimen Especial IPSI",
-      "description": "Identificadores del tipo de régimen IPSI."
+      "label": "R\u00e9gimen Especial IPSI",
+      "description": "Identificadores del tipo de r\u00e9gimen IPSI."
     },
     "Codigo": {
-      "label": "Código",
-      "description": "Código de identificación de la factura."
+      "label": "C\u00f3digo",
+      "description": "C\u00f3digo de identificaci\u00f3n de la factura."
     },
     "Etvfac_C_Invoice_Verifactu_ID": {
-      "label": "Datos Envío Verifactu",
-      "description": "Datos de envío de la factura a Verifactu."
+      "label": "Datos Env\u00edo Verifactu",
+      "description": "Datos de env\u00edo de la factura a Verifactu."
     },
     "Etvfac_Inv_Sent_Status_Mv_ID": {
-      "label": "Estado de Envío de Factura",
-      "description": "Vista materializada que muestra datos de los registros de facturación enviados a Verifactu."
+      "label": "Estado de Env\u00edo de Factura",
+      "description": "Vista materializada que muestra datos de los registros de facturaci\u00f3n enviados a Verifactu."
     },
     "EM_Tbai_Issent": {
       "label": "Enviada a TBAI",
-      "description": "Estado de envío de la factura al sistema TBAI."
+      "description": "Estado de env\u00edo de la factura al sistema TBAI."
     },
     "EM_Aeat303_Is_Nat_Per": {
-      "label": "Es Persona Física",
-      "description": "Es Persona Física"
+      "label": "Es Persona F\u00edsica",
+      "description": "Es Persona F\u00edsica"
     },
     "Expiration_Date": {
-      "label": "Fecha de Expiración",
+      "label": "Fecha de Expiraci\u00f3n",
       "description": "La fecha en la cual el certificado expira."
     },
     "EM_Etvfac_Date_Issue": {
-      "label": "Fecha Generación RF",
-      "description": "Fecha de generación del registro de facturación."
+      "label": "Fecha Generaci\u00f3n RF",
+      "description": "Fecha de generaci\u00f3n del registro de facturaci\u00f3n."
     },
     "Power_Date": {
       "label": "Fecha Poder",
@@ -13137,16 +13137,16 @@
       "description": "Apellidos"
     },
     "Certificate_Pass": {
-      "label": "Contraseña del Certificado",
-      "description": "Contraseña del Certificado"
+      "label": "Contrase\u00f1a del Certificado",
+      "description": "Contrase\u00f1a del Certificado"
     },
     "EM_Tbai_Issue_Date": {
       "label": "Fecha registro contable",
-      "description": "Fecha en la que se registró la factura en el sistema contable."
+      "description": "Fecha en la que se registr\u00f3 la factura en el sistema contable."
     },
     "EM_Etvfac_System_ID": {
-      "label": "ID Sistema Informático",
-      "description": "Código identificativo dado por la persona o entidad productora a su sistema informático de facturación (SIF)."
+      "label": "ID Sistema Inform\u00e1tico",
+      "description": "C\u00f3digo identificativo dado por la persona o entidad productora a su sistema inform\u00e1tico de facturaci\u00f3n (SIF)."
     },
     "Lastname2": {
       "label": "Segundo Apellido",
@@ -13162,27 +13162,27 @@
     },
     "EM_Tbai_Sequence": {
       "label": "Secuencia de encadenamiento",
-      "description": "Secuencia que identifica la relación entre las facturas emitidas."
+      "description": "Secuencia que identifica la relaci\u00f3n entre las facturas emitidas."
     },
     "Epiae_Code_ID": {
-      "label": "Código",
+      "label": "C\u00f3digo",
       "description": ""
     },
     "EM_Tbai_Claveregimeniva": {
-      "label": "Clave de Régimen Especial de IVA",
-      "description": "Código que identifica si la factura se encuentra bajo un régimen especial de tributación."
+      "label": "Clave de R\u00e9gimen Especial de IVA",
+      "description": "C\u00f3digo que identifica si la factura se encuentra bajo un r\u00e9gimen especial de tributaci\u00f3n."
     },
     "EM_Aeat390_Istotal": {
       "label": "Modelo 390: Generar total",
-      "description": "Este parámetro incluye un campo con el total"
+      "description": "Este par\u00e1metro incluye un campo con el total"
     },
     "EM_Etvfac_Rect_Create": {
-      "label": "Crear Rectificación Importe Negativo",
+      "label": "Crear Rectificaci\u00f3n Importe Negativo",
       "description": "Clona la factura pero con signo invertido."
     },
     "URL_Cancel": {
       "label": "Url para anulacion de factura",
-      "description": "URL utilizada para enviar una solicitud de anulación de una factura registrada en TBAI."
+      "description": "URL utilizada para enviar una solicitud de anulaci\u00f3n de una factura registrada en TBAI."
     },
     "Epiae_Type_ID": {
       "label": "Clave",
@@ -13190,7 +13190,7 @@
     },
     "UpdatedBy": {
       "label": "UpdatedBy",
-      "description": "Usuario que actualizó el registro"
+      "description": "Usuario que actualiz\u00f3 el registro"
     },
     "EM_Aeat390_Rep_Name": {
       "label": "Nombre del Representante Legal",
@@ -13198,11 +13198,11 @@
     },
     "License_Name_Test": {
       "label": "Nombre licencia test",
-      "description": "Nombre de la licencia de prueba utilizada para testear la integración."
+      "description": "Nombre de la licencia de prueba utilizada para testear la integraci\u00f3n."
     },
     "EM_Etvfac_Invnoidart61d": {
       "label": "Sin ID Destinatario Art61d",
-      "description": "Factura sin identificación destinatario artículo 6.1.d) RD 1619/2012."
+      "description": "Factura sin identificaci\u00f3n destinatario art\u00edculo 6.1.d) RD 1619/2012."
     },
     "EM_Etvfac_Void": {
       "label": "Baja en Verifactu",
@@ -13213,20 +13213,20 @@
       "description": ""
     },
     "EM_Tbai_Reverseinvoicecode": {
-      "label": "Código de Factura Rectificativa",
-      "description": "Código asignado a la factura rectificativa."
+      "label": "C\u00f3digo de Factura Rectificativa",
+      "description": "C\u00f3digo asignado a la factura rectificativa."
     },
     "Jasperreport_Path": {
       "label": "Ruta de Reporte Jasper",
-      "description": "Ruta del archivo de reporte Jasper utilizado para la generación de reportes de factura."
+      "description": "Ruta del archivo de reporte Jasper utilizado para la generaci\u00f3n de reportes de factura."
     },
     "EM_Etvfac_Vat_Regime": {
-      "label": "Régimen Especial IVA",
-      "description": "Lista de claves de régimen IVA."
+      "label": "R\u00e9gimen Especial IVA",
+      "description": "Lista de claves de r\u00e9gimen IVA."
     },
     "USE_Asproduct_Desc": {
-      "label": "Utilizar descripción también para nombre producto",
-      "description": "Indica si la descripción del producto también se debe utilizar como el nombre del producto en la factura."
+      "label": "Utilizar descripci\u00f3n tambi\u00e9n para nombre producto",
+      "description": "Indica si la descripci\u00f3n del producto tambi\u00e9n se debe utilizar como el nombre del producto en la factura."
     },
     "EM_Etvfac_Senttoverifac": {
       "label": "Enviado a Verifactu",
@@ -13234,35 +13234,35 @@
     },
     "License_Name": {
       "label": "Nombre licencia",
-      "description": "Nombre de la licencia utilizada en la integración de TicketBAI."
+      "description": "Nombre de la licencia utilizada en la integraci\u00f3n de TicketBAI."
     },
     "Next_Send_Wait_Time": {
-      "label": "Tiempo de Espera para el Siguiente Envío",
+      "label": "Tiempo de Espera para el Siguiente Env\u00edo",
       "description": "El tiempo de espera para enviar el siguiente grupo de facturas a Verifactu."
     },
     "EM_Etvfac_External_Ref": {
       "label": "Referencia Externa",
-      "description": "Dato adicional con el objetivo de que se pueda asociar opcionalmente información interna del SIF al registro de facturación."
+      "description": "Dato adicional con el objetivo de que se pueda asociar opcionalmente informaci\u00f3n interna del SIF al registro de facturaci\u00f3n."
     },
     "Orep_Representative_Info_ID": {
       "label": "Representante legal",
-      "description": "Representante legal de la Organización"
+      "description": "Representante legal de la Organizaci\u00f3n"
     },
     "EM_Etaf_Inv_Traceability": {
       "label": "Datos de Trazabilidad de factura",
       "description": "Datos de factura borrador y pedidos y albaranes asociados para garantizar trazabilidad e inalterabilidad."
     },
     "EM_Aeat390_DocumentType": {
-      "label": "Modelo 390: Incluir sólo facturas",
+      "label": "Modelo 390: Incluir s\u00f3lo facturas",
       "description": ""
     },
     "EM_Etvfac_Version": {
-      "label": "Versión SIF",
-      "description": "Versión del Sistema Informático (SIF)."
+      "label": "Versi\u00f3n SIF",
+      "description": "Versi\u00f3n del Sistema Inform\u00e1tico (SIF)."
     },
     "Date_Found": {
-      "label": "Fecha Detección",
-      "description": "Fecha en la que se detectó la discrepancia."
+      "label": "Fecha Detecci\u00f3n",
+      "description": "Fecha en la que se detect\u00f3 la discrepancia."
     },
     "Spec_Type": {
       "label": "Spec Type",
@@ -13273,12 +13273,12 @@
       "description": "Registro de la factura en el sistema TBAI."
     },
     "EM_Etaf_Issuer_Name": {
-      "label": "Razón Social de Emisor",
+      "label": "Raz\u00f3n Social de Emisor",
       "description": "Nombre legal del emisor que genera la factura."
     },
     "Tbai_Valcode_ID": {
       "label": "Tbai_Valcode_ID",
-      "description": "Código de validación asignado por el sistema TBAI a la factura."
+      "description": "C\u00f3digo de validaci\u00f3n asignado por el sistema TBAI a la factura."
     },
     "EM_Etvfac_Corrected_Inv": {
       "label": "Factura Corregida",
@@ -13293,8 +13293,8 @@
       "description": "Indica si la factura ya ha sido emitida a Verifactu utilizando otro SIF"
     },
     "Etvfac_Verifactu_Config_ID": {
-      "label": "Configuración Verifactu",
-      "description": "Configuración general de Verifactu."
+      "label": "Configuraci\u00f3n Verifactu",
+      "description": "Configuraci\u00f3n general de Verifactu."
     },
     "EM_Aeat390_IsCashVATPayment": {
       "label": "Modelo 390: Importe cobrado/pagado IVA de Caja",
@@ -13306,11 +13306,11 @@
     },
     "EM_Etvfac_Qr_Url": {
       "label": "URL para QR Factura",
-      "description": "Contiene la URL con la que se debe formar el código QR que se añadirá en la impresión de la factura"
+      "description": "Contiene la URL con la que se debe formar el c\u00f3digo QR que se a\u00f1adir\u00e1 en la impresi\u00f3n de la factura"
     },
     "Calculated_Hashcode": {
-      "label": "Código Hash Calculado",
-      "description": "El código hash calculado durante la verificación."
+      "label": "C\u00f3digo Hash Calculado",
+      "description": "El c\u00f3digo hash calculado durante la verificaci\u00f3n."
     },
     "EM_Etvfac_Simpinvart7273": {
       "label": "Factura Simplificada Art 7.2 y 7.3",
@@ -13318,31 +13318,31 @@
     },
     "Version_Test": {
       "label": "Version test",
-      "description": "Versión utilizada para el entorno de pruebas."
+      "description": "Versi\u00f3n utilizada para el entorno de pruebas."
     },
     "Incident_Report": {
       "label": "Detalle Incidencia",
-      "description": "Información acerca del problema técnico que ocurrió."
+      "description": "Informaci\u00f3n acerca del problema t\u00e9cnico que ocurri\u00f3."
     },
     "EM_Tbai_Invoicenum": {
       "label": "Serie Factura",
-      "description": "Serie de la factura para su identificación dentro del sistema."
+      "description": "Serie de la factura para su identificaci\u00f3n dentro del sistema."
     },
     "Csv": {
       "label": "CSV",
-      "description": "Código Seguro de Verificación"
+      "description": "C\u00f3digo Seguro de Verificaci\u00f3n"
     },
     "EM_Etvfac_Installation_Number": {
-      "label": "Número de Instalación",
-      "description": "Número de instalación del sistema informático de facturación (SIF) utilizado."
+      "label": "N\u00famero de Instalaci\u00f3n",
+      "description": "N\u00famero de instalaci\u00f3n del sistema inform\u00e1tico de facturaci\u00f3n (SIF) utilizado."
     },
     "IsGetbyid": {
       "label": "Get By ID",
       "description": "Enable this to include an endpoint for fetching a single entity by its ID."
     },
     "EM_Tbai_Exemptioncause": {
-      "label": "TBAI - Causa de Exención",
-      "description": "Razón por la cual la factura está exenta de impuestos."
+      "label": "TBAI - Causa de Exenci\u00f3n",
+      "description": "Raz\u00f3n por la cual la factura est\u00e1 exenta de impuestos."
     },
     "Etsg_Certificate_ID": {
       "label": "Certificado Digital",
@@ -13354,7 +13354,7 @@
     },
     "EM_Etvfac_Reversed_Invoice": {
       "label": "Factura Rectificada",
-      "description": "Factura original que se utilizará para enlazarla a la rectificativa."
+      "description": "Factura original que se utilizar\u00e1 para enlazarla a la rectificativa."
     },
     "EM_Aeat390_Firstname": {
       "label": "Nombre",
@@ -13366,15 +13366,15 @@
     },
     "Taxid": {
       "label": "CIF/NIF",
-      "description": "Número único definido por el gobierno para asignar y pagar impuestos."
+      "description": "N\u00famero \u00fanico definido por el gobierno para asignar y pagar impuestos."
     },
     "EM_Etvfac_Exemption_Cause": {
-      "label": "Verifactu - Causa de Exención",
-      "description": "Causa de exención."
+      "label": "Verifactu - Causa de Exenci\u00f3n",
+      "description": "Causa de exenci\u00f3n."
     },
     "EM_Etvfac_System_Name": {
-      "label": "Nombre Sistema Informático",
-      "description": "Nombre dado por la persona o entidad productora a su sistema informático de facturación (SIF)."
+      "label": "Nombre Sistema Inform\u00e1tico",
+      "description": "Nombre dado por la persona o entidad productora a su sistema inform\u00e1tico de facturaci\u00f3n (SIF)."
     },
     "IsDelete": {
       "label": "Delete",
@@ -13382,11 +13382,11 @@
     },
     "em_tbai_qrcode": {
       "label": "Imprimir factura con QR",
-      "description": "Opción para imprimir la factura con un código QR."
+      "description": "Opci\u00f3n para imprimir la factura con un c\u00f3digo QR."
     },
     "EM_Etvfac_Reverseinvtype": {
       "label": "Tipo de Factura Rectificativa",
-      "description": "Tipos de rectificación."
+      "description": "Tipos de rectificaci\u00f3n."
     },
     "Legal_Entity_Nif": {
       "label": "NIF de Entidad Legal",
@@ -13401,8 +13401,8 @@
       "description": "Indica la fecha en que el entorno no esta operativo."
     },
     "Certificate_Password": {
-      "label": "Contraseña del Certificado",
-      "description": "La contraseña del certificado."
+      "label": "Contrase\u00f1a del Certificado",
+      "description": "La contrase\u00f1a del certificado."
     },
     "Populate": {
       "label": "Populate",
@@ -13410,7 +13410,7 @@
     },
     "EM_Tbai_Isreverseinvoice": {
       "label": "Factura Rectificativa",
-      "description": "Indica si la factura es una rectificación de una anterior."
+      "description": "Indica si la factura es una rectificaci\u00f3n de una anterior."
     },
     "Correct_Invoice": {
       "label": "Corregir Factura",
@@ -13421,12 +13421,12 @@
       "description": "Indica si se debe validar la factura anterior al generar una nueva."
     },
     "em_etvfac_igic_regime": {
-      "label": "Régimen Especial IGIC",
-      "description": "Lista de claves de régimen IGIC"
+      "label": "R\u00e9gimen Especial IGIC",
+      "description": "Lista de claves de r\u00e9gimen IGIC"
     },
     "EM_Etvfac_Verifac_Desc": {
-      "label": "Descripción Operación",
-      "description": "Descripción del objeto de la factura."
+      "label": "Descripci\u00f3n Operaci\u00f3n",
+      "description": "Descripci\u00f3n del objeto de la factura."
     },
     "EM_AEAT349_BP_BaseAmount": {
       "label": "Base Imponible del 349 Productos",
@@ -13434,11 +13434,11 @@
     },
     "EM_Aeat390_Xml_Element": {
       "label": "Modelo 390: Elemento del fichero XML",
-      "description": "Elemento del fichero XML por el que se representa el parámetro"
+      "description": "Elemento del fichero XML por el que se representa el par\u00e1metro"
     },
     "Nif": {
       "label": "NIF",
-      "description": "NIF (Número de Identificación Fiscal)"
+      "description": "NIF (N\u00famero de Identificaci\u00f3n Fiscal)"
     },
     "Issuer_Nif": {
       "label": "NIF de Emisor",
@@ -13453,36 +13453,36 @@
       "description": "Estado de registro en Verifactu."
     },
     "EM_Tbai_Nonsubjectcause": {
-      "label": "TBAI - Causa de No Sujeción",
-      "description": "Razón por la cual la factura no está sujeta a impuestos."
+      "label": "TBAI - Causa de No Sujeci\u00f3n",
+      "description": "Raz\u00f3n por la cual la factura no est\u00e1 sujeta a impuestos."
     },
     "URL_Cancel_Test": {
       "label": "Url para anulacion de factura test",
-      "description": "URL utilizada en entornos de prueba para la anulación de facturas en TBAI."
+      "description": "URL utilizada en entornos de prueba para la anulaci\u00f3n de facturas en TBAI."
     },
     "Epiae_Epigraph_ID": {
-      "label": "Epígrafe IAE",
-      "description": "Epígrafe del Impuesto sobre Actividades Económicas"
+      "label": "Ep\u00edgrafe IAE",
+      "description": "Ep\u00edgrafe del Impuesto sobre Actividades Econ\u00f3micas"
     },
     "EM_Tbai_Invoiceseq": {
       "label": "Secuencia Factura",
-      "description": "Secuencia numérica asignada a la factura."
+      "description": "Secuencia num\u00e9rica asignada a la factura."
     },
     "EM_Aeat390_Box": {
       "label": "Modelo 390: Casilla",
-      "description": "Casilla a la que corresponde el parámetro en el Modelo"
+      "description": "Casilla a la que corresponde el par\u00e1metro en el Modelo"
     },
     "EM_Etvfac_Issubsanation": {
-      "label": "Subsanación",
-      "description": "Especifica que se trata de una subsanación de un registro de facturación de alta previamente generado."
+      "label": "Subsanaci\u00f3n",
+      "description": "Especifica que se trata de una subsanaci\u00f3n de un registro de facturaci\u00f3n de alta previamente generado."
     },
     "Developer_Nif": {
       "label": "Nif desarrollador",
-      "description": "NIF del desarrollador responsable de la integración."
+      "description": "NIF del desarrollador responsable de la integraci\u00f3n."
     },
     "Invoice_Description": {
-      "label": "Descripción de Facturas",
-      "description": "Descripción general de las facturas emitidas."
+      "label": "Descripci\u00f3n de Facturas",
+      "description": "Descripci\u00f3n general de las facturas emitidas."
     },
     "EM_Etsg_Isrectificative": {
       "label": "Es Rectificativo",
@@ -13494,7 +13494,7 @@
     },
     "EM_Etaf_Iscash": {
       "label": "Es en Efectivo",
-      "description": "Indica si el método de pago es en efectivo. Marcar obligatoriamente si el método de pago es en efectivo."
+      "description": "Indica si el m\u00e9todo de pago es en efectivo. Marcar obligatoriamente si el m\u00e9todo de pago es en efectivo."
     },
     "EM_Aeat303_Person_Name": {
       "label": "Nombre",
@@ -13506,15 +13506,15 @@
     },
     "Auto_Send_Invoices": {
       "label": "Auto enviar facturas al completarse",
-      "description": "Configuración que permite el envío automático de facturas cuando se completen."
+      "description": "Configuraci\u00f3n que permite el env\u00edo autom\u00e1tico de facturas cuando se completen."
     },
     "EM_Tbai_Ad_Sequence_ID": {
       "label": "Secuencia de encadenamiento para TBAI",
-      "description": "Número de secuencia utilizado para el encadenamiento de las facturas."
+      "description": "N\u00famero de secuencia utilizado para el encadenamiento de las facturas."
     },
     "EM_Aeat390_Factorymethod": {
-      "label": "Modelo 390: Método de la factoría",
-      "description": "Método de la factoría usado para construir el objeto"
+      "label": "Modelo 390: M\u00e9todo de la factor\u00eda",
+      "description": "M\u00e9todo de la factor\u00eda usado para construir el objeto"
     },
     "EM_Tbai_Reverseinvoicetype": {
       "label": "Tipo de rectificativa",
@@ -13522,15 +13522,15 @@
     },
     "Default_Qr": {
       "label": "QR Por Defecto",
-      "description": "Implementación por defecto del QR Verifactu en facturas."
+      "description": "Implementaci\u00f3n por defecto del QR Verifactu en facturas."
     },
     "EM_Etvfac_Issue": {
       "label": "Incidencia",
-      "description": "Indica si hubo un problema técnico en el envío."
+      "description": "Indica si hubo un problema t\u00e9cnico en el env\u00edo."
     },
     "EM_Etvfac_Is_Gen_Manual": {
       "label": "Generado Manualmente",
-      "description": "Indicador de como se emitió la factura."
+      "description": "Indicador de como se emiti\u00f3 la factura."
     },
     "Schema_Uri_Purchase": {
       "label": "Uri del esquema de alta para Factura (Proveedor)",
@@ -13538,26 +13538,26 @@
     },
     "IN_Vfactu_System": {
       "label": "Fecha de Acogida",
-      "description": "Indica la fecha de adhesión a Verifactu."
+      "description": "Indica la fecha de adhesi\u00f3n a Verifactu."
     },
     "IS_Ready": {
       "label": "Marcar Como Listo",
-      "description": "Deja la configuración lista para usarse."
+      "description": "Deja la configuraci\u00f3n lista para usarse."
     },
     "em_etvfac_cause_not_taxable": {
-      "label": "Verifactu - Causa No Sujeción",
-      "description": "Tipos de transacciones según su tratamiento fiscal, en relación a si están sujetas o exentas del impuesto correspondiente."
+      "label": "Verifactu - Causa No Sujeci\u00f3n",
+      "description": "Tipos de transacciones seg\u00fan su tratamiento fiscal, en relaci\u00f3n a si est\u00e1n sujetas o exentas del impuesto correspondiente."
     },
     "EM_Aeat390_Isperson": {
-      "label": "Persona Física 390",
+      "label": "Persona F\u00edsica 390",
       "description": ""
     },
     "Notary_Name": {
-      "label": "Notaría",
+      "label": "Notar\u00eda",
       "description": ""
     },
     "Epiae_Orginfo_Epigraph_ID": {
-      "label": "Epígrafe del IAE para la Organización",
+      "label": "Ep\u00edgrafe del IAE para la Organizaci\u00f3n",
       "description": ""
     },
     "Tbaisystemdate": {
@@ -13570,11 +13570,11 @@
     },
     "Refresh_Data": {
       "label": "Refrescar Datos",
-      "description": "Refrescar los datos de envío a Verifactu, organizados por estado."
+      "description": "Refrescar los datos de env\u00edo a Verifactu, organizados por estado."
     },
     "Policy_Url": {
       "label": "Politica url",
-      "description": "URL de la política utilizada para el procesamiento de la factura."
+      "description": "URL de la pol\u00edtica utilizada para el procesamiento de la factura."
     },
     "Tbai_License_Test": {
       "label": "Licencia TBAI test",
@@ -13582,11 +13582,11 @@
     },
     "EM_Etvfac_Company_Name": {
       "label": "Nombre Entidad Productora",
-      "description": "Nombre-razón social de la persona o entidad productora."
+      "description": "Nombre-raz\u00f3n social de la persona o entidad productora."
     },
     "URL_Qr_Base": {
       "label": "Url base para QR",
-      "description": "URL base que se utiliza para generar el código QR en las facturas."
+      "description": "URL base que se utiliza para generar el c\u00f3digo QR en las facturas."
     },
     "Cancellationdate": {
       "label": "Fecha de baja",
@@ -13643,16 +13643,16 @@
       "label": "Plan de pago de facturas de compra"
     },
     "Data Pool Selection": {
-      "label": "Selección de Pool de Datos"
+      "label": "Selecci\u00f3n de Pool de Datos"
     },
     "Navigation Bar Components": {
       "label": "Componentes de Barra de Navegacion"
     },
     "Grid Configuration at Window/Tab/Field Level": {
-      "label": "Configuración de grid a nivel de ventana/solapa/campo"
+      "label": "Configuraci\u00f3n de grid a nivel de ventana/solapa/campo"
     },
     "Process Definition": {
-      "label": "Definición del Proceso"
+      "label": "Definici\u00f3n del Proceso"
     },
     "Widget": {
       "label": "Widget"
@@ -13694,22 +13694,22 @@
       "label": "SII Cash Receipts"
     },
     "Add Multiple Payments P&E": {
-      "label": "Añadir Múltiples Pagos P&E"
+      "label": "A\u00f1adir M\u00faltiples Pagos P&E"
     },
     "Log Management": {
-      "label": "Gestión de Log"
+      "label": "Gesti\u00f3n de Log"
     },
     "View Implementation": {
       "label": "Implementacion de Vista"
     },
     "Grid Configuration at System Level": {
-      "label": "Configuración de grid a nivel de sistema"
+      "label": "Configuraci\u00f3n de grid a nivel de sistema"
     },
     "Window Personalization": {
-      "label": "Personalización de Ventana"
+      "label": "Personalizaci\u00f3n de Ventana"
     },
     "Intrastat Declaration": {
-      "label": "Declaración de Intrastat"
+      "label": "Declaraci\u00f3n de Intrastat"
     },
     "Intrastat Supplementary Unit of Measure": {
       "label": "Unidad Suplementaria de Medida de Intrastat"
@@ -13721,13 +13721,13 @@
       "label": "Instancia de Widget"
     },
     "Tax Report": {
-      "label": "Declaración de impuestos"
+      "label": "Declaraci\u00f3n de impuestos"
     },
     "Job Result": {
       "label": "Resultado de Job"
     },
     "Number to Word Converter": {
-      "label": "Conversor de números a letras"
+      "label": "Conversor de n\u00fameros a letras"
     },
     "Cause exemption SII": {
       "label": "Cause exemption SII"
@@ -13751,16 +13751,16 @@
       "label": "SII Monitor"
     },
     "Check Printing": {
-      "label": "Impresión de cheques"
+      "label": "Impresi\u00f3n de cheques"
     },
     "Inventory Status": {
       "label": "Estado de Inventario"
     },
     "AD Implementation Mapping": {
-      "label": "Mapeo de Implementación del Diccionario"
+      "label": "Mapeo de Implementaci\u00f3n del Diccionario"
     },
     "Return Reasons": {
-      "label": "Motivos de devolución"
+      "label": "Motivos de devoluci\u00f3n"
     },
     "Tables and Columns": {
       "label": "Tablas y columnas"
@@ -13775,13 +13775,13 @@
       "label": "Administrar necesidades"
     },
     "Heartbeat Configuration": {
-      "label": "Configuración Heartbeat"
+      "label": "Configuraci\u00f3n Heartbeat"
     },
     "Transaction code": {
-      "label": "Clave de operación (IVA)"
+      "label": "Clave de operaci\u00f3n (IVA)"
     },
     "Invoice Register Book Setup": {
-      "label": "Configuración de Libro de Facturas"
+      "label": "Configuraci\u00f3n de Libro de Facturas"
     },
     "Reference": {
       "label": "Referencia"
@@ -13790,13 +13790,13 @@
       "label": "Ventanas, solapas y campos"
     },
     "Validation Setup": {
-      "label": "Reglas de validación"
+      "label": "Reglas de validaci\u00f3n"
     },
     "Message": {
       "label": "Mensaje"
     },
     "Menu": {
-      "label": "Menú"
+      "label": "Men\u00fa"
     },
     "Language": {
       "label": "Idioma"
@@ -13811,19 +13811,19 @@
       "label": "Entidad"
     },
     "Organization": {
-      "label": "Organización"
+      "label": "Organizaci\u00f3n"
     },
     "Role": {
       "label": "Rol"
     },
     "Document Sequence": {
-      "label": "Secuencia de documento (numeración)"
+      "label": "Secuencia de documento (numeraci\u00f3n)"
     },
     "Currency": {
       "label": "Moneda"
     },
     "Conversion Rates": {
-      "label": "Rangos de conversión"
+      "label": "Rangos de conversi\u00f3n"
     },
     "Dimensions Mapping": {
       "label": "Mapeo de dimensiones"
@@ -13832,25 +13832,25 @@
       "label": "Calendario anual y periodos"
     },
     "Account Tree": {
-      "label": "Árbol de cuentas"
+      "label": "\u00c1rbol de cuentas"
     },
     "Brand": {
       "label": "Marca"
     },
     "Organization Type": {
-      "label": "Tipo de Organización"
+      "label": "Tipo de Organizaci\u00f3n"
     },
     "Unit of Measure": {
       "label": "Unidad de medida"
     },
     "Country and Region": {
-      "label": "País, provincia y ciudad"
+      "label": "Pa\u00eds, provincia y ciudad"
     },
     "Business Partner": {
       "label": "Terceros"
     },
     "Return Material Receipt": {
-      "label": "Recibo devolución de material"
+      "label": "Recibo devoluci\u00f3n de material"
     },
     "General Ledger Configuration": {
       "label": "Esquema contable"
@@ -13859,13 +13859,13 @@
       "label": "Preferencias"
     },
     "Landed Cost Distribution Algorithm": {
-      "label": "Algoritmo de Distribución de Landed Cost"
+      "label": "Algoritmo de Distribuci\u00f3n de Landed Cost"
     },
     "Multiphase Project": {
       "label": "Proyecto multifase"
     },
     "G/L Category": {
-      "label": "Categoría de LM"
+      "label": "Categor\u00eda de LM"
     },
     "G/L Journal": {
       "label": "Asientos manuales"
@@ -13880,10 +13880,10 @@
       "label": "Impuesto"
     },
     "Tax Category": {
-      "label": "Categoría de Impuesto"
+      "label": "Categor\u00eda de Impuesto"
     },
     "Warehouse and Storage Bins": {
-      "label": "Almacén y huecos"
+      "label": "Almac\u00e9n y huecos"
     },
     "Product": {
       "label": "Producto"
@@ -13898,16 +13898,16 @@
       "label": "Pedido de venta"
     },
     "Product Category": {
-      "label": "Categoría del producto"
+      "label": "Categor\u00eda del producto"
     },
     "Price List": {
       "label": "Tarifa"
     },
     "Invoice Schedule": {
-      "label": "Calendario de facturación"
+      "label": "Calendario de facturaci\u00f3n"
     },
     "Sales Campaign": {
-      "label": "Campaña de Marketing"
+      "label": "Campa\u00f1a de Marketing"
     },
     "Channel": {
       "label": "Canal"
@@ -13919,13 +13919,13 @@
       "label": "Zona de venta"
     },
     "Account Combination": {
-      "label": "Combinación de cuentas"
+      "label": "Combinaci\u00f3n de cuentas"
     },
     "Accounting Transaction Details": {
       "label": "Datos de contabilidad"
     },
     "Tree and Node Image": {
-      "label": "Imagen de los árboles y nodos"
+      "label": "Imagen de los \u00e1rboles y nodos"
     },
     "Report and Process": {
       "label": "Informes y procesos"
@@ -13934,13 +13934,13 @@
       "label": "Factura (Cliente)"
     },
     "Physical Inventory": {
-      "label": "Inventario físico"
+      "label": "Inventario f\u00edsico"
     },
     "Cost Adjustment": {
       "label": "Ajuste de Costes"
     },
     "Goods Shipment": {
-      "label": "Albarán (Cliente)"
+      "label": "Albar\u00e1n (Cliente)"
     },
     "Goods Movement": {
       "label": "Movimiento entre almacenes"
@@ -13958,13 +13958,13 @@
       "label": "Factura (Proveedor)"
     },
     "Goods Receipt": {
-      "label": "Albarán (Proveedor)"
+      "label": "Albar\u00e1n (Proveedor)"
     },
     "Form": {
       "label": "Formulario"
     },
     "Bill of Materials Production": {
-      "label": "Producción LDM"
+      "label": "Producci\u00f3n LDM"
     },
     "Business Partner Category": {
       "label": "Grupos de Terceros"
@@ -13973,16 +13973,16 @@
       "label": "Propuesta de Pago"
     },
     "LCCosts to Match from Invoice Line": {
-      "label": "Costes Landed Cost para Asociar desde Línea de Factura"
+      "label": "Costes Landed Cost para Asociar desde L\u00ednea de Factura"
     },
     "Field Category": {
-      "label": "Tipo agrupación campos"
+      "label": "Tipo agrupaci\u00f3n campos"
     },
     "Commission": {
-      "label": "Comisión"
+      "label": "Comisi\u00f3n"
     },
     "Commission Payment": {
-      "label": "Procesar comisión"
+      "label": "Procesar comisi\u00f3n"
     },
     "Goods Transaction": {
       "label": "Operaciones de material (uso indirecto)"
@@ -13994,7 +13994,7 @@
       "label": "Pedidos de compra cuadrados"
     },
     "Price List Schema": {
-      "label": "Esquema de tarificación"
+      "label": "Esquema de tarificaci\u00f3n"
     },
     "Expense Sheet": {
       "label": "Informe de gasto"
@@ -14003,10 +14003,10 @@
       "label": "Gastos para facturar"
     },
     "Execution Process": {
-      "label": "Proceso de Ejecución"
+      "label": "Proceso de Ejecuci\u00f3n"
     },
     "Asset Group": {
-      "label": "Categoría de Activos"
+      "label": "Categor\u00eda de Activos"
     },
     "Employee Expenses": {
       "label": "Gastos no reembolsados"
@@ -14018,13 +14018,13 @@
       "label": "Control lote"
     },
     "Serial Number Sequence": {
-      "label": "Control nº serie"
+      "label": "Control n\u00ba serie"
     },
     "Attribute": {
       "label": "Atributo"
     },
     "Session": {
-      "label": "Sesión"
+      "label": "Sesi\u00f3n"
     },
     "Project Type": {
       "label": "Tipo de proyecto"
@@ -14033,34 +14033,34 @@
       "label": "Rol permisos"
     },
     "Return to Vendor Shipment": {
-      "label": "Devolución a albarán de proveedor"
+      "label": "Devoluci\u00f3n a albar\u00e1n de proveedor"
     },
     "Alert": {
       "label": "Alertas"
     },
     "Freight Category": {
-      "label": "Categoría portes"
+      "label": "Categor\u00eda portes"
     },
     "Business Partner Info": {
-      "label": "Información de terceros"
+      "label": "Informaci\u00f3n de terceros"
     },
     "Offer Product Category Selector": {
-      "label": "Selector de Categoría de Producto de Oferta"
+      "label": "Selector de Categor\u00eda de Producto de Oferta"
     },
     "Dataset": {
       "label": "Conjunto de datos"
     },
     "Cluster Instance": {
-      "label": "Instancia del Clúster"
+      "label": "Instancia del Cl\u00faster"
     },
     "RM Shipment Pick and Edit": {
-      "label": "Elegir y editar albarán de devolución de material"
+      "label": "Elegir y editar albar\u00e1n de devoluci\u00f3n de material"
     },
     "Unbox Referenced Inventory P&E": {
       "label": "Desempaquetar Inventario Referenciado P&E"
     },
     "Payment Method": {
-      "label": "Método de pago"
+      "label": "M\u00e9todo de pago"
     },
     "Referenced Inventory Type": {
       "label": "Tipo de Inventario Referenciado"
@@ -14069,16 +14069,16 @@
       "label": "Conjunto de Terceros"
     },
     "Costing Rules": {
-      "label": "Reglas de cálculo de costes"
+      "label": "Reglas de c\u00e1lculo de costes"
     },
     "Cluster Service Settings": {
-      "label": "Configuración Servicios Cluster"
+      "label": "Configuraci\u00f3n Servicios Cluster"
     },
     "Reservation Pick and Edit": {
       "label": "Elegir y editar de reservas"
     },
     "Extension Points": {
-      "label": "Puntos de Extensión"
+      "label": "Puntos de Extensi\u00f3n"
     },
     "Process Request": {
       "label": "Procesamiento de Peticiones"
@@ -14087,13 +14087,13 @@
       "label": "Formato Fichero Banco"
     },
     "System Info": {
-      "label": "Información del Sistema"
+      "label": "Informaci\u00f3n del Sistema"
     },
     "PLM Status": {
       "label": "Estado PLM"
     },
     "RFC/RTV HQL Pick / Edit Lines": {
-      "label": "Elegir/Editar Líneas Huérfanas RFC HQL"
+      "label": "Elegir/Editar L\u00edneas Hu\u00e9rfanas RFC HQL"
     },
     "Offer Product Selector": {
       "label": "Selector de Producto de Oferta"
@@ -14108,22 +14108,22 @@
       "label": "Presupuesto de ventas"
     },
     "Costing Algorithm": {
-      "label": "Algoritmo de cálculo de costes"
+      "label": "Algoritmo de c\u00e1lculo de costes"
     },
     "Payment Out": {
       "label": "Pago"
     },
     "Product Characteristic": {
-      "label": "Característica de producto"
+      "label": "Caracter\u00edstica de producto"
     },
     "Offer Organization Selector": {
-      "label": "Selector de Organización de Oferta"
+      "label": "Selector de Organizaci\u00f3n de Oferta"
     },
     "Cost Center": {
       "label": "Centro de costos"
     },
     "Attachments Configuration": {
-      "label": "Configuración de Adjuntos"
+      "label": "Configuraci\u00f3n de Adjuntos"
     },
     "Applications": {
       "label": "Aplicaciones"
@@ -14162,22 +14162,22 @@
       "label": "Dimensiones"
     },
     "Amortization": {
-      "label": "Amortización"
+      "label": "Amortizaci\u00f3n"
     },
     "Assets": {
       "label": "Activosa"
     },
     "Discounts and Promotions": {
-      "label": "Modificación de precios"
+      "label": "Modificaci\u00f3n de precios"
     },
     "Section": {
-      "label": "Área"
+      "label": "\u00c1rea"
     },
     "Manufacturing Cost Center": {
       "label": "Centro de Costos"
     },
     "Machine": {
-      "label": "Máquina"
+      "label": "M\u00e1quina"
     },
     "Work Center": {
       "label": "Puesto Trabajo"
@@ -14189,10 +14189,10 @@
       "label": "Incidencia de Trabajo"
     },
     "Process Plan": {
-      "label": "Plan de Producción"
+      "label": "Plan de Producci\u00f3n"
     },
     "Work Requirement": {
-      "label": "Orden de Fabricación"
+      "label": "Orden de Fabricaci\u00f3n"
     },
     "Work Effort": {
       "label": "Parte de Trabajo"
@@ -14201,16 +14201,16 @@
       "label": "Proceso"
     },
     "Quality Control Point": {
-      "label": "Punto de Control Crítico"
+      "label": "Punto de Control Cr\u00edtico"
     },
     "Quality Control Report": {
       "label": "Toma de Datos de PCC"
     },
     "Periodic Quality Control": {
-      "label": "Control Periódico"
+      "label": "Control Peri\u00f3dico"
     },
     "Periodic Quality Control Data": {
-      "label": "Datos del control de calidad periódico"
+      "label": "Datos del control de calidad peri\u00f3dico"
     },
     "Text Interfaces": {
       "label": "Texto interfaces"
@@ -14219,10 +14219,10 @@
       "label": "Callout"
     },
     "Machine Category": {
-      "label": "Tipo de Máquina"
+      "label": "Tipo de M\u00e1quina"
     },
     "Maintenance Task": {
-      "label": "Operación de Mantenimiento"
+      "label": "Operaci\u00f3n de Mantenimiento"
     },
     "Maintenance Plan": {
       "label": "Mantenimiento Programado"
@@ -14237,55 +14237,55 @@
       "label": "Presupuesto"
     },
     "User Defined Accounting Report Setup": {
-      "label": "Configuración Informes contables"
+      "label": "Configuraci\u00f3n Informes contables"
     },
     "Salary Category": {
-      "label": "Categoría Salarial"
+      "label": "Categor\u00eda Salarial"
     },
     "Indirect Cost": {
       "label": "Costo Indirecto"
     },
     "Business Partner Tax Category": {
-      "label": "Categoría de Impuestos de Terceros"
+      "label": "Categor\u00eda de Impuestos de Terceros"
     },
     "Planner": {
       "label": "Planificador"
     },
     "MRP Forecast": {
-      "label": "Previsión de ventas"
+      "label": "Previsi\u00f3n de ventas"
     },
     "Requisition": {
       "label": "Necesidad de material"
     },
     "Planning Method": {
-      "label": "Método de planificación"
+      "label": "M\u00e9todo de planificaci\u00f3n"
     },
     "Manufacturing Plan": {
-      "label": "Planificación de la producción"
+      "label": "Planificaci\u00f3n de la producci\u00f3n"
     },
     "Purchasing Plan": {
-      "label": "Planificación de compras"
+      "label": "Planificaci\u00f3n de compras"
     },
     "Balance sheet and P&L structure Setup": {
-      "label": "Configuración de informes contables"
+      "label": "Configuraci\u00f3n de informes contables"
     },
     "Tax Report Setup": {
-      "label": "Configuración informes de impuestos"
+      "label": "Configuraci\u00f3n informes de impuestos"
     },
     "Services Modify Tax": {
       "label": "Servicios Modifican Impuestos"
     },
     "RFC HQL Pick / Edit Orphan Lines": {
-      "label": "Elegir/Editar Líneas Huérfanas RFC HQL"
+      "label": "Elegir/Editar L\u00edneas Hu\u00e9rfanas RFC HQL"
     },
     "Service Order Line Pick and Edit": {
-      "label": "Elegir y Editar Líneas de Pedido de Servicios"
+      "label": "Elegir y Editar L\u00edneas de Pedido de Servicios"
     },
     "Discounts and Promotions Types": {
       "label": "Tipos de descuentos y promociones"
     },
     "User Defined Dimension 1": {
-      "label": "Dimensión de usuario 1"
+      "label": "Dimensi\u00f3n de usuario 1"
     },
     "Landed Cost Type": {
       "label": "Tipo de Landed Cost"
@@ -14294,16 +14294,16 @@
       "label": "Cuenta financiera"
     },
     "RM Receipt Pick and Edit": {
-      "label": "Elegir y editar recibo de devolución de material"
+      "label": "Elegir y editar recibo de devoluci\u00f3n de material"
     },
     "Services Related Products": {
       "label": "Productos Relacionados con Servicios"
     },
     "User Defined Dimension 2": {
-      "label": "Dimensión de usuario 2"
+      "label": "Dimensi\u00f3n de usuario 2"
     },
     "Add Products": {
-      "label": "Añadir Productos"
+      "label": "A\u00f1adir Productos"
     },
     "Copy from Orders P&E": {
       "label": "Copiar desde Pedidos P&E"
@@ -14315,7 +14315,7 @@
       "label": "Motivo del rechazo"
     },
     "Payment Run": {
-      "label": "Histórico Ejecución de Pagos"
+      "label": "Hist\u00f3rico Ejecuci\u00f3n de Pagos"
     },
     "Box Referenced Inventory P&E": {
       "label": "Desempaquetar Inventario Referenciado P&E"
@@ -14324,7 +14324,7 @@
       "label": "Plantillas de Contabilidad"
     },
     "CRM Connector Configuration": {
-      "label": "Configuración del Conector CRM"
+      "label": "Configuraci\u00f3n del Conector CRM"
     },
     "Service Price Rule": {
       "label": "Regla de Precio de Servicio"
@@ -14333,7 +14333,7 @@
       "label": "Estado del producto"
     },
     "End Year Close": {
-      "label": "Cierre de año"
+      "label": "Cierre de a\u00f1o"
     },
     "Reserved Goods Movement": {
       "label": "Movimiento entre almacenes reservado"
@@ -14348,13 +14348,13 @@
       "label": "Servicios Cluster"
     },
     "Product Category Tax": {
-      "label": "Impuestos por Categoría de Producto"
+      "label": "Impuestos por Categor\u00eda de Producto"
     },
     "Attachment Method": {
-      "label": "Método de Adjuntos"
+      "label": "M\u00e9todo de Adjuntos"
     },
     "Return to Vendor": {
-      "label": "Devolución a proveedor"
+      "label": "Devoluci\u00f3n a proveedor"
     },
     "Process Group": {
       "label": "Grupo de Procesos"
@@ -14363,31 +14363,31 @@
       "label": "Reserva de existencias"
     },
     "Create Invoice Lines From Order Lines": {
-      "label": "Crear Líneas de Factura Desde Líneas de Pedido"
+      "label": "Crear L\u00edneas de Factura Desde L\u00edneas de Pedido"
     },
     "Landed Cost": {
       "label": "Landed Cost"
     },
     "Matching Algorithm": {
-      "label": "Algoritmo de Reconciliación"
+      "label": "Algoritmo de Reconciliaci\u00f3n"
     },
     "Payment Priority": {
       "label": "Prioridad de Pago"
     },
     "Module": {
-      "label": "Módulo"
+      "label": "M\u00f3dulo"
     },
     "Services Related Product Categories": {
-      "label": "Categorías de Productos Relacionadas con Servicios"
+      "label": "Categor\u00edas de Productos Relacionadas con Servicios"
     },
     "Create Invoice Lines From Shipment/Receipt lines": {
-      "label": "Crear Líneas de Factura Desde Líneas de Albarán"
+      "label": "Crear L\u00edneas de Factura Desde L\u00edneas de Albar\u00e1n"
     },
     "Payment In": {
       "label": "Cobro"
     },
     "Period Control Log": {
-      "label": "Histórico de Control de Periodos"
+      "label": "Hist\u00f3rico de Control de Periodos"
     },
     "Open/Close Period Control": {
       "label": "Abrir/Cerrar periodos"
@@ -14402,25 +14402,25 @@
       "label": "Gestionar variantes seleccionar y ejecutar"
     },
     "Create Purchase Order Lines": {
-      "label": "Crear líneas de pedido de compra"
+      "label": "Crear l\u00edneas de pedido de compra"
     },
     "Data Import Entry Archive": {
       "label": "Archivo de Entradas de Datos Importados"
     },
     "Warehouse Rules": {
-      "label": "Reglas de almacén"
+      "label": "Reglas de almac\u00e9n"
     },
     "Audit Trail": {
-      "label": "Histórico de auditoría"
+      "label": "Hist\u00f3rico de auditor\u00eda"
     },
     "Return from Customer": {
-      "label": "Devolución de cliente"
+      "label": "Devoluci\u00f3n de cliente"
     },
     "Production Run": {
-      "label": "Parte de Fabricación"
+      "label": "Parte de Fabricaci\u00f3n"
     },
     "Credit To Use": {
-      "label": "Crédito a utilizar"
+      "label": "Cr\u00e9dito a utilizar"
     },
     "Modify Payment In Plan": {
       "label": "Modificar Plan de Cobros"
@@ -14432,10 +14432,10 @@
       "label": "Elegir y editar dudoso cobro"
     },
     "Match Statement P&E": {
-      "label": "P&E de Conciliación"
+      "label": "P&E de Conciliaci\u00f3n"
     },
     "Doubtful Debt Method": {
-      "label": "Método de dudoso cobro"
+      "label": "M\u00e9todo de dudoso cobro"
     },
     "Modify Payment Out Plan": {
       "label": "Modificar Plan de Pagos"
@@ -14444,7 +14444,7 @@
       "label": "Sales Invoice Payment Plan"
     },
     "Intrastat File Configuration": {
-      "label": "Configuración del Fichero Intrastat"
+      "label": "Configuraci\u00f3n del Fichero Intrastat"
     },
     "Tax key": {
       "label": "Clave tributaria"
@@ -14455,14 +14455,14 @@
     "TBAI Facturas Enviadas": {
       "label": "TBAI Facturas Enviadas"
     },
-    "Discrepancias de Auditoría": {
-      "label": "Discrepancias de Auditoría"
+    "Discrepancias de Auditor\u00eda": {
+      "label": "Discrepancias de Auditor\u00eda"
     },
     "IAE Activity Type": {
       "label": "IAE Activity Type"
     },
-    "Configuración Verifactu": {
-      "label": "Configuración Verifactu"
+    "Configuraci\u00f3n Verifactu": {
+      "label": "Configuraci\u00f3n Verifactu"
     },
     "Schema Forge Configuration": {
       "label": "Schema Forge Configuration"
@@ -14470,20 +14470,20 @@
     "Monitor Verifactu": {
       "label": "Monitor Verifactu"
     },
-    "Configuración TBAI": {
-      "label": "Configuración TBAI"
+    "Configuraci\u00f3n TBAI": {
+      "label": "Configuraci\u00f3n TBAI"
     },
-    "Epígrafes IAE": {
-      "label": "Epígrafes IAE"
+    "Ep\u00edgrafes IAE": {
+      "label": "Ep\u00edgrafes IAE"
     },
     "Destinos TBAI": {
       "label": "Destinos TBAI"
     },
-    "Código de Actividad": {
-      "label": "Código de Actividad"
+    "C\u00f3digo de Actividad": {
+      "label": "C\u00f3digo de Actividad"
     },
     "Goods Movements": {
-      "label": "Movimientos de mercancía"
+      "label": "Movimientos de mercanc\u00eda"
     }
   },
   "tabs": {
@@ -14491,7 +14491,7 @@
       "label": "SII Connections"
     },
     "Lines": {
-      "label": "Líneas"
+      "label": "L\u00edneas"
     },
     "Intrastat": {
       "label": "Intrastat"
@@ -14509,7 +14509,7 @@
       "label": "Instancia"
     },
     "Parameter Translation": {
-      "label": "Traducción parámetro"
+      "label": "Traducci\u00f3n par\u00e1metro"
     },
     "Header": {
       "label": "Header"
@@ -14569,7 +14569,7 @@
       "label": "Mobile Identifier"
     },
     "Create Invoice Lines From Shipment/Receipt lines": {
-      "label": "Crear Líneas de Factura Desde Líneas de Albarán"
+      "label": "Crear L\u00edneas de Factura Desde L\u00edneas de Albar\u00e1n"
     },
     "Payment Plan": {
       "label": "Plan de Pago"
@@ -14578,7 +14578,7 @@
       "label": "Contabilidad"
     },
     "Add Multiple Payments P&E": {
-      "label": "Añadir Múltiples Pagos P&E"
+      "label": "A\u00f1adir M\u00faltiples Pagos P&E"
     },
     "Datasource field": {
       "label": "Campo de fuente de datos"
@@ -14590,22 +14590,22 @@
       "label": "Resultados"
     },
     "Secure web services configuration": {
-      "label": "Configuración de Secure Web Services"
+      "label": "Configuraci\u00f3n de Secure Web Services"
     },
     "Create Invoices From Orders Header": {
       "label": "Crear facturas desde cabecera de pedidos"
     },
     "Doubtful Debt Method": {
-      "label": "Método de dudoso cobro"
+      "label": "M\u00e9todo de dudoso cobro"
     },
     "Grid Configuration at System Level": {
-      "label": "Configuración de grid a nivel de sistema"
+      "label": "Configuraci\u00f3n de grid a nivel de sistema"
     },
     "Navigation Bar Component": {
-      "label": "Componente de Barra de Navegación"
+      "label": "Componente de Barra de Navegaci\u00f3n"
     },
     "Report Definition": {
-      "label": "Definición Informe"
+      "label": "Definici\u00f3n Informe"
     },
     "Filter": {
       "label": "Filtro"
@@ -14614,7 +14614,7 @@
       "label": "Solapa"
     },
     "Navigation Bar Component Role Access": {
-      "label": "Permisos de Rol de Componente de Barra de Navegación"
+      "label": "Permisos de Rol de Componente de Barra de Navegaci\u00f3n"
     },
     "Transactions": {
       "label": "Operaciones"
@@ -14677,10 +14677,10 @@
       "label": "Fuentes de datos"
     },
     "Number to Word Converter": {
-      "label": "Conversor de números a letras"
+      "label": "Conversor de n\u00fameros a letras"
     },
     "Email Configuration": {
-      "label": "Configuración del correo electrónico"
+      "label": "Configuraci\u00f3n del correo electr\u00f3nico"
     },
     "Analytics Synchronization Header": {
       "label": "Analytics Synchronization Header"
@@ -14713,7 +14713,7 @@
       "label": "AEAT 347 Tipo de documento"
     },
     "Parameter": {
-      "label": "Parámetro"
+      "label": "Par\u00e1metro"
     },
     "Widget Class Access": {
       "label": "Permiso de la Clase de Widget"
@@ -14722,55 +14722,55 @@
       "label": "Clave tributaria"
     },
     "Transaction code": {
-      "label": "Clave de operación (IVA)"
+      "label": "Clave de operaci\u00f3n (IVA)"
     },
     "Invoice Register Book": {
       "label": "Libro de Facturas"
     },
     "Selector Field Translation": {
-      "label": "Traducción del Campo de Selector"
+      "label": "Traducci\u00f3n del Campo de Selector"
     },
     "Defined Selector Translation": {
-      "label": "Traducción del Selector Definido"
+      "label": "Traducci\u00f3n del Selector Definido"
     },
     "Cash VAT pending to be settled P&E": {
       "label": "Cash VAT pending to be settled P&E"
     },
     "Check Printing": {
-      "label": "Impresión de cheques"
+      "label": "Impresi\u00f3n de cheques"
     },
     "Payment Method": {
-      "label": "Método de Pago"
+      "label": "M\u00e9todo de Pago"
     },
     "Payments": {
       "label": "Pagos"
     },
     "Line": {
-      "label": "Línea"
+      "label": "L\u00ednea"
     },
     "Query": {
       "label": "Consulta"
     },
     "Parameter Values": {
-      "label": "Valores de Parámetro"
+      "label": "Valores de Par\u00e1metro"
     },
     "Widget Translation": {
-      "label": "Traducción de Widget"
+      "label": "Traducci\u00f3n de Widget"
     },
     "Widget Menu Items": {
-      "label": "Items de Menú de Widget"
+      "label": "Items de Men\u00fa de Widget"
     },
     "Widget Class": {
       "label": "Clase de Widget"
     },
     "Tax Report Group": {
-      "label": "Seccion de declaración"
+      "label": "Seccion de declaraci\u00f3n"
     },
     "Tax Report": {
-      "label": "Declaración de impuestos"
+      "label": "Declaraci\u00f3n de impuestos"
     },
     "Tax Report Parameter": {
-      "label": "Parámetro de declaración"
+      "label": "Par\u00e1metro de declaraci\u00f3n"
     },
     "Defined Selector": {
       "label": "Selector Definido"
@@ -14779,7 +14779,7 @@
       "label": "Campo de Selector Definido"
     },
     "Line Tax": {
-      "label": "Línea de impuestos"
+      "label": "L\u00ednea de impuestos"
     },
     "Landed Cost": {
       "label": "Landed Cost"
@@ -14791,25 +14791,25 @@
       "label": "Plantillas para Informes"
     },
     "Email Definitions": {
-      "label": "Definiciones del correo electrónico"
+      "label": "Definiciones del correo electr\u00f3nico"
     },
     "Withholding": {
-      "label": "Retención"
+      "label": "Retenci\u00f3n"
     },
     "Withholding Account": {
-      "label": "Cuenta de retención"
+      "label": "Cuenta de retenci\u00f3n"
     },
     "Tax Register Header": {
       "label": "Cabecera del registro de impuesto"
     },
     "Matched PO Lines": {
-      "label": "Líneas de pedido de compra"
+      "label": "L\u00edneas de pedido de compra"
     },
     "Cost Salary Category": {
-      "label": "Categoría salarial"
+      "label": "Categor\u00eda salarial"
     },
     "Heartbeat Configuration": {
-      "label": "Configuración Heartbeat"
+      "label": "Configuraci\u00f3n Heartbeat"
     },
     "Heartbeat Log": {
       "label": "Registro Heartbeat"
@@ -14839,28 +14839,28 @@
       "label": "Field"
     },
     "Validation": {
-      "label": "Validación"
+      "label": "Validaci\u00f3n"
     },
     "Message": {
       "label": "Mensaje"
     },
     "Menu": {
-      "label": "Menú"
+      "label": "Men\u00fa"
     },
     "Translation": {
-      "label": "Traducción"
+      "label": "Traducci\u00f3n"
     },
     "Language": {
       "label": "Idioma"
     },
     "Field Translation": {
-      "label": "Traducción"
+      "label": "Traducci\u00f3n"
     },
     "Tab Translation": {
-      "label": "Traducción"
+      "label": "Traducci\u00f3n"
     },
     "Window Translation": {
-      "label": "Traducción"
+      "label": "Traducci\u00f3n"
     },
     "User": {
       "label": "Usuario"
@@ -14869,13 +14869,13 @@
       "label": "Rol"
     },
     "User Assignment": {
-      "label": "Asignación de usuarios"
+      "label": "Asignaci\u00f3n de usuarios"
     },
     "User Roles": {
       "label": "Roles del usuario"
     },
     "Conversion Rates": {
-      "label": "Reglas de conversión"
+      "label": "Reglas de conversi\u00f3n"
     },
     "Calendar": {
       "label": "Calendario"
@@ -14893,19 +14893,19 @@
       "label": "Unidad de medida"
     },
     "Conversion": {
-      "label": "Conversión"
+      "label": "Conversi\u00f3n"
     },
     "Dependency": {
       "label": "Dependencia"
     },
     "Country": {
-      "label": "País"
+      "label": "Pa\u00eds"
     },
     "Region": {
       "label": "Provincia"
     },
     "Organization": {
-      "label": "Organización"
+      "label": "Organizaci\u00f3n"
     },
     "Client": {
       "label": "Entidad/Cliente"
@@ -14920,7 +14920,7 @@
       "label": "Elemento "
     },
     "Location": {
-      "label": "Dirección"
+      "label": "Direcci\u00f3n"
     },
     "Preference": {
       "label": "Preferencia"
@@ -14929,34 +14929,34 @@
       "label": "Proyecto multifase"
     },
     "G/L Category": {
-      "label": "Categoría Libro Mayor"
+      "label": "Categor\u00eda Libro Mayor"
     },
     "Batch": {
       "label": "Conjunto Asientos"
     },
     "Pick / Edit Lines": {
-      "label": "Líneas Elegir / Editar"
+      "label": "L\u00edneas Elegir / Editar"
     },
     "Box Referenced Inventory P&E": {
       "label": "Empaquetar en Inventario Referenciado P&E"
     },
     "Document Definition": {
-      "label": "Definición de documento"
+      "label": "Definici\u00f3n de documento"
     },
     "Information": {
-      "label": "Información"
+      "label": "Informaci\u00f3n"
     },
     "Reference Translation": {
-      "label": "Traducción"
+      "label": "Traducci\u00f3n"
     },
     "Tax": {
       "label": "Impuesto"
     },
     "Tax Category": {
-      "label": "Categoría de Impuesto"
+      "label": "Categor\u00eda de Impuesto"
     },
     "Warehouse": {
-      "label": "Almacén"
+      "label": "Almac\u00e9n"
     },
     "Storage Bin": {
       "label": "Hueco"
@@ -14977,7 +14977,7 @@
       "label": "Transportista"
     },
     "Product Category": {
-      "label": "Categoría de producto"
+      "label": "Categor\u00eda de producto"
     },
     "Price List": {
       "label": "Tarifa"
@@ -14986,7 +14986,7 @@
       "label": "Tarifa de Precios"
     },
     "Invoice Schedule": {
-      "label": "Calendario de facturación"
+      "label": "Calendario de facturaci\u00f3n"
     },
     "Conversion Rate": {
       "label": "Rangos"
@@ -15007,7 +15007,7 @@
       "label": "Contabilidad general"
     },
     "Sales Campaign": {
-      "label": "Campaña"
+      "label": "Campa\u00f1a"
     },
     "Channel": {
       "label": "Canal"
@@ -15016,7 +15016,7 @@
       "label": "Zonas de venta"
     },
     "Combination": {
-      "label": "Combinación"
+      "label": "Combinaci\u00f3n"
     },
     "Stock": {
       "label": "Stock"
@@ -15058,16 +15058,16 @@
       "label": "Banco"
     },
     "Transaction": {
-      "label": "Transacción"
+      "label": "Transacci\u00f3n"
     },
     "Price List Version": {
-      "label": "Versión de tarifa"
+      "label": "Versi\u00f3n de tarifa"
     },
     "Purchasing": {
       "label": "Compras"
     },
     "Tree": {
-      "label": "Árbol"
+      "label": "\u00c1rbol"
     },
     "Report & Process": {
       "label": "Informes y procesos"
@@ -15091,16 +15091,16 @@
       "label": "Factura Rectificativa"
     },
     "Production Plan": {
-      "label": "Plan de producción"
+      "label": "Plan de producci\u00f3n"
     },
     "Data Package": {
       "label": "Paquete de Datos"
     },
     "Return Reasons": {
-      "label": "Motivos devolución"
+      "label": "Motivos devoluci\u00f3n"
     },
     "Navigation Rules": {
-      "label": "Reglas de Navegación"
+      "label": "Reglas de Navegaci\u00f3n"
     },
     "Cost Center": {
       "label": "Centro de costos"
@@ -15151,28 +15151,28 @@
       "label": "Permiso a organizaciones"
     },
     "Price Rule Version": {
-      "label": "Versión de Regla de Precio"
+      "label": "Versi\u00f3n de Regla de Precio"
     },
     "Service Price Rule": {
       "label": "Regla de Precio de Servicio"
     },
     "Amounts": {
-      "label": "Cuantía de la comisión"
+      "label": "Cuant\u00eda de la comisi\u00f3n"
     },
     "Used in Columns": {
       "label": "Usado en columnas"
     },
     "Details": {
-      "label": "Detalle de la comisión"
+      "label": "Detalle de la comisi\u00f3n"
     },
     "Value": {
       "label": "Costo"
     },
     "Audit Trail": {
-      "label": "Histórico de auditoría"
+      "label": "Hist\u00f3rico de auditor\u00eda"
     },
     "Goods Transaction": {
-      "label": "Transacción de materiales"
+      "label": "Transacci\u00f3n de materiales"
     },
     "Reserved Stock": {
       "label": "Stock reservado"
@@ -15187,7 +15187,7 @@
       "label": "Excepciones de Nombres"
     },
     "Product Category Selector": {
-      "label": "Selector de Categoría de Producto"
+      "label": "Selector de Categor\u00eda de Producto"
     },
     "Copy from Orders": {
       "label": "Copiar desde Pedidos"
@@ -15199,7 +15199,7 @@
       "label": "Plan de pago"
     },
     "Modify Taxes Categories": {
-      "label": "Modificar Categorías de Impuestos"
+      "label": "Modificar Categor\u00edas de Impuestos"
     },
     "Dimensions Mapping": {
       "label": "Mapeo de dimensiones"
@@ -15247,28 +15247,28 @@
       "label": "Control lote"
     },
     "Number Control": {
-      "label": "Nº serie"
+      "label": "N\u00ba serie"
     },
     "Assigned Attribute": {
       "label": "Atributos asignados"
     },
     "Session": {
-      "label": "Sesión"
+      "label": "Sesi\u00f3n"
     },
     "Project Type": {
       "label": "Tipo de proyecto"
     },
     "Matching Algorithm": {
-      "label": "Algoritmo de Reconciliación"
+      "label": "Algoritmo de Reconciliaci\u00f3n"
     },
     "Standard Phase": {
-      "label": "Fase estándar"
+      "label": "Fase est\u00e1ndar"
     },
     "Project Phase": {
       "label": "Fase"
     },
     "Usage Audit": {
-      "label": "Uso de Auditoría"
+      "label": "Uso de Auditor\u00eda"
     },
     "Table Access": {
       "label": "Permiso tablas"
@@ -15277,16 +15277,16 @@
       "label": "Tarea"
     },
     "Standard Task": {
-      "label": "Tarea estándar"
+      "label": "Tarea est\u00e1ndar"
     },
     "Contact": {
       "label": "Contacto"
     },
     "Parameters": {
-      "label": "Parámetros"
+      "label": "Par\u00e1metros"
     },
     "Period Control Log": {
-      "label": "Histórico de Control de Periodos"
+      "label": "Hist\u00f3rico de Control de Periodos"
     },
     "Applications": {
       "label": "Aplicaciones"
@@ -15295,31 +15295,31 @@
       "label": "Porte"
     },
     "Freight Category": {
-      "label": "Categoría portes"
+      "label": "Categor\u00eda portes"
     },
     "Business Partner Dimension": {
-      "label": "Dimensión terceros"
+      "label": "Dimensi\u00f3n terceros"
     },
     "Product Dimension": {
-      "label": "Dimensión producto"
+      "label": "Dimensi\u00f3n producto"
     },
     "Project Dimension": {
-      "label": "Dimensión proyecto"
+      "label": "Dimensi\u00f3n proyecto"
     },
     "Organization Dimension": {
-      "label": "Dimensión organización"
+      "label": "Dimensi\u00f3n organizaci\u00f3n"
     },
     "Sales Region Dimension": {
-      "label": "Dimensión de la región de ventas"
+      "label": "Dimensi\u00f3n de la regi\u00f3n de ventas"
     },
     "Order Lines": {
-      "label": "Líneas de Pedido"
+      "label": "L\u00edneas de Pedido"
     },
     "Process Group": {
       "label": "Grupo de Procesos"
     },
     "Settlement": {
-      "label": "Liquidación"
+      "label": "Liquidaci\u00f3n"
     },
     "Partner Selection": {
       "label": "Elegir tercero"
@@ -15343,7 +15343,7 @@
       "label": "Objeto"
     },
     "Organization Type": {
-      "label": "Tipo de Organización"
+      "label": "Tipo de Organizaci\u00f3n"
     },
     "Outsourced": {
       "label": "Subcontratado"
@@ -15352,10 +15352,10 @@
       "label": "Incidencia"
     },
     "Extension Point": {
-      "label": "Punto de Extensión"
+      "label": "Punto de Extensi\u00f3n"
     },
     "CRM Connector Configuration": {
-      "label": "Configuración del Conector CRM"
+      "label": "Configuraci\u00f3n del Conector CRM"
     },
     "Prereserved Qty": {
       "label": "Cantidad pre-reservada"
@@ -15370,16 +15370,16 @@
       "label": "Tipos de cambio"
     },
     "Tree Reference": {
-      "label": "Referencia de árbol"
+      "label": "Referencia de \u00e1rbol"
     },
     "User Defined Dimension 1": {
-      "label": "Dimensión de usuario 1"
+      "label": "Dimensi\u00f3n de usuario 1"
     },
     "Related Products": {
       "label": "Productos Relacionados"
     },
     "Costing Rule": {
-      "label": "Regla de cálculo de costes"
+      "label": "Regla de c\u00e1lculo de costes"
     },
     "Subset": {
       "label": "Subconjunto"
@@ -15388,7 +15388,7 @@
       "label": "Dimensiones"
     },
     "Table Tree Category": {
-      "label": "Categoría de árbol"
+      "label": "Categor\u00eda de \u00e1rbol"
     },
     "Unit Cost": {
       "label": "Coste Unitario"
@@ -15406,22 +15406,22 @@
       "label": "Motivo del rechazo"
     },
     "Characteristics": {
-      "label": "Incluir Características"
+      "label": "Incluir Caracter\u00edsticas"
     },
     "Characteristic Configuration": {
-      "label": "Configuración de características"
+      "label": "Configuraci\u00f3n de caracter\u00edsticas"
     },
     "Toolset": {
       "label": "Utillajes"
     },
     "Discounts and Promotions Types": {
-      "label": "Tipos de descuento y promoción"
+      "label": "Tipos de descuento y promoci\u00f3n"
     },
     "External Business Partner": {
       "label": "Tercero Externo"
     },
     "Bank Statement Lines": {
-      "label": "Líneas de Extracto Bancario"
+      "label": "L\u00edneas de Extracto Bancario"
     },
     "Auxiliary Input": {
       "label": "Inputs auxiliares"
@@ -15430,7 +15430,7 @@
       "label": "Proyecto de servicio"
     },
     "Project Line": {
-      "label": "Líneas"
+      "label": "L\u00edneas"
     },
     "Proposal": {
       "label": "Presupuesto"
@@ -15439,7 +15439,7 @@
       "label": "Proveedor"
     },
     "Proposal Line": {
-      "label": "Líneas"
+      "label": "L\u00edneas"
     },
     "Followup": {
       "label": "Seguimiento "
@@ -15460,7 +15460,7 @@
       "label": "Efectos generados"
     },
     "Manual Settlement": {
-      "label": "Liquidación manual"
+      "label": "Liquidaci\u00f3n manual"
     },
     "Create Payment": {
       "label": "Efectos manuales"
@@ -15478,16 +15478,16 @@
       "label": "Tablas a contabilizar"
     },
     "Shipment in line": {
-      "label": "Línea albarán"
+      "label": "L\u00ednea albar\u00e1n"
     },
     "Shipment in": {
-      "label": "Albarán entrada"
+      "label": "Albar\u00e1n entrada"
     },
     "Shipment out": {
-      "label": "Albarán salida"
+      "label": "Albar\u00e1n salida"
     },
     "Shipment out line": {
-      "label": "Línea de envío"
+      "label": "L\u00ednea de env\u00edo"
     },
     "Process Scheduling": {
       "label": "Planificador procesos"
@@ -15517,16 +15517,16 @@
       "label": "Ofertas"
     },
     "Section": {
-      "label": "Área"
+      "label": "\u00c1rea"
     },
     "Machine": {
-      "label": "Máquina"
+      "label": "M\u00e1quina"
     },
     "Work Center": {
       "label": "Puesto Trabajo"
     },
     "Machine Station": {
-      "label": "Máquina Puesto"
+      "label": "M\u00e1quina Puesto"
     },
     "Toolset Type": {
       "label": "Tipo Utillaje"
@@ -15535,19 +15535,19 @@
       "label": "Incidencia"
     },
     "Process Plan": {
-      "label": "Plan de Producción"
+      "label": "Plan de Producci\u00f3n"
     },
     "Operation": {
-      "label": "Fase de Orden de Fabricación"
+      "label": "Fase de Orden de Fabricaci\u00f3n"
     },
     "Work Effort": {
       "label": "Parte Trabajo"
     },
     "Production Run": {
-      "label": "Parte de fabricación"
+      "label": "Parte de fabricaci\u00f3n"
     },
     "Version": {
-      "label": "Versión"
+      "label": "Versi\u00f3n"
     },
     "Check Point Set": {
       "label": "Grupo"
@@ -15574,7 +15574,7 @@
       "label": "Consumo Global"
     },
     "Asset Amortization": {
-      "label": "Plan de amortización"
+      "label": "Plan de amortizaci\u00f3n"
     },
     "Text Interface": {
       "label": "Texto interfaces"
@@ -15586,10 +15586,10 @@
       "label": "Turno"
     },
     "Selector Reference": {
-      "label": "Validación por Selector"
+      "label": "Validaci\u00f3n por Selector"
     },
     "Promissory format": {
-      "label": "Formato pagaré"
+      "label": "Formato pagar\u00e9"
     },
     "Callout": {
       "label": "Callout"
@@ -15613,10 +15613,10 @@
       "label": "Mantenimiento"
     },
     "Machine Category": {
-      "label": "Tipo de Máquina"
+      "label": "Tipo de M\u00e1quina"
     },
     "Maintenance Task": {
-      "label": "Operación"
+      "label": "Operaci\u00f3n"
     },
     "Periodicity": {
       "label": "Periodicidad"
@@ -15631,7 +15631,7 @@
       "label": "Mantenimiento"
     },
     "Selector Reference Columns": {
-      "label": "Columnas de validación por selector"
+      "label": "Columnas de validaci\u00f3n por selector"
     },
     "Form Class": {
       "label": "Form class"
@@ -15655,22 +15655,22 @@
       "label": "Punto de Venta Externo"
     },
     "Product Categories": {
-      "label": "Categorías de Productos "
+      "label": "Categor\u00edas de Productos "
     },
     "Salary Category": {
-      "label": "Categoría Salarial"
+      "label": "Categor\u00eda Salarial"
     },
     "Indirect Cost": {
       "label": "Costo indirecto"
     },
     "Business Partner Tax Category": {
-      "label": "Categorías de Impuestos de Terceros"
+      "label": "Categor\u00edas de Impuestos de Terceros"
     },
     "Salary Category / Employee": {
-      "label": "Categoría salarial"
+      "label": "Categor\u00eda salarial"
     },
     "Manufacturing": {
-      "label": "Producción"
+      "label": "Producci\u00f3n"
     },
     "Planner": {
       "label": "Planificador"
@@ -15679,13 +15679,13 @@
       "label": "Necesidades de material"
     },
     "Setup": {
-      "label": "Configuración"
+      "label": "Configuraci\u00f3n"
     },
     "Node": {
       "label": "Nodos"
     },
     "Grouping category": {
-      "label": "Categoría de agrupación"
+      "label": "Categor\u00eda de agrupaci\u00f3n"
     },
     "Tax Report Setup": {
       "label": "Informes de impuestos"
@@ -15700,19 +15700,19 @@
       "label": "Alerta"
     },
     "Initialization": {
-      "label": "Inicialización"
+      "label": "Inicializaci\u00f3n"
     },
     "Templates": {
       "label": "Plantillas"
     },
     "Accounting Configuration": {
-      "label": "Configuración de Contabilidad"
+      "label": "Configuraci\u00f3n de Contabilidad"
     },
     "Condition of the goods": {
       "label": "Estado del Producto"
     },
     "System Info": {
-      "label": "Información del Sistema"
+      "label": "Informaci\u00f3n del Sistema"
     },
     "Matched Amount": {
       "label": "Importe Asociado"
@@ -15721,16 +15721,16 @@
       "label": "Regla"
     },
     "User Defined Dimension 2": {
-      "label": "Dimensión de usuario 2"
+      "label": "Dimensi\u00f3n de usuario 2"
     },
     "Process Execution": {
-      "label": "Ejecución de Procesos"
+      "label": "Ejecuci\u00f3n de Procesos"
     },
     "Average Cost Transactions": {
       "label": "Transacciones Coste Medio"
     },
     "Pick Edit Lines": {
-      "label": "Elegir editar líneas"
+      "label": "Elegir editar l\u00edneas"
     },
     "Subset Value": {
       "label": "Valor de subconjunto"
@@ -15739,10 +15739,10 @@
       "label": "Inventarios"
     },
     "End Year Close": {
-      "label": "Cierre de año"
+      "label": "Cierre de a\u00f1o"
     },
     "Product Price Rule Version": {
-      "label": "Versión de Regla de Precio de Producto"
+      "label": "Versi\u00f3n de Regla de Precio de Producto"
     },
     "Reserved Goods Movement": {
       "label": "Movimiento entre almacenes reservado"
@@ -15754,7 +15754,7 @@
       "label": "Archivo de Entradas Importadas"
     },
     "Characteristic": {
-      "label": "Característica"
+      "label": "Caracter\u00edstica"
     },
     "Variants": {
       "label": "Variantes"
@@ -15766,7 +15766,7 @@
       "label": "Unidad Alternativa"
     },
     "Transaction Adjustments": {
-      "label": "Ajustes de Transacción"
+      "label": "Ajustes de Transacci\u00f3n"
     },
     "Referenced Inventory": {
       "label": "Inventario Referenciado"
@@ -15790,7 +15790,7 @@
       "label": "Mapeo"
     },
     "Product Category Tax P&E": {
-      "label": "Impuestos por Categoría de Producto P&E"
+      "label": "Impuestos por Categor\u00eda de Producto P&E"
     },
     "Ranges": {
       "label": "Rangos"
@@ -15811,13 +15811,13 @@
       "label": "Extractos bancarios importados"
     },
     "Payment Run": {
-      "label": "Histórico de Ejecución de Pagos/Cobros"
+      "label": "Hist\u00f3rico de Ejecuci\u00f3n de Pagos/Cobros"
     },
     "Product Selector": {
       "label": "Selector de Producto"
     },
     "Receipt Line Amount": {
-      "label": "Importe de la Línea de Albarán"
+      "label": "Importe de la L\u00ednea de Albar\u00e1n"
     },
     "Process Request": {
       "label": "Procesamiento de Peticiones"
@@ -15826,7 +15826,7 @@
       "label": "Reserva"
     },
     "Cluster Instance": {
-      "label": "Instancia del Clúster"
+      "label": "Instancia del Cl\u00faster"
     },
     "Procedures": {
       "label": "Procedimientos"
@@ -15838,7 +15838,7 @@
       "label": "Importar Entradas"
     },
     "Tree Field": {
-      "label": "Campo de árbol"
+      "label": "Campo de \u00e1rbol"
     },
     "Box Transactions": {
       "label": "Transacciones Empaquetado"
@@ -15853,16 +15853,16 @@
       "label": "Estado PLM"
     },
     "Create Invoice Lines From Order Lines": {
-      "label": "Crear Líneas de Factura Desde Líneas de Pedido"
+      "label": "Crear L\u00edneas de Factura Desde L\u00edneas de Pedido"
     },
     "Organization Selector": {
-      "label": "Selector de Organización"
+      "label": "Selector de Organizaci\u00f3n"
     },
     "Prereservation": {
       "label": "Pre-reserva"
     },
     "Module": {
-      "label": "Módulo"
+      "label": "M\u00f3dulo"
     },
     "Payment Out Details": {
       "label": "Detalles del pago"
@@ -15871,19 +15871,19 @@
       "label": "Formato de fichero de banco"
     },
     "Exclude Characteristics": {
-      "label": "Excluir Características"
+      "label": "Excluir Caracter\u00edsticas"
     },
     "Category Price Rule Version": {
-      "label": "Versión de Regla de Precio de Categoría"
+      "label": "Versi\u00f3n de Regla de Precio de Categor\u00eda"
     },
     "DB Prefix": {
       "label": "Prefijo de Base de Datos"
     },
     "Transaction Costs": {
-      "label": "Costes Transacción"
+      "label": "Costes Transacci\u00f3n"
     },
     "Pick / Edit lines": {
-      "label": "Elegir / editar líneas"
+      "label": "Elegir / editar l\u00edneas"
     },
     "Tab Access": {
       "label": "Acceso a Solapa"
@@ -15895,7 +15895,7 @@
       "label": "Copiar de atributo"
     },
     "Used Credit Source": {
-      "label": "Origen del crédito usado"
+      "label": "Origen del cr\u00e9dito usado"
     },
     "Exceptions": {
       "label": "Excepciones"
@@ -15904,10 +15904,10 @@
       "label": "Plantilla"
     },
     "Mask Reference": {
-      "label": "Referencia de máscara"
+      "label": "Referencia de m\u00e1scara"
     },
     "User Interface Definition ": {
-      "label": "Definición de Interfaz de Usuario "
+      "label": "Definici\u00f3n de Interfaz de Usuario "
     },
     "Template Dependency": {
       "label": "Dependencia de plantilla"
@@ -15922,10 +15922,10 @@
       "label": "Detalles del pago"
     },
     "Cleared items": {
-      "label": "Líneas de Reconciliación"
+      "label": "L\u00edneas de Reconciliaci\u00f3n"
     },
     "Pick and Edit Lines": {
-      "label": "Elegir y seleccionar líneas"
+      "label": "Elegir y seleccionar l\u00edneas"
     },
     "Doubtful Debt": {
       "label": "Dudoso cobro"
@@ -15940,10 +15940,10 @@
       "label": "Concepto contable"
     },
     "Credit To Use": {
-      "label": "Crédito a utilizar"
+      "label": "Cr\u00e9dito a utilizar"
     },
     "Match Statement": {
-      "label": "Conciliación"
+      "label": "Conciliaci\u00f3n"
     },
     "Doubtful Debt Run": {
       "label": "Procesado del dudoso cobro"
@@ -15952,34 +15952,34 @@
       "label": "Reconciliaciones"
     },
     "Column Translation": {
-      "label": "Traducción de Columna"
+      "label": "Traducci\u00f3n de Columna"
     },
     "Process Definition": {
-      "label": "Definición de proceso"
+      "label": "Definici\u00f3n de proceso"
     },
     "View Role Access": {
       "label": "Mostrar Permisos de Rol"
     },
     "Attachment Metadata Translation": {
-      "label": "Traducción de Metadatos de Adjuntos"
+      "label": "Traducci\u00f3n de Metadatos de Adjuntos"
     },
     "Attachment Metadata": {
       "label": "Metadatos de Adjuntos"
     },
     "Metadata Translation": {
-      "label": "Traducción de Metadatos"
+      "label": "Traducci\u00f3n de Metadatos"
     },
     "Menu Parameters": {
-      "label": "Parámetros de Menú"
+      "label": "Par\u00e1metros de Men\u00fa"
     },
     "Metadata": {
       "label": "Metadatos"
     },
     "View Implementation": {
-      "label": "Implementación de Vista"
+      "label": "Implementaci\u00f3n de Vista"
     },
     "Window Personalization": {
-      "label": "Personalización de Ventana"
+      "label": "Personalizaci\u00f3n de Ventana"
     },
     "Process Access": {
       "label": "Acceso a Proceso"
@@ -15988,7 +15988,7 @@
       "label": "Referencia de Ventana"
     },
     "File Configuration": {
-      "label": "Configuración del Fichero"
+      "label": "Configuraci\u00f3n del Fichero"
     },
     "Intrastat Adquisitions": {
       "label": "Adquisiciones de Intrastat"
@@ -15997,16 +15997,16 @@
       "label": "Unidad de Medida Suplementaria"
     },
     "Intrastat Declaration": {
-      "label": "Declaración de Intrastat"
+      "label": "Declaraci\u00f3n de Intrastat"
     },
     "Intrastat Shipments": {
-      "label": "Envíos de Intrastat"
+      "label": "Env\u00edos de Intrastat"
     },
     "Widget Access": {
       "label": "Permiso de Widget"
     },
     "Widget Menu Item Translation": {
-      "label": "Traducción del Item de Menú de Widget"
+      "label": "Traducci\u00f3n del Item de Men\u00fa de Widget"
     },
     "URL": {
       "label": "URL"
@@ -16015,28 +16015,28 @@
       "label": "Widget en Formulario"
     },
     "Tax Parameter": {
-      "label": "Parámetro de declaración"
+      "label": "Par\u00e1metro de declaraci\u00f3n"
     },
     "Tax subkey": {
       "label": "Subclave tributaria"
     },
     "Withholding Parameter": {
-      "label": "Parámetro de declaración"
+      "label": "Par\u00e1metro de declaraci\u00f3n"
     },
     "Verifactu": {
       "label": "Verifactu"
     },
-    "Resultado Validación": {
-      "label": "Resultado Validación"
+    "Resultado Validaci\u00f3n": {
+      "label": "Resultado Validaci\u00f3n"
     },
     "Facturas Parcialmente Aceptadas": {
       "label": "Facturas Parcialmente Aceptadas"
     },
-    "Cabecera de Configuración Verifactu": {
-      "label": "Cabecera de Configuración Verifactu"
+    "Cabecera de Configuraci\u00f3n Verifactu": {
+      "label": "Cabecera de Configuraci\u00f3n Verifactu"
     },
-    "Epígrafes IAE": {
-      "label": "Epígrafes IAE"
+    "Ep\u00edgrafes IAE": {
+      "label": "Ep\u00edgrafes IAE"
     },
     "Destinos TBAI": {
       "label": "Destinos TBAI"
@@ -16062,23 +16062,23 @@
     "IAE Activity Type": {
       "label": "IAE Activity Type"
     },
-    "Facturas Inválidas": {
-      "label": "Facturas Inválidas"
+    "Facturas Inv\u00e1lidas": {
+      "label": "Facturas Inv\u00e1lidas"
     },
     "Representante Legal": {
       "label": "Representante Legal"
     },
-    "Sincronización": {
-      "label": "Sincronización"
+    "Sincronizaci\u00f3n": {
+      "label": "Sincronizaci\u00f3n"
     },
     "Entity": {
       "label": "Entity"
     },
-    "Discrepancias de Auditoría - Cabecera": {
-      "label": "Discrepancias de Auditoría - Cabecera"
+    "Discrepancias de Auditor\u00eda - Cabecera": {
+      "label": "Discrepancias de Auditor\u00eda - Cabecera"
     },
-    "Código de Actividad": {
-      "label": "Código de Actividad"
+    "C\u00f3digo de Actividad": {
+      "label": "C\u00f3digo de Actividad"
     },
     "Batuz": {
       "label": "Batuz"
@@ -16137,19 +16137,19 @@
       "label": "Cerrada"
     },
     "Customer Return": {
-      "label": "Devolución"
+      "label": "Devoluci\u00f3n"
     },
     "Customer Returns": {
-      "label": "Devolución"
+      "label": "Devoluci\u00f3n"
     },
     "Returns": {
-      "label": "Devolución"
+      "label": "Devoluci\u00f3n"
     },
     "Return Material": {
-      "label": "Devolución"
+      "label": "Devoluci\u00f3n"
     },
     "Return Shipment": {
-      "label": "Albarán de devolución"
+      "label": "Albar\u00e1n de devoluci\u00f3n"
     },
     "Purchase Invoice": {
       "label": "Factura de Compra"
@@ -16182,7 +16182,7 @@
       "label": "Proyectos"
     },
     "Settings": {
-      "label": "Configuración"
+      "label": "Configuraci\u00f3n"
     },
     "Proof of Concept": {
       "label": "Prueba de Concepto"
@@ -16194,7 +16194,7 @@
       "label": "Operaciones"
     },
     "Analytics": {
-      "label": "Analítica"
+      "label": "Anal\u00edtica"
     },
     "First Steps": {
       "label": "Primeros pasos"
@@ -16242,10 +16242,10 @@
       "label": "General"
     },
     "Goods Receipt": {
-      "label": "Albarán de Compra"
+      "label": "Albar\u00e1n de Compra"
     },
     "Return Shipments": {
-      "label": "Envíos de devolución"
+      "label": "Env\u00edos de devoluci\u00f3n"
     },
     "Payments In": {
       "label": "Cobros"
@@ -16254,7 +16254,7 @@
       "label": "Pagos"
     },
     "Bank Reconciliation": {
-      "label": "Conciliación bancaria"
+      "label": "Conciliaci\u00f3n bancaria"
     },
     "Chart of Accounts": {
       "label": "Plan de cuentas"
@@ -16269,34 +16269,34 @@
       "label": "Pedido de Venta"
     },
     "Goods Shipment": {
-      "label": "Albarán de Venta"
+      "label": "Albar\u00e1n de Venta"
     },
     "Sales Invoice": {
       "label": "Factura de Venta"
     },
     "Return from Customer": {
-      "label": "Devolución de Cliente"
+      "label": "Devoluci\u00f3n de Cliente"
     },
     "Return Material Receipt": {
-      "label": "Recibo de Devolución"
+      "label": "Recibo de Devoluci\u00f3n"
     },
     "Purchase Order": {
       "label": "Pedido de Compra"
     },
     "Return to Vendor": {
-      "label": "Devolución a Proveedor"
+      "label": "Devoluci\u00f3n a Proveedor"
     },
     "Return to Vendor Shipment": {
-      "label": "Albarán de Devolución a Proveedor"
+      "label": "Albar\u00e1n de Devoluci\u00f3n a Proveedor"
     },
     "Quotation": {
       "label": "Presupuesto"
     },
     "Return Material Receipts": {
-      "label": "Albarán de devolución"
+      "label": "Albar\u00e1n de devoluci\u00f3n"
     },
     "Return Receipt": {
-      "label": "Albarán de devolución"
+      "label": "Albar\u00e1n de devoluci\u00f3n"
     },
     "Invoice": {
       "label": "Factura"
@@ -16314,10 +16314,10 @@
       "label": "Productos"
     },
     "Categories": {
-      "label": "Categorías"
+      "label": "Categor\u00edas"
     },
     "Physical Inventory": {
-      "label": "Inventario físico"
+      "label": "Inventario f\u00edsico"
     },
     "Storage Bins": {
       "label": "Ubicaciones"
@@ -16359,7 +16359,7 @@
       "label": "Plazos de pago"
     },
     "Payment Methods": {
-      "label": "Métodos de pago"
+      "label": "M\u00e9todos de pago"
     },
     "Taxes": {
       "label": "Impuestos"
@@ -16374,16 +16374,16 @@
       "label": "Escaneo Inteligente"
     },
     "Fiscal Configuration": {
-      "label": "Configuración Fiscal"
+      "label": "Configuraci\u00f3n Fiscal"
     },
     "Fiscal Monitor": {
       "label": "Monitor Fiscal"
     },
     "Quick Sales Order": {
-      "label": "Venta Rápida"
+      "label": "Venta R\u00e1pida"
     },
     "Quick Purchase Order": {
-      "label": "Compra Rápida"
+      "label": "Compra R\u00e1pida"
     },
     "Connections": {
       "label": "Conexiones"
@@ -16413,7 +16413,7 @@
       "label": "Mejores clientes"
     },
     "Quick Actions": {
-      "label": "Acciones rápidas"
+      "label": "Acciones r\u00e1pidas"
     },
     "Cash Flow": {
       "label": "Flujo de caja"
@@ -16445,8 +16445,8 @@
     "Top Clients (12 months)": {
       "label": "Mejores clientes (12 meses)"
     },
-    "Cash Flow — This Month": {
-      "label": "Flujo de caja — Este mes"
+    "Cash Flow \u2014 This Month": {
+      "label": "Flujo de caja \u2014 Este mes"
     },
     "Revenue": {
       "label": "Ingresos"
@@ -16469,11 +16469,11 @@
     "No invoices found": {
       "label": "Sin facturas"
     },
-    "12 months · by revenue": {
-      "label": "12 meses · por ingresos"
+    "12 months \u00b7 by revenue": {
+      "label": "12 meses \u00b7 por ingresos"
     },
-    "12 months · by qty": {
-      "label": "12 meses · por cantidad"
+    "12 months \u00b7 by qty": {
+      "label": "12 meses \u00b7 por cantidad"
     },
     "No data available": {
       "label": "Sin datos"
@@ -16509,7 +16509,7 @@
       "label": "Arrastra para reordenar. Activa/desactiva para mostrar/ocultar."
     },
     "Changes are saved automatically.": {
-      "label": "Los cambios se guardan automáticamente."
+      "label": "Los cambios se guardan autom\u00e1ticamente."
     },
     "Reset to defaults": {
       "label": "Restablecer predeterminados"
@@ -16524,13 +16524,13 @@
       "label": "pedidos de compra por confirmar"
     },
     "shipments-pending": {
-      "label": "envíos pendientes"
+      "label": "env\u00edos pendientes"
     },
     "sales-orders-pending": {
       "label": "pedidos de venta pendientes"
     },
     "goods-receipts-pending": {
-      "label": "recepciones de mercancía pendientes"
+      "label": "recepciones de mercanc\u00eda pendientes"
     },
     "quotations-pending": {
       "label": "presupuestos pendientes"
@@ -16559,19 +16559,19 @@
     "reactivateOrder": "Reactivar pedido",
     "cannotReactivateLinkedDocs": "No se puede reactivar: el pedido tiene documentos vinculados",
     "bulkCompletion": "Procesado masivo",
-    "documentAction": "Acción de documento",
+    "documentAction": "Acci\u00f3n de documento",
     "book": "Procesar",
     "processExecuted": "PROCESO EJECUTADO: {ok} registros procesados correctamente y {failed} registros fallidos.",
     "reactivatePartial": "{ok} de {total} pedidos reactivados",
     "completePartial": "{ok} de {total} pedidos procesados",
-    "noDraftSelected": "Ningún borrador en la selección",
-    "actionCompleted": "Acción completada",
+    "noDraftSelected": "Ning\u00fan borrador en la selecci\u00f3n",
+    "actionCompleted": "Acci\u00f3n completada",
     "reactivated": "Documento reactivado",
     "salesOrderRef": "Pedido de venta #",
     "delete": "Eliminar",
     "deleteRecord": "Eliminar registro",
     "deleteConfirmTitle": "Eliminar registro",
-    "deleteConfirmMessage": "¿Estás seguro de que deseas eliminar este registro? Esta acción no se puede deshacer.",
+    "deleteConfirmMessage": "\u00bfEst\u00e1s seguro de que deseas eliminar este registro? Esta acci\u00f3n no se puede deshacer.",
     "edit": "Editar",
     "print": "Imprimir",
     "preview": "Vista Previa",
@@ -16582,49 +16582,49 @@
     "clear": "Limpiar",
     "clearSort": "Quitar orden",
     "refresh": "Actualizar",
-    "forceAppRefresh": "Forzar actualización de la app",
+    "forceAppRefresh": "Forzar actualizaci\u00f3n de la app",
     "newPayment": "Nuevo pago",
-    "paymentRecordedLocally": "Pago registrado localmente — se sincronizará cuando el endpoint esté disponible",
-    "financeCollections": "Finanzas · Cobros",
+    "paymentRecordedLocally": "Pago registrado localmente \u2014 se sincronizar\u00e1 cuando el endpoint est\u00e9 disponible",
+    "financeCollections": "Finanzas \u00b7 Cobros",
     "activity": "Actividad",
     "closeActivityPanel": "Cerrar panel de actividad",
     "paymentCreated": "Cobro creado",
     "linkedToInvoice": "Vinculado a la factura #{number}",
-    "statusChangedTo": "Estado → {status}",
-    "noActivityYet": "Sin actividad todavía",
+    "statusChangedTo": "Estado \u2192 {status}",
+    "noActivityYet": "Sin actividad todav\u00eda",
     "add": "Agregar",
-    "unallocatedCredit": "crédito no asignado",
+    "unallocatedCredit": "cr\u00e9dito no asignado",
     "invoice": "Factura",
     "paid": "Pagado",
     "pending": "Pendiente",
-    "you": "Tú",
+    "you": "T\u00fa",
     "customer": "Cliente",
     "paymentDate": "Fecha",
-    "method": "Método",
+    "method": "M\u00e9todo",
     "depositTo": "Depositar en",
     "statusCleared": "Conciliado",
     "statusDraft": "Borrador",
     "statusAwaiting": "Pendiente",
     "statusVoided": "Anulado",
     "statusNotCleared": "No conciliado",
-    "creditAdvance": "Anticipo / crédito",
-    "creditAdvanceDescription": "Anticipo o crédito sin aplicar",
+    "creditAdvance": "Anticipo / cr\u00e9dito",
+    "creditAdvanceDescription": "Anticipo o cr\u00e9dito sin aplicar",
     "linkedToInvoiceMode": "Vinculado a factura",
     "linkedToInvoiceModeDescription": "Aplica el cobro a una factura existente",
     "selectCustomer": "Selecciona un cliente...",
     "selectCustomerFirst": "Selecciona primero un cliente",
     "selectInvoice": "Selecciona una factura...",
-    "selectPaymentMethod": "Selecciona un método de pago...",
+    "selectPaymentMethod": "Selecciona un m\u00e9todo de pago...",
     "selectAccount": "Seleccionar cuenta...",
     "loadingInvoices": "Cargando facturas...",
     "noPendingInvoices": "No hay facturas pendientes",
     "account": "Cuenta",
     "date": "Fecha",
     "amount": "Importe",
-    "description": "Descripción",
+    "description": "Descripci\u00f3n",
     "fillAllRequiredFields": "Completa todos los campos obligatorios",
-    "createPayment": "Crear cobro →",
-    "createCredit": "Crear anticipo →",
+    "createPayment": "Crear cobro \u2192",
+    "createCredit": "Crear anticipo \u2192",
     "creating": "Creando...",
     "selectBusinessPartnerToViewPendingInvoices": "Selecciona un socio comercial para ver las facturas pendientes.",
     "noInvoicesAppliedToThisPayment": "No hay facturas aplicadas a este cobro.",
@@ -16641,49 +16641,49 @@
     "selectAtLeastOneInvoiceToApply": "Selecciona al menos una factura para aplicar.",
     "totalAppliedExceedsPaymentAmount": "El total aplicado supera el importe del cobro.",
     "paymentRegisteredSuccessfully": "Cobro registrado correctamente",
-    "creditDescriptionPlaceholder": "Motivo del anticipo o crédito...",
+    "creditDescriptionPlaceholder": "Motivo del anticipo o cr\u00e9dito...",
     "appliedToInvoices": "Aplicado a facturas",
     "unallocated": "Sin asignar",
-    "remainingCredit": "Crédito restante",
+    "remainingCredit": "Cr\u00e9dito restante",
     "statusUnknown": "Desconocido",
     "testAccount": "Cuenta de prueba",
     "mainAccount": "Cuenta principal",
     "pettyCash": "Caja chica",
     "stockMovement": "Movimiento de stock",
     "price": "Precio",
-    "line": "línea",
-    "shipment": "envío",
+    "line": "l\u00ednea",
+    "shipment": "env\u00edo",
     "createInvoiceBtn": "Crear Factura",
-    "createReturn": "Crear Devolución",
+    "createReturn": "Crear Devoluci\u00f3n",
     "invoiceRef": "Factura #",
-    "shipmentRef": "Envío #",
+    "shipmentRef": "Env\u00edo #",
     "createdAsDraft": "creada como Borrador",
     "reviewBeforeConfirming": "Revisar antes de confirmar",
-    "viewInvoice": "Ver Factura →",
-    "loadingShipmentLines": "Cargando líneas del envío...",
-    "noLinesInSelectedShipments": "No se encontraron líneas en los envíos seleccionados.",
-    "noLinesInThisShipment": "No se encontraron líneas en este envío.",
-    "draftInvoiceExistsForShipments": "Ya existe una factura borrador para estos envíos",
-    "thisShipmentHasDraftInvoice": "Este envío ya tiene una factura en Borrador",
-    "viewExistingInvoice": "Ver factura existente →",
+    "viewInvoice": "Ver Factura \u2192",
+    "loadingShipmentLines": "Cargando l\u00edneas del env\u00edo...",
+    "noLinesInSelectedShipments": "No se encontraron l\u00edneas en los env\u00edos seleccionados.",
+    "noLinesInThisShipment": "No se encontraron l\u00edneas en este env\u00edo.",
+    "draftInvoiceExistsForShipments": "Ya existe una factura borrador para estos env\u00edos",
+    "thisShipmentHasDraftInvoice": "Este env\u00edo ya tiene una factura en Borrador",
+    "viewExistingInvoice": "Ver factura existente \u2192",
     "createAnotherAnyway": "Crear otra de todas formas",
-    "selectLinesToInvoice": "Seleccionar líneas a facturar",
-    "createReturnFromShipment": "Crear Devolución desde Envío",
-    "returnReceipt": "Recepción de Devolución",
-    "stockMovementToWarehouse": "Movimiento de stock de vuelta al almacén",
-    "creditNote": "Nota de Crédito",
+    "selectLinesToInvoice": "Seleccionar l\u00edneas a facturar",
+    "createReturnFromShipment": "Crear Devoluci\u00f3n desde Env\u00edo",
+    "returnReceipt": "Recepci\u00f3n de Devoluci\u00f3n",
+    "stockMovementToWarehouse": "Movimiento de stock de vuelta al almac\u00e9n",
+    "creditNote": "Nota de Cr\u00e9dito",
     "linkedToOriginalInvoice": "Vinculada a la factura original",
-    "reasonForReturn": "Motivo de devolución",
-    "followingDocumentsWillBeCreated": "Se crearán los siguientes documentos:",
+    "reasonForReturn": "Motivo de devoluci\u00f3n",
+    "followingDocumentsWillBeCreated": "Se crear\u00e1n los siguientes documentos:",
     "delivered": "Entregado",
-    "returnQty": "Cant. devolución",
+    "returnQty": "Cant. devoluci\u00f3n",
     "reason": "Motivo:",
-    "allShipmentsAlreadyInvoiced": "Todos los envíos seleccionados ya están facturados",
-    "selectShipmentsSameCustomer": "Selecciona envíos del mismo cliente",
+    "allShipmentsAlreadyInvoiced": "Todos los env\u00edos seleccionados ya est\u00e1n facturados",
+    "selectShipmentsSameCustomer": "Selecciona env\u00edos del mismo cliente",
     "invoiceCreatedAsDraftToast": "Factura creada como Borrador",
     "failedToCreateInvoice": "Error al crear la factura",
     "from": "de",
-    "stockByWarehouse": "Stock por almacén",
+    "stockByWarehouse": "Stock por almac\u00e9n",
     "onHand": "Disponible",
     "reserved": "Reservado",
     "locations": "ubicaciones",
@@ -16695,21 +16695,21 @@
     "warehouses": "Almacenes",
     "available": "Disponible",
     "commercial": "Comercial",
-    "logistics": "Logística",
+    "logistics": "Log\u00edstica",
     "pricing": "Precios",
     "main": "Principal",
-    "commercialDescription": "Configuración comercial secundaria del producto.",
-    "logisticsDescription": "Datos operativos de stock, peso y comportamiento logístico.",
+    "commercialDescription": "Configuraci\u00f3n comercial secundaria del producto.",
+    "logisticsDescription": "Datos operativos de stock, peso y comportamiento log\u00edstico.",
     "principalPrice": "Precio principal",
-    "saveProductFirstPricing": "Guarda primero el producto. Luego podrás definir precios de venta y compra en una versión de tarifa predeterminada.",
-    "configureMainSaleAndPurchasePrice": "Configura un precio principal de venta y compra. Si todavía no existe un precio, se crea automáticamente una línea de tarifa predeterminada.",
+    "saveProductFirstPricing": "Guarda primero el producto. Luego podr\u00e1s definir precios de venta y compra en una versi\u00f3n de tarifa predeterminada.",
+    "configureMainSaleAndPurchasePrice": "Configura un precio principal de venta y compra. Si todav\u00eda no existe un precio, se crea autom\u00e1ticamente una l\u00ednea de tarifa predeterminada.",
     "savePricing": "Guardar precios",
     "editPricing": "Editar precios",
     "setPricing": "Establecer precios",
-    "noPricingConfigured": "Todavía no hay precios configurados para este producto.",
+    "noPricingConfigured": "Todav\u00eda no hay precios configurados para este producto.",
     "loadingPricing": "Cargando precios...",
     "mainPriceUsedForSales": "Precio principal utilizado para ventas.",
-    "usesListPriceFromSameRow": "Usa el precio de lista de la misma línea cuando no existe una línea de compra dedicada.",
+    "usesListPriceFromSameRow": "Usa el precio de lista de la misma l\u00ednea cuando no existe una l\u00ednea de compra dedicada.",
     "mainPriceUsedForPurchasing": "Precio principal utilizado para compras.",
     "enterAtLeastOneValueCreatePricing": "Introduce al menos un valor para crear el precio.",
     "enterAtLeastOneValueUpdatePricing": "Introduce al menos un valor para actualizar el precio.",
@@ -16717,7 +16717,7 @@
     "priceColUnitPrice": "Precio unitario",
     "priceColListPrice": "Precio de lista",
     "priceRemove": "Eliminar",
-    "priceSelectVersion": "Seleccionar versión…",
+    "priceSelectVersion": "Seleccionar versi\u00f3n\u2026",
     "priceZeroPlaceholder": "0,00",
     "priceSalesPrice": "Precio de venta",
     "priceSalesDescription": "Precio inicial utilizado para listas de ventas.",
@@ -16725,44 +16725,44 @@
     "pricePurchaseDescription": "Precio inicial utilizado para listas de compras.",
     "pricingCreatedUsingDefaultValues": "Precio creado usando valores predeterminados.",
     "unableToSavePricing": "No se pudo guardar el precio.",
-    "addEntity": "Añadir {label}",
-    "addLine": "Añadir línea",
+    "addEntity": "A\u00f1adir {label}",
+    "addLine": "A\u00f1adir l\u00ednea",
     "noAdditionalActions": "No hay acciones adicionales",
     "entityDetail": "Detalle de {label}",
-    "saveHeaderFirst": "Guarda el encabezado primero para agregar líneas.",
+    "saveHeaderFirst": "Guarda el encabezado primero para agregar l\u00edneas.",
     "documentStatus": "Estado del documento",
     "subtotal": "Subtotal",
     "tax": "Impuesto",
     "total": "Total",
-    "addTotalDiscount": "Añadir descuento total",
+    "addTotalDiscount": "A\u00f1adir descuento total",
     "subtotalWithoutDiscount": "Subtotal sin descuento",
     "discountPerProduct": "Descuento por producto",
     "totalDiscount": "Descuento total",
     "docs": "Documentos",
     "notes": "Notas",
-    "addLines": "Añadir líneas",
-    "importFromShipment": "Importar desde envío",
-    "noLinesYet": "Sin líneas todavía",
-    "addLinesManuallyOrImportFromShipment": "Añade líneas manualmente o impórtalas desde un envío",
-    "addLinesManuallyOrImportFromPurchaseOrder": "Añade líneas manualmente o impórtalas desde un pedido de compra",
-    "addLinesManually": "Añade líneas manualmente",
+    "addLines": "A\u00f1adir l\u00edneas",
+    "importFromShipment": "Importar desde env\u00edo",
+    "noLinesYet": "Sin l\u00edneas todav\u00eda",
+    "addLinesManuallyOrImportFromShipment": "A\u00f1ade l\u00edneas manualmente o imp\u00f3rtalas desde un env\u00edo",
+    "addLinesManuallyOrImportFromPurchaseOrder": "A\u00f1ade l\u00edneas manualmente o imp\u00f3rtalas desde un pedido de compra",
+    "addLinesManually": "A\u00f1ade l\u00edneas manualmente",
     "importFromPurchaseOrder": "Importar desde pedido de compra",
     "searchPurchaseOrder": "Buscar pedido de compra...",
-    "loadingLines": "Cargando líneas...",
-    "noLinesFound": "No se encontraron líneas",
+    "loadingLines": "Cargando l\u00edneas...",
+    "noLinesFound": "No se encontraron l\u00edneas",
     "importQty": "Cant. a importar",
     "alreadyFullyReceived": "ya recibido completamente",
-    "selectedLinesCount": "{count} línea(s) seleccionada(s)",
-    "selectLinesToImport": "Selecciona líneas para importar",
+    "selectedLinesCount": "{count} l\u00ednea(s) seleccionada(s)",
+    "selectLinesToImport": "Selecciona l\u00edneas para importar",
     "importing": "Importando...",
     "importSelected": "Importar seleccionadas{count}",
-    "importedLinesWithErrors": "Se importaron {count} línea(s) con {errors} error(es)",
-    "linesImportedFromPurchaseOrder": "Se importaron {count} línea(s) desde el pedido de compra",
-    "couldNotImportSelectedLines": "No se pudieron importar las líneas seleccionadas",
-    "noLinesWereImported": "No se importó ninguna línea",
-    "failedToImportLines": "No se pudieron importar las líneas",
+    "importedLinesWithErrors": "Se importaron {count} l\u00ednea(s) con {errors} error(es)",
+    "linesImportedFromPurchaseOrder": "Se importaron {count} l\u00ednea(s) desde el pedido de compra",
+    "couldNotImportSelectedLines": "No se pudieron importar las l\u00edneas seleccionadas",
+    "noLinesWereImported": "No se import\u00f3 ninguna l\u00ednea",
+    "failedToImportLines": "No se pudieron importar las l\u00edneas",
     "noCompletedPurchaseOrdersWithPendingQuantitiesForThisVendor": "No hay pedidos de compra completados con cantidades pendientes para este proveedor.",
-    "noOrdersMatchYourSearch": "Ningún pedido coincide con tu búsqueda.",
+    "noOrdersMatchYourSearch": "Ning\u00fan pedido coincide con tu b\u00fasqueda.",
     "noPaymentDetailsFound": "No se encontraron detalles de pago",
     "financialAccount": "Cuenta financiera",
     "receivedAmount": "Importe recibido",
@@ -16772,32 +16772,32 @@
     "businessPartner": "Tercero",
     "invoiceDate": "Fecha de factura",
     "noProductsFound": "No se encontraron productos",
-    "addNoteHint": "Añadir una nota...",
-    "linesImportedFromShipment": "Líneas importadas desde envío",
+    "addNoteHint": "A\u00f1adir una nota...",
+    "linesImportedFromShipment": "L\u00edneas importadas desde env\u00edo",
     "noRelatedDocuments": "Sin documentos relacionados",
     "Complete": "Completar",
     "Confirm & Send": "Confirmar y enviar",
     "Process Payment": "Procesar pago",
     "Process  Receipt": "Procesar recibo",
-    "Complete Return": "Completar devolución",
+    "Complete Return": "Completar devoluci\u00f3n",
     "Process Inventory Count": "Procesar conteo de inventario",
     "Set New Currency": "Establecer nueva moneda",
-    "Doc Action": "Acción de documento",
-    "Create P O From Requisition": "Crear OC desde requisición",
-    "Doc Action_ Process": "Acción de documento",
+    "Doc Action": "Acci\u00f3n de documento",
+    "Create P O From Requisition": "Crear OC desde requisici\u00f3n",
+    "Doc Action_ Process": "Acci\u00f3n de documento",
     "Complete Cost Adjustment": "Completar ajuste de costo",
     "Void Cost Adjustment": "Anular ajuste de costo",
     "Void": "Anular",
     "Reactivate": "Reactivar",
-    "shipmentDoc": "Envío #{number}",
+    "shipmentDoc": "Env\u00edo #{number}",
     "invoiceDoc": "Factura #{number}",
     "paymentDoc": "Pago #{number}",
     "quotationDoc": "Presupuesto #{number}",
     "quotation": "Presupuesto",
     "receiptDoc": "Recibo #{number}",
-    "returnDoc": "Devolución #{number}",
+    "returnDoc": "Devoluci\u00f3n #{number}",
     "orderDoc": "Pedido #{number}",
-    "creditNoteDoc": "Nota de crédito #{number}",
+    "creditNoteDoc": "Nota de cr\u00e9dito #{number}",
     "statusReceived": "Recibido",
     "statusDeposited": "Depositado",
     "clearAll": "Limpiar todo",
@@ -16807,42 +16807,42 @@
     "allStatuses": "Todos los estados",
     "searchStatuses": "Buscar estado...",
     "searchValues": "Buscar valor...",
-    "lastYear": "Último año",
+    "lastYear": "\u00daltimo a\u00f1o",
     "dateRangeAnyTime": "Cualquier fecha",
     "dateRangeToday": "Hoy",
     "dateRangeYesterday": "Ayer",
-    "dateRangeLast7Days": "Últimos 7 días",
-    "dateRangeLast30Days": "Últimos 30 días",
-    "dateRangeLast12Months": "Últimos 12 meses",
-    "dateRangeThisYear": "Este año",
+    "dateRangeLast7Days": "\u00daltimos 7 d\u00edas",
+    "dateRangeLast30Days": "\u00daltimos 30 d\u00edas",
+    "dateRangeLast12Months": "\u00daltimos 12 meses",
+    "dateRangeThisYear": "Este a\u00f1o",
     "dateRangeAllTime": "Todo el tiempo",
     "dateRangeCustom": "Personalizado",
     "dateRangeApply": "Aplicar",
     "dateRangeCancel": "Cancelar",
     "advancedFilters": "Filtros avanzados",
-    "advancedFiltersComingSoon": "Pronto podrás configurar filtros sobre cualquier columna desde aquí.",
+    "advancedFiltersComingSoon": "Pronto podr\u00e1s configurar filtros sobre cualquier columna desde aqu\u00ed.",
     "advancedFilterTitle": "Filtro por condicionales",
     "advancedFilterWhere": "Donde",
     "advancedFilterAnd": "Y",
     "advancedFilterOr": "O",
     "advancedFilterSelectField": "Selector de campo",
-    "advancedFilterSelectOp": "Seleccionar condición",
+    "advancedFilterSelectOp": "Seleccionar condici\u00f3n",
     "advancedFilterSelectValue": "Seleccionar valor",
     "advancedFilterSelectorOf": "Selector de {label}",
-    "advancedFilterAddCondition": "Añadir condición",
+    "advancedFilterAddCondition": "A\u00f1adir condici\u00f3n",
     "advancedFilterApply": "Aplicar",
     "advancedFilterClear": "Limpiar",
     "advancedFilterSave": "Guardar filtro",
-    "advancedFilterSaveComingSoon": "Próximamente",
+    "advancedFilterSaveComingSoon": "Pr\u00f3ximamente",
     "filterPresets": "Filtros guardados",
     "filterPresetsButton": "Mis filtros",
-    "filterPresetsEmpty": "Aún no hay filtros guardados",
-    "filterPresetSaveCurrent": "Guardar filtros actuales como…",
+    "filterPresetsEmpty": "A\u00fan no hay filtros guardados",
+    "filterPresetSaveCurrent": "Guardar filtros actuales como\u2026",
     "filterPresetDelete": "Eliminar",
     "filterPresetPromptName": "Nombre para esta plantilla de filtro:",
-    "filterPresetOverwriteConfirm": "Ya existe una plantilla llamada \"{name}\". ¿Sobrescribir?",
+    "filterPresetOverwriteConfirm": "Ya existe una plantilla llamada \"{name}\". \u00bfSobrescribir?",
     "filterPresetOverwriteAction": "Sobrescribir",
-    "filterPresetDeleteConfirm": "¿Eliminar la plantilla de filtro \"{name}\"?",
+    "filterPresetDeleteConfirm": "\u00bfEliminar la plantilla de filtro \"{name}\"?",
     "advancedFilterInSetPlaceholder": "Valores separados por coma",
     "search": "Buscar",
     "opContains": "Contiene",
@@ -16855,26 +16855,26 @@
     "opLessOrEqual": "Menor o igual",
     "opBetween": "Entre",
     "opInSet": "Es cualquiera de",
-    "opIsEmpty": "Está vacío",
-    "opIsNotEmpty": "No está vacío",
+    "opIsEmpty": "Est\u00e1 vac\u00edo",
+    "opIsNotEmpty": "No est\u00e1 vac\u00edo",
     "opBefore": "Antes de",
-    "opAfter": "Después de",
-    "loadingMore": "Cargando más...",
+    "opAfter": "Despu\u00e9s de",
+    "loadingMore": "Cargando m\u00e1s...",
     "allRecordsLoaded": "Todos los registros cargados",
     "loading": "Cargando...",
     "of": "de",
     "view": "Ver",
-    "invoicePreviewStats": "Estadísticas",
+    "invoicePreviewStats": "Estad\u00edsticas",
     "invoicePreviewMessages": "Mensajes",
     "invoicePreviewHistory": "Historial",
     "invoicePreviewPdf": "PDF",
-    "invoicePreviewAddPayment": "Añadir pago",
+    "invoicePreviewAddPayment": "A\u00f1adir pago",
     "invoicePreviewEdit": "Editar",
     "invoicePreviewClose": "Cerrar",
     "invoicePreviewSend": "Enviar",
     "invoicePreviewDownloadPdf": "Descargar PDF",
     "invoicePreviewClient": "Contacto:",
-    "invoicePreviewCategorization": "Categorización",
+    "invoicePreviewCategorization": "Categorizaci\u00f3n",
     "invoicePreviewAccountingAccount": "Cuenta contable",
     "invoicePreviewEmails": "Emails",
     "invoicePreviewSendEmail": "Enviar email",
@@ -16883,88 +16883,88 @@
     "invoicePreviewPayments": "Pagos",
     "invoicePreviewFiles": "Archivos",
     "invoicePreviewTotal": "Total",
-    "invoicePreviewDocumentNumber": "Número de documento",
+    "invoicePreviewDocumentNumber": "N\u00famero de documento",
     "invoicePreviewContact": "Contacto",
     "invoicePreviewDate": "Fecha",
     "invoicePreviewDueDate": "Fecha de vencimiento",
     "invoicePreviewStatus": "Estado",
     "invoicePreviewNoPaymentsRecorded": "No hay pagos registrados",
-    "invoicePreviewPendingSync": "pendiente de sincronización",
-    "invoicePreviewDropFileHere": "Suelta el archivo aquí",
+    "invoicePreviewPendingSync": "pendiente de sincronizaci\u00f3n",
+    "invoicePreviewDropFileHere": "Suelta el archivo aqu\u00ed",
     "invoicePreviewUploadYourDocument": "Sube tu documento",
-    "invoicePreviewClickHereToUploadYourFile": "Haz clic aquí para subir tu archivo",
+    "invoicePreviewClickHereToUploadYourFile": "Haz clic aqu\u00ed para subir tu archivo",
     "invoicePreviewAcceptedDocumentTypes": "PDF, JPG, PNG, WebP, GIF",
-    "invoicePreviewNoMessagesYet": "Aún no hay mensajes",
+    "invoicePreviewNoMessagesYet": "A\u00fan no hay mensajes",
     "invoicePreviewNoActivityRecorded": "No hay actividad registrada",
-    "invoicePreviewCannotAddPaymentsToDraftInvoice": "No se pueden añadir pagos a una factura en borrador",
-    "invoicePreviewInvoiceIsFullyPaid": "La factura está totalmente pagada",
-    "invoicePreviewInvoiceMustBeCompletedToAddPayments": "La factura debe estar completada para añadir pagos",
-    "invoicePreviewAddAttachment": "Añadir adjunto",
+    "invoicePreviewCannotAddPaymentsToDraftInvoice": "No se pueden a\u00f1adir pagos a una factura en borrador",
+    "invoicePreviewInvoiceIsFullyPaid": "La factura est\u00e1 totalmente pagada",
+    "invoicePreviewInvoiceMustBeCompletedToAddPayments": "La factura debe estar completada para a\u00f1adir pagos",
+    "invoicePreviewAddAttachment": "A\u00f1adir adjunto",
     "invoicePendingPayment": "Pendiente de pago",
     "sendModalTitle": "Enviar {documentType} #{documentNo}",
     "sendModalTo": "Para",
-    "sendModalNoEmail": "No se encontró email para este contacto",
+    "sendModalNoEmail": "No se encontr\u00f3 email para este contacto",
     "sendModalSubject": "Asunto",
     "sendModalMessage": "Mensaje",
-    "sendModalMessagePlaceholder": "Añade un mensaje personal...",
+    "sendModalMessagePlaceholder": "A\u00f1ade un mensaje personal...",
     "sendModalSend": "Enviar",
     "sendModalSending": "Enviando...",
     "sendModalDownloading": "Descargando...",
     "sendModalLoadingPreview": "Cargando vista previa...",
     "sendModalPdfPreview": "Vista previa PDF",
-    "sendModalPdfNotConfigured": "El PDF aparecerá aquí cuando se configuren las plantillas del documento",
+    "sendModalPdfNotConfigured": "El PDF aparecer\u00e1 aqu\u00ed cuando se configuren las plantillas del documento",
     "depreciatedValue": "Amortizado real",
     "depreciatedPlan": "Amortizado planificado",
-    "depreciation": "Amortización",
+    "depreciation": "Amortizaci\u00f3n",
     "Grouped Report": "Informe agrupado",
     "Listing Report": "Informe de listado",
     "Landscape": "Horizontal",
     "Search": "Buscar",
     "loadingPreview": "Cargando vista previa...",
-    "moreDetails": "Más detalles",
+    "moreDetails": "M\u00e1s detalles",
     "others": "Otros",
     "relatedDocuments": "Documentos relacionados",
     "searchPlaceholder": "Buscar clientes, pedidos, facturas...",
     "searchWithVoice": "Buscar por voz",
     "helpAndSupport": "Ayuda y soporte",
-    "helpComingSoon": "La ayuda y soporte estará disponible pronto.",
+    "helpComingSoon": "La ayuda y soporte estar\u00e1 disponible pronto.",
     "notifications": "Notificaciones",
     "aiAssistant": "Copilot",
     "yourCompany": "Tu empresa",
     "switchCompany": "Cambiar empresa",
-    "navigation": "Navegación",
-    "collapseMenu": "Contraer menú",
-    "expandMenu": "Expandir menú",
+    "navigation": "Navegaci\u00f3n",
+    "collapseMenu": "Contraer men\u00fa",
+    "expandMenu": "Expandir men\u00fa",
     "toggleSidebar": "Alternar barra lateral",
-    "more": "Más",
-    "addToFavorites": "Añadir a favoritos",
+    "more": "M\u00e1s",
+    "addToFavorites": "A\u00f1adir a favoritos",
     "removeFromFavorites": "Quitar de favoritos",
-    "noFavoritesYet": "Aún no tienes favoritos",
-    "andNMore": "+{n} más",
-    "pageHelp": "Ayuda de esta página",
+    "noFavoritesYet": "A\u00fan no tienes favoritos",
+    "andNMore": "+{n} m\u00e1s",
+    "pageHelp": "Ayuda de esta p\u00e1gina",
     "configureDashboard": "Configurar dashboard",
     "searchInvoices": "Buscar facturas...",
-    "searchPages": "Buscar páginas...",
+    "searchPages": "Buscar p\u00e1ginas...",
     "askSomething": "Pregunta algo...",
     "noResults": "Sin resultados",
     "noResultsFor": "Sin resultados para",
     "noResultsFound": "No se encontraron resultados.",
-    "oauthAuthorizeConnection": "Autorizar conexión",
-    "oauthAuthorizeConnectionDesc": "Una aplicación está solicitando acceso a tu cuenta de Etendo",
-    "oauthApplication": "Aplicación",
-    "oauthSignedInAs": "Sesión iniciada como",
+    "oauthAuthorizeConnection": "Autorizar conexi\u00f3n",
+    "oauthAuthorizeConnectionDesc": "Una aplicaci\u00f3n est\u00e1 solicitando acceso a tu cuenta de Etendo",
+    "oauthApplication": "Aplicaci\u00f3n",
+    "oauthSignedInAs": "Sesi\u00f3n iniciada como",
     "oauthRequestedPermissions": "Permisos solicitados",
     "oauthAuthorizedRedirecting": "Autorizado. Redirigiendo...",
     "oauthDeny": "Denegar",
     "oauthAuthorizing": "Autorizando...",
     "oauthAuthorize": "Autorizar",
-    "oauthRedirect": "Redirección",
-    "oauthConnectLandingDesc": "Conecta Claude Desktop o cualquier cliente compatible con MCP a tu instancia de Etendo. El cliente será redirigido aquí para solicitar tu permiso.",
-    "oauthHowItWorks": "Cómo funciona",
-    "oauthStep1": "Añade este servidor de Etendo como remoto MCP en Claude Desktop",
-    "oauthStep2": "Claude abrirá esta página para solicitar acceso",
+    "oauthRedirect": "Redirecci\u00f3n",
+    "oauthConnectLandingDesc": "Conecta Claude Desktop o cualquier cliente compatible con MCP a tu instancia de Etendo. El cliente ser\u00e1 redirigido aqu\u00ed para solicitar tu permiso.",
+    "oauthHowItWorks": "C\u00f3mo funciona",
+    "oauthStep1": "A\u00f1ade este servidor de Etendo como remoto MCP en Claude Desktop",
+    "oauthStep2": "Claude abrir\u00e1 esta p\u00e1gina para solicitar acceso",
     "oauthStep3": "Revisa los permisos y haz clic en Autorizar",
-    "oauthStep4": "Claude ahora podrá leer y escribir datos en Etendo en tu nombre",
+    "oauthStep4": "Claude ahora podr\u00e1 leer y escribir datos en Etendo en tu nombre",
     "oauthMcpServerUrl": "URL del servidor MCP",
     "oauthReadData": "Leer datos",
     "oauthReadDataDesc": "Ver registros, selectores y esquemas",
@@ -16976,66 +16976,66 @@
     "oauthGenerateReportsDesc": "Generar y descargar informes",
     "oauthFullAccess": "Acceso completo",
     "oauthFullAccessDesc": "Todos los permisos (lectura, escritura, procesos e informes)",
-    "noRecordsYet": "Sin registros aún",
+    "noRecordsYet": "Sin registros a\u00fan",
     "noMatchingRecords": "No se encontraron coincidencias",
     "adjustFilters": "Intenta ajustar los filtros.",
     "createNewRecord": "Crea un nuevo registro para empezar.",
     "previewNotAvailable": "Vista previa no disponible",
     "pdfPreview": "Vista previa del PDF",
     "pdfViewerZoomIn": "Acercar",
-    "pdfViewerFitToPage": "Ajustar a la página",
+    "pdfViewerFitToPage": "Ajustar a la p\u00e1gina",
     "pdfViewerZoomOut": "Alejar",
     "deleteDocument": "Eliminar documento",
-    "pdfPreviewPlaceholder": "El PDF aparecerá aquí cuando se configuren las plantillas de documentos",
+    "pdfPreviewPlaceholder": "El PDF aparecer\u00e1 aqu\u00ed cuando se configuren las plantillas de documentos",
     "downloadPdf": "Descargar PDF",
     "downloading": "Descargando...",
     "download": "Descargar",
     "documentPreview": "Vista previa del documento",
-    "comingSoon": "Próximamente",
+    "comingSoon": "Pr\u00f3ximamente",
     "report": "Informe",
     "records": "registros",
     "loadingAllRecords": "Cargando todos los registros...",
     "fetchingAllRecords": "Obteniendo todos los registros...",
     "renderingReport": "Generando informe...",
     "jsreportNotAvailable": "jsreport no disponible",
-    "jsreportNotAvailableBanner": "jsreport no disponible — exportaciones PDF, Excel y CSV deshabilitadas. Inícialo con:",
+    "jsreportNotAvailableBanner": "jsreport no disponible \u2014 exportaciones PDF, Excel y CSV deshabilitadas. In\u00edcialo con:",
     "excel": "Excel",
     "csv": "CSV",
     "pdf": "PDF",
-    "noEmailFound": "No se encontró email para este contacto",
+    "noEmailFound": "No se encontr\u00f3 email para este contacto",
     "addNote": "Agregar una nota...",
     "addMessage": "Agregar un mensaje personal...",
     "sendByEmail": "Enviar por email",
     "selected": "{count} Seleccionados",
-    "editSelection": "Editar selección",
+    "editSelection": "Editar selecci\u00f3n",
     "resetFilters": "Restablecer filtros",
     "reportBuilder": "Generador de Informes",
     "reportScope": "Alcance del Informe",
     "refineDimensions": "Refinar por Dimensiones",
-    "displayOptions": "Opciones de Visualización",
+    "displayOptions": "Opciones de Visualizaci\u00f3n",
     "runReport": "Ejecutar Informe",
     "running": "Ejecutando...",
     "taxReportPurchases": "Compras / Pagos",
     "taxReportSales": "Ventas / Cobros",
     "taxReportDetail": "Detalle",
-    "taxReportSummaryByCategory": "Resumen por Categoría",
+    "taxReportSummaryByCategory": "Resumen por Categor\u00eda",
     "taxReportSummaryByRate": "Resumen por Porcentaje",
     "taxReportTotalByBp": "Total por Tercero",
-    "taxReportTotalByTax": "Total por Impuesto / Retención",
+    "taxReportTotalByTax": "Total por Impuesto / Retenci\u00f3n",
     "selectPlaceholder": "Seleccionar...",
     "selectLabelPrefix": "Seleccionar",
     "searchLabelPrefix": "Buscar",
     "selectParentFirst": "Selecciona primero el campo padre",
     "recordsFound": "{count} registros encontrados",
-    "reportReadyTitle": "Tu informe está listo",
+    "reportReadyTitle": "Tu informe est\u00e1 listo",
     "reportReadyHint": "Selecciona los filtros y haz clic en Ejecutar Informe",
     "resetToDefaults": "Restablecer valores predeterminados",
     "filterHelpText": "Escriba para filtrar. Enter o Tab para aplicar.",
     "filterHelpDate": "Fecha: 15/04/2026, >15/04/2026, <=15/04/2026, 01/04/2026..15/04/2026, 2026",
-    "filterHelpNumeric": "Número: 100, >100, <=50",
+    "filterHelpNumeric": "N\u00famero: 100, >100, <=50",
     "filterHelpSelector": "Escriba para buscar por nombre",
     "filterAll": "Todos",
-    "filterBooleanYes": "Sí",
+    "filterBooleanYes": "S\u00ed",
     "filterBooleanNo": "No",
     "all": "Todos",
     "overdueOnly": "Solo vencidas",
@@ -17043,7 +17043,7 @@
     "filter": "Filtrar...",
     "clearAllFilters": "Limpiar todos los filtros",
     "cancelEsc": "Cancelar (Esc)",
-    "inlineAddHint": "Enter o clic fuera para guardar · Esc para cancelar",
+    "inlineAddHint": "Enter o clic fuera para guardar \u00b7 Esc para cancelar",
     "statusComplete": "Completado",
     "statusCompleted": "Completado",
     "statusVoid": "Anulado",
@@ -17059,58 +17059,58 @@
     "statusOverdue": "Vencido",
     "allTab": "Todos",
     "invoicesTab": "Facturas",
-    "creditNotesTab": "Notas de crédito",
+    "creditNotesTab": "Notas de cr\u00e9dito",
     "allPayments": "Todos los pagos",
     "statusColumn": "Estado",
-    "creditNoteLabel": "Nota de crédito",
+    "creditNoteLabel": "Nota de cr\u00e9dito",
     "totalContacts": "Total de contactos",
     "customers": "Clientes",
     "vendors": "Proveedores",
     "commercialName": "Nombre comercial",
     "firstNameColumn": "Nombre",
     "lastNameColumn": "Apellidos",
-    "locationColumn": "Dirección",
+    "locationColumn": "Direcci\u00f3n",
     "webColumn": "Web",
-    "emailColumn": "Correo electrónico",
+    "emailColumn": "Correo electr\u00f3nico",
     "typeColumn": "Tipo",
-    "phoneColumn": "Teléfono",
+    "phoneColumn": "Tel\u00e9fono",
     "detail": "Detalle",
     "basicDiscount": "Descuento",
-    "locationAddress": "Dirección",
-    "billingPreferences": "Preferencias de facturación",
-    "billingPreferencesDesc": "Configuración de facturación de cliente y proveedor.",
-    "billingPreferencesAfterSave": "Guarda el contacto para configurar preferencias de facturación.",
+    "locationAddress": "Direcci\u00f3n",
+    "billingPreferences": "Preferencias de facturaci\u00f3n",
+    "billingPreferencesDesc": "Configuraci\u00f3n de facturaci\u00f3n de cliente y proveedor.",
+    "billingPreferencesAfterSave": "Guarda el contacto para configurar preferencias de facturaci\u00f3n.",
     "validationRequiredField": "El campo \"{field}\" es obligatorio.",
     "validationRequiredGeneric": "Falta un campo obligatorio.",
     "validationDuplicateRecord": "Ya existe un registro con el mismo valor.",
-    "validationError": "Error de validación",
+    "validationError": "Error de validaci\u00f3n",
     "validationFieldGeneric": "Campo",
     "validationFieldSearchKey": "Identificador",
     "validationFieldName": "Nombre",
-    "validationFieldOrganization": "Organización",
+    "validationFieldOrganization": "Organizaci\u00f3n",
     "validationFieldClient": "Cliente",
-    "validationFieldBusinessPartnerCategory": "Categoría de tercero",
-    "validationFieldNifCountryKey": "Clave NIF País Residencia",
-    "lineAdded": "Línea añadida",
+    "validationFieldBusinessPartnerCategory": "Categor\u00eda de tercero",
+    "validationFieldNifCountryKey": "Clave NIF Pa\u00eds Residencia",
+    "lineAdded": "L\u00ednea a\u00f1adida",
     "recordCreated": "Registro creado",
     "recordSaved": "Registro guardado",
-    "requiredFieldsMissing": "Completá todos los campos requeridos",
+    "requiredFieldsMissing": "Complet\u00e1 todos los campos requeridos",
     "fieldRequired": "Requerido",
     "invoicePdfGenerating": "Generando factura...",
     "invoicePdfError": "No se pudo generar el PDF de la factura.",
     "invoicePdfTitle": "Factura de venta",
-    "invoicePdfDocumentNo": "Nº de factura",
+    "invoicePdfDocumentNo": "N\u00ba de factura",
     "invoicePdfTaxId": "CIF:",
-    "invoicePdfPage": "Página",
+    "invoicePdfPage": "P\u00e1gina",
     "invoicePdfCustomerSection": "Datos del cliente",
     "invoicePdfInvoiceSection": "Datos de la factura",
     "invoicePdfCustomer": "Cliente:",
-    "invoicePdfAddress": "Dirección:",
+    "invoicePdfAddress": "Direcci\u00f3n:",
     "invoicePdfDate": "Fecha:",
     "invoicePdfPaymentTerms": "Condiciones:",
-    "invoicePdfPaymentMethod": "Método de pago:",
-    "invoicePdfColCode": "Cód.",
-    "invoicePdfColDescription": "Descripción",
+    "invoicePdfPaymentMethod": "M\u00e9todo de pago:",
+    "invoicePdfColCode": "C\u00f3d.",
+    "invoicePdfColDescription": "Descripci\u00f3n",
     "invoicePdfColQty": "Cantidad",
     "invoicePdfColUnitPrice": "P. Unitario",
     "invoicePdfColDiscount": "Desc.%",
@@ -17129,7 +17129,7 @@
     "invoiceFullyPaid": "Factura pagada completamente",
     "paymentRegistered": "Pago registrado",
     "fullyPaid": "Pagado",
-    "viewArrow": "Ver →",
+    "viewArrow": "Ver \u2192",
     "paidAmount": "Pagado",
     "outstandingLabel": "Pendiente",
     "registerPayment": "Registrar pago",
@@ -17137,14 +17137,14 @@
     "paymentAccount": "Cuenta",
     "amountExceedsOutstanding": "El importe supera el pendiente",
     "alreadyImported": "ya importado",
-    "searchShipment": "Buscar albarán...",
+    "searchShipment": "Buscar albar\u00e1n...",
     "paymentPlan": "Plan de pagos",
     "dueShort": "Vence",
     "subject": "Asunto",
     "message": "Mensaje",
     "outstandingColon": "Pendiente:",
-    "viewPaymentArrow": "Ver pago →",
-    "registerPaymentLabel": "+ Registrar pago ·",
+    "viewPaymentArrow": "Ver pago \u2192",
+    "registerPaymentLabel": "+ Registrar pago \u00b7",
     "outstandingLower": "pendiente",
     "emailPlaceholder": "email@empresa.com",
     "All": "Todos",
@@ -17156,12 +17156,12 @@
     "bpRevenueThisMonth": "Ingresos del mes",
     "bpExpensesThisMonth": "Gastos del mes",
     "bpSalesPurchases": "Ventas y compras",
-    "bpLast6Months": "Últimos 6 meses",
+    "bpLast6Months": "\u00daltimos 6 meses",
     "bpRevenue": "Ingresos",
     "bpExpenses": "Gastos",
     "bpSalesPurchasesChartAria": "Tendencia de ventas y compras",
     "bpNoInvoiceData": "Sin datos de factura",
-    "bpExpandChart": "Expandir gráfico",
+    "bpExpandChart": "Expandir gr\u00e1fico",
     "General": "General",
     "Financial": "Financiero",
     "Contact Person": "Persona",
@@ -17172,7 +17172,7 @@
     "statusUnderEvaluation": "En evaluación",
     "statusCancelled": "Cancelado",
     "statusPaymentReceived": "Pago recibido",
-    "statusAwaitingExecution": "Pendiente de ejecución",
+    "statusAwaitingExecution": "Pendiente de ejecuci\u00f3n",
     "statusAwaitingPayment": "Pendiente de pago",
     "statusPaymentCleared": "Pago liquidado",
     "statusPaymentMade": "Pago realizado",
@@ -17181,14 +17181,14 @@
     "dashboardTitle": "Inicio",
     "dashboardGreetingHello": "Hola, {name}",
     "dashboardGreetingHeadline": "Estas son tus tareas pendientes",
-    "dashboardCopilotCta": "¿En qué te puedo ayudar hoy?",
-    "dashboardRangeLastYear": "Último año",
-    "dashboardRangeLast90d": "Últimos 90 días",
-    "dashboardRangeLast30d": "Últimos 30 días",
+    "dashboardCopilotCta": "\u00bfEn qu\u00e9 te puedo ayudar hoy?",
+    "dashboardRangeLastYear": "\u00daltimo a\u00f1o",
+    "dashboardRangeLast90d": "\u00daltimos 90 d\u00edas",
+    "dashboardRangeLast30d": "\u00daltimos 30 d\u00edas",
     "dashboardRangeMtd": "Mes en curso",
-    "dashboardRangeYtd": "Año en curso",
+    "dashboardRangeYtd": "A\u00f1o en curso",
     "pendingTasksTitle": "TAREAS PENDIENTES",
-    "pendingTasksEmptyTitle": "Todo al día",
+    "pendingTasksEmptyTitle": "Todo al d\u00eda",
     "pendingTasksEmptySubtitle": "No tienes pendientes por gestionar",
     "salesCategory": "Ventas",
     "purchasesCategory": "Compras",
@@ -17198,11 +17198,11 @@
     "stockCategory": "Stock",
     "pendingStatusOverdueInvoices": "Facturas vencidas",
     "pendingStatusUnreconciled": "Sin conciliar",
-    "pendingStatusPendingShipment": "Pendiente de envío",
-    "pendingStatusPendingReception": "Pendiente de recepción",
+    "pendingStatusPendingShipment": "Pendiente de env\u00edo",
+    "pendingStatusPendingReception": "Pendiente de recepci\u00f3n",
     "pendingStatusLowStock": "Bajo stock",
     "pendingSubjectSalesInvoices": "Facturas de ventas",
-    "pendingSubjectShipments": "Envíos",
+    "pendingSubjectShipments": "Env\u00edos",
     "pendingSubjectCollections": "Cobros",
     "pendingSubjectPayments": "Pagos",
     "pendingSubjectReceptions": "Recepciones",
@@ -17215,48 +17215,48 @@
     "financialSummaryEmptyTitle": "Sin datos financieros",
     "financialSummaryEmptySubtitle": "Registra ventas y compras para ver ingresos, gastos y beneficio",
     "newInvoice": "Nueva factura",
-    "financialSummaryPositive": "Tus ingresos superaron a los gastos este año",
+    "financialSummaryPositive": "Tus ingresos superaron a los gastos este a\u00f1o",
     "financialSummaryIncome": "Ingresos",
     "financialSummaryExpenses": "Gastos",
     "financialSummaryProfit": "Beneficio",
-    "yoyUp": "↑ {pct}% vs año anterior",
-    "yoyDown": "↓ {pct}% vs año anterior",
-    "quickActionsTitle": "ACCESOS RÁPIDOS",
+    "yoyUp": "\u2191 {pct}% vs a\u00f1o anterior",
+    "yoyDown": "\u2193 {pct}% vs a\u00f1o anterior",
+    "quickActionsTitle": "ACCESOS R\u00c1PIDOS",
     "quickAccessSalesOrders": "Pedidos de venta",
     "quickAccessSalesInvoices": "Facturas de venta",
     "quickAccessContacts": "Contactos",
     "topClientsTitle": "CLIENTES DESTACADOS",
-    "topClientsEmptyTitle": "Aún no hay clientes destacados",
-    "topClientsEmptySubtitle": "Cuando tengas más actividad, verás aquí tus clientes más importantes",
+    "topClientsEmptyTitle": "A\u00fan no hay clientes destacados",
+    "topClientsEmptySubtitle": "Cuando tengas m\u00e1s actividad, ver\u00e1s aqu\u00ed tus clientes m\u00e1s importantes",
     "createWithCopilot": "Crear con Copilot",
     "newClient": "Nuevo cliente",
     "collectionsPaymentsTitle": "COBROS Y PAGOS",
-    "collectionsPaymentsEmptyTitle": "Todo al día",
+    "collectionsPaymentsEmptyTitle": "Todo al d\u00eda",
     "collectionsPaymentsEmptySubtitle": "No hay saldos pendientes",
     "toCollectLabel": "Por cobrar",
     "toPayLabel": "Por pagar",
     "recentSalesTitle": "VENTAS RECIENTES",
-    "recentSalesEmptyTitle": "Aún no hay ventas recientes",
-    "recentSalesEmptySubtitle": "Registra tu primera venta y empieza a ver actividad aquí",
+    "recentSalesEmptyTitle": "A\u00fan no hay ventas recientes",
+    "recentSalesEmptySubtitle": "Registra tu primera venta y empieza a ver actividad aqu\u00ed",
     "newSale": "Nueva venta",
     "newPurchase": "Nueva compra",
-    "financialTrendTitle": "EVOLUCIÓN FINANCIERA",
+    "financialTrendTitle": "EVOLUCI\u00d3N FINANCIERA",
     "financialTrendEmptyTitle": "Sin datos financieros",
-    "financialTrendEmptySubtitle": "Registra ventas y compras para ver la evolución",
+    "financialTrendEmptySubtitle": "Registra ventas y compras para ver la evoluci\u00f3n",
     "financialTrendGrowthUp": "Tus ingresos crecieron un {pct}%",
     "financialTrendGrowthDown": "Tus ingresos cayeron un {pct}%",
     "financialTrendIncomeLegend": "Ingresos",
     "financialTrendExpensesLegend": "Gastos",
-    "bestProductsTitle": "PRODUCTOS MÁS VENDIDOS",
+    "bestProductsTitle": "PRODUCTOS M\u00c1S VENDIDOS",
     "bestProductsEmptyTitle": "Sin datos de ventas",
-    "bestProductsEmptySubtitle": "Aquí verás tus productos más vendidos",
+    "bestProductsEmptySubtitle": "Aqu\u00ed ver\u00e1s tus productos m\u00e1s vendidos",
     "bestProductsTrendPositive": "Tendencia positiva",
     "bestProductsTrendNegative": "Tendencia negativa",
     "bestProductsToggleUnits": "Unidades",
     "bestProductsToggleRevenue": "Ingresos",
     "smartScanTitle": "Escaneo inteligente",
-    "smartScanSubtitle": "Procesa documentos entrantes automáticamente.",
-    "smartScanUploadTitle": "Suelta documentos aquí o haz clic para subirlos",
+    "smartScanSubtitle": "Procesa documentos entrantes autom\u00e1ticamente.",
+    "smartScanUploadTitle": "Suelta documentos aqu\u00ed o haz clic para subirlos",
     "smartScanUploadHint": "Compatible con PDF, JPG y PNG hasta 25 MB. Se admite carga por lotes.",
     "smartScanBrowseFiles": "Buscar archivos",
     "smartScanRecentScans": "Escaneos recientes",
@@ -17267,37 +17267,37 @@
     "smartScanConfidence": "Confianza",
     "smartScanActivity": "Actividad de escaneo",
     "smartScanDocumentsScanned": "Documentos escaneados",
-    "smartScanPendingReview": "Pendientes de revisión",
-    "smartScanAutoMatched": "Coincidencia automática",
+    "smartScanPendingReview": "Pendientes de revisi\u00f3n",
+    "smartScanAutoMatched": "Coincidencia autom\u00e1tica",
     "smartScanExceptions": "Excepciones",
     "smartScanInvoiceType": "Factura",
     "smartScanPurchaseOrderType": "Pedido de compra",
     "smartScanReceiptType": "Recibo",
     "smartScanStatementType": "Extracto",
     "smartScanMatchedStatus": "Coincide",
-    "smartScanReviewStatus": "Revisión",
-    "smartScanExceptionStatus": "Excepción",
-    "smartScanActivity1": "INV-2026-0891 emparejado automáticamente con SO-4421",
+    "smartScanReviewStatus": "Revisi\u00f3n",
+    "smartScanExceptionStatus": "Excepci\u00f3n",
+    "smartScanActivity1": "INV-2026-0891 emparejado autom\u00e1ticamente con SO-4421",
     "smartScanActivity2": "Escaneo por lotes completado: 12 documentos procesados",
-    "smartScanActivity3": "REC-2026-0112 marcado para revisión manual",
-    "smartScanActivity4": "STMT-2026-03 marcado como excepción",
-    "smartScanActivity5": "INV-2026-0890 emparejado automáticamente con PO-3398",
+    "smartScanActivity3": "REC-2026-0112 marcado para revisi\u00f3n manual",
+    "smartScanActivity4": "STMT-2026-03 marcado como excepci\u00f3n",
+    "smartScanActivity5": "INV-2026-0890 emparejado autom\u00e1ticamente con PO-3398",
     "smartScanTime2Min": "hace 2 min",
     "smartScanTime15Min": "hace 15 min",
     "smartScanTime1Hr": "hace 1 h",
     "smartScanTime3Hr": "hace 3 h",
     "smartScanTime5Hr": "hace 5 h",
-    "qsoTitle": "Venta Rápida",
+    "qsoTitle": "Venta R\u00e1pida",
     "qsoSubtitle": "Punto de venta",
     "qsoSearchProducts": "Buscar productos...",
     "qsoSearchCustomer": "Buscar cliente...",
-    "qsoAnonymousCustomer": "Cliente Anónimo",
+    "qsoAnonymousCustomer": "Cliente An\u00f3nimo",
     "qsoCart": "Carrito",
-    "qsoEmptyCart": "Sin artículos en el carrito",
+    "qsoEmptyCart": "Sin art\u00edculos en el carrito",
     "qsoEmptyCartHint": "Busca y agrega productos para comenzar",
     "qsoQty": "Cant.",
     "qsoPrice": "Precio",
-    "qsoLineTotal": "Total línea",
+    "qsoLineTotal": "Total l\u00ednea",
     "qsoSubtotal": "Subtotal",
     "qsoTax": "IVA ({rate}%)",
     "qsoTotal": "Total",
@@ -17323,33 +17323,33 @@
     "qsoInStock": "En stock",
     "qsoOutOfStock": "Agotado",
     "qsoNewOrder": "Nuevo Pedido",
-    "qsoItems": "{count} artículo(s)",
-    "qsoPaymentMethod": "Método de pago",
+    "qsoItems": "{count} art\u00edculo(s)",
+    "qsoPaymentMethod": "M\u00e9todo de pago",
     "qsoCustomer": "Cliente",
     "qsoTopSeller": "Top",
     "qsoPriority": "Prioridad",
-    "qsoGridView": "Vista cuadrícula",
+    "qsoGridView": "Vista cuadr\u00edcula",
     "qsoListView": "Vista lista",
     "qsoLoading": "Cargando datos de ventas...",
     "qsoPreviousOrders": "Historial",
     "qsoNoPreviousOrders": "Sin pedidos anteriores",
-    "qsoNoPreviousOrdersHint": "Los pedidos completados aparecerán aquí",
+    "qsoNoPreviousOrdersHint": "Los pedidos completados aparecer\u00e1n aqu\u00ed",
     "qsoRepeatOrder": "Repetir",
     "qsoRepeatNoProducts": "No se encontraron productos coincidentes",
     "qsoRepeatPartial": "Algunos productos no encontrados",
     "qsoOrderRepeated": "Pedido cargado al carrito",
-    "qsoScanDetected": "Escáner detectado",
+    "qsoScanDetected": "Esc\u00e1ner detectado",
     "qsoScanNotFound": "Producto no encontrado",
     "qsoScanAdded": "Escaneado y agregado",
     "qsoNoCustomerResults": "No se encontraron clientes",
-    "qpoTitle": "Compra Rápida",
-    "qpoSubtitle": "Compras rápidas",
+    "qpoTitle": "Compra R\u00e1pida",
+    "qpoSubtitle": "Compras r\u00e1pidas",
     "qpoSupplier": "Proveedor",
     "qpoSelectSupplier": "Seleccionar proveedor...",
     "qpoSearchSupplier": "Buscar proveedor...",
     "qpoSearchProducts": "Buscar productos...",
     "qpoCart": "Carrito",
-    "qpoEmptyCart": "Sin artículos en el carrito",
+    "qpoEmptyCart": "Sin art\u00edculos en el carrito",
     "qpoEmptyCartHint": "Busca y agrega productos para comenzar",
     "qpoQty": "Cant.",
     "qpoPrice": "Precio",
@@ -17363,12 +17363,12 @@
     "qpoEmail": "Email",
     "qpoWhatsApp": "WhatsApp",
     "qpoPDF": "PDF",
-    "qpoSendMethod": "Método de envío",
+    "qpoSendMethod": "M\u00e9todo de env\u00edo",
     "qpoEmailTo": "Enviar a",
-    "qpoEmailTemplateHint": "El pedido se enviará usando la plantilla estándar de pedido de compra.",
+    "qpoEmailTemplateHint": "El pedido se enviar\u00e1 usando la plantilla est\u00e1ndar de pedido de compra.",
     "qpoMessagePreview": "Vista previa del mensaje",
     "qpoOpenWhatsApp": "Abrir en WhatsApp",
-    "qpoPDFHint": "Se generará un PDF con los detalles del pedido para descargar.",
+    "qpoPDFHint": "Se generar\u00e1 un PDF con los detalles del pedido para descargar.",
     "qpoSendEmail": "Enviar Email",
     "qpoSendWhatsApp": "Enviar por WhatsApp",
     "qpoGeneratePDF": "Generar PDF",
@@ -17380,38 +17380,38 @@
     "qpoNoResults": "No se encontraron resultados",
     "qpoPreviousOrders": "Pedidos Anteriores",
     "qpoNoPreviousOrders": "Sin pedidos anteriores",
-    "qpoNoPreviousOrdersHint": "Los pedidos realizados a este proveedor aparecerán aquí",
+    "qpoNoPreviousOrdersHint": "Los pedidos realizados a este proveedor aparecer\u00e1n aqu\u00ed",
     "qpoDelivered": "Entregado",
     "qpoRepeatOrder": "Repetir",
     "qpoOrderRepeated": "Pedido cargado en el carrito",
-    "qpoRepeatNoProducts": "No se encontraron productos en el catálogo",
-    "qpoRepeatPartial": "Algunos productos no se encontraron en el catálogo",
+    "qpoRepeatNoProducts": "No se encontraron productos en el cat\u00e1logo",
+    "qpoRepeatPartial": "Algunos productos no se encontraron en el cat\u00e1logo",
     "qpoNewOrder": "Nuevo Pedido",
     "qpoPriority": "Prioridad",
     "qpoTopSeller": "Top",
     "qpoWspGreeting": "Hola",
     "qpoWspIntro": "Queremos realizar el siguiente pedido:",
-    "qpoWspClosing": "Por favor confirmar disponibilidad y fecha de entrega. ¡Gracias!",
+    "qpoWspClosing": "Por favor confirmar disponibilidad y fecha de entrega. \u00a1Gracias!",
     "qpoAllSuppliers": "Todos los Proveedores",
     "qpoScanDetected": "Escaneado",
-    "qpoScanNotFound": "Producto no encontrado para código",
+    "qpoScanNotFound": "Producto no encontrado para c\u00f3digo",
     "qpoScanAdded": "Escaneado y agregado",
     "copilot": "Copilot",
     "closeCopilot": "Cerrar Copilot",
     "openCopilot": "Abrir Copilot",
-    "copilotWelcome": "¡Hola! Soy tu asistente ERP. ¿En qué puedo ayudarte hoy?",
-    "copilotInvoiceResponse": "Te ayudaré a crear una factura. Abriendo Factura de venta...\n\nTambién puedes decir 'mostrar facturas pendientes' para ver lo que falta.",
-    "copilotStockResponse": "Aquí tienes un resumen rápido del stock:\n• Cerveza Ale 0.5L: 150 unidades\n• Vino Tinto Reserva: 80 unidades\n• Aceite de Oliva 1L: 230 unidades\n\n¿Quieres comprobar un producto específico?",
-    "copilotOrderResponse": "Tienes 5 pedidos pendientes:\n• SO-2026-0234 — Empresa ABC ($8,500)\n• SO-2026-0235 — Tech Solutions ($3,200)\n• SO-2026-0236 — Global Trade ($15,000)\n\n¿Abro la lista de pedidos?",
-    "copilotContactResponse": "He encontrado 156 contactos. Principales clientes por facturación:\n1. Global Trade Ltd — $85,000\n2. Empresa ABC — $52,000\n3. Ibérica Industrial — $34,000\n\n¿A quién estás buscando?",
-    "copilotDefaultResponse": "Puedo ayudarte con facturas, pedidos, stock, contactos y más. ¿Qué te gustaría hacer?",
+    "copilotWelcome": "\u00a1Hola! Soy tu asistente ERP. \u00bfEn qu\u00e9 puedo ayudarte hoy?",
+    "copilotInvoiceResponse": "Te ayudar\u00e9 a crear una factura. Abriendo Factura de venta...\n\nTambi\u00e9n puedes decir 'mostrar facturas pendientes' para ver lo que falta.",
+    "copilotStockResponse": "Aqu\u00ed tienes un resumen r\u00e1pido del stock:\n\u2022 Cerveza Ale 0.5L: 150 unidades\n\u2022 Vino Tinto Reserva: 80 unidades\n\u2022 Aceite de Oliva 1L: 230 unidades\n\n\u00bfQuieres comprobar un producto espec\u00edfico?",
+    "copilotOrderResponse": "Tienes 5 pedidos pendientes:\n\u2022 SO-2026-0234 \u2014 Empresa ABC ($8,500)\n\u2022 SO-2026-0235 \u2014 Tech Solutions ($3,200)\n\u2022 SO-2026-0236 \u2014 Global Trade ($15,000)\n\n\u00bfAbro la lista de pedidos?",
+    "copilotContactResponse": "He encontrado 156 contactos. Principales clientes por facturaci\u00f3n:\n1. Global Trade Ltd \u2014 $85,000\n2. Empresa ABC \u2014 $52,000\n3. Ib\u00e9rica Industrial \u2014 $34,000\n\n\u00bfA qui\u00e9n est\u00e1s buscando?",
+    "copilotDefaultResponse": "Puedo ayudarte con facturas, pedidos, stock, contactos y m\u00e1s. \u00bfQu\u00e9 te gustar\u00eda hacer?",
     "createInvoice": "Crear una factura",
     "checkStockLevels": "Consultar stock",
     "showPendingOrders": "Mostrar pedidos pendientes",
     "findContact": "Buscar un contacto",
-    "onboardingCompanySetup": "Configuración de la empresa",
+    "onboardingCompanySetup": "Configuraci\u00f3n de la empresa",
     "onboardingUserProfile": "Perfil de usuario",
-    "onboardingModuleSelection": "Selección de módulos",
+    "onboardingModuleSelection": "Selecci\u00f3n de m\u00f3dulos",
     "onboardingImportData": "Importar datos",
     "onboardingReviewLaunch": "Revisar y lanzar",
     "stepOf": "Paso {step} de {total}",
@@ -17419,24 +17419,24 @@
     "companyName": "Nombre de la empresa",
     "name": "Nombre",
     "industry": "Sector",
-    "companySize": "Tamaño de la empresa",
-    "size": "Tamaño",
+    "companySize": "Tama\u00f1o de la empresa",
+    "size": "Tama\u00f1o",
     "timezone": "Zona horaria",
     "fullName": "Nombre completo",
-    "email": "Correo electrónico",
+    "email": "Correo electr\u00f3nico",
     "role": "Rol",
-    "selectedModules": "Módulos seleccionados",
-    "dataImport": "Importación de datos",
-    "avatarGenerated": "El avatar se generará a partir de tus iniciales",
+    "selectedModules": "M\u00f3dulos seleccionados",
+    "dataImport": "Importaci\u00f3n de datos",
+    "avatarGenerated": "El avatar se generar\u00e1 a partir de tus iniciales",
     "selectIndustry": "Selecciona un sector...",
-    "selectSize": "Selecciona un tamaño...",
+    "selectSize": "Selecciona un tama\u00f1o...",
     "selectTimezone": "Selecciona una zona horaria...",
     "selectRole": "Selecciona un rol...",
     "administrator": "Administrador",
     "manager": "Responsable",
-    "standardUser": "Usuario estándar",
+    "standardUser": "Usuario est\u00e1ndar",
     "viewer": "Visualizador",
-    "back": "Atrás",
+    "back": "Atr\u00e1s",
     "next": "Siguiente",
     "launch": "Lanzar",
     "warehouseSummaryTab": "Resumen",
@@ -17444,53 +17444,53 @@
     "warehouseProducts": "Productos",
     "warehouseTotalUnits": "Unidades totales",
     "warehouseStockTrend": "Tendencia de stock",
-    "warehouseStockBarAria": "Gráfico de barras de stock",
-    "warehouseLineChart": "Gráfico de líneas",
-    "warehouseBarChart": "Gráfico de barras",
-    "warehouseExpandChart": "Expandir gráfico",
-    "warehouseNoMovementData": "Sin datos de movimiento para este período",
-    "warehouseLoadingStock": "Cargando datos de stock…",
+    "warehouseStockBarAria": "Gr\u00e1fico de barras de stock",
+    "warehouseLineChart": "Gr\u00e1fico de l\u00edneas",
+    "warehouseBarChart": "Gr\u00e1fico de barras",
+    "warehouseExpandChart": "Expandir gr\u00e1fico",
+    "warehouseNoMovementData": "Sin datos de movimiento para este per\u00edodo",
+    "warehouseLoadingStock": "Cargando datos de stock\u2026",
     "warehouseStockError": "No se pudieron cargar los datos de stock.",
     "warehouseTooltipUnits": "{label}: {n} unidades",
     "warehouseTransactionsTab": "Transacciones",
-    "warehouseFilterPlaceholder": "Filtrar por producto o tipo…",
+    "warehouseFilterPlaceholder": "Filtrar por producto o tipo\u2026",
     "warehouseDate": "Fecha",
     "warehouseProduct": "Producto",
     "warehouseType": "Tipo",
     "warehouseQty": "Cant.",
     "warehouseUom": "Unidad",
     "warehouseQtyOnHand": "Cantidad disponible",
-    "warehouseLoadingProducts": "Cargando productos…",
+    "warehouseLoadingProducts": "Cargando productos\u2026",
     "warehouseProductsError": "No se pudieron cargar los productos: {error}",
-    "warehouseNoStock": "No hay stock para este almacén.",
-    "warehouseLoadingTransactions": "Cargando transacciones…",
+    "warehouseNoStock": "No hay stock para este almac\u00e9n.",
+    "warehouseLoadingTransactions": "Cargando transacciones\u2026",
     "warehouseTransactionsError": "No se pudieron cargar las transacciones: {error}",
-    "warehouseNoTransactions": "No se encontraron transacciones para este almacén.",
-    "warehouseNoFilterResults": "Ningún resultado coincide con el filtro.",
+    "warehouseNoTransactions": "No se encontraron transacciones para este almac\u00e9n.",
+    "warehouseNoFilterResults": "Ning\u00fan resultado coincide con el filtro.",
     "warehouseMoveTitle": "Transferir stock",
-    "warehouseMoveDestinationLabel": "Almacén de destino",
+    "warehouseMoveDestinationLabel": "Almac\u00e9n de destino",
     "warehouseMoveQtyLabel": "Cantidad a transferir",
-    "warehouseMoveQtyMax": "(máx. {n})",
+    "warehouseMoveQtyMax": "(m\u00e1x. {n})",
     "warehouseMoveConfirm": "Transferir",
-    "warehouseMoveLoadingWarehouses": "Cargando almacenes…",
+    "warehouseMoveLoadingWarehouses": "Cargando almacenes\u2026",
     "warehouseMoveNoWarehouses": "No hay otros almacenes disponibles",
-    "warehouseMoveActionTooltip": "Transferir a otro almacén",
-    "warehouseMoveComingSoon": "El proceso de transferencia estará disponible próximamente",
-    "warehouseMoveTransferring": "Transfiriendo…",
+    "warehouseMoveActionTooltip": "Transferir a otro almac\u00e9n",
+    "warehouseMoveComingSoon": "El proceso de transferencia estar\u00e1 disponible pr\u00f3ximamente",
+    "warehouseMoveTransferring": "Transfiriendo\u2026",
     "warehouseMoveSuccess": "Stock transferido correctamente",
     "warehouseMoveError": "Error al transferir: {error}",
     "internalConsumptionProcess": "Procesar",
-    "internalConsumptionProcessing": "Procesando…",
+    "internalConsumptionProcessing": "Procesando\u2026",
     "internalConsumptionProcessed": "Consumo interno procesado correctamente",
     "internalConsumptionProcessError": "No se pudo procesar: {error}",
-    "movTypeVendorReceipt": "Recepción de proveedor",
+    "movTypeVendorReceipt": "Recepci\u00f3n de proveedor",
     "movTypeInventoryIn": "Inventario entrante",
     "movTypeInventoryOut": "Inventario saliente",
     "movTypeMovementTo": "Movimiento entrada",
     "movTypeMovementFrom": "Movimiento salida",
-    "movTypeProductionIn": "Producción +",
-    "movTypeProductionOut": "Producción -",
-    "movTypeCustomerShipment": "Envío a cliente",
+    "movTypeProductionIn": "Producci\u00f3n +",
+    "movTypeProductionOut": "Producci\u00f3n -",
+    "movTypeCustomerShipment": "Env\u00edo a cliente",
     "movTypeInternalConsumption": "Consumo interno",
     "moduleSales": "Ventas",
     "moduleSalesDesc": "Cotizaciones, pedidos, facturas",
@@ -17499,15 +17499,15 @@
     "moduleInventory": "Inventario",
     "moduleInventoryDesc": "Stock, movimientos, almacenes",
     "moduleAccounting": "Contabilidad",
-    "moduleAccountingDesc": "Libro mayor, pagos, conciliación",
+    "moduleAccountingDesc": "Libro mayor, pagos, conciliaci\u00f3n",
     "moduleCrm": "CRM",
     "moduleCrmDesc": "Leads, acuerdos, actividades",
     "moduleHr": "RR. HH.",
-    "moduleHrDesc": "Empleados, ausencias, nómina",
+    "moduleHrDesc": "Empleados, ausencias, n\u00f3mina",
     "moduleProjects": "Proyectos",
     "moduleProjectsDesc": "Tareas, control horario, documentos",
     "importStartFresh": "Empezar desde cero",
-    "importStartFreshDesc": "Comienza con una base de datos vacía y configura todo desde cero.",
+    "importStartFreshDesc": "Comienza con una base de datos vac\u00eda y configura todo desde cero.",
     "importCsv": "Importar desde CSV",
     "importCsvDesc": "Sube archivos CSV para productos, contactos y saldos iniciales.",
     "customizeDashboard": "Personalizar panel",
@@ -17517,13 +17517,13 @@
     "revenueVsExpenses": "Ingresos vs Gastos",
     "pendingTasks": "Tareas pendientes",
     "topClients": "Clientes principales",
-    "quickActions": "Acciones rápidas",
+    "quickActions": "Acciones r\u00e1pidas",
     "cashFlow": "Flujo de caja",
     "collectionsPayments": "Cobros y pagos",
     "recentInvoices": "Ventas recientes",
-    "recentInvoicesSubtitle": "Facturas de ventas completadas de los últimos 7 días",
-    "bestSellers": "Más vendidos",
-    "bestSellers12m": "Más vendidos (12 meses)",
+    "recentInvoicesSubtitle": "Facturas de ventas completadas de los \u00faltimos 7 d\u00edas",
+    "bestSellers": "M\u00e1s vendidos",
+    "bestSellers12m": "M\u00e1s vendidos (12 meses)",
     "income": "Ingresos",
     "expenses": "Gastos",
     "net": "Neto",
@@ -17539,12 +17539,12 @@
     "revenue": "Ingresos",
     "revenueVsExpenses12m": "Ingresos vs Gastos (12 meses)",
     "topClients12m": "Clientes principales (12 meses)",
-    "months12ByRevenue": "12 meses · por ingresos",
-    "months12ByQty": "12 meses · por cantidad",
+    "months12ByRevenue": "12 meses \u00b7 por ingresos",
+    "months12ByQty": "12 meses \u00b7 por cantidad",
     "noDataAvailable": "Datos no disponibles",
     "dragCardsToReorder": "Arrastra las tarjetas para reordenarlas. Alterna para mostrar/ocultar.",
     "dragToReorder": "Arrastra para reordenar",
-    "changesSavedAutomatically": "Los cambios se guardan automáticamente.",
+    "changesSavedAutomatically": "Los cambios se guardan autom\u00e1ticamente.",
     "invoicePending": "{count} factura pendiente",
     "invoicesPending": "{count} facturas pendientes",
     "pendingSalesInvoices": "{count} Factura de venta pendiente",
@@ -17555,59 +17555,59 @@
     "quickActionSalesOrder": "Pedido de Venta",
     "dashboardCurrencyContext": "Moneda",
     "dashboardCurrencyUnavailable": "Moneda no disponible",
-    "pendingPOs": "{count} Pedidos de compra pendientes de confirmación",
+    "pendingPOs": "{count} Pedidos de compra pendientes de confirmaci\u00f3n",
     "overdueInvoices": "{count} Factura de venta con saldo vencido",
     "overdueInvoices_plural": "{count} Facturas de venta con saldo vencido",
-    "pendingReceptions": "{count} Pedido de compra con recepción pendiente",
-    "pendingReceptions_plural": "{count} Pedidos de compra con recepción pendiente",
+    "pendingReceptions": "{count} Pedido de compra con recepci\u00f3n pendiente",
+    "pendingReceptions_plural": "{count} Pedidos de compra con recepci\u00f3n pendiente",
     "pendingSalesDeliveries": "{count} Pedido de venta con entrega pendiente",
     "pendingSalesDeliveries_plural": "{count} Pedidos de venta con entrega pendiente",
     "collectionsDueToday": "{count} Cobro con vencimiento hoy",
     "collectionsDueToday_plural": "{count} Cobros con vencimiento hoy",
     "paymentsDueToday": "{count} Pago con vencimiento hoy",
     "paymentsDueToday_plural": "{count} Pagos con vencimiento hoy",
-    "lowStockAlert": "{count} Producto con stock por debajo del mínimo",
-    "lowStockAlerts": "{count} Productos con stock por debajo del mínimo",
-    "invoiceTrendLabel": "Gráfico de tendencia de ingresos y gastos de los últimos 12 meses",
-    "barChartAria": "Gráfico de barras de ventas mensuales",
+    "lowStockAlert": "{count} Producto con stock por debajo del m\u00ednimo",
+    "lowStockAlerts": "{count} Productos con stock por debajo del m\u00ednimo",
+    "invoiceTrendLabel": "Gr\u00e1fico de tendencia de ingresos y gastos de los \u00faltimos 12 meses",
+    "barChartAria": "Gr\u00e1fico de barras de ventas mensuales",
     "language": "Idioma",
-    "logout": "Cerrar sesión",
-    "onboardingLanguageSpanish": "Español",
-    "onboardingLanguageEnglish": "Inglés",
-    "onboardingAuthFeatureNoCard": "Sin tarjeta de crédito",
+    "logout": "Cerrar sesi\u00f3n",
+    "onboardingLanguageSpanish": "Espa\u00f1ol",
+    "onboardingLanguageEnglish": "Ingl\u00e9s",
+    "onboardingAuthFeatureNoCard": "Sin tarjeta de cr\u00e9dito",
     "onboardingAuthFeatureTrial": "Prueba gratuita",
     "onboardingAuthFeatureInstantAccess": "Acceso inmediato",
     "onboardingMarketingTitle": "Gestiona tu negocio con Copilot",
-    "onboardingMarketingDescription": "Factura, registra gastos y obtén reportes en segundos con una interfaz simple y guiada.",
-    "onboardingSwitchToLoginPrompt": "¿Ya tienes una cuenta?",
-    "onboardingSwitchToLoginAction": "Iniciar sesión",
-    "onboardingSwitchToRegisterPrompt": "¿Aún no tienes una cuenta?",
+    "onboardingMarketingDescription": "Factura, registra gastos y obt\u00e9n reportes en segundos con una interfaz simple y guiada.",
+    "onboardingSwitchToLoginPrompt": "\u00bfYa tienes una cuenta?",
+    "onboardingSwitchToLoginAction": "Iniciar sesi\u00f3n",
+    "onboardingSwitchToRegisterPrompt": "\u00bfA\u00fan no tienes una cuenta?",
     "onboardingSwitchToRegisterAction": "Crear cuenta",
     "onboardingRegisterTitle": "Crea tu cuenta gratis",
     "onboardingRegisterSubtitle": "Empieza en menos de 1 minuto",
-    "onboardingLoginTitle": "Inicia sesión en tu cuenta",
-    "onboardingLoginSubtitle": "Continúa donde lo dejaste",
+    "onboardingLoginTitle": "Inicia sesi\u00f3n en tu cuenta",
+    "onboardingLoginSubtitle": "Contin\u00faa donde lo dejaste",
     "onboardingNameLabel": "Nombre",
     "onboardingNamePlaceholder": "Tu nombre",
-    "onboardingEmailLabel": "Correo electrónico",
+    "onboardingEmailLabel": "Correo electr\u00f3nico",
     "onboardingEmailPlaceholder": "tu@email.com",
-    "onboardingPasswordLabel": "Contraseña",
+    "onboardingPasswordLabel": "Contrase\u00f1a",
     "onboardingPasswordPlaceholder": "********",
-    "onboardingShowPassword": "Mostrar contraseña",
-    "onboardingHidePassword": "Ocultar contraseña",
+    "onboardingShowPassword": "Mostrar contrase\u00f1a",
+    "onboardingHidePassword": "Ocultar contrase\u00f1a",
     "onboardingCreatingAccount": "Creando cuenta...",
     "onboardingCreateAccountAction": "Crear cuenta",
-    "onboardingSigningIn": "Iniciando sesión...",
-    "onboardingLoginAction": "Iniciar sesión",
+    "onboardingSigningIn": "Iniciando sesi\u00f3n...",
+    "onboardingLoginAction": "Iniciar sesi\u00f3n",
     "onboardingRegisterFailed": "No se pudo crear la cuenta.",
-    "onboardingConnectionError": "Error de conexión. Intenta de nuevo.",
-    "onboardingInvalidCredentials": "Credenciales inválidas.",
+    "onboardingConnectionError": "Error de conexi\u00f3n. Intenta de nuevo.",
+    "onboardingInvalidCredentials": "Credenciales inv\u00e1lidas.",
     "onboardingEnvironmentLoginFailed": "No se pudo entrar al entorno.",
-    "onboardingGenericError": "Ocurrió un problema durante el onboarding.",
-    "onboardingInvalidSession": "Tu sesión ya no es válida.",
+    "onboardingGenericError": "Ocurri\u00f3 un problema durante el onboarding.",
+    "onboardingInvalidSession": "Tu sesi\u00f3n ya no es v\u00e1lida.",
     "onboardingLoadEnvironmentsFailed": "No se pudieron cargar los entornos.",
-    "onboardingStreamUnavailable": "El progreso del onboarding no está disponible en este momento.",
-    "onboardingMissingResult": "El onboarding terminó sin un resultado final.",
+    "onboardingStreamUnavailable": "El progreso del onboarding no est\u00e1 disponible en este momento.",
+    "onboardingMissingResult": "El onboarding termin\u00f3 sin un resultado final.",
     "onboardingEnvironmentsShort": "Tus entornos",
     "onboardingNewEnvironment": "Nuevo entorno",
     "onboardingEnvironmentsTitle": "Tus entornos",
@@ -17616,201 +17616,201 @@
     "onboardingCreateFirstEnvironment": "Crea tu primer entorno para comenzar.",
     "onboardingCreateEnvironment": "Crear entorno",
     "onboardingEnterEnvironment": "Entrar",
-    "onboardingProgressAlmostReady": "Un paso más",
+    "onboardingProgressAlmostReady": "Un paso m\u00e1s",
     "onboardingProgressAlmostDone": "Casi listo",
-    "onboardingGreetingFallback": "ahí",
-    "onboardingGreeting": "Hola {name} 👋",
+    "onboardingGreetingFallback": "ah\u00ed",
+    "onboardingGreeting": "Hola {name} \ud83d\udc4b",
     "onboardingSetupSubtitle": "Vamos a dejar todo listo en menos de 1 minuto",
     "onboardingFullNameLabel": "Nombre completo",
-    "onboardingFullNamePlaceholder": "Juan Pérez",
-    "onboardingCountryLabel": "País",
-    "onboardingCountrySpain": "España",
+    "onboardingFullNamePlaceholder": "Juan P\u00e9rez",
+    "onboardingCountryLabel": "Pa\u00eds",
+    "onboardingCountrySpain": "Espa\u00f1a",
     "onboardingBusinessTypeLabel": "Tipo de negocio",
     "onboardingBusinessTypeCompany": "Empresa",
-    "onboardingBusinessTypeFreelancer": "Autónomo",
-    "onboardingBusinessTypeAdvisory": "Asesoría",
+    "onboardingBusinessTypeFreelancer": "Aut\u00f3nomo",
+    "onboardingBusinessTypeAdvisory": "Asesor\u00eda",
     "onboardingContinueAction": "Continuar",
     "onboardingCompanyTitle": "Datos para empezar a facturar",
-    "onboardingCompanySubtitle": "Puedes editarlos más adelante",
+    "onboardingCompanySubtitle": "Puedes editarlos m\u00e1s adelante",
     "onboardingCompanyNameLabel": "Nombre de la empresa",
     "onboardingCompanyNamePlaceholder": "Mi empresa",
-    "onboardingFiscalIdLabel": "Identificación fiscal",
+    "onboardingFiscalIdLabel": "Identificaci\u00f3n fiscal",
     "onboardingFiscalIdPlaceholder": "12345678Z",
-    "onboardingAddressLabel": "Dirección",
+    "onboardingAddressLabel": "Direcci\u00f3n",
     "onboardingAddressPlaceholder": "Av. Corrientes 1234",
     "onboardingSectorLabel": "Sector",
-    "onboardingSectorTechnology": "Tecnología",
+    "onboardingSectorTechnology": "Tecnolog\u00eda",
     "onboardingSectorServices": "Servicios",
     "onboardingSectorCommerce": "Comercio",
     "onboardingSectorManufacturing": "Industria",
     "onboardingStarting": "Empezando...",
     "onboardingStartAction": "Empezar",
-    "onboardingSuccessTitle": "Tu cuenta ya está en marcha",
+    "onboardingSuccessTitle": "Tu cuenta ya est\u00e1 en marcha",
     "onboardingSuccessDescription": "Ya puedes empezar a gestionar tu negocio",
     "onboardingCompleted": "Completado",
     "onboardingPreparingTitle": "Estamos preparando tu espacio",
-    "onboardingPreparingActivatingDescription": "Activando tus módulos...",
+    "onboardingPreparingActivatingDescription": "Activando tus m\u00f3dulos...",
     "onboardingPreparingFinishingDescription": "Dejando todo listo...",
-    "onboardingPreparingSequencesDescription": "Generando secuencias de la organización...",
-    "onboardingPreparingTaxesDescription": "Configurando impuestos según tu país...",
-    "onboardingReadinessFailed": "El entorno se creó, pero todavía no está listo para facturar: {reasons}",
-    "onboardingReadinessSession": "La sesión del ERP todavía no está lista.",
-    "onboardingReadinessDefaults": "Los valores por defecto de factura de venta todavía no están listos.",
-    "onboardingReadinessPaymentTerms": "Las condiciones de pago de factura de venta no están disponibles.",
-    "onboardingReadinessCustomers": "Los clientes de factura de venta no están disponibles.",
-    "onboardingReadinessDocumentType": "El tipo de documento de factura de venta falta o no es válido.",
+    "onboardingPreparingSequencesDescription": "Generando secuencias de la organizaci\u00f3n...",
+    "onboardingPreparingTaxesDescription": "Configurando impuestos seg\u00fan tu pa\u00eds...",
+    "onboardingReadinessFailed": "El entorno se cre\u00f3, pero todav\u00eda no est\u00e1 listo para facturar: {reasons}",
+    "onboardingReadinessSession": "La sesi\u00f3n del ERP todav\u00eda no est\u00e1 lista.",
+    "onboardingReadinessDefaults": "Los valores por defecto de factura de venta todav\u00eda no est\u00e1n listos.",
+    "onboardingReadinessPaymentTerms": "Las condiciones de pago de factura de venta no est\u00e1n disponibles.",
+    "onboardingReadinessCustomers": "Los clientes de factura de venta no est\u00e1n disponibles.",
+    "onboardingReadinessDocumentType": "El tipo de documento de factura de venta falta o no es v\u00e1lido.",
     "onboardingBrandName": "Etendo",
-    "organization": "Organización",
-    "selectOrg": "Selecciona una organización...",
+    "organization": "Organizaci\u00f3n",
+    "selectOrg": "Selecciona una organizaci\u00f3n...",
     "apply": "Aplicar",
     "switching": "Cambiando...",
     "contextUpdated": "Contexto actualizado",
-    "enterPasswordToSwitch": "Introduce la contraseña para cambiar.",
+    "enterPasswordToSwitch": "Introduce la contrase\u00f1a para cambiar.",
     "failedToSwitch": "Error al cambiar de contexto.",
-    "password": "Contraseña",
-    "yourPassword": "Tu contraseña...",
+    "password": "Contrase\u00f1a",
+    "yourPassword": "Tu contrase\u00f1a...",
     "noRole": "Sin rol",
-    "noOrg": "Sin organización",
-    "creditTax": "Crédito",
-    "creditTaxDescription": "Límite de línea de crédito de este contacto.",
+    "noOrg": "Sin organizaci\u00f3n",
+    "creditTax": "Cr\u00e9dito",
+    "creditTaxDescription": "L\u00edmite de l\u00ednea de cr\u00e9dito de este contacto.",
     "vendor": "Proveedor",
-    "searchAddress": "Buscar dirección…",
-    "typeToSearch": "Escribe para buscar…",
-    "searching": "Buscando…",
+    "searchAddress": "Buscar direcci\u00f3n\u2026",
+    "typeToSearch": "Escribe para buscar\u2026",
+    "searching": "Buscando\u2026",
     "typeAtLeast2Characters": "Escribe al menos 2 caracteres",
-    "setLocation": "Establecer ubicación",
-    "locationSelectorTitle": "Ubicación",
-    "addressLine1": "Primera línea",
-    "addressLine2": "Segunda línea",
-    "postalCodeLabel": "Código postal",
+    "setLocation": "Establecer ubicaci\u00f3n",
+    "locationSelectorTitle": "Ubicaci\u00f3n",
+    "addressLine1": "Primera l\u00ednea",
+    "addressLine2": "Segunda l\u00ednea",
+    "postalCodeLabel": "C\u00f3digo postal",
     "cityLabel": "Ciudad",
-    "countryLabel": "País",
-    "countrySearchPlaceholder": "Buscar país...",
-    "countryLoadError": "No se pudieron cargar los países",
-    "locationCountryRequired": "Debes seleccionar un país antes de guardar la ubicación",
-    "regionLabel": "Región",
-    "regionSearchPlaceholder": "Buscar región...",
+    "countryLabel": "Pa\u00eds",
+    "countrySearchPlaceholder": "Buscar pa\u00eds...",
+    "countryLoadError": "No se pudieron cargar los pa\u00edses",
+    "locationCountryRequired": "Debes seleccionar un pa\u00eds antes de guardar la ubicaci\u00f3n",
+    "regionLabel": "Regi\u00f3n",
+    "regionSearchPlaceholder": "Buscar regi\u00f3n...",
     "regionLoadError": "No se pudieron cargar las regiones",
-    "selectCountryFirst": "Selecciona un país primero",
+    "selectCountryFirst": "Selecciona un pa\u00eds primero",
     "removeLocation": "Eliminar",
-    "addLocation": "+ Agregar Dirección",
-    "addAddress": "+ Agregar dirección",
+    "addLocation": "+ Agregar Direcci\u00f3n",
+    "addAddress": "+ Agregar direcci\u00f3n",
     "none": "Ninguno",
     "soConfirmBtn": "Confirmar",
     "soConfirmTitle": "Confirmar pedido #{number}",
-    "soConfirmWarning": "Una vez confirmado no podrás editar el pedido",
+    "soConfirmWarning": "Una vez confirmado no podr\u00e1s editar el pedido",
     "soConfirmOnly": "Solo confirmar",
     "soConfirmOnlyDesc": "El pedido queda confirmado sin generar documentos",
-    "soConfirmWithShipment": "Confirmar y crear albarán",
-    "soConfirmWithShipmentDesc": "Se generará un envío en borrador",
+    "soConfirmWithShipment": "Confirmar y crear albar\u00e1n",
+    "soConfirmWithShipmentDesc": "Se generar\u00e1 un env\u00edo en borrador",
     "soConfirmWithInvoice": "Confirmar y facturar",
-    "soConfirmWithInvoiceDesc": "Se generará una factura en borrador",
+    "soConfirmWithInvoiceDesc": "Se generar\u00e1 una factura en borrador",
     "soProcessing": "Procesando...",
-    "soConfirmAction": "Confirmar →",
-    "soErrorOccurred": "Ocurrió un error",
-    "soManageShipmentAndInvoice": "Gestionar envío y factura ▾",
-    "soManageShipment": "Gestionar envío ▾",
-    "soManageInvoice": "Gestionar factura ▾",
-    "soShipmentSection": "Envío",
+    "soConfirmAction": "Confirmar \u2192",
+    "soErrorOccurred": "Ocurri\u00f3 un error",
+    "soManageShipmentAndInvoice": "Gestionar env\u00edo y factura \u25be",
+    "soManageShipment": "Gestionar env\u00edo \u25be",
+    "soManageInvoice": "Gestionar factura \u25be",
+    "soShipmentSection": "Env\u00edo",
     "soInvoiceSection": "Factura",
-    "soQtyDeliveredOf": "{delivered} / {total} uds. entregadas · {pending} pendientes",
+    "soQtyDeliveredOf": "{delivered} / {total} uds. entregadas \u00b7 {pending} pendientes",
     "soQtyPendingDelivery": "{pending} uds. pendientes de entrega",
-    "soAmountInvoicedOf": "{invoiced} / {total} facturados · {pending} pendientes",
+    "soAmountInvoicedOf": "{invoiced} / {total} facturados \u00b7 {pending} pendientes",
     "soAmountPendingInvoice": "{pending} pendientes de facturar",
-    "soCreateShipment": "+ Crear albarán",
+    "soCreateShipment": "+ Crear albar\u00e1n",
     "soCreateInvoice": "+ Crear factura",
     "soCreating": "Creando...",
     "soAllDelivered": "Entregado",
     "soAllInvoiced": "Facturado",
-    "soNShipments": "{count} envíos",
+    "soNShipments": "{count} env\u00edos",
     "soInDraft": "En borrador",
-    "soWhatToDo": "¿Qué querés hacer?",
-    "soCreateShipmentTitle": "Crear albarán",
-    "soCreateShipmentDesc": "Genera el albarán en borrador para gestionar la entrega. Desde ahí podés facturar.",
+    "soWhatToDo": "\u00bfQu\u00e9 quer\u00e9s hacer?",
+    "soCreateShipmentTitle": "Crear albar\u00e1n",
+    "soCreateShipmentDesc": "Genera el albar\u00e1n en borrador para gestionar la entrega. Desde ah\u00ed pod\u00e9s facturar.",
     "soRecommended": "Recomendado",
     "soInvoiceDirectly": "Facturar directamente",
-    "soInvoiceDirectlyDesc": "Para servicios o ventas sin entrega física. Sin albarán.",
-    "soOnlyConfirmDesc": "Confirma el pedido sin crear ningún documento adicional ahora.",
-    "soLines": "{count} líneas",
-    "soLine": "1 línea",
+    "soInvoiceDirectlyDesc": "Para servicios o ventas sin entrega f\u00edsica. Sin albar\u00e1n.",
+    "soOnlyConfirmDesc": "Confirma el pedido sin crear ning\u00fan documento adicional ahora.",
+    "soLines": "{count} l\u00edneas",
+    "soLine": "1 l\u00ednea",
     "soSubtotal": "Subtotal",
-    "soConfirmActionShipment": "Confirmar + albarán →",
-    "soConfirmActionInvoice": "Confirmar + factura →",
-    "soConfirmActionBoth": "Confirmar + albarán + factura →",
+    "soConfirmActionShipment": "Confirmar + albar\u00e1n \u2192",
+    "soConfirmActionInvoice": "Confirmar + factura \u2192",
+    "soConfirmActionBoth": "Confirmar + albar\u00e1n + factura \u2192",
     "soGenerateDocs": "Generar documentos (opcional)",
     "soCreateInvoiceTitle": "Crear factura",
-    "soCreateShipmentCheckDesc": "Se generará un albarán en borrador, independiente de la factura",
-    "soCreateInvoiceCheckDesc": "Se generará una factura en borrador con las cantidades del pedido",
-    "soBothCreated": "Albarán y factura creados",
+    "soCreateShipmentCheckDesc": "Se generar\u00e1 un albar\u00e1n en borrador, independiente de la factura",
+    "soCreateInvoiceCheckDesc": "Se generar\u00e1 una factura en borrador con las cantidades del pedido",
+    "soBothCreated": "Albar\u00e1n y factura creados",
     "soConfirmedTitle": "Pedido confirmado",
     "soConfirmedSubtitle": "Se generaron los siguientes documentos en borrador:",
     "soConfirmActionOnly": "Confirmar pedido",
     "soManageDocsTitle": "Gestionar documentos",
-    "soCreateDocsBtn": "Crear →",
+    "soCreateDocsBtn": "Crear \u2192",
     "soDocsCreatedTitle": "Documentos creados",
     "soOrderConfirmed": "Pedido confirmado",
-    "soOrderConfirmedDesc": "Order #{number} listo para facturar o generar albarán.",
-    "soShipmentCreated": "Albarán creado",
+    "soOrderConfirmedDesc": "Order #{number} listo para facturar o generar albar\u00e1n.",
+    "soShipmentCreated": "Albar\u00e1n creado",
     "soInvoiceCreated": "Factura creada",
-    "soShipmentCreatedNote": "Revisá las cantidades antes de procesar la entrega.",
+    "soShipmentCreatedNote": "Revis\u00e1 las cantidades antes de procesar la entrega.",
     "soClose": "Cerrar",
-    "soViewShipment": "Ver albarán →",
-    "soViewInvoice": "Ver factura →",
+    "soViewShipment": "Ver albar\u00e1n \u2192",
+    "soViewInvoice": "Ver factura \u2192",
     "datePickerBack": "Volver",
     "datePickerOk": "Ok",
     "datePickerMonth": "Mes",
-    "datePickerYear": "Año",
+    "datePickerYear": "A\u00f1o",
     "datePickerOpen": "Abrir calendario",
-    "soOrderConfirmedShipmentError": "El pedido fue procesado pero no se pudo crear el albarán. ",
+    "soOrderConfirmedShipmentError": "El pedido fue procesado pero no se pudo crear el albar\u00e1n. ",
     "soOrderConfirmedInvoiceError": "El pedido fue procesado pero no se pudo crear la factura. ",
     "soAlreadyCreated": "Ya creado",
     "soBulkCreateInvoices": "Crear facturas masivamente",
     "soBulkCreateShipments": "Crear albaranes masivamente",
-    "soBulkOrderNotCompleted": "Pedido {documentNo} no está procesado (estado debe ser CO).",
+    "soBulkOrderNotCompleted": "Pedido {documentNo} no est\u00e1 procesado (estado debe ser CO).",
     "soBulkOrderHasDraftInvoice": "Pedido {documentNo} ya tiene una factura en borrador.",
-    "soBulkOrderHasDraftShipment": "Pedido {documentNo} ya tiene un albarán en borrador.",
+    "soBulkOrderHasDraftShipment": "Pedido {documentNo} ya tiene un albar\u00e1n en borrador.",
     "quotationDocumentLabel": "Presupuesto",
-    "sqWhatToDo": "¿Cómo querés confirmar?",
+    "sqWhatToDo": "\u00bfC\u00f3mo quer\u00e9s confirmar?",
     "sqCreateOrder": "Crear pedido de venta",
-    "sqCreateOrderDesc": "Para productos con stock, entregas o pedidos con múltiples envíos.",
-    "sqInvoiceDirectlyDesc": "Para servicios o ventas sin entrega física. Sin albarán.",
-    "sqConfirmActionOrder": "Confirmar → Pedido de venta",
+    "sqCreateOrderDesc": "Para productos con stock, entregas o pedidos con m\u00faltiples env\u00edos.",
+    "sqInvoiceDirectlyDesc": "Para servicios o ventas sin entrega f\u00edsica. Sin albar\u00e1n.",
+    "sqConfirmActionOrder": "Confirmar \u2192 Pedido de venta",
     "sqOrderCreated": "Pedido creado",
-    "sqViewOrder": "Ver pedido →",
+    "sqViewOrder": "Ver pedido \u2192",
     "sqOrderConfirmedError": "El presupuesto fue procesado pero no se pudo crear el pedido. ",
-    "sqSendToEvalTitle": "¿Enviar a Bajo Evaluación?",
-    "sqSendToEvalDesc": "La cotización quedará lista para crear pedido o factura.",
-    "sqSendToEvalConfirm": "Enviar a evaluación",
+    "sqSendToEvalTitle": "\u00bfEnviar a Bajo Evaluaci\u00f3n?",
+    "sqSendToEvalDesc": "La cotizaci\u00f3n quedar\u00e1 lista para crear pedido o factura.",
+    "sqSendToEvalConfirm": "Enviar a evaluaci\u00f3n",
     "sqOrderConfirmedInvoiceError": "El presupuesto fue procesado pero no se pudo crear la factura. ",
     "rejectQuotation": "Rechazar",
     "rejectQuotationTitle": "Rechazar Presupuesto",
-    "rejectQuotationDesc": "Selecciona un motivo de rechazo. Esta acción cambiará el estado del presupuesto a rechazado.",
+    "rejectQuotationDesc": "Selecciona un motivo de rechazo. Esta acci\u00f3n cambiar\u00e1 el estado del presupuesto a rechazado.",
     "rejectReasonLabel": "Selecciona un motivo",
     "rejectReasonPlaceholder": "Selecciona o crea un motivo",
     "rejectQuotationConfirm": "Rechazar presupuesto",
     "rejectQuotationError": "No se pudo rechazar el presupuesto. ",
     "rejectReasonSearchPlaceholder": "Selecciona o crea un motivo",
     "rejectReasonNoResults": "No hay razones que coincidan",
-    "createRejectReason": "Crear razón",
-    "createRejectReasonTitle": "Crear razón de rechazo",
+    "createRejectReason": "Crear raz\u00f3n",
+    "createRejectReasonTitle": "Crear raz\u00f3n de rechazo",
     "rejectReasonNameLabel": "Nombre",
     "rejectReasonNamePlaceholder": "ej. Precio demasiado alto",
-    "rejectReasonCreateConfirm": "Crear razón",
-    "rejectReasonCreateError": "No se pudo crear la razón de rechazo. ",
+    "rejectReasonCreateConfirm": "Crear raz\u00f3n",
+    "rejectReasonCreateError": "No se pudo crear la raz\u00f3n de rechazo. ",
     "productPctFree": "{pct}% libre",
     "productTotalOnHand": "Total en stock",
     "productInWarehouse": "En {name}",
     "productDistributedIn": "Distribuido en {count} almacenes",
-    "productLast12Months": "Últimos 12 meses.",
+    "productLast12Months": "\u00daltimos 12 meses.",
     "expand": "Expandir",
     "paymentInGroup": "Cobro",
     "paymentOutGroup": "Pago",
     "payinAllow": "Cobro permitido",
-    "automaticReceipt": "Cobro automático",
-    "automaticDeposit": "Depósito automático",
+    "automaticReceipt": "Cobro autom\u00e1tico",
+    "automaticDeposit": "Dep\u00f3sito autom\u00e1tico",
     "payoutAllow": "Pago permitido",
-    "automaticPayment": "Pago automático",
-    "automaticWithdrawn": "Retiro automático",
+    "automaticPayment": "Pago autom\u00e1tico",
+    "automaticWithdrawn": "Retiro autom\u00e1tico",
     "priceSalesLists": "Listas de precios de venta",
     "pricePurchaseLists": "Listas de precios de compra",
     "priceNoLists": "No hay listas de precios configuradas para este tipo.",
@@ -17821,39 +17821,39 @@
     "saveChanges": "Guardar cambios",
     "discardChanges": "Descartar cambios",
     "unsavedChanges": "Cambios sin guardar",
-    "unsavedChangesDesc": "Tenés cambios sin guardar. ¿Qué querés hacer?",
+    "unsavedChangesDesc": "Ten\u00e9s cambios sin guardar. \u00bfQu\u00e9 quer\u00e9s hacer?",
     "pricingUpdated": "Precios actualizados correctamente.",
     "uploadImage": "Subir imagen",
-    "uploadingImage": "Subiendo…",
-    "assetsAmortizationPlan": "Plan de amortización",
-    "assetsAmortizationPlanDesc": "Muestra qué pasará con el activo a lo largo del tiempo.",
-    "assetsPlannedLine": "línea planificada",
-    "assetsPlannedLines": "líneas planificadas",
+    "uploadingImage": "Subiendo\u2026",
+    "assetsAmortizationPlan": "Plan de amortizaci\u00f3n",
+    "assetsAmortizationPlanDesc": "Muestra qu\u00e9 pasar\u00e1 con el activo a lo largo del tiempo.",
+    "assetsPlannedLine": "l\u00ednea planificada",
+    "assetsPlannedLines": "l\u00edneas planificadas",
     "assetsLoading": "Cargando...",
-    "assetsNoAmortizationLines": "Aún no hay líneas de amortización. Usá \"Crear amortización\" para generar el plan.",
-    "assetsPeriod": "Período",
+    "assetsNoAmortizationLines": "A\u00fan no hay l\u00edneas de amortizaci\u00f3n. Us\u00e1 \"Crear amortizaci\u00f3n\" para generar el plan.",
+    "assetsPeriod": "Per\u00edodo",
     "assetsPercentage": "Porcentaje",
     "assetsStatus": "Estado",
     "assetsTotalPlanned": "Total planificado:",
     "assetsStatusProcessed": "Procesado",
     "assetsStatusPlanned": "Planificado",
-    "assetsDepreciationSummary": "Resumen de depreciación",
+    "assetsDepreciationSummary": "Resumen de depreciaci\u00f3n",
     "assetsCurrentValue": "Valor actual",
     "assetsBookValue": "Valor contable del activo",
-    "assetsPlannedDepreciation": "Depreciación planificada",
+    "assetsPlannedDepreciation": "Depreciaci\u00f3n planificada",
     "assetsTotalScheduled": "Monto total programado",
     "assetsDepreciated": "Depreciado",
     "assetsFullyDepreciated": "Totalmente depreciado",
     "assetsStillInProgress": "En progreso",
-    "assetsDepreciationProgress": "Progreso de depreciación",
+    "assetsDepreciationProgress": "Progreso de depreciaci\u00f3n",
     "assetsPendingCount": "Pendiente: {count}",
     "assetsDoneCount": "Hecho: {count}",
-    "assetsCreateAmortization": "Crear amortización",
-    "assetsConfigDesc": "Configurá el método, el calendario y los montos de depreciación para este activo.",
+    "assetsCreateAmortization": "Crear amortizaci\u00f3n",
+    "assetsConfigDesc": "Configur\u00e1 el m\u00e9todo, el calendario y los montos de depreciaci\u00f3n para este activo.",
     "assetsDepreciateLabel": "Depreciar",
-    "assetsDepreciateDesc": "Habilitar la depreciación para este activo.",
-    "assets30DaysLabel": "Cada mes tiene 30 días",
-    "assets30DaysDesc": "Usar meses de 30 días para el cálculo de depreciación.",
+    "assetsDepreciateDesc": "Habilitar la depreciaci\u00f3n para este activo.",
+    "assets30DaysLabel": "Cada mes tiene 30 d\u00edas",
+    "assets30DaysDesc": "Usar meses de 30 d\u00edas para el c\u00e1lculo de depreciaci\u00f3n.",
     "assetsOptLinear": "Lineal",
     "assetsOptPercentage": "Porcentaje",
     "assetsOptTime": "Tiempo",
@@ -17861,101 +17861,101 @@
     "assetsOptYearly": "Anual",
     "assetsCurrencyLabel": "Moneda",
     "assetsPurchaseDateLabel": "Fecha de compra",
-    "assetsCancellationDateLabel": "Fecha de cancelación",
-    "assetsDepStartDateLabel": "Fecha inicio de depreciación",
-    "assetsDepEndDateLabel": "Fecha fin de depreciación",
+    "assetsCancellationDateLabel": "Fecha de cancelaci\u00f3n",
+    "assetsDepStartDateLabel": "Fecha inicio de depreciaci\u00f3n",
+    "assetsDepEndDateLabel": "Fecha fin de depreciaci\u00f3n",
     "assetsAssetValueLabel": "Valor del activo",
     "assetsResidualValueLabel": "Valor residual del activo",
-    "assetsDepreciationAmtLabel": "Monto de depreciación",
+    "assetsDepreciationAmtLabel": "Monto de depreciaci\u00f3n",
     "assetsPrevDepreciatedLabel": "Monto ya depreciado",
     "poSave": "Guardar",
     "poSaveDraft": "Guardar borrador",
     "poConfirmBtn": "Confirmar",
     "poConfirmTitle": "Confirmar pedido #{number}",
-    "poConfirmWarning": "Una vez confirmado no podrás editar el pedido",
+    "poConfirmWarning": "Una vez confirmado no podr\u00e1s editar el pedido",
     "poConfirmOnly": "Solo confirmar",
     "poConfirmOnlyDesc": "El pedido queda confirmado sin generar documentos adicionales",
     "poConfirmWithInvoice": "Confirmar y facturar",
-    "poConfirmWithInvoiceDesc": "Se generará una factura de compra en borrador",
-    "poConfirmAction": "Confirmar →",
+    "poConfirmWithInvoiceDesc": "Se generar\u00e1 una factura de compra en borrador",
+    "poConfirmAction": "Confirmar \u2192",
     "poProcessing": "Procesando...",
-    "poErrorOccurred": "Ocurrió un error",
+    "poErrorOccurred": "Ocurri\u00f3 un error",
     "poOrderConfirmed": "Pedido confirmado",
-    "poOrderConfirmedDesc": "El pedido #{number} está confirmado y listo para recibir mercadería o facturar.",
+    "poOrderConfirmedDesc": "El pedido #{number} est\u00e1 confirmado y listo para recibir mercader\u00eda o facturar.",
     "poOrderConfirmedInvoiceError": "Pedido confirmado, pero no se pudo crear la factura.",
-    "poOrderConfirmedReceiptError": "Pedido confirmado, pero no se pudo crear la recepción de mercadería.",
-    "poReceiveGoods": "Recibir mercadería",
+    "poOrderConfirmedReceiptError": "Pedido confirmado, pero no se pudo crear la recepci\u00f3n de mercader\u00eda.",
+    "poReceiveGoods": "Recibir mercader\u00eda",
     "poCreateInvoice": "Crear factura",
     "poInvoiceCreated": "Factura creada",
-    "poReviewBeforeConfirming": "Revisá antes de confirmar",
-    "poViewInvoice": "Ver factura →",
-    "poReceiveGoodsTitle": "Recibir mercadería",
+    "poReviewBeforeConfirming": "Revis\u00e1 antes de confirmar",
+    "poViewInvoice": "Ver factura \u2192",
+    "poReceiveGoodsTitle": "Recibir mercader\u00eda",
     "poProduct": "Producto",
     "poOrdered": "Pedido",
     "poReceive": "Recibir",
-    "poNoLines": "Sin líneas",
+    "poNoLines": "Sin l\u00edneas",
     "poReceiveAll": "Recibir todo",
     "poConfirmReceive": "Confirmar",
-    "poReceiptCreated": "Albarán creado",
-    "poViewReceipt": "Ver albarán →",
+    "poReceiptCreated": "Albar\u00e1n creado",
+    "poViewReceipt": "Ver albar\u00e1n \u2192",
     "poConfirmWithReceipt": "Confirmar y recibir",
-    "poConfirmWithReceiptDesc": "Se generará un albarán de entrada en borrador",
-    "poManageReceiptAndInvoice": "Gestionar recepción y factura",
-    "poManageReceipt": "Gestionar recepción",
+    "poConfirmWithReceiptDesc": "Se generar\u00e1 un albar\u00e1n de entrada en borrador",
+    "poManageReceiptAndInvoice": "Gestionar recepci\u00f3n y factura",
+    "poManageReceipt": "Gestionar recepci\u00f3n",
     "poManageInvoice": "Gestionar factura",
-    "poReceiptSection": "Albarán de entrada",
+    "poReceiptSection": "Albar\u00e1n de entrada",
     "poInvoiceSection": "Factura de compra",
-    "poCreateReceipt": "+ Crear albarán de entrada",
+    "poCreateReceipt": "+ Crear albar\u00e1n de entrada",
     "poPendingReceipt": "uds. pendientes de recibir",
-    "poQtyReceivedOf": "Recibido: {received} / {total} uds. · {pending} pendientes",
+    "poQtyReceivedOf": "Recibido: {received} / {total} uds. \u00b7 {pending} pendientes",
     "poPendingInvoice": "pendientes de facturar",
-    "poAmountInvoicedOf": "Facturado: {invoiced} · {pending} pendientes",
-    "poReceiptDraftChip": "📦 Albarán #{number} · Pendiente de confirmar",
-    "poInvoiceDraftChip": "🧾 Factura #{number} · Pendiente de confirmar",
+    "poAmountInvoicedOf": "Facturado: {invoiced} \u00b7 {pending} pendientes",
+    "poReceiptDraftChip": "\ud83d\udce6 Albar\u00e1n #{number} \u00b7 Pendiente de confirmar",
+    "poInvoiceDraftChip": "\ud83e\uddfe Factura #{number} \u00b7 Pendiente de confirmar",
     "poCreating": "Creando...",
     "poAllReceived": "Recibido",
     "poAllInvoiced": "Facturado",
     "poNReceipts": "{count} albaranes",
-    "poConfirmActionReceipt": "Confirmar + albarán →",
-    "poConfirmActionInvoice": "Confirmar + factura →",
-    "poConfirmActionBoth": "Confirmar + albarán + factura →",
-    "poCreateReceiptTitle": "Crear albarán de proveedor",
-    "poCreateReceiptCheckDesc": "Se creará un albarán de proveedor en borrador",
-    "poCreateInvoiceCheckDesc": "Se creará una factura de compra en borrador",
+    "poConfirmActionReceipt": "Confirmar + albar\u00e1n \u2192",
+    "poConfirmActionInvoice": "Confirmar + factura \u2192",
+    "poConfirmActionBoth": "Confirmar + albar\u00e1n + factura \u2192",
+    "poCreateReceiptTitle": "Crear albar\u00e1n de proveedor",
+    "poCreateReceiptCheckDesc": "Se crear\u00e1 un albar\u00e1n de proveedor en borrador",
+    "poCreateInvoiceCheckDesc": "Se crear\u00e1 una factura de compra en borrador",
     "poConfirmedTitle": "Pedido de compra confirmado",
-    "poReceiptDoc": "Albarán #{number}",
+    "poReceiptDoc": "Albar\u00e1n #{number}",
     "poPurchaseInvoiceDoc": "Factura #{number}",
     "poBulkCreateInvoices": "Crear facturas masivamente",
     "poBulkCreateReceipts": "Crear albaranes masivamente",
-    "poBulkOrderNotCompleted": "Pedido {documentNo} no está procesado (estado debe ser CO).",
+    "poBulkOrderNotCompleted": "Pedido {documentNo} no est\u00e1 procesado (estado debe ser CO).",
     "poBulkOrderHasDraftInvoice": "Pedido {documentNo} ya tiene una factura en borrador.",
-    "poBulkOrderHasDraftReceipt": "Pedido {documentNo} ya tiene un albarán en borrador.",
+    "poBulkOrderHasDraftReceipt": "Pedido {documentNo} ya tiene un albar\u00e1n en borrador.",
     "cloneOrderBtn": "Clonar",
     "cloneOrderConfirmTitle": "Clonar pedido",
-    "cloneOrderConfirmBody": "Se creará una copia en borrador de este pedido con los mismos datos.",
-    "cloneOrderAction": "Clonar →",
-    "cloneOrderError": "Ocurrió un error al clonar el pedido",
+    "cloneOrderConfirmBody": "Se crear\u00e1 una copia en borrador de este pedido con los mismos datos.",
+    "cloneOrderAction": "Clonar \u2192",
+    "cloneOrderError": "Ocurri\u00f3 un error al clonar el pedido",
     "cloneInvoiceConfirmTitle": "Clonar factura",
-    "cloneInvoiceConfirmBody": "Se creará una copia en borrador de esta factura con los mismos datos.",
-    "cloneInvoiceAction": "Clonar →",
-    "cloneInvoiceError": "Ocurrió un error al clonar la factura",
+    "cloneInvoiceConfirmBody": "Se crear\u00e1 una copia en borrador de esta factura con los mismos datos.",
+    "cloneInvoiceAction": "Clonar \u2192",
+    "cloneInvoiceError": "Ocurri\u00f3 un error al clonar la factura",
     "cloneConfirmTitleOne": "Clonar documento",
     "cloneConfirmTitleMany": "Clonar {count} documentos",
-    "cloneConfirmSubtitleOne": "Se creará una copia en estado borrador",
-    "cloneConfirmSubtitleMany": "Se crearán {count} copias en estado borrador",
-    "cloneInfoBanner": "Los documentos clonados conservarán todos los datos del original.",
+    "cloneConfirmSubtitleOne": "Se crear\u00e1 una copia en estado borrador",
+    "cloneConfirmSubtitleMany": "Se crear\u00e1n {count} copias en estado borrador",
+    "cloneInfoBanner": "Los documentos clonados conservar\u00e1n todos los datos del original.",
     "cloneDoneTitleOne": "Documento clonado",
     "cloneDoneTitleMany": "{count} documentos clonados",
-    "cloneDoneSubtitle": "Hacé clic en uno para abrirlo",
+    "cloneDoneSubtitle": "Hac\u00e9 clic en uno para abrirlo",
     "invoiceProcessing": "Procesando...",
     "orderStatusDraft": "Borrador",
     "orderStatusCompleted": "Completado",
     "orderStatusClosed": "Cerrado",
     "orderStatusVoided": "Anulado",
     "createInventoryCountList": "Crear lista de conteo",
-    "productSearchKey": "Clave de búsqueda del producto",
-    "productCategory": "Categoría de producto",
-    "allCategories": "Todas las categorías",
+    "productSearchKey": "Clave de b\u00fasqueda del producto",
+    "productCategory": "Categor\u00eda de producto",
+    "allCategories": "Todas las categor\u00edas",
     "inventoryQuantity": "Cantidad de inventario",
     "qtyNotZero": "distinto de 0",
     "qtyZero": "0",
@@ -17974,43 +17974,43 @@
     "recordsDeleted": "{count} registro(s) eliminado(s)",
     "recordsCouldNotBeDeleted": "{count} registro(s) no pudieron ser eliminados",
     "networkError": "Error de red",
-    "uomTypeArea": "Área",
+    "uomTypeArea": "\u00c1rea",
     "uomTypeLength": "Longitud",
     "uomTypeTime": "Tiempo",
     "uomTypeVolume": "Volumen",
     "uomTypeWeight": "Peso",
-    "yes": "Sí",
+    "yes": "S\u00ed",
     "no": "No",
     "createContact": "Crear contacto",
     "newContact": "Nuevo contacto",
-    "addressSection": "Dirección",
-    "noAddressYet": "Sin dirección",
-    "hideAddressButton": "Ocultar dirección",
+    "addressSection": "Direcci\u00f3n",
+    "noAddressYet": "Sin direcci\u00f3n",
+    "hideAddressButton": "Ocultar direcci\u00f3n",
     "financieroTab": "Financiero",
     "profileComplete": "Perfil completo",
     "identifier": "Identificador",
     "contactName": "Nombre",
-    "contactLegalName": "Razón social",
+    "contactLegalName": "Raz\u00f3n social",
     "taxIDField": "CIF/NIF",
     "bpGroupField": "Grupos de terceros",
-    "taxIdTypeField": "Clave NIF país residencia",
+    "taxIdTypeField": "Clave NIF pa\u00eds residencia",
     "contactPersonSubtable": "Persona de contacto",
     "bankAccountSubtable": "Cuenta bancaria del contacto",
     "contactFirstName": "Nombre",
     "contactLastName": "Apellido",
-    "contactEmail": "Correo electrónico",
-    "contactPhone": "Teléfono",
-    "websiteField": "Página web",
+    "contactEmail": "Correo electr\u00f3nico",
+    "contactPhone": "Tel\u00e9fono",
+    "websiteField": "P\u00e1gina web",
     "bankNameField": "Nombre del banco",
     "bankAccountFormatField": "Formato de cuenta bancaria",
-    "genericAccountNoField": "Nro. de cuenta genérico",
+    "genericAccountNoField": "Nro. de cuenta gen\u00e9rico",
     "ibanField": "IBAN",
-    "creditLimitField": "Crédito límite",
+    "creditLimitField": "Cr\u00e9dito l\u00edmite",
     "discountField": "Descuento",
     "noneDiscount": "Ninguno",
     "isVendorField": "Proveedor",
     "purchasePriceListField": "Tarifa de compra",
-    "paymentMethodPOField": "Método de pago PO",
+    "paymentMethodPOField": "M\u00e9todo de pago PO",
     "paymentTermPOField": "Condiciones de pago",
     "financialAccountPOField": "Cuenta financiera PO",
     "vendorBlockField": "Bloqueo de proveedor",
@@ -18020,8 +18020,8 @@
     "noFinancialData": "Sin datos financieros",
     "customerBlockField": "Bloqueo de cliente",
     "generalTab": "General",
-    "direccionTab": "Dirección",
-    "masTab": "Más",
+    "direccionTab": "Direcci\u00f3n",
+    "masTab": "M\u00e1s",
     "contactPersonTab": "Persona",
     "bankTab": "Cuenta bancaria",
     "addContactPerson": "Agregar persona de contacto",
@@ -18032,131 +18032,131 @@
     "errorLoadingOptions": "Error al cargar",
     "retryLoad": "Reintentar",
     "salesPriceListField": "Tarifa",
-    "paymentMethodField": "Método de pago",
+    "paymentMethodField": "M\u00e9todo de pago",
     "paymentTermField": "Condiciones de pago",
     "financialAccountField": "Cuenta financiera",
     "customerDataSection": "Datos de cliente",
     "vendorDataSection": "Datos de proveedor",
-    "fiscal.title": "Configuración Fiscal",
+    "fiscal.title": "Configuraci\u00f3n Fiscal",
     "fiscal.wip.badge": "Trabajo en progreso",
-    "fiscal.wip.tooltip": "Esta ventana está en desarrollo activo. Los campos, el diseño y el comportamiento pueden cambiar sin previo aviso y no son definitivos.",
-    "fiscal.territory.question": "¿En qué territorio fiscal opera esta organización?",
-    "fiscal.territory.espania": "España / Baleares",
+    "fiscal.wip.tooltip": "Esta ventana est\u00e1 en desarrollo activo. Los campos, el dise\u00f1o y el comportamiento pueden cambiar sin previo aviso y no son definitivos.",
+    "fiscal.territory.question": "\u00bfEn qu\u00e9 territorio fiscal opera esta organizaci\u00f3n?",
+    "fiscal.territory.espania": "Espa\u00f1a / Baleares",
     "fiscal.territory.canarias": "Canarias (IGIC)",
     "fiscal.territory.ceuta": "Ceuta / Melilla (IPSI)",
     "fiscal.territory.navarra": "Navarra",
-    "fiscal.territory.paisvasco": "País Vasco",
-    "fiscal.sii.question": "¿Está inscrita en el SII? (facturación anual > 6M€ o adhesión voluntaria)",
-    "fiscal.sii.enrolled": "Sí, estoy en el SII",
+    "fiscal.territory.paisvasco": "Pa\u00eds Vasco",
+    "fiscal.sii.question": "\u00bfEst\u00e1 inscrita en el SII? (facturaci\u00f3n anual > 6M\u20ac o adhesi\u00f3n voluntaria)",
+    "fiscal.sii.enrolled": "S\u00ed, estoy en el SII",
     "fiscal.sii.notEnrolled": "No, usar Verifactu",
     "fiscal.sii.badge.navarra": "Hacienda Foral de Navarra",
-    "fiscal.tbai.sii.question": "¿También está obligada al SII nacional? (facturación > 6M€)",
-    "fiscal.tbai.with.sii": "Sí, SII + TBAI",
+    "fiscal.tbai.sii.question": "\u00bfTambi\u00e9n est\u00e1 obligada al SII nacional? (facturaci\u00f3n > 6M\u20ac)",
+    "fiscal.tbai.with.sii": "S\u00ed, SII + TBAI",
     "fiscal.tbai.without.sii": "No, solo TBAI",
     "fiscal.skip": "Omitir por ahora",
-    "fiscal.skip.hint": "Puedes configurar el sistema fiscal más adelante desde este mismo menú.",
+    "fiscal.skip.hint": "Puedes configurar el sistema fiscal m\u00e1s adelante desde este mismo men\u00fa.",
     "fiscal.verifactu.ready.modal.title": "Activar Verifactu",
-    "fiscal.verifactu.ready.modal.body": "Esta acción bloqueará la configuración de Verifactu permanentemente. Una vez activado, no podrás modificar los parámetros del sistema. ¿Continuar?",
+    "fiscal.verifactu.ready.modal.body": "Esta acci\u00f3n bloquear\u00e1 la configuraci\u00f3n de Verifactu permanentemente. Una vez activado, no podr\u00e1s modificar los par\u00e1metros del sistema. \u00bfContinuar?",
     "fiscal.verifactu.locked.badge": "Activo",
     "fiscal.verifactu.unlocked.badge": "No activado",
-    "fiscal.conflict.title": "Configuración inválida",
-    "fiscal.conflict.body": "Esta organización tiene Verifactu y SII/TBAI configurados simultáneamente. Estos sistemas son incompatibles. Elimina uno de los dos antes de continuar.",
+    "fiscal.conflict.title": "Configuraci\u00f3n inv\u00e1lida",
+    "fiscal.conflict.body": "Esta organizaci\u00f3n tiene Verifactu y SII/TBAI configurados simult\u00e1neamente. Estos sistemas son incompatibles. Elimina uno de los dos antes de continuar.",
     "fiscal.save": "Guardar",
-    "fiscal.saving": "Guardando…",
-    "fiscal.noOrg": "No se ha seleccionado una organización en la sesión actual.",
-    "fiscal.org.label": "Organización: {name}",
-    "fiscal.loadError": "Error al cargar configuración: {error}",
+    "fiscal.saving": "Guardando\u2026",
+    "fiscal.noOrg": "No se ha seleccionado una organizaci\u00f3n en la sesi\u00f3n actual.",
+    "fiscal.org.label": "Organizaci\u00f3n: {name}",
+    "fiscal.loadError": "Error al cargar configuraci\u00f3n: {error}",
     "fiscal.retry": "Reintentar",
     "fiscal.sii.error": "Error SII: {error}",
     "fiscal.tbai.error": "Error TBAI: {error}",
     "fiscal.cert.modal.title": "Subir certificado digital",
-    "fiscal.cert.subtitle.tbai": "Certificado de representante (.p12 o .pfx) para firmar facturas TicketBAI antes del envío a la Hacienda Foral.",
-    "fiscal.cert.subtitle.sii": "Certificado de representante (.p12 o .pfx) para autenticar la conexión con la AEAT.",
-    "fiscal.cert.subtitle.verifactu": "Certificado de representante (.p12 o .pfx) para firmar y autenticar los registros de facturación con la AEAT (Verifactu).",
-    "fiscal.cert.subtitle.default": "Certificado digital de representante de la organización (.p12 o .pfx). Se usará para firmar y autenticar los envíos fiscales.",
+    "fiscal.cert.subtitle.tbai": "Certificado de representante (.p12 o .pfx) para firmar facturas TicketBAI antes del env\u00edo a la Hacienda Foral.",
+    "fiscal.cert.subtitle.sii": "Certificado de representante (.p12 o .pfx) para autenticar la conexi\u00f3n con la AEAT.",
+    "fiscal.cert.subtitle.verifactu": "Certificado de representante (.p12 o .pfx) para firmar y autenticar los registros de facturaci\u00f3n con la AEAT (Verifactu).",
+    "fiscal.cert.subtitle.default": "Certificado digital de representante de la organizaci\u00f3n (.p12 o .pfx). Se usar\u00e1 para firmar y autenticar los env\u00edos fiscales.",
     "fiscal.cert.step.file": "Archivo",
-    "fiscal.cert.step.verify": "Verificación",
-    "fiscal.cert.step.confirm": "Confirmación",
+    "fiscal.cert.step.verify": "Verificaci\u00f3n",
+    "fiscal.cert.step.confirm": "Confirmaci\u00f3n",
     "fiscal.cert.close": "Cerrar",
-    "fiscal.cert.dropzone.drag": "Arrastra tu certificado aquí",
-    "fiscal.cert.dropzone.click": "o haz clic para seleccionar · .p12 o .pfx · máx. 5 MB",
+    "fiscal.cert.dropzone.drag": "Arrastra tu certificado aqu\u00ed",
+    "fiscal.cert.dropzone.click": "o haz clic para seleccionar \u00b7 .p12 o .pfx \u00b7 m\u00e1x. 5 MB",
     "fiscal.cert.dropzone.changeHint": "haz clic para cambiar",
-    "fiscal.cert.pwd.label": "Contraseña del certificado",
+    "fiscal.cert.pwd.label": "Contrase\u00f1a del certificado",
     "fiscal.cert.pwd.hide": "Ocultar",
     "fiscal.cert.pwd.show": "Mostrar",
-    "fiscal.cert.pwd.hint": "Etendo no almacena la contraseña en claro · cifrado AES-256.",
-    "fiscal.cert.info.title": "¿No tienes el certificado?",
-    "fiscal.cert.info.body": "Solicítalo a la FNMT o a tu Diputación Foral. La emisión tarda 5–10 días hábiles.",
-    "fiscal.cert.verifying.title": "Verificando certificado…",
-    "fiscal.cert.verifying.body": "Comprobando estructura PKCS#12, contraseña, vigencia y almacenando en Etendo.",
-    "fiscal.cert.nif.warning.title": "La organización no tiene NIF configurado",
-    "fiscal.cert.nif.warning.body": "El certificado contiene el NIF {nif}. Si lo confirmas, se establecerá como NIF de la organización y el certificado se almacenará.",
+    "fiscal.cert.pwd.hint": "Etendo no almacena la contrase\u00f1a en claro \u00b7 cifrado AES-256.",
+    "fiscal.cert.info.title": "\u00bfNo tienes el certificado?",
+    "fiscal.cert.info.body": "Solic\u00edtalo a la FNMT o a tu Diputaci\u00f3n Foral. La emisi\u00f3n tarda 5\u201310 d\u00edas h\u00e1biles.",
+    "fiscal.cert.verifying.title": "Verificando certificado\u2026",
+    "fiscal.cert.verifying.body": "Comprobando estructura PKCS#12, contrase\u00f1a, vigencia y almacenando en Etendo.",
+    "fiscal.cert.nif.warning.title": "La organizaci\u00f3n no tiene NIF configurado",
+    "fiscal.cert.nif.warning.body": "El certificado contiene el NIF {nif}. Si lo confirmas, se establecer\u00e1 como NIF de la organizaci\u00f3n y el certificado se almacenar\u00e1.",
     "fiscal.cert.nif.row.file": "Archivo",
     "fiscal.cert.nif.row.nif": "NIF del certificado",
     "fiscal.cert.success.title": "Certificado cargado correctamente",
-    "fiscal.cert.success.body": "Almacenado y listo para autenticar envíos fiscales.",
+    "fiscal.cert.success.body": "Almacenado y listo para autenticar env\u00edos fiscales.",
     "fiscal.cert.success.encrypted": "El certificado se almacena cifrado en tu instancia Etendo.",
     "fiscal.cert.detail.file": "Archivo",
     "fiscal.cert.detail.holder": "Titular",
     "fiscal.cert.detail.issuer": "Emisor",
-    "fiscal.cert.detail.validFrom": "Válido desde",
-    "fiscal.cert.detail.validTo": "Válido hasta",
+    "fiscal.cert.detail.validFrom": "V\u00e1lido desde",
+    "fiscal.cert.detail.validTo": "V\u00e1lido hasta",
     "fiscal.cert.detail.algorithm": "Algoritmo",
     "fiscal.cert.footer.formats": "Formatos: PKCS#12 (.p12, .pfx)",
     "fiscal.cert.btn.cancel": "Cancelar",
     "fiscal.cert.btn.verify": "Verificar certificado",
     "fiscal.cert.btn.change": "Cambiar archivo",
-    "fiscal.cert.btn.use": "✓ Usar este certificado",
+    "fiscal.cert.btn.use": "\u2713 Usar este certificado",
     "fiscal.cert.btn.useNif": "Usar NIF {nif}",
     "fiscal.cert.err.format": "Formato no soportado. Usa un archivo .p12 o .pfx (PKCS#12).",
-    "fiscal.cert.err.size": "El archivo supera el límite de 5 MB.",
-    "fiscal.cert.err.connection": "Error de conexión al verificar el certificado.",
+    "fiscal.cert.err.size": "El archivo supera el l\u00edmite de 5 MB.",
+    "fiscal.cert.err.connection": "Error de conexi\u00f3n al verificar el certificado.",
     "fiscal.cert.err.default": "Error al verificar el certificado.",
-    "fiscal.cert.err.nifMismatch": "El NIF del certificado no coincide con el NIF de la organización.",
+    "fiscal.cert.err.nifMismatch": "El NIF del certificado no coincide con el NIF de la organizaci\u00f3n.",
     "fiscal.cert.section.legend": "Certificado digital",
     "fiscal.cert.loaded": "Certificado cargado",
-    "fiscal.cert.validUntil": "Válido hasta {date}",
+    "fiscal.cert.validUntil": "V\u00e1lido hasta {date}",
     "fiscal.cert.replace": "Reemplazar",
     "fiscal.cert.none.title": "Sin certificado",
-    "fiscal.cert.none.hint": "Necesario para autenticar con la Hacienda · .p12 o .pfx",
+    "fiscal.cert.none.hint": "Necesario para autenticar con la Hacienda \u00b7 .p12 o .pfx",
     "fiscal.cert.upload": "Subir certificado",
     "fiscal.sii.legend.status": "Estado",
     "fiscal.sii.legend.env": "Entorno",
-    "fiscal.sii.legend.sends": "Envíos",
-    "fiscal.sii.legend.special": "Régimen especial",
+    "fiscal.sii.legend.sends": "Env\u00edos",
+    "fiscal.sii.legend.special": "R\u00e9gimen especial",
     "fiscal.sii.legend.actions": "Acciones",
     "fiscal.sii.field.enrolled": "En sistema SII",
-    "fiscal.sii.field.enrollDate": "Fecha incorporación al SII",
+    "fiscal.sii.field.enrollDate": "Fecha incorporaci\u00f3n al SII",
     "fiscal.sii.field.monitorDate": "Fecha inicio monitor SII",
-    "fiscal.sii.field.production": "Entorno producción",
+    "fiscal.sii.field.production": "Entorno producci\u00f3n",
     "fiscal.sii.field.attachXml": "Adjuntar XMLs",
-    "fiscal.sii.field.deadline": "Plazo envío SII (días)",
-    "fiscal.sii.field.cadenceSale": "Cadencia facturas venta (días)",
-    "fiscal.sii.field.cadencePurchase": "Cadencia facturas compra (días)",
+    "fiscal.sii.field.deadline": "Plazo env\u00edo SII (d\u00edas)",
+    "fiscal.sii.field.cadenceSale": "Cadencia facturas venta (d\u00edas)",
+    "fiscal.sii.field.cadencePurchase": "Cadencia facturas compra (d\u00edas)",
     "fiscal.sii.field.postedOnly": "Solo facturas contabilizadas",
     "fiscal.sii.field.recc": "RECC",
     "fiscal.sii.field.redeme": "REDEME",
-    "fiscal.sii.field.authno": "Nº autorización",
+    "fiscal.sii.field.authno": "N\u00ba autorizaci\u00f3n",
     "fiscal.sii.action.validateHash": "Validar Hash",
-    "fiscal.sii.err.deadline": "El plazo de envío SII es obligatorio.",
+    "fiscal.sii.err.deadline": "El plazo de env\u00edo SII es obligatorio.",
     "fiscal.sii.err.noRecordId": "Identificador de registro SII no encontrado.",
     "fiscal.tbai.legend.env": "Entorno",
-    "fiscal.tbai.legend.billing": "Facturación",
-    "fiscal.tbai.legend.technical": "Técnico",
+    "fiscal.tbai.legend.billing": "Facturaci\u00f3n",
+    "fiscal.tbai.legend.technical": "T\u00e9cnico",
     "fiscal.tbai.field.enrollDate": "Fecha acogida TBAI",
-    "fiscal.tbai.field.production": "Entorno producción",
-    "fiscal.tbai.field.invoiceDesc": "Descripción de facturas",
-    "fiscal.tbai.field.useAsProduct": "Usar descripción como nombre de producto",
-    "fiscal.tbai.field.autoSend": "Envío automático al completar factura",
+    "fiscal.tbai.field.production": "Entorno producci\u00f3n",
+    "fiscal.tbai.field.invoiceDesc": "Descripci\u00f3n de facturas",
+    "fiscal.tbai.field.useAsProduct": "Usar descripci\u00f3n como nombre de producto",
+    "fiscal.tbai.field.autoSend": "Env\u00edo autom\u00e1tico al completar factura",
     "fiscal.tbai.field.jasper": "Ruta Jasper Report",
     "fiscal.tbai.field.jasper.placeholder": "/ruta/al/informe.jrxml",
     "fiscal.tbai.field.validatePrev": "Validar factura anterior",
     "fiscal.tbai.err.enrollDate": "La fecha de acogida TBAI es obligatoria.",
-    "fiscal.tbai.err.invoiceDesc": "La descripción de facturas es obligatoria.",
+    "fiscal.tbai.err.invoiceDesc": "La descripci\u00f3n de facturas es obligatoria.",
     "fiscal.tbai.err.noRecordId": "Identificador de registro TBAI no encontrado.",
     "fiscal.verifactu.err.noRecordId": "Identificador de registro Verifactu no encontrado.",
     "fiscal.verifactu.err.noTaxType": "Seleccione un tipo de impuesto antes de guardar.",
-    "fiscal.verifactu.field.tax": "Impuesto de aplicación",
+    "fiscal.verifactu.field.tax": "Impuesto de aplicaci\u00f3n",
     "fiscal.verifactu.field.selectTax": "Selecciona un impuesto",
     "fiscal.verifactu.field.qr": "QR por defecto",
     "fiscal.verifactu.field.nif": "NIF de emisor",
@@ -18164,23 +18164,23 @@
     "fiscal.verifactu.field.systemStop": "Parada del sistema",
     "fiscal.verifactu.field.incident": "Detalle de incidencia",
     "fiscal.verifactu.field.enrollDate": "Fecha de acogida",
-    "fiscal.verifactu.saving": "Guardando…",
+    "fiscal.verifactu.saving": "Guardando\u2026",
     "fiscal.onboarding.step.territory": "Territorio",
     "fiscal.onboarding.step.details": "Detalles",
     "fiscal.onboarding.step.confirm": "Confirmar",
-    "fiscal.onboarding.org.label": "Organización:",
-    "fiscal.onboarding.back": "← Volver",
-    "fiscal.onboarding.continue": "Continuar ›",
-    "fiscal.onboarding.saving": "Creando…",
+    "fiscal.onboarding.org.label": "Organizaci\u00f3n:",
+    "fiscal.onboarding.back": "\u2190 Volver",
+    "fiscal.onboarding.continue": "Continuar \u203a",
+    "fiscal.onboarding.saving": "Creando\u2026",
     "fiscal.onboarding.goHome": "Ir al inicio",
-    "fiscal.onboarding.viewConfig": "Ver configuración",
-    "fiscal.onboarding.back.wizard": "← Volver al asistente",
-    "fiscal.onboarding.skipped.title": "Configuración omitida",
-    "fiscal.onboarding.skipped.hint": "Puedes volver a esta pantalla en cualquier momento desde Ajustes → Configuración fiscal.",
-    "fiscal.onboarding.applied.title": "Configuración aplicada",
-    "fiscal.onboarding.applied.subtitle": "{system} ya está activo para esta organización. Puedes empezar a emitir facturas electrónicas o ajustar los detalles operativos cuando quieras.",
+    "fiscal.onboarding.viewConfig": "Ver configuraci\u00f3n",
+    "fiscal.onboarding.back.wizard": "\u2190 Volver al asistente",
+    "fiscal.onboarding.skipped.title": "Configuraci\u00f3n omitida",
+    "fiscal.onboarding.skipped.hint": "Puedes volver a esta pantalla en cualquier momento desde Ajustes \u2192 Configuraci\u00f3n fiscal.",
+    "fiscal.onboarding.applied.title": "Configuraci\u00f3n aplicada",
+    "fiscal.onboarding.applied.subtitle": "{system} ya est\u00e1 activo para esta organizaci\u00f3n. Puedes empezar a emitir facturas electr\u00f3nicas o ajustar los detalles operativos cuando quieras.",
     "fiscal.onboarding.applied.configured": "{system} configurado correctamente",
-    "fiscal.onboarding.applied.body": "Etendo enviará tus facturas según los parámetros que has definido.",
+    "fiscal.onboarding.applied.body": "Etendo enviar\u00e1 tus facturas seg\u00fan los par\u00e1metros que has definido.",
     "fiscal.onboarding.applied.row.territory": "Territorio fiscal",
     "fiscal.onboarding.applied.row.system": "Sistema",
     "fiscal.onboarding.applied.row.tax": "Hacienda",
@@ -18189,9 +18189,9 @@
     "fiscal.onboarding.applied.row.chosen": "Sistema elegido",
     "fiscal.onboarding.applied.row.env": "Entorno",
     "fiscal.onboarding.applied.row.activated": "Activado",
-    "fiscal.onboarding.applied.env.sandbox": "Sandbox · pruebas",
-    "fiscal.onboarding.applied.volume.high": "> 6.010.121 €",
-    "fiscal.onboarding.applied.volume.low": "≤ 6.010.121 €",
+    "fiscal.onboarding.applied.env.sandbox": "Sandbox \u00b7 pruebas",
+    "fiscal.onboarding.applied.volume.high": "> 6.010.121 \u20ac",
+    "fiscal.onboarding.applied.volume.low": "\u2264 6.010.121 \u20ac",
     "fiscal.onboarding.applied.national.active": "Activa",
     "fiscal.onboarding.applied.national.na": "No aplica",
     "fiscal.onboarding.applied.chosen.sii": "SII voluntario",
@@ -18200,85 +18200,85 @@
     "fiscal.onboarding.cert.upload.title": "Subir certificado digital",
     "fiscal.onboarding.cert.loaded.title": "Certificado digital cargado",
     "fiscal.onboarding.cert.upload.desc": "Necesario para firmar y autenticar las facturas. Soporta .p12 y .pfx.",
-    "fiscal.onboarding.cert.loaded.desc": "{name} · válido hasta {validTo} · haz clic para reemplazar.",
+    "fiscal.onboarding.cert.loaded.desc": "{name} \u00b7 v\u00e1lido hasta {validTo} \u00b7 haz clic para reemplazar.",
     "fiscal.onboarding.cert.pending": "Pendiente",
-    "fiscal.onboarding.next.test.title": "Programar primer envío de prueba",
-    "fiscal.onboarding.next.test.desc": "Verifica la conexión con la Hacienda en sandbox antes de pasar a producción.",
-    "fiscal.onboarding.next.copilot.title": "Pídeselo a Copilot",
-    "fiscal.onboarding.next.copilot.desc": "\"Repasa mi configuración fiscal y avísame de los plazos clave.\"",
+    "fiscal.onboarding.next.test.title": "Programar primer env\u00edo de prueba",
+    "fiscal.onboarding.next.test.desc": "Verifica la conexi\u00f3n con la Hacienda en sandbox antes de pasar a producci\u00f3n.",
+    "fiscal.onboarding.next.copilot.title": "P\u00eddeselo a Copilot",
+    "fiscal.onboarding.next.copilot.desc": "\"Repasa mi configuraci\u00f3n fiscal y av\u00edsame de los plazos clave.\"",
     "fiscal.onboarding.detail.saveapply": "Guardar y aplicar",
-    "fiscal.onboarding.detail.sii.desc": "Configura los detalles operativos del Suministro Inmediato de Información a la AEAT.",
-    "fiscal.onboarding.detail.tbai.desc": "Configura el certificado, el software garante y los parámetros de envío a la Hacienda Foral.",
+    "fiscal.onboarding.detail.sii.desc": "Configura los detalles operativos del Suministro Inmediato de Informaci\u00f3n a la AEAT.",
+    "fiscal.onboarding.detail.tbai.desc": "Configura el certificado, el software garante y los par\u00e1metros de env\u00edo a la Hacienda Foral.",
     "fiscal.onboarding.detail.siitbai.desc": "Configura ambos sistemas. La operativa foral usa TicketBAI; la nacional, SII.",
-    "fiscal.onboarding.detail.verifactu.desc": "Configura el sistema antifraude del Reglamento de facturación (RD 1007/2023).",
-    "fiscal.onboarding.detail.sii.header": "Configuración SII (operativa nacional)",
-    "fiscal.onboarding.detail.tbai.header": "Configuración TicketBAI (operativa foral)",
-    "fiscal.onboarding.breadcrumb.fiscal": "Configuración fiscal",
+    "fiscal.onboarding.detail.verifactu.desc": "Configura el sistema antifraude del Reglamento de facturaci\u00f3n (RD 1007/2023).",
+    "fiscal.onboarding.detail.sii.header": "Configuraci\u00f3n SII (operativa nacional)",
+    "fiscal.onboarding.detail.tbai.header": "Configuraci\u00f3n TicketBAI (operativa foral)",
+    "fiscal.onboarding.breadcrumb.fiscal": "Configuraci\u00f3n fiscal",
     "fiscal.onboarding.breadcrumb.territory": "Territorio",
-    "fiscal.onboarding.breadcrumb.confirm": "Confirmación",
+    "fiscal.onboarding.breadcrumb.confirm": "Confirmaci\u00f3n",
     "fiscal.onboarding.breadcrumb.details": "Detalles",
-    "fiscal.onboarding.breadcrumb.manual": "Configuración manual",
-    "fiscal.onboarding.confirm.title": "Confirma la configuración",
-    "fiscal.onboarding.confirm.subtitle": "Revisa los datos antes de continuar. Podrás editar cualquier campo después en Ajustes → Configuración fiscal.",
+    "fiscal.onboarding.breadcrumb.manual": "Configuraci\u00f3n manual",
+    "fiscal.onboarding.confirm.title": "Confirma la configuraci\u00f3n",
+    "fiscal.onboarding.confirm.subtitle": "Revisa los datos antes de continuar. Podr\u00e1s editar cualquier campo despu\u00e9s en Ajustes \u2192 Configuraci\u00f3n fiscal.",
     "fiscal.onboarding.confirm.row.territory": "Territorio",
     "fiscal.onboarding.confirm.row.hacienda": "Hacienda",
-    "fiscal.onboarding.confirm.row.national.yes": "Sí · también declara SII",
-    "fiscal.onboarding.confirm.row.national.no": "No · solo TicketBAI",
+    "fiscal.onboarding.confirm.row.national.yes": "S\u00ed \u00b7 tambi\u00e9n declara SII",
+    "fiscal.onboarding.confirm.row.national.no": "No \u00b7 solo TicketBAI",
     "fiscal.onboarding.confirm.row.national": "Operativa nacional",
-    "fiscal.onboarding.confirm.row.volume.high": "> 6.010.121 €",
-    "fiscal.onboarding.confirm.row.volume.low": "≤ 6.010.121 €",
+    "fiscal.onboarding.confirm.row.volume.high": "> 6.010.121 \u20ac",
+    "fiscal.onboarding.confirm.row.volume.low": "\u2264 6.010.121 \u20ac",
     "fiscal.onboarding.confirm.row.volume": "Volumen anual",
     "fiscal.onboarding.confirm.row.choice.sii": "SII voluntario",
     "fiscal.onboarding.confirm.row.choice.verifactu": "Verifactu",
-    "fiscal.onboarding.confirm.row.choice": "Elección",
+    "fiscal.onboarding.confirm.row.choice": "Elecci\u00f3n",
     "fiscal.onboarding.confirm.row.system": "Sistema fiscal",
-    "fiscal.onboarding.confirm.next.title": "Próximo paso",
-    "fiscal.onboarding.confirm.next.body": "Tras confirmar, podrás añadir los detalles operativos (fechas de incorporación, cadencias de envío, entorno de pruebas o producción).",
-    "fiscal.onboarding.confirm.creating": "Creando…",
+    "fiscal.onboarding.confirm.next.title": "Pr\u00f3ximo paso",
+    "fiscal.onboarding.confirm.next.body": "Tras confirmar, podr\u00e1s a\u00f1adir los detalles operativos (fechas de incorporaci\u00f3n, cadencias de env\u00edo, entorno de pruebas o producci\u00f3n).",
+    "fiscal.onboarding.confirm.creating": "Creando\u2026",
     "fiscal.onboarding.confirm.btn": "Confirmar",
-    "fiscal.onboarding.manual.title": "Configuración manual",
-    "fiscal.onboarding.manual.subtitle": "Selecciona el territorio y el sistema fiscal que corresponde a esta organización. Podrás completar los detalles después.",
+    "fiscal.onboarding.manual.title": "Configuraci\u00f3n manual",
+    "fiscal.onboarding.manual.subtitle": "Selecciona el territorio y el sistema fiscal que corresponde a esta organizaci\u00f3n. Podr\u00e1s completar los detalles despu\u00e9s.",
     "fiscal.onboarding.manual.territory.header": "Territorio",
     "fiscal.onboarding.manual.system.header": "Sistema fiscal",
     "fiscal.onboarding.manual.system.placeholder": "Selecciona primero un territorio para ver los sistemas compatibles.",
     "fiscal.onboarding.manual.btn": "Seleccionar sistema fiscal manualmente",
-    "fiscal.onboarding.territory.manualConfig.header": "Configuración manual",
+    "fiscal.onboarding.territory.manualConfig.header": "Configuraci\u00f3n manual",
     "fiscal.onboarding.territory.manualConfig.desc": "Elegir sistema directamente",
-    "fiscal.onboarding.territory.title": "¿En qué territorio fiscal opera esta organización?",
-    "fiscal.onboarding.territory.subtitle": "Etendo configurará el sistema de facturación electrónica adecuado según la Hacienda que te corresponda. Podrás ajustar los detalles después.",
-    "fiscal.onboarding.subq.also.title": "¿También facturas en territorio común?",
-    "fiscal.onboarding.subq.also.subtitle": "Las empresas con sede en {territory} usan TicketBAI para sus facturas forales. Si además operáis con clientes o proveedores en el resto de España, necesitarás declarar también por SII nacional.",
+    "fiscal.onboarding.territory.title": "\u00bfEn qu\u00e9 territorio fiscal opera esta organizaci\u00f3n?",
+    "fiscal.onboarding.territory.subtitle": "Etendo configurar\u00e1 el sistema de facturaci\u00f3n electr\u00f3nica adecuado seg\u00fan la Hacienda que te corresponda. Podr\u00e1s ajustar los detalles despu\u00e9s.",
+    "fiscal.onboarding.subq.also.title": "\u00bfTambi\u00e9n facturas en territorio com\u00fan?",
+    "fiscal.onboarding.subq.also.subtitle": "Las empresas con sede en {territory} usan TicketBAI para sus facturas forales. Si adem\u00e1s oper\u00e1is con clientes o proveedores en el resto de Espa\u00f1a, necesitar\u00e1s declarar tambi\u00e9n por SII nacional.",
     "fiscal.onboarding.subq.tbai.label": "Solo TicketBAI",
-    "fiscal.onboarding.subq.tbai.desc": "Toda nuestra facturación se declara a la Hacienda Foral de {territory}.",
+    "fiscal.onboarding.subq.tbai.desc": "Toda nuestra facturaci\u00f3n se declara a la Hacienda Foral de {territory}.",
     "fiscal.onboarding.subq.sii.label": "SII + TicketBAI",
-    "fiscal.onboarding.subq.sii.desc": "También emitimos facturas a clientes en territorio común — necesitamos declarar por SII estatal.",
-    "fiscal.onboarding.subq.volume.title": "¿Cuál es vuestro volumen de facturación anual?",
-    "fiscal.onboarding.subq.volume.subtitle": "Las empresas que superan los 6.010.121,04 € de volumen de operaciones están obligadas a presentar el SII. Por debajo, puedes elegir entre SII (acogimiento voluntario) o Verifactu.",
-    "fiscal.onboarding.subq.volume.low.label": "Hasta 6.010.121,04 € anuales",
-    "fiscal.onboarding.subq.volume.low.desc": "Régimen general · podrás elegir entre SII (voluntario) o Verifactu en el siguiente paso.",
-    "fiscal.onboarding.subq.volume.high.label": "Más de 6.010.121,04 € anuales",
-    "fiscal.onboarding.subq.volume.high.desc": "Gran empresa · SII obligatorio (envío inmediato a la AEAT).",
-    "fiscal.onboarding.subq.system.title": "¿Qué sistema prefieres?",
-    "fiscal.onboarding.subq.system.subtitle": "Ambas opciones cumplen con la normativa AEAT. SII envía cada factura al instante; Verifactu firma localmente y permite envío diferido.",
+    "fiscal.onboarding.subq.sii.desc": "Tambi\u00e9n emitimos facturas a clientes en territorio com\u00fan \u2014 necesitamos declarar por SII estatal.",
+    "fiscal.onboarding.subq.volume.title": "\u00bfCu\u00e1l es vuestro volumen de facturaci\u00f3n anual?",
+    "fiscal.onboarding.subq.volume.subtitle": "Las empresas que superan los 6.010.121,04 \u20ac de volumen de operaciones est\u00e1n obligadas a presentar el SII. Por debajo, puedes elegir entre SII (acogimiento voluntario) o Verifactu.",
+    "fiscal.onboarding.subq.volume.low.label": "Hasta 6.010.121,04 \u20ac anuales",
+    "fiscal.onboarding.subq.volume.low.desc": "R\u00e9gimen general \u00b7 podr\u00e1s elegir entre SII (voluntario) o Verifactu en el siguiente paso.",
+    "fiscal.onboarding.subq.volume.high.label": "M\u00e1s de 6.010.121,04 \u20ac anuales",
+    "fiscal.onboarding.subq.volume.high.desc": "Gran empresa \u00b7 SII obligatorio (env\u00edo inmediato a la AEAT).",
+    "fiscal.onboarding.subq.system.title": "\u00bfQu\u00e9 sistema prefieres?",
+    "fiscal.onboarding.subq.system.subtitle": "Ambas opciones cumplen con la normativa AEAT. SII env\u00eda cada factura al instante; Verifactu firma localmente y permite env\u00edo diferido.",
     "fiscal.onboarding.subq.verifactu.label": "Verifactu",
-    "fiscal.onboarding.subq.verifactu.desc": "Antifraude AEAT · firma local + QR + envío diferido. Recomendado para PYMEs.",
+    "fiscal.onboarding.subq.verifactu.desc": "Antifraude AEAT \u00b7 firma local + QR + env\u00edo diferido. Recomendado para PYMEs.",
     "fiscal.onboarding.subq.sii.vol.label": "SII voluntario",
-    "fiscal.onboarding.subq.sii.vol.desc": "Acogimiento voluntario · envío inmediato (4 días). Útil si tu cliente principal lo exige.",
-    "fiscal.territory.alava": "Álava",
+    "fiscal.onboarding.subq.sii.vol.desc": "Acogimiento voluntario \u00b7 env\u00edo inmediato (4 d\u00edas). \u00datil si tu cliente principal lo exige.",
+    "fiscal.territory.alava": "\u00c1lava",
     "fiscal.territory.bizkaia": "Bizkaia",
     "fiscal.territory.gipuzkoa": "Gipuzkoa",
-    "fiscal.territory.navarra.systemLong": "SII Foral · Hacienda de Navarra",
-    "fiscal.territory.alava.systemLong": "TicketBAI · Hacienda Foral de Álava",
-    "fiscal.territory.bizkaia.systemLong": "TicketBAI · Hacienda Foral de Bizkaia",
-    "fiscal.territory.gipuzkoa.systemLong": "TicketBAI · Hacienda Foral de Gipuzkoa",
-    "fiscal.territory.baleares.systemLong": "Régimen general · AEAT",
-    "fiscal.territory.canarias.systemLong": "IGIC · Hacienda Canaria",
-    "fiscal.territory.ceuta.systemLong": "IPSI · Ciudades Autónomas",
+    "fiscal.territory.navarra.systemLong": "SII Foral \u00b7 Hacienda de Navarra",
+    "fiscal.territory.alava.systemLong": "TicketBAI \u00b7 Hacienda Foral de \u00c1lava",
+    "fiscal.territory.bizkaia.systemLong": "TicketBAI \u00b7 Hacienda Foral de Bizkaia",
+    "fiscal.territory.gipuzkoa.systemLong": "TicketBAI \u00b7 Hacienda Foral de Gipuzkoa",
+    "fiscal.territory.baleares.systemLong": "R\u00e9gimen general \u00b7 AEAT",
+    "fiscal.territory.canarias.systemLong": "IGIC \u00b7 Hacienda Canaria",
+    "fiscal.territory.ceuta.systemLong": "IPSI \u00b7 Ciudades Aut\u00f3nomas",
     "fiscal.territory.navarra.example": "Empresas con domicilio fiscal en Navarra",
-    "fiscal.territory.alava.example": "Sociedades con sede en Álava",
+    "fiscal.territory.alava.example": "Sociedades con sede en \u00c1lava",
     "fiscal.territory.bizkaia.example": "Sociedades con sede en Bizkaia",
     "fiscal.territory.gipuzkoa.example": "Sociedades con sede en Gipuzkoa",
-    "fiscal.territory.baleares.example": "Régimen común · IVA estatal",
+    "fiscal.territory.baleares.example": "R\u00e9gimen com\u00fan \u00b7 IVA estatal",
     "fiscal.territory.canarias.example": "Empresas con IGIC en lugar de IVA",
     "fiscal.territory.ceuta.example": "Empresas con IPSI en lugar de IVA",
     "fiscal.territory.system.sii": "SII",
@@ -18287,27 +18287,27 @@
     "fiscal.territory.group.sii.label": "SII",
     "fiscal.territory.group.sii.desc": "Hacienda Foral de Navarra",
     "fiscal.territory.group.tbai.label": "TBAI / SII + TBAI",
-    "fiscal.territory.group.tbai.desc": "Se preguntará si también opera bajo SII nacional",
+    "fiscal.territory.group.tbai.desc": "Se preguntar\u00e1 si tambi\u00e9n opera bajo SII nacional",
     "fiscal.territory.group.siiver.label": "SII / VERIFACTU",
-    "fiscal.territory.group.siiver.desc": "Se preguntará según tu volumen de facturación",
-    "fiscal.system.sii.long": "Sistema de Información Inmediata",
-    "fiscal.system.sii.desc": "Suministro Inmediato de Información de IVA · AEAT",
-    "fiscal.system.tbai.long": "TicketBAI (País Vasco)",
+    "fiscal.territory.group.siiver.desc": "Se preguntar\u00e1 seg\u00fan tu volumen de facturaci\u00f3n",
+    "fiscal.system.sii.long": "Sistema de Informaci\u00f3n Inmediata",
+    "fiscal.system.sii.desc": "Suministro Inmediato de Informaci\u00f3n de IVA \u00b7 AEAT",
+    "fiscal.system.tbai.long": "TicketBAI (Pa\u00eds Vasco)",
     "fiscal.system.tbai.desc": "Sistema antifraude de las Haciendas Forales vascas",
     "fiscal.system.siitbai.long": "SII nacional y TicketBAI",
-    "fiscal.system.siitbai.desc": "Para empresas vascas que también declaran IVA estatal",
-    "fiscal.system.verifactu.long": "Sistema de verificación de facturas",
-    "fiscal.system.verifactu.desc": "Antifraude AEAT (Reglamento de facturación)",
+    "fiscal.system.siitbai.desc": "Para empresas vascas que tambi\u00e9n declaran IVA estatal",
+    "fiscal.system.verifactu.long": "Sistema de verificaci\u00f3n de facturas",
+    "fiscal.system.verifactu.desc": "Antifraude AEAT (Reglamento de facturaci\u00f3n)",
     "fiscalMonitor.title": "Monitor Fiscal",
-    "fiscalMonitor.unconfigured": "No hay sistema fiscal configurado para esta organización.",
-    "fiscalMonitor.conflict": "Configuración inválida: Verifactu y SII/TBAI no pueden coexistir.",
+    "fiscalMonitor.unconfigured": "No hay sistema fiscal configurado para esta organizaci\u00f3n.",
+    "fiscalMonitor.conflict": "Configuraci\u00f3n inv\u00e1lida: Verifactu y SII/TBAI no pueden coexistir.",
     "fiscalMonitor.error": "Error cargando datos del monitor: {error}",
     "fiscalMonitor.empty": "No hay registros.",
     "fiscalMonitor.prev": "Anterior",
     "fiscalMonitor.next": "Siguiente",
-    "fiscalMonitor.pagination": "Página {page} de {total}",
+    "fiscalMonitor.pagination": "P\u00e1gina {page} de {total}",
     "fiscalMonitor.openInvoice": "Abrir factura",
-    "fiscalMonitor.col.invoiceNumber": "Nº Factura",
+    "fiscalMonitor.col.invoiceNumber": "N\u00ba Factura",
     "fiscalMonitor.section.sii": "SII",
     "fiscalMonitor.section.tbai": "TBAI",
     "fiscalMonitor.sii.tab.issued": "Emitidas",
@@ -18317,7 +18317,7 @@
     "fiscalMonitor.verifactu.tab.accepted": "Aceptadas",
     "fiscalMonitor.verifactu.tab.partiallyAccepted": "Parcialmente aceptadas",
     "fiscalMonitor.verifactu.tab.rejected": "Rechazadas",
-    "fiscalMonitor.verifactu.tab.invalid": "Inválidas",
+    "fiscalMonitor.verifactu.tab.invalid": "Inv\u00e1lidas",
     "fiscalMonitor.tbai.status.all": "Todas",
     "fiscalMonitor.tbai.status.Recibido": "Recibida",
     "fiscalMonitor.tbai.status.Rechazado": "Rechazada",
@@ -18328,30 +18328,30 @@
     "fiscalMonitor.kpi.verifactu.accepted": "Aceptadas",
     "fiscalMonitor.kpi.verifactu.partiallyAccepted": "Parcialmente aceptadas",
     "fiscalMonitor.kpi.verifactu.rejected": "Rechazadas",
-    "fiscalMonitor.kpi.verifactu.invalid": "Inválidas",
+    "fiscalMonitor.kpi.verifactu.invalid": "Inv\u00e1lidas",
     "fiscalMonitor.export": "Exportar",
-    "fiscalMonitor.sii.title": "Suministro Inmediato de Información",
-    "fiscalMonitor.sii.lastSync": "Última sincronización con AEAT",
+    "fiscalMonitor.sii.title": "Suministro Inmediato de Informaci\u00f3n",
+    "fiscalMonitor.sii.lastSync": "\u00daltima sincronizaci\u00f3n con AEAT",
     "fiscalMonitor.tbai.title": "Facturas enviadas a Hacienda Foral",
-    "fiscalMonitor.tbai.queueMeta": "Cola de envío",
-    "fiscalMonitor.verifactu.title": "Sistema verificable de facturación (AEAT)",
+    "fiscalMonitor.tbai.queueMeta": "Cola de env\u00edo",
+    "fiscalMonitor.verifactu.title": "Sistema verificable de facturaci\u00f3n (AEAT)",
     "fiscalMonitor.verifactu.chainMeta": "Encadenamiento verificado",
     "fiscalMonitor.col.date": "Fecha",
     "fiscalMonitor.col.type": "Tipo",
     "fiscalMonitor.col.total": "Total",
     "fiscalMonitor.col.status": "Estado",
     "fiscalMonitor.col.csv": "CSV AEAT",
-    "fiscalMonitor.col.description": "Descripción",
+    "fiscalMonitor.col.description": "Descripci\u00f3n",
     "fiscalMonitor.col.signature": "Firma",
     "fiscalMonitor.col.issuerNIF": "NIF emisor",
     "fiscalMonitor.col.errorReason": "Motivo error",
-    "fiscalMonitor.orgMeta": "Monitor de facturas · sistema fiscal activo",
+    "fiscalMonitor.orgMeta": "Monitor de facturas \u00b7 sistema fiscal activo",
     "fiscalMonitor.synced": "Sincronizado",
-    "fiscalMonitor.setupDescription": "Esta organización aún no tiene activo un sistema de envío telemático (SII, TicketBAI o Verifactu). Configúralo en Configuración Fiscal para empezar a ver el estado de tus facturas.",
+    "fiscalMonitor.setupDescription": "Esta organizaci\u00f3n a\u00fan no tiene activo un sistema de env\u00edo telem\u00e1tico (SII, TicketBAI o Verifactu). Config\u00faralo en Configuraci\u00f3n Fiscal para empezar a ver el estado de tus facturas.",
     "fiscalMonitor.setupCta": "Configurar sistema fiscal",
     "fiscalMonitor.errorTitle": "Error cargando datos",
-    "fiscalMonitor.conflictTitle": "Configuración inválida",
-    "fiscalMonitor.siiPlusTbaiDivider": "Y también",
+    "fiscalMonitor.conflictTitle": "Configuraci\u00f3n inv\u00e1lida",
+    "fiscalMonitor.siiPlusTbaiDivider": "Y tambi\u00e9n",
     "fiscalMonitor.sii.party.cliente": "Cliente",
     "fiscalMonitor.sii.party.proveedor": "Proveedor",
     "fiscalMonitor.kpi.sii.sub.current": "periodo actual",
@@ -18360,11 +18360,11 @@
     "fiscalMonitor.kpi.tbai.received.label": "Enviadas (Recibido)",
     "fiscalMonitor.kpi.tbai.received.sub": "confirmadas por hacienda",
     "fiscalMonitor.kpi.tbai.error.label": "Con error / Rechazadas",
-    "fiscalMonitor.kpi.tbai.error.sub": "requieren atención",
+    "fiscalMonitor.kpi.tbai.error.sub": "requieren atenci\u00f3n",
     "fiscalMonitor.kpi.verifactu.accepted.sub": "enviadas y registradas",
     "fiscalMonitor.kpi.verifactu.partiallyAccepted.sub": "con advertencias",
-    "fiscalMonitor.kpi.verifactu.rejected.sub": "requieren acción",
-    "fiscalMonitor.kpi.verifactu.invalid.sub": "estructura no válida",
+    "fiscalMonitor.kpi.verifactu.rejected.sub": "requieren acci\u00f3n",
+    "fiscalMonitor.kpi.verifactu.invalid.sub": "estructura no v\u00e1lida",
     "fiscalMonitor.tbai.tab.all": "Todas",
     "fiscalMonitor.tbai.tab.Recibido": "Enviadas (Recibido)",
     "fiscalMonitor.tbai.tab.Rechazado": "Rechazadas",
@@ -18380,7 +18380,7 @@
     "fiscalMonitor.status.vf.accepted": "Aceptado",
     "fiscalMonitor.status.vf.partiallyAccepted": "Parcialmente aceptado",
     "fiscalMonitor.status.vf.rejected": "Rechazado",
-    "fiscalMonitor.status.vf.invalid": "Inválido",
+    "fiscalMonitor.status.vf.invalid": "Inv\u00e1lido",
     "fiscalMonitor.pager.showing": "Mostrando",
     "fiscalMonitor.pager.of": "de",
     "fiscalMonitor.pager.records": "registros",
@@ -18442,7 +18442,121 @@
     "sifDataTabs.status.verifactu.invalid": "Inválida",
     "sifDataTabs.status.verifactu.rejected": "Rechazada",
     "sifDataTabs.status.verifactu.pending": "Pendiente",
-    "sifDataTabs.status.verifactu.notSent": "No enviada"
+    "sifDataTabs.status.verifactu.notSent": "No enviada",
+    "recentSalesInvoices": "Facturas de venta recientes",
+    "recentPurchaseInvoices": "Facturas de compra recientes",
+    "bankAccountsSummary": "Resumen de cuentas bancarias",
+    "taxObligations": "Obligaciones fiscales",
+    "installed": "Instalado",
+    "addsMenuEntries": "A\u00f1ade entradas de men\u00fa",
+    "uninstall": "Desinstalar",
+    "installing": "Instalando\u2026",
+    "appStore": "Tienda de aplicaciones",
+    "appStoreDescription": "Aplicaciones externas creadas con el SDK de Etendo. Cada app se ejecuta en su propio iframe \u2014 instalarla a\u00f1ade sus entradas de men\u00fa al shell; desinstalarla las elimina. No se necesita reconstruir el shell.",
+    "appStoreTip": "Sugerencia: esta secci\u00f3n est\u00e1 oculta por defecto \u2014 rev\u00e9lala con",
+    "appStoreTipHide": ", oc\u00faltala con",
+    "hideAppStoreTitle": "Ocultar la tienda de aplicaciones de la barra lateral",
+    "hideAppStore": "Ocultar tienda",
+    "artifactSchemaRaw": "Schema Raw",
+    "artifactSchemaCurated": "Schema Curado",
+    "artifactContract": "Contrato",
+    "artifactsTitle": "Artefactos",
+    "searchWindows": "Buscar ventanas...",
+    "noWindowsFound": "No se encontraron ventanas",
+    "selectWindowFromList": "Selecciona una ventana de la lista",
+    "currentVersion": "Versi\u00f3n actual",
+    "noDataToDisplay": "No hay datos para mostrar",
+    "closeDetailPanel": "Cerrar panel de detalle",
+    "activitySummary": "Resumen de actividad",
+    "lastSale": "\u00daltima venta",
+    "totalInvoiced12m": "Total facturado (12m)",
+    "pendingBalanceLabel": "Saldo pendiente",
+    "totalInvoicedHeader": "Total facturado",
+    "pendingBalanceHeader": "Saldo pendiente",
+    "category": "Categor\u00eda",
+    "viewKanban": "Kanban",
+    "viewList": "Lista",
+    "recentActivities": "Actividades recientes",
+    "teamActivity": "Actividad del equipo",
+    "firstStepsPageTitle": "Primeros pasos",
+    "firstStepsCopilotBanner": "Copilot puede ayudarte a configurarlo",
+    "firstStepsStart": "Empezar",
+    "firstStepsPrepareAccount": "Vamos a preparar tu cuenta",
+    "firstStepsSubtitle": "Sigue estos pasos y en menos de 10 minutos tendr\u00e1s todo listo para empezar.",
+    "completed": "Completados",
+    "firstStepsConfigure": "Configurar",
+    "minutes": "min",
+    "markAsCompleted": "Marcar como completado",
+    "firstStepsCreateAccount": "Crear cuenta",
+    "firstStepsCompanyData": "Datos de tu empresa",
+    "firstStepsCompanyDataDesc": "A\u00f1ade la informaci\u00f3n b\u00e1sica para emitir documentos.",
+    "firstStepsCustomizeInvoices": "Personaliza tus facturas",
+    "firstStepsConnectBank": "Conecta tu banco",
+    "firstStepsSetupPayments": "Configura m\u00e9todos de pago",
+    "firstStepsInviteTeam": "Invita a tu equipo",
+    "firstStepsFirstInvoice": "Crea tu primera factura",
+    "employeeDirectory": "Directorio de empleados",
+    "hrUpdates": "Novedades de RRHH",
+    "stockLevels": "Niveles de stock",
+    "minimum": "m\u00ednimo",
+    "recentMovements": "Movimientos recientes",
+    "oauth2Clients": "Clientes OAuth2",
+    "manageMcpCredentials": "Gestionar credenciales de agentes MCP",
+    "loadingClients": "Cargando clientes...",
+    "noOAuth2Clients": "No hay clientes OAuth2",
+    "createClientDescription": "Crea un cliente para que los agentes MCP puedan autenticarse con Etendo.",
+    "createFirstClient": "Crear primer cliente",
+    "clientId": "ID de cliente",
+    "scopes": "Permisos",
+    "active": "Activo",
+    "clickToCopy": "Clic para copiar",
+    "regenerateSecret": "Regenerar secreto",
+    "revokeTokens": "Revocar tokens",
+    "deleteClientDesc": "Esto eliminar\u00e1 permanentemente el cliente y revocar\u00e1 todos sus tokens. Esta acci\u00f3n no se puede deshacer.",
+    "regenerateSecretDesc": "\u00bfEst\u00e1s seguro? El secreto actual quedar\u00e1 invalidado inmediatamente. Los agentes que usen el secreto antiguo dejar\u00e1n de funcionar.",
+    "revokeTokensDesc": "Esto invalidar\u00e1 todos los tokens activos de este cliente. Los agentes deber\u00e1n volver a autenticarse.",
+    "recentTimeEntries": "Entradas de tiempo recientes",
+    "recentDocuments": "Documentos recientes",
+    "purchaseOrders": "\u00d3rdenes de compra",
+    "docNo": "N\u00ba doc.",
+    "documentNo": "N\u00ba documento",
+    "settings": "Configuraci\u00f3n",
+    "settingsDescription": "Gestiona el contexto de tu sesi\u00f3n. Cambiar el rol u organizaci\u00f3n volver\u00e1 a autenticar tu sesi\u00f3n.",
+    "currentSession": "Sesi\u00f3n actual",
+    "user": "Usuario",
+    "activeContext": "Contexto activo",
+    "balanceSheet": "Balance general",
+    "profitLoss": "P&G",
+    "profitLossTitle": "P\u00e9rdidas y ganancias",
+    "agingReceivable": "Aging de cobros",
+    "agingReceivableTitle": "Antig\u00fcedad de cobros",
+    "agingPayable": "Aging de pagos",
+    "agingPayableTitle": "Antig\u00fcedad de pagos",
+    "required": "Requerido",
+    "selectedCount": "seleccionados",
+    "loadingDetails": "Cargando detalles...",
+    "detailReport": "Informe de detalle",
+    "detailsSuffix": " \u2014 Detalles",
+    "invoiceTitle": "Factura",
+    "install": "Instalar",
+    "quotations": "Cotizaciones",
+    "location": "Ubicaci\u00f3n",
+    "oauthClientNew": "Nuevo cliente",
+    "oauthClientManage": "Gestionar credenciales de agentes MCP",
+    "oauthClientNoClients": "Sin clientes OAuth2",
+    "oauthClientNoClientsDesc": "Crea un cliente para permitir que los agentes MCP se autentiquen con Etendo.",
+    "oauthClientCreateFirst": "Crear primer cliente",
+    "oauthClientId": "ID de cliente",
+    "oauthScopes": "Alcances",
+    "oauthActive": "Activo",
+    "oauthInactive": "Inactivo",
+    "oauthRegenerateSecret": "Regenerar secreto",
+    "oauthRevokeTokens": "Revocar tokens",
+    "oauthClickToCopy": "Clic para copiar",
+    "oauthDeleteDesc": "Esto eliminar\u00e1 permanentemente el cliente y revocar\u00e1 todos sus tokens. Esta acci\u00f3n no se puede deshacer.",
+    "oauthRegenerateDesc": "\u00bfEst\u00e1s seguro? El secreto actual quedar\u00e1 invalidado inmediatamente. Los agentes que usen el secreto anterior dejar\u00e1n de funcionar.",
+    "oauthRevokeDesc": "Esto invalidar\u00e1 todos los tokens activos de este cliente. Los agentes deber\u00e1n volver a autenticarse.",
+    "firstStepsCompleted": "Completados"
   },
   "menus": {
     "Tax": {
@@ -18455,7 +18569,7 @@
       "label": "Activo"
     },
     "Warehouse": {
-      "label": "Almacén"
+      "label": "Almac\u00e9n"
     },
     "Service": {
       "label": "Servicios"
@@ -18500,7 +18614,7 @@
       "label": "Crear facturas desde pedidos"
     },
     "Execution Process": {
-      "label": "Proceso de Ejecución"
+      "label": "Proceso de Ejecuci\u00f3n"
     },
     "Process Price Difference Adjustment": {
       "label": "Procesar Ajuste de Diferencias de Precio"
@@ -18512,31 +18626,31 @@
       "label": "Plan de pago de facturas de compra"
     },
     "Doubtful Debt Method": {
-      "label": "Método de dudoso cobro"
+      "label": "M\u00e9todo de dudoso cobro"
     },
     "Datasource": {
       "label": "Fuente de datos"
     },
     "Alert Management": {
-      "label": "Gestión de Alertas"
+      "label": "Gesti\u00f3n de Alertas"
     },
     "Data Pool Selection": {
-      "label": "Selección de Pool de Datos"
+      "label": "Selecci\u00f3n de Pool de Datos"
     },
     "Navigation Bar Components": {
       "label": "Componentes de Barra de Navegacion"
     },
     "Grid Configuration at Window/Tab/Field Level": {
-      "label": "Configuración de grid a nivel de ventana/solapa/campo"
+      "label": "Configuraci\u00f3n de grid a nivel de ventana/solapa/campo"
     },
     "Log Management": {
-      "label": "Gestión de Log"
+      "label": "Gesti\u00f3n de Log"
     },
     "View Implementation": {
       "label": "Implementacion de Vista"
     },
     "Grid Configuration at System Level": {
-      "label": "Configuración de grid a nivel de sistema"
+      "label": "Configuraci\u00f3n de grid a nivel de sistema"
     },
     "Job Result": {
       "label": "Resultado de Job"
@@ -18563,7 +18677,7 @@
       "label": "Interfaz de Usuario"
     },
     "Instance Activation": {
-      "label": "Activación de la Instancia"
+      "label": "Activaci\u00f3n de la Instancia"
     },
     "Heartbeat Log": {
       "label": "Heartbeat Log"
@@ -18577,8 +18691,8 @@
     "SII Configuration": {
       "label": "SII Configuration"
     },
-    "Suministro Inmediato de Información (SII)": {
-      "label": "Suministro Inmediato de Información (SII)"
+    "Suministro Inmediato de Informaci\u00f3n (SII)": {
+      "label": "Suministro Inmediato de Informaci\u00f3n (SII)"
     },
     "SII Invoices Query": {
       "label": "SII Invoices Query"
@@ -18596,7 +18710,7 @@
       "label": "Business Intelligence"
     },
     "Check Printing": {
-      "label": "Impresión de cheques"
+      "label": "Impresi\u00f3n de cheques"
     },
     "Intrastat Launcher": {
       "label": "Generador de Intrastat"
@@ -18605,13 +18719,13 @@
       "label": "Intrastat"
     },
     "Transaction code": {
-      "label": "Clave de operación (IVA)"
+      "label": "Clave de operaci\u00f3n (IVA)"
     },
     "Setup": {
-      "label": "Configuración"
+      "label": "Configuraci\u00f3n"
     },
     "Intrastat Declaration": {
-      "label": "Declaración de Intrastat"
+      "label": "Declaraci\u00f3n de Intrastat"
     },
     "Intrastat Supplementary Unit of Measure": {
       "label": "Unidad Suplementaria de Medida de Intrastat"
@@ -18629,13 +18743,13 @@
       "label": "Generador de declaraciones de impuestos"
     },
     "Invoice Register Book Setup": {
-      "label": "Configuración de Libro de Facturas"
+      "label": "Configuraci\u00f3n de Libro de Facturas"
     },
     "Jobs": {
       "label": "Jobs"
     },
     "Number to Word Converter": {
-      "label": "Conversor de números a letras"
+      "label": "Conversor de n\u00fameros a letras"
     },
     "Manual Cash VAT Settlement": {
       "label": "Manual Cash VAT Settlement"
@@ -18650,43 +18764,43 @@
       "label": "Informe dimensional de impuestos"
     },
     "Valued Stock Report": {
-      "label": "Informe de Valuación de Existencias"
+      "label": "Informe de Valuaci\u00f3n de Existencias"
     },
     "Cluster": {
       "label": "Cluster"
     },
     "Withholding Report": {
-      "label": "Informe anual de certificación"
+      "label": "Informe anual de certificaci\u00f3n"
     },
     "Session Preferences": {
-      "label": "Preferencias Sesión"
+      "label": "Preferencias Sesi\u00f3n"
     },
     "Session Variables": {
-      "label": "Variables Sesión"
+      "label": "Variables Sesi\u00f3n"
     },
     "Requisition To Order": {
       "label": "Necesidad a Pedido"
     },
     "Payment Aging Balance": {
-      "label": "Informe de efectos por antigüedad"
+      "label": "Informe de efectos por antig\u00fcedad"
     },
     "Analysis Tools": {
-      "label": "Herramientas de análisis"
+      "label": "Herramientas de an\u00e1lisis"
     },
     "Intrastat File Configuration": {
-      "label": "Configuración del Fichero Intrastat"
+      "label": "Configuraci\u00f3n del Fichero Intrastat"
     },
     "Tax Report": {
-      "label": "Declaración de impuestos"
+      "label": "Declaraci\u00f3n de impuestos"
     },
     "Invoice Register Book": {
       "label": "Libro de Facturas"
     },
     "Application Dictionary": {
-      "label": "Diccionario de la Aplicación"
+      "label": "Diccionario de la Aplicaci\u00f3n"
     },
     "General Setup": {
-      "label": "Configuración General"
+      "label": "Configuraci\u00f3n General"
     },
     "Client": {
       "label": "Entidad"
@@ -18695,34 +18809,34 @@
       "label": "Datos"
     },
     "Performance Measurement": {
-      "label": "Medición de rendimiento"
+      "label": "Medici\u00f3n de rendimiento"
     },
     "Utility": {
-      "label": "Común"
+      "label": "Com\u00fan"
     },
     "Project and Service Management": {
-      "label": "Gestión de Proyectos y Servicios"
+      "label": "Gesti\u00f3n de Proyectos y Servicios"
     },
     "Customer Invoice Report": {
       "label": "Facturas "
     },
     "Application": {
-      "label": "Aplicación"
+      "label": "Aplicaci\u00f3n"
     },
     "Business Partner Rules": {
       "label": "Reglas para terceros"
     },
     "Sales Management": {
-      "label": "Gestión de Ventas"
+      "label": "Gesti\u00f3n de Ventas"
     },
     "Enterprise Model": {
-      "label": "Organización"
+      "label": "Organizaci\u00f3n"
     },
     "Cashflow Forecast Report": {
-      "label": "Informe de previsión de tesorería"
+      "label": "Informe de previsi\u00f3n de tesorer\u00eda"
     },
     "Product Management": {
-      "label": "Gestión de Productos"
+      "label": "Gesti\u00f3n de Productos"
     },
     "Generate Invoices": {
       "label": "Facturar"
@@ -18731,7 +18845,7 @@
       "label": "Importar Entidad"
     },
     "Procurement Management": {
-      "label": "Gestión de Compras"
+      "label": "Gesti\u00f3n de Compras"
     },
     "System Admin": {
       "label": "Prueba"
@@ -18740,25 +18854,25 @@
       "label": "Crear entidad"
     },
     "Receivables and Payables": {
-      "label": "Gestión de Cobros y Pagos"
+      "label": "Gesti\u00f3n de Cobros y Pagos"
     },
     "Initial organization setup": {
-      "label": "Crear organización"
+      "label": "Crear organizaci\u00f3n"
     },
     "Partner Relations": {
-      "label": "Gestión de terceros"
+      "label": "Gesti\u00f3n de terceros"
     },
     "Sales Invoice Dimensional Report": {
-      "label": "Análisis dimensional facturas ventas"
+      "label": "An\u00e1lisis dimensional facturas ventas"
     },
     "Financial Management": {
-      "label": "Gestión Financiera"
+      "label": "Gesti\u00f3n Financiera"
     },
     "Direct Process Import Entries": {
-      "label": "Proceso Directo de Importación de Entradas"
+      "label": "Proceso Directo de Importaci\u00f3n de Entradas"
     },
     "Synchronize Terminology": {
-      "label": "Sincronizar términos"
+      "label": "Sincronizar t\u00e9rminos"
     },
     "Reset Unit Cost": {
       "label": "Reinicializar Coste Unitario"
@@ -18767,10 +18881,10 @@
       "label": "Recompilar objetos BD"
     },
     "Printing Options": {
-      "label": "Impresión"
+      "label": "Impresi\u00f3n"
     },
     "Create Sales Orders from Expenses": {
-      "label": "Crear pedidos de venta según gastos"
+      "label": "Crear pedidos de venta seg\u00fan gastos"
     },
     "Create AP Expense Invoices": {
       "label": "Crear facturas de gastos AP "
@@ -18794,13 +18908,13 @@
       "label": "Conocimientos"
     },
     "Asset report for depreciation schedule": {
-      "label": "Informe del plan de amortización"
+      "label": "Informe del plan de amortizaci\u00f3n"
     },
     "CRM Connector": {
       "label": "Conector CRM"
     },
     "Enterprise module management": {
-      "label": "Gestión del módulo de Empresa"
+      "label": "Gesti\u00f3n del m\u00f3dulo de Empresa"
     },
     "Reset Accounting": {
       "label": "Reinicializar cuentas"
@@ -18821,7 +18935,7 @@
       "label": "Albaranes "
     },
     "Material Transaction Report": {
-      "label": "Informe Transacción de Material"
+      "label": "Informe Transacci\u00f3n de Material"
     },
     "Balance sheet and P&L structure": {
       "label": "Cuadros plan general contable"
@@ -18833,7 +18947,7 @@
       "label": "Proceso contable"
     },
     "Warehouse Control Report": {
-      "label": "Informe Control Almacén"
+      "label": "Informe Control Almac\u00e9n"
     },
     "Trial Balance": {
       "label": "Balance sumas y saldos"
@@ -18845,7 +18959,7 @@
       "label": "Informe Movimiento de Productos"
     },
     "Shipments Dimensional Report": {
-      "label": "Análisis dimensional albaranes ventas"
+      "label": "An\u00e1lisis dimensional albaranes ventas"
     },
     "Invoiced Sales Order Report": {
       "label": "Pedidos facturados "
@@ -18887,10 +19001,10 @@
       "label": "Consulta SQL"
     },
     "Production Management": {
-      "label": "Gestión de Producción"
+      "label": "Gesti\u00f3n de Producci\u00f3n"
     },
     "Calculate Standard Costs": {
-      "label": "Calcular costo estándar"
+      "label": "Calcular costo est\u00e1ndar"
     },
     "Insert Maintenances": {
       "label": "Insertar Mantenimientos"
@@ -18902,7 +19016,7 @@
       "label": "Informe transportista"
     },
     "User Defined Accounting Report": {
-      "label": "Creación de informes contables"
+      "label": "Creaci\u00f3n de informes contables"
     },
     "Import/Export Translations": {
       "label": "Importar/Exportar traducciones"
@@ -18914,16 +19028,16 @@
       "label": "Informe ofertas"
     },
     "Cashflow Forecast": {
-      "label": "Previsión de Tesorería"
+      "label": "Previsi\u00f3n de Tesorer\u00eda"
     },
     "Project Profitability": {
       "label": "Rentabilidad de Proyectos"
     },
     "Production Cost Report": {
-      "label": "Costo de producción"
+      "label": "Costo de producci\u00f3n"
     },
     "Material Requirement Planning": {
-      "label": "Gestión de MRP"
+      "label": "Gesti\u00f3n de MRP"
     },
     "Sales Order Report": {
       "label": "Pedidos "
@@ -18932,7 +19046,7 @@
       "label": "Documentos no contabilizados"
     },
     "Create Tax Report": {
-      "label": "Creación de informes de impuestos"
+      "label": "Creaci\u00f3n de informes de impuestos"
     },
     "Purchase Order Report": {
       "label": "Informe pedidos de compra "
@@ -18941,13 +19055,13 @@
       "label": "Mantenimiento"
     },
     "Master Data Management": {
-      "label": "Gestión de Datos Maestros"
+      "label": "Gesti\u00f3n de Datos Maestros"
     },
     "Business Partner Setup": {
-      "label": "Configuración de terceros"
+      "label": "Configuraci\u00f3n de terceros"
     },
     "Product Setup": {
-      "label": "Configuración de productos"
+      "label": "Configuraci\u00f3n de productos"
     },
     "Pricing": {
       "label": "Tarifas"
@@ -18956,7 +19070,7 @@
       "label": "Transacciones"
     },
     "Warehouse Management": {
-      "label": "Gestión de Almacén"
+      "label": "Gesti\u00f3n de Almac\u00e9n"
     },
     "Accounting": {
       "label": "Contabilidad"
@@ -18965,10 +19079,10 @@
       "label": "Deprecados"
     },
     "Production Run Status Report": {
-      "label": "Informe Partes de Fabricación "
+      "label": "Informe Partes de Fabricaci\u00f3n "
     },
     "BOM Production Report": {
-      "label": "Informe Producción"
+      "label": "Informe Producci\u00f3n"
     },
     "Pending Work Requirement": {
       "label": "Fases de OF a realizar "
@@ -18983,16 +19097,16 @@
       "label": "Facturas "
     },
     "Purchase Dimensional Report": {
-      "label": "Análisis dimensional pedidos compras"
+      "label": "An\u00e1lisis dimensional pedidos compras"
     },
     "Goods Receipts Dimensional Report": {
-      "label": "Análisis dimensional albaranes compras"
+      "label": "An\u00e1lisis dimensional albaranes compras"
     },
     "Purchase Invoice Dimensional Report": {
-      "label": "Análisis dimensional facturas compras"
+      "label": "An\u00e1lisis dimensional facturas compras"
     },
     "Sales Dimensional Report": {
-      "label": "Análisis dimensional pedidos ventas"
+      "label": "An\u00e1lisis dimensional pedidos ventas"
     },
     "Stock Report": {
       "label": "Informe Stock"
@@ -19007,7 +19121,7 @@
       "label": "Detalle facturas "
     },
     "Standard Costs Report": {
-      "label": "Costo estándar "
+      "label": "Costo est\u00e1ndar "
     },
     "Generate Cash Flow Statement": {
       "label": "Generar Cash Flow"
@@ -19019,16 +19133,16 @@
       "label": "Exportar Entidad"
     },
     "Payables Aging Schedule": {
-      "label": "Listado de saldos a pagar por antigüedad"
+      "label": "Listado de saldos a pagar por antig\u00fcedad"
     },
     "Update Product Characteristics Description": {
-      "label": "Actualizar descripción de las características de producto"
+      "label": "Actualizar descripci\u00f3n de las caracter\u00edsticas de producto"
     },
     "Customer Statement": {
       "label": "Extracto de cuenta de Cliente"
     },
     "Receivables Aging Schedule": {
-      "label": "Listado de saldos a cobrar por antigüedad"
+      "label": "Listado de saldos a cobrar por antig\u00fcedad"
     },
     "Process Scheduling": {
       "label": "Planificador de procesos"
@@ -19043,16 +19157,16 @@
       "label": "Estado de Inventario"
     },
     "AD Implementation Mapping": {
-      "label": "Mapeo de Implementación del Diccionario"
+      "label": "Mapeo de Implementaci\u00f3n del Diccionario"
     },
     "Return Reasons": {
-      "label": "Motivos de devolución"
+      "label": "Motivos de devoluci\u00f3n"
     },
     "Tables and Columns": {
       "label": "Tablas y columnas"
     },
     "Withholding": {
-      "label": "Retención"
+      "label": "Retenci\u00f3n"
     },
     "Tax Register Type": {
       "label": "Tipo de registro de impuesto"
@@ -19070,13 +19184,13 @@
       "label": "Ventanas, solapas y campos"
     },
     "Validation Setup": {
-      "label": "Reglas de validación"
+      "label": "Reglas de validaci\u00f3n"
     },
     "Message": {
       "label": "Mensaje"
     },
     "Menu": {
-      "label": "Menú"
+      "label": "Men\u00fa"
     },
     "Language": {
       "label": "Idioma"
@@ -19088,19 +19202,19 @@
       "label": "Usuario"
     },
     "Organization": {
-      "label": "Organización"
+      "label": "Organizaci\u00f3n"
     },
     "Role": {
       "label": "Rol"
     },
     "Document Sequence": {
-      "label": "Secuencia de documento (numeración)"
+      "label": "Secuencia de documento (numeraci\u00f3n)"
     },
     "Currency": {
       "label": "Moneda"
     },
     "Conversion Rates": {
-      "label": "Rangos de conversión"
+      "label": "Rangos de conversi\u00f3n"
     },
     "Dimensions Mapping": {
       "label": "Mapeo de dimensiones"
@@ -19109,25 +19223,25 @@
       "label": "Calendario anual y periodos"
     },
     "Account Tree": {
-      "label": "Árbol de cuentas"
+      "label": "\u00c1rbol de cuentas"
     },
     "Brand": {
       "label": "Marca"
     },
     "Organization Type": {
-      "label": "Tipo de Organización"
+      "label": "Tipo de Organizaci\u00f3n"
     },
     "Unit of Measure": {
       "label": "Unidad de medida"
     },
     "Country and Region": {
-      "label": "País, provincia y ciudad"
+      "label": "Pa\u00eds, provincia y ciudad"
     },
     "Business Partner": {
       "label": "Terceros"
     },
     "Return Material Receipt": {
-      "label": "Recibo de Devolución"
+      "label": "Recibo de Devoluci\u00f3n"
     },
     "General Ledger Configuration": {
       "label": "Esquema contable"
@@ -19136,13 +19250,13 @@
       "label": "Preferencias"
     },
     "Landed Cost Distribution Algorithm": {
-      "label": "Algoritmo de Distribución de Landed Cost"
+      "label": "Algoritmo de Distribuci\u00f3n de Landed Cost"
     },
     "Multiphase Project": {
       "label": "Proyecto multifase"
     },
     "G/L Category": {
-      "label": "Categoría de LM"
+      "label": "Categor\u00eda de LM"
     },
     "G/L Journal": {
       "label": "Asientos manuales"
@@ -19157,10 +19271,10 @@
       "label": "Impuesto"
     },
     "Tax Category": {
-      "label": "Categoría de Impuesto"
+      "label": "Categor\u00eda de Impuesto"
     },
     "Warehouse and Storage Bins": {
-      "label": "Almacén y huecos"
+      "label": "Almac\u00e9n y huecos"
     },
     "Product": {
       "label": "Producto"
@@ -19175,16 +19289,16 @@
       "label": "Pedido de Venta"
     },
     "Product Category": {
-      "label": "Categoría del producto"
+      "label": "Categor\u00eda del producto"
     },
     "Price List": {
       "label": "Tarifa"
     },
     "Invoice Schedule": {
-      "label": "Calendario de facturación"
+      "label": "Calendario de facturaci\u00f3n"
     },
     "Sales Campaign": {
-      "label": "Campaña de Marketing"
+      "label": "Campa\u00f1a de Marketing"
     },
     "Channel": {
       "label": "Canal"
@@ -19196,7 +19310,7 @@
       "label": "Zona de venta"
     },
     "Account Combination": {
-      "label": "Combinación de cuentas"
+      "label": "Combinaci\u00f3n de cuentas"
     },
     "Bank": {
       "label": "Banco-Sucursal"
@@ -19211,13 +19325,13 @@
       "label": "Factura de Venta"
     },
     "Physical Inventory": {
-      "label": "Inventario físico"
+      "label": "Inventario f\u00edsico"
     },
     "Cost Adjustment": {
       "label": "Ajuste de Costes"
     },
     "Goods Shipment": {
-      "label": "Albarán de Venta"
+      "label": "Albar\u00e1n de Venta"
     },
     "Goods Movements": {
       "label": "Movimiento entre almacenes"
@@ -19235,13 +19349,13 @@
       "label": "Factura de Compra"
     },
     "Goods Receipt": {
-      "label": "Albarán de Compra"
+      "label": "Albar\u00e1n de Compra"
     },
     "Form": {
       "label": "Formulario"
     },
     "Bill of Materials Production": {
-      "label": "Producción LDM"
+      "label": "Producci\u00f3n LDM"
     },
     "Business Partner Category": {
       "label": "Grupos de Terceros"
@@ -19256,13 +19370,13 @@
       "label": "Diario de caja"
     },
     "Field Category": {
-      "label": "Tipo agrupación campos"
+      "label": "Tipo agrupaci\u00f3n campos"
     },
     "Commission": {
-      "label": "Comisión"
+      "label": "Comisi\u00f3n"
     },
     "Commission Payment": {
-      "label": "Procesar comisión"
+      "label": "Procesar comisi\u00f3n"
     },
     "Goods Transaction": {
       "label": "Operaciones de material (uso indirecto)"
@@ -19271,7 +19385,7 @@
       "label": "Pedidos de compra cuadrados"
     },
     "Price List Schema": {
-      "label": "Esquema de tarificación"
+      "label": "Esquema de tarificaci\u00f3n"
     },
     "Expense Sheet": {
       "label": "Informe de gasto"
@@ -19280,7 +19394,7 @@
       "label": "Gastos para facturar"
     },
     "Asset Group": {
-      "label": "Categoría de Activos"
+      "label": "Categor\u00eda de Activos"
     },
     "Employee Expenses": {
       "label": "Gastos no reembolsados"
@@ -19292,13 +19406,13 @@
       "label": "Control lote"
     },
     "Serial Number Sequence": {
-      "label": "Control nº serie"
+      "label": "Control n\u00ba serie"
     },
     "Attribute": {
       "label": "Atributo"
     },
     "Session": {
-      "label": "Sesión"
+      "label": "Sesi\u00f3n"
     },
     "Project Type": {
       "label": "Tipo de proyecto"
@@ -19307,22 +19421,22 @@
       "label": "Rol permisos"
     },
     "Return to Vendor Shipment": {
-      "label": "Albarán de Devolución a Proveedor"
+      "label": "Albar\u00e1n de Devoluci\u00f3n a Proveedor"
     },
     "Alert": {
       "label": "Alertas"
     },
     "Freight Category": {
-      "label": "Categoría portes"
+      "label": "Categor\u00eda portes"
     },
     "Business Partner Info": {
-      "label": "Información de terceros"
+      "label": "Informaci\u00f3n de terceros"
     },
     "Dataset": {
       "label": "Conjunto de datos"
     },
     "Cluster Instance": {
-      "label": "Instancia del Clúster"
+      "label": "Instancia del Cl\u00faster"
     },
     "Referenced Inventory Type": {
       "label": "Tipo de Inventario Referenciado"
@@ -19331,19 +19445,19 @@
       "label": "Conjunto de Terceros"
     },
     "Costing Rules": {
-      "label": "Reglas de cálculo de costes"
+      "label": "Reglas de c\u00e1lculo de costes"
     },
     "Cluster Service Settings": {
-      "label": "Configuración Servicios Cluster"
+      "label": "Configuraci\u00f3n Servicios Cluster"
     },
     "Extension Points": {
-      "label": "Puntos de Extensión"
+      "label": "Puntos de Extensi\u00f3n"
     },
     "Process Request": {
       "label": "Procesamiento de Peticiones"
     },
     "System Info": {
-      "label": "Información del Sistema"
+      "label": "Informaci\u00f3n del Sistema"
     },
     "PLM Status": {
       "label": "Estado PLM"
@@ -19355,16 +19469,16 @@
       "label": "Presupuesto de Venta"
     },
     "Costing Algorithm": {
-      "label": "Algoritmo de cálculo de costes"
+      "label": "Algoritmo de c\u00e1lculo de costes"
     },
     "Product Characteristic": {
-      "label": "Característica de producto"
+      "label": "Caracter\u00edstica de producto"
     },
     "Cost Center": {
       "label": "Centro de costos"
     },
     "Attachments Configuration": {
-      "label": "Configuración de Adjuntos"
+      "label": "Configuraci\u00f3n de Adjuntos"
     },
     "Applications": {
       "label": "Aplicaciones"
@@ -19379,19 +19493,19 @@
       "label": "Rappels"
     },
     "Settlement": {
-      "label": "Liquidación"
+      "label": "Liquidaci\u00f3n"
     },
     "Manual Settlement": {
-      "label": "Liquidación manual"
+      "label": "Liquidaci\u00f3n manual"
     },
     "G/L Item": {
       "label": "Concepto contable"
     },
     "Incoming Shipment": {
-      "label": "Albarán logístico entrada"
+      "label": "Albar\u00e1n log\u00edstico entrada"
     },
     "Outgoing Shipment": {
-      "label": "Albarán logístico salida"
+      "label": "Albar\u00e1n log\u00edstico salida"
     },
     "Data File Type": {
       "label": "Tipos de datos de archivos"
@@ -19409,19 +19523,19 @@
       "label": "Dimensiones"
     },
     "Amortization": {
-      "label": "Amortización"
+      "label": "Amortizaci\u00f3n"
     },
     "Discounts and Promotions": {
-      "label": "Modificación de precios"
+      "label": "Modificaci\u00f3n de precios"
     },
     "Section": {
-      "label": "Área"
+      "label": "\u00c1rea"
     },
     "Manufacturing Cost Center": {
       "label": "Centro de Costos"
     },
     "Machine": {
-      "label": "Máquina"
+      "label": "M\u00e1quina"
     },
     "Work Center": {
       "label": "Puesto Trabajo"
@@ -19433,10 +19547,10 @@
       "label": "Incidencia de Trabajo"
     },
     "Process Plan": {
-      "label": "Plan de Producción"
+      "label": "Plan de Producci\u00f3n"
     },
     "Work Requirement": {
-      "label": "Orden de Fabricación"
+      "label": "Orden de Fabricaci\u00f3n"
     },
     "Work Effort": {
       "label": "Parte de Trabajo"
@@ -19445,31 +19559,31 @@
       "label": "Proceso"
     },
     "Quality Control Point": {
-      "label": "Punto de Control Crítico"
+      "label": "Punto de Control Cr\u00edtico"
     },
     "Quality Control Report": {
       "label": "Toma de Datos de PCC"
     },
     "Periodic Quality Control": {
-      "label": "Control Periódico"
+      "label": "Control Peri\u00f3dico"
     },
     "Periodic Quality Control Data": {
-      "label": "Datos del control de calidad periódico"
+      "label": "Datos del control de calidad peri\u00f3dico"
     },
     "Text Interfaces": {
       "label": "Texto interfaces"
     },
     "Promissory Note Format": {
-      "label": "Formato pagaré"
+      "label": "Formato pagar\u00e9"
     },
     "Callout": {
       "label": "Callout"
     },
     "Machine Category": {
-      "label": "Tipo de Máquina"
+      "label": "Tipo de M\u00e1quina"
     },
     "Maintenance Task": {
-      "label": "Operación de Mantenimiento"
+      "label": "Operaci\u00f3n de Mantenimiento"
     },
     "Maintenance Plan": {
       "label": "Mantenimiento Programado"
@@ -19484,46 +19598,46 @@
       "label": "Presupuesto"
     },
     "Payment Status Management": {
-      "label": "Gestión estado efectos"
+      "label": "Gesti\u00f3n estado efectos"
     },
     "User Defined Accounting Report Setup": {
-      "label": "Configuración Informes contables"
+      "label": "Configuraci\u00f3n Informes contables"
     },
     "Remittance": {
       "label": "Remesas"
     },
     "Salary Category": {
-      "label": "Categoría Salarial"
+      "label": "Categor\u00eda Salarial"
     },
     "Indirect Cost": {
       "label": "Costo Indirecto"
     },
     "Business Partner Tax Category": {
-      "label": "Categoría de Impuestos de Terceros"
+      "label": "Categor\u00eda de Impuestos de Terceros"
     },
     "Planner": {
       "label": "Planificador"
     },
     "MRP Forecast": {
-      "label": "Previsión de ventas"
+      "label": "Previsi\u00f3n de ventas"
     },
     "Requisition": {
       "label": "Necesidad de material"
     },
     "Planning Method": {
-      "label": "Método de planificación"
+      "label": "M\u00e9todo de planificaci\u00f3n"
     },
     "Manufacturing Plan": {
-      "label": "Planificación de la producción"
+      "label": "Planificaci\u00f3n de la producci\u00f3n"
     },
     "Purchasing Plan": {
-      "label": "Planificación de compras"
+      "label": "Planificaci\u00f3n de compras"
     },
     "Balance sheet and P&L structure Setup": {
-      "label": "Configuración de informes contables"
+      "label": "Configuraci\u00f3n de informes contables"
     },
     "Tax Report Setup": {
-      "label": "Configuración informes de impuestos"
+      "label": "Configuraci\u00f3n informes de impuestos"
     },
     "Discounts and Promotions Types": {
       "label": "Tipos de descuentos y promociones"
@@ -19541,7 +19655,7 @@
       "label": "Plantillas de Contabilidad"
     },
     "CRM Connector Configuration": {
-      "label": "Configuración del Conector CRM"
+      "label": "Configuraci\u00f3n del Conector CRM"
     },
     "Service Price Rule": {
       "label": "Regla de Precio de Servicio"
@@ -19550,7 +19664,7 @@
       "label": "Estado del producto"
     },
     "End Year Close": {
-      "label": "Cierre de año"
+      "label": "Cierre de a\u00f1o"
     },
     "Simple G/L Journal": {
       "label": "Asientos Manuales Simplificados"
@@ -19559,10 +19673,10 @@
       "label": "Servicios Cluster"
     },
     "Attachment Method": {
-      "label": "Método de Adjuntos"
+      "label": "M\u00e9todo de Adjuntos"
     },
     "Return to Vendor": {
-      "label": "Devolución a Proveedor"
+      "label": "Devoluci\u00f3n a Proveedor"
     },
     "Process Group": {
       "label": "Grupo de Procesos"
@@ -19577,10 +19691,10 @@
       "label": "Cuenta financiera"
     },
     "Module": {
-      "label": "Módulo"
+      "label": "M\u00f3dulo"
     },
     "Period Control Log": {
-      "label": "Histórico de Control de Periodos"
+      "label": "Hist\u00f3rico de Control de Periodos"
     },
     "Open/Close Period Control": {
       "label": "Abrir/Cerrar periodos"
@@ -19595,16 +19709,16 @@
       "label": "Archivo de Entradas de Datos Importados"
     },
     "Warehouse Rules": {
-      "label": "Reglas de almacén"
+      "label": "Reglas de almac\u00e9n"
     },
     "Audit Trail": {
-      "label": "Histórico de auditoría"
+      "label": "Hist\u00f3rico de auditor\u00eda"
     },
     "Return from Customer": {
-      "label": "Devolución de Cliente"
+      "label": "Devoluci\u00f3n de Cliente"
     },
     "Production Run": {
-      "label": "Parte de Fabricación"
+      "label": "Parte de Fabricaci\u00f3n"
     },
     "Payment Proposal": {
       "label": "Propuesta de Pago"
@@ -19613,49 +19727,49 @@
       "label": "Formato Fichero Banco"
     },
     "Payment Method": {
-      "label": "Método de pago"
+      "label": "M\u00e9todo de pago"
     },
     "Payment Out": {
       "label": "Pago"
     },
     "Payment Run": {
-      "label": "Histórico Ejecución de Pagos"
+      "label": "Hist\u00f3rico Ejecuci\u00f3n de Pagos"
     },
     "Matching Algorithm": {
-      "label": "Algoritmo de Reconciliación"
+      "label": "Algoritmo de Reconciliaci\u00f3n"
     },
     "Payment In": {
       "label": "Cobro"
     },
     "Window Personalization": {
-      "label": "Personalización de Ventana"
+      "label": "Personalizaci\u00f3n de Ventana"
     },
     "Process Definition": {
-      "label": "Definición del Proceso"
+      "label": "Definici\u00f3n del Proceso"
     },
-    "Código de Actividad": {
-      "label": "Código de Actividad"
+    "C\u00f3digo de Actividad": {
+      "label": "C\u00f3digo de Actividad"
     },
-    "Configuración TBAI": {
-      "label": "Configuración TBAI"
+    "Configuraci\u00f3n TBAI": {
+      "label": "Configuraci\u00f3n TBAI"
     },
     "TicketBAI": {
       "label": "TicketBAI"
     },
-    "Sistemas de Facturación": {
-      "label": "Sistemas de Facturación"
+    "Sistemas de Facturaci\u00f3n": {
+      "label": "Sistemas de Facturaci\u00f3n"
     },
     "IAE Activity Type": {
       "label": "IAE Activity Type"
     },
-    "Epígrafes IAE": {
-      "label": "Epígrafes IAE"
+    "Ep\u00edgrafes IAE": {
+      "label": "Ep\u00edgrafes IAE"
     },
     "Monitor Verifactu": {
       "label": "Monitor Verifactu"
     },
-    "Rellenar Fechas de Operación": {
-      "label": "Rellenar Fechas de Operación"
+    "Rellenar Fechas de Operaci\u00f3n": {
+      "label": "Rellenar Fechas de Operaci\u00f3n"
     },
     "Verifactu": {
       "label": "Verifactu"
@@ -19666,8 +19780,8 @@
     "Consulta Facturas Verifactu": {
       "label": "Consulta Facturas Verifactu"
     },
-    "Discrepancias de Auditoría": {
-      "label": "Discrepancias de Auditoría"
+    "Discrepancias de Auditor\u00eda": {
+      "label": "Discrepancias de Auditor\u00eda"
     },
     "PYMEs Chart of Accounts Update": {
       "label": "PYMEs Chart of Accounts Update"
@@ -19681,17 +19795,17 @@
     "TBAI Facturas Enviadas": {
       "label": "TBAI Facturas Enviadas"
     },
-    "Configuración Verifactu": {
-      "label": "Configuración Verifactu"
+    "Configuraci\u00f3n Verifactu": {
+      "label": "Configuraci\u00f3n Verifactu"
     },
     "Additional Info": {
-      "label": "Información adicional"
+      "label": "Informaci\u00f3n adicional"
     },
     "Create Amortization": {
-      "label": "Crear amortización"
+      "label": "Crear amortizaci\u00f3n"
     },
     "Depreciation Setup": {
-      "label": "Configuración de depreciación"
+      "label": "Configuraci\u00f3n de depreciaci\u00f3n"
     },
     "Order": {
       "label": "Pedido"
@@ -19703,19 +19817,19 @@
       "label": "Presupuesto"
     },
     "Shipment": {
-      "label": "Albarán"
+      "label": "Albar\u00e1n"
     },
     "Receipt": {
-      "label": "Albarán"
+      "label": "Albar\u00e1n"
     },
     "Return": {
-      "label": "Devolución"
+      "label": "Devoluci\u00f3n"
     },
     "Return Receipt": {
-      "label": "Recibo de Devolución"
+      "label": "Recibo de Devoluci\u00f3n"
     },
     "Return Shipment": {
-      "label": "Albarán de Devolución"
+      "label": "Albar\u00e1n de Devoluci\u00f3n"
     },
     "Account": {
       "label": "Plan de cuentas"
@@ -19768,16 +19882,16 @@
       "label": "Anulado"
     },
     "UE": {
-      "label": "Bajo evaluación"
+      "label": "Bajo evaluaci\u00f3n"
     },
     "VO": {
       "label": "Anulada"
     },
     "basicDiscount": {
-      "label": "Descuento básico"
+      "label": "Descuento b\u00e1sico"
     },
     "locationAddress": {
-      "label": "Ubicación / Dirección"
+      "label": "Ubicaci\u00f3n / Direcci\u00f3n"
     },
     "importFromPurchaseOrder": {
       "label": "Importar desde pedido de compra"
@@ -19786,10 +19900,10 @@
       "label": "Buscar pedido de compra..."
     },
     "loadingLines": {
-      "label": "Cargando líneas..."
+      "label": "Cargando l\u00edneas..."
     },
     "noLinesFound": {
-      "label": "No se encontraron líneas"
+      "label": "No se encontraron l\u00edneas"
     },
     "importQty": {
       "label": "Cant. a importar"
@@ -19798,10 +19912,10 @@
       "label": "ya recibido completamente"
     },
     "selectedLinesCount": {
-      "label": "{count} línea(s) seleccionada(s)"
+      "label": "{count} l\u00ednea(s) seleccionada(s)"
     },
     "selectLinesToImport": {
-      "label": "Selecciona líneas para importar"
+      "label": "Selecciona l\u00edneas para importar"
     },
     "importing": {
       "label": "Importando..."
@@ -19810,34 +19924,34 @@
       "label": "Importar seleccionadas{count}"
     },
     "importedLinesWithErrors": {
-      "label": "Se importaron {count} línea(s) con {errors} error(es)"
+      "label": "Se importaron {count} l\u00ednea(s) con {errors} error(es)"
     },
     "linesImportedFromPurchaseOrder": {
-      "label": "Se importaron {count} línea(s) desde el pedido de compra"
+      "label": "Se importaron {count} l\u00ednea(s) desde el pedido de compra"
     },
     "couldNotImportSelectedLines": {
-      "label": "No se pudieron importar las líneas seleccionadas"
+      "label": "No se pudieron importar las l\u00edneas seleccionadas"
     },
     "noLinesWereImported": {
-      "label": "No se importó ninguna línea"
+      "label": "No se import\u00f3 ninguna l\u00ednea"
     },
     "failedToImportLines": {
-      "label": "No se pudieron importar las líneas"
+      "label": "No se pudieron importar las l\u00edneas"
     },
     "noCompletedPurchaseOrdersWithPendingQuantitiesForThisVendor": {
       "label": "No hay pedidos de compra completados con cantidades pendientes para este proveedor."
     },
     "noOrdersMatchYourSearch": {
-      "label": "Ningún pedido coincide con tu búsqueda."
+      "label": "Ning\u00fan pedido coincide con tu b\u00fasqueda."
     },
     "noLinesYet": {
-      "label": "Aún no hay líneas"
+      "label": "A\u00fan no hay l\u00edneas"
     },
     "addLinesManuallyOrImportFromPurchaseOrder": {
-      "label": "Añade líneas manualmente o impórtalas desde un pedido de compra"
+      "label": "A\u00f1ade l\u00edneas manualmente o imp\u00f3rtalas desde un pedido de compra"
     },
     "addLines": {
-      "label": "Añadir líneas"
+      "label": "A\u00f1adir l\u00edneas"
     },
     "noPaymentDetailsFound": {
       "label": "No se encontraron detalles de pago"

--- a/tools/app-shell/src/pages/AccountingPage.jsx
+++ b/tools/app-shell/src/pages/AccountingPage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { KPIHeader, DataTable } from '@/components/contract-ui';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { FileText, Receipt, Landmark, Scale } from 'lucide-react';
+import { useUI } from '@/i18n';
 
 import { kpisConfig, sections } from '@generated/accounting/generated/config';
 import * as mockData from '@generated/accounting/generated/mockData';
@@ -26,6 +27,7 @@ const TAX_SUMMARY_DATA = mockData.taxSummary;
 // -- Component -----------------------------------------------------------------
 
 export default function AccountingPage() {
+  const ui = useUI();
   return (
     <div className="space-y-6">
       {/* KPIs */}
@@ -38,7 +40,7 @@ export default function AccountingPage() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <FileText className="h-5 w-5 text-muted-foreground" />
-                Recent Sales Invoices
+                {ui('recentSalesInvoices')}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -52,7 +54,7 @@ export default function AccountingPage() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Receipt className="h-5 w-5 text-muted-foreground" />
-                Recent Purchase Invoices
+                {ui('recentPurchaseInvoices')}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -69,7 +71,7 @@ export default function AccountingPage() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Landmark className="h-5 w-5 text-muted-foreground" />
-                Bank Accounts Summary
+                {ui('bankAccountsSummary')}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -83,7 +85,7 @@ export default function AccountingPage() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Scale className="h-5 w-5 text-muted-foreground" />
-                Tax Obligations
+                {ui('taxObligations')}
               </CardTitle>
             </CardHeader>
             <CardContent>

--- a/tools/app-shell/src/pages/AppStorePage.jsx
+++ b/tools/app-shell/src/pages/AppStorePage.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useUI } from '@/i18n';
 import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -31,6 +32,7 @@ function pickIcon(name) {
 }
 
 function AppCard({ app, installed, busy, onInstall, onUninstall }) {
+  const ui = useUI();
   const Icon = pickIcon(app.icon);
 
   return (
@@ -53,7 +55,7 @@ function AppCard({ app, installed, busy, onInstall, onUninstall }) {
           {installed && (
             <Badge variant="secondary" className="gap-1">
               <CheckCircle2 className="h-3 w-3" />
-              Installed
+              {ui("installed")}
             </Badge>
           )}
         </div>
@@ -63,7 +65,7 @@ function AppCard({ app, installed, busy, onInstall, onUninstall }) {
         <p className="text-sm text-muted-foreground">{app.description}</p>
 
         <div className="text-xs text-muted-foreground">
-          <div className="font-medium text-foreground mb-1">Adds menu entries</div>
+          <div className="font-medium text-foreground mb-1">{ui("addsMenuEntries")}</div>
           <ul className="list-disc pl-4 space-y-0.5">
             {app.menuEntries.map((e) => (
               <li key={e.name}>
@@ -88,7 +90,7 @@ function AppCard({ app, installed, busy, onInstall, onUninstall }) {
             onClick={() => onUninstall(app.appId)}
             disabled={busy}
           >
-            Uninstall
+            {ui("uninstall")}
           </Button>
         ) : (
           <Button
@@ -99,10 +101,10 @@ function AppCard({ app, installed, busy, onInstall, onUninstall }) {
             {busy ? (
               <>
                 <Loader2 className="h-3 w-3 animate-spin" />
-                Installing…
+                {ui("installing")}
               </>
             ) : (
-              'Install'
+              ui('install')
             )}
           </Button>
         )}
@@ -112,6 +114,7 @@ function AppCard({ app, installed, busy, onInstall, onUninstall }) {
 }
 
 export default function AppStorePage() {
+  const ui = useUI();
   const installedIds = useInstalledApps();
   const installedSet = new Set(installedIds);
   const [busyId, setBusyId] = useState(null);
@@ -137,17 +140,15 @@ export default function AppStorePage() {
             <Store className="h-5 w-5 text-primary" />
           </div>
           <div>
-            <h1 className="text-xl font-semibold">App Store</h1>
+            <h1 className="text-xl font-semibold">{ui("appStore")}</h1>
             <p className="text-sm text-muted-foreground mt-1 max-w-2xl">
-              External apps built on the Etendo Apps SDK. Each app runs in its
-              own iframe with its own BFF — installing one here adds its menu
-              entries to the shell; uninstalling removes them. No shell rebuild
-              required.
+              {ui("appStoreDescription")}
             </p>
             <p className="text-xs text-muted-foreground/80 mt-2">
-              Tip: this section is hidden by default — reveal it with{' '}
+              {ui("appStoreTip")}{' '}
               <code className="px-1 py-0.5 rounded bg-muted text-foreground">playstoreon</code>,
-              hide it with{' '}
+              {ui("appStoreTipHide")}{' '}
+{/* i18n-allowlist: ["playstoreon", "playstoreoff"] */}
               <code className="px-1 py-0.5 rounded bg-muted text-foreground">playstoreoff</code>.
             </p>
           </div>
@@ -156,9 +157,9 @@ export default function AppStorePage() {
           variant="ghost"
           size="sm"
           onClick={() => lockAppStore()}
-          title="Hide the App Store from the sidebar"
+          title={ui("hideAppStoreTitle")}
         >
-          Hide App Store
+          {ui("hideAppStore")}
         </Button>
       </div>
 

--- a/tools/app-shell/src/pages/ArtifactViewerPage.jsx
+++ b/tools/app-shell/src/pages/ArtifactViewerPage.jsx
@@ -1,11 +1,12 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useUI } from '@/i18n';
 import { useParams, useNavigate } from 'react-router-dom';
 import { FileJson, Search, History, Loader2, FolderOpen } from 'lucide-react';
 
 const ARTIFACT_FILES = [
-  { key: 'schema-raw.json', label: 'Schema Raw' },
-  { key: 'schema-curated.json', label: 'Schema Curated' },
-  { key: 'contract.json', label: 'Contract' },
+  { key: 'schema-raw.json', labelKey: 'artifactSchemaRaw' },
+  { key: 'schema-curated.json', labelKey: 'artifactSchemaCurated' },
+  { key: 'contract.json', labelKey: 'artifactContract' },
 ];
 
 /**
@@ -75,6 +76,7 @@ function JsonView({ data }) {
 }
 
 export default function ArtifactViewerPage() {
+  const ui = useUI();
   const { windowName: paramWindow } = useParams();
   const navigate = useNavigate();
 
@@ -168,7 +170,7 @@ export default function ArtifactViewerPage() {
         <div className="border-b border-gray-200 p-3">
           <div className="flex items-center gap-2 mb-2">
             <FileJson className="h-4 w-4 text-gray-500" />
-            <h2 className="text-sm font-semibold text-gray-700">Artifacts</h2>
+            <h2 className="text-sm font-semibold text-gray-700">{ui("artifactsTitle")}</h2>
             <span className="ml-auto rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-500">
               {windows.length}
             </span>
@@ -177,7 +179,7 @@ export default function ArtifactViewerPage() {
             <Search className="absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" />
             <input
               type="text"
-              placeholder="Search windows..."
+              placeholder={ui("searchWindows")}
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               className="w-full rounded-md border border-gray-200 bg-gray-50 py-1.5 pl-7 pr-2 text-xs placeholder:text-gray-400 focus:border-blue-300 focus:outline-none focus:ring-1 focus:ring-blue-200"
@@ -200,7 +202,7 @@ export default function ArtifactViewerPage() {
             </button>
           ))}
           {filteredWindows.length === 0 && (
-            <p className="px-3 py-4 text-xs text-gray-400">No windows found</p>
+            <p className="px-3 py-4 text-xs text-gray-400">{ui("noWindowsFound")}</p>
           )}
         </nav>
       </aside>
@@ -211,7 +213,7 @@ export default function ArtifactViewerPage() {
           <div className="flex flex-1 items-center justify-center text-gray-400">
             <div className="text-center">
               <FolderOpen className="mx-auto mb-3 h-12 w-12 text-gray-300" />
-              <p className="text-sm">Select a window from the list</p>
+              <p className="text-sm">{ui("selectWindowFromList")}</p>
             </div>
           </div>
         ) : (
@@ -220,7 +222,7 @@ export default function ArtifactViewerPage() {
             <div className="flex items-center gap-4 border-b border-gray-200 bg-white px-4 py-2">
               {/* File tabs */}
               <div className="flex gap-1">
-                {ARTIFACT_FILES.map(({ key, label }) => (
+                {ARTIFACT_FILES.map(({ key, labelKey }) => (
                   <button
                     key={key}
                     onClick={() => {
@@ -233,7 +235,7 @@ export default function ArtifactViewerPage() {
                         : 'text-gray-600 hover:bg-gray-100'
                     }`}
                   >
-                    {label}
+                    {ui(labelKey)}
                   </button>
                 ))}
               </div>
@@ -249,7 +251,7 @@ export default function ArtifactViewerPage() {
                   onChange={(e) => setSelectedRef(e.target.value || null)}
                   className="rounded-md border border-gray-200 bg-white px-2 py-1 text-xs text-gray-700 focus:border-blue-300 focus:outline-none focus:ring-1 focus:ring-blue-200"
                 >
-                  <option value="">Current version</option>
+                  <option value="">{ui("currentVersion")}</option>
                   {commits.map((c) => (
                     <option key={c.hash} value={c.hash}>
                       {c.hash} — {c.date?.substring(0, 10)} — {c.subject?.substring(0, 50)}
@@ -269,7 +271,7 @@ export default function ArtifactViewerPage() {
               {loading && (
                 <div className="flex items-center justify-center py-16">
                   <Loader2 className="h-6 w-6 animate-spin text-gray-400" />
-                  <span className="ml-2 text-sm text-gray-500">Loading...</span>
+                  <span className="ml-2 text-sm text-gray-500">{ui("loading")}</span>
                 </div>
               )}
 
@@ -283,7 +285,7 @@ export default function ArtifactViewerPage() {
 
               {!jsonData && !loading && !error && (
                 <div className="flex items-center justify-center py-16 text-gray-400">
-                  <p className="text-sm">No data to display</p>
+                  <p className="text-sm">{ui("noDataToDisplay")}</p>
                 </div>
               )}
             </div>

--- a/tools/app-shell/src/pages/ContactsPage.jsx
+++ b/tools/app-shell/src/pages/ContactsPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo } from 'react';
+import { useUI } from '@/i18n';
 import { KPIHeader } from '@/components/contract-ui/KPIHeader';
 import { KanbanBoard } from '@/components/contract-ui/KanbanBoard';
 import { Chatter } from '@/components/contract-ui/Chatter';
@@ -52,6 +53,7 @@ function formatCurrency(value) {
 }
 
 function DetailPanel({ contact, onClose }) {
+  const ui = useUI();
   if (!contact) return null;
 
   const tags = [CATEGORY_LABEL[contact.columnId]];
@@ -64,7 +66,7 @@ function DetailPanel({ contact, onClose }) {
       <div className="p-4">
         {/* Close button */}
         <div className="flex justify-end mb-2">
-          <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close detail panel">
+          <Button variant="ghost" size="icon" onClick={onClose} aria-label={ui("closeDetailPanel")}>
             <X className="h-4 w-4" />
           </Button>
         </div>
@@ -104,19 +106,20 @@ function DetailPanel({ contact, onClose }) {
         {/* Activity summary */}
         <Card>
           <CardHeader className="p-3 pb-2">
-            <CardTitle className="text-sm font-medium">Activity Summary</CardTitle>
+            <CardTitle className="text-sm font-medium">{ui("activitySummary")}</CardTitle>
           </CardHeader>
           <CardContent className="p-3 pt-0 space-y-2">
             <div className="flex justify-between text-sm">
-              <span className="text-muted-foreground">Last sale</span>
+              <span className="text-muted-foreground">{ui("lastSale")}</span>
+              {/* i18n-allowlist: ["Mar 2, 2026"] */}
               <span className="font-medium">Mar 2, 2026</span>
             </div>
             <div className="flex justify-between text-sm">
-              <span className="text-muted-foreground">Total invoiced (12m)</span>
+              <span className="text-muted-foreground">{ui("totalInvoiced12m")}</span>
               <span className="font-medium">{contact.value ? formatCurrency(contact.value) : '-'}</span>
             </div>
             <div className="flex justify-between text-sm">
-              <span className="text-muted-foreground">Pending balance</span>
+              <span className="text-muted-foreground">{ui("pendingBalanceLabel")}</span>
               <span className="font-medium">{contact.value ? formatCurrency(Math.round(contact.value * 0.12)) : '-'}</span>
             </div>
           </CardContent>
@@ -142,17 +145,18 @@ function DetailPanel({ contact, onClose }) {
 }
 
 function ListView({ contacts, onRowClick }) {
+  const ui = useUI();
   return (
     <div className="border rounded-lg overflow-hidden">
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b bg-muted/50">
-            <th className="text-left p-3 font-medium">Name</th>
-            <th className="text-left p-3 font-medium">Category</th>
-            <th className="text-left p-3 font-medium">Location</th>
-            <th className="text-left p-3 font-medium">Email</th>
-            <th className="text-right p-3 font-medium">Total Invoiced</th>
-            <th className="text-right p-3 font-medium">Pending Balance</th>
+            <th className="text-left p-3 font-medium">{ui("name")}</th>
+            <th className="text-left p-3 font-medium">{ui("category")}</th>
+            <th className="text-left p-3 font-medium">{ui("location")}</th>
+            <th className="text-left p-3 font-medium">{ui("email")}</th>
+            <th className="text-right p-3 font-medium">{ui("totalInvoicedHeader")}</th>
+            <th className="text-right p-3 font-medium">{ui("pendingBalanceHeader")}</th>
           </tr>
         </thead>
         <tbody>
@@ -181,6 +185,7 @@ function ListView({ contacts, onRowClick }) {
 }
 
 export default function ContactsPage() {
+  const ui = useUI();
   const [search, setSearch] = useState('');
   const [activeView, setActiveView] = useState('kanban');
   const [selectedContact, setSelectedContact] = useState(null);
@@ -217,14 +222,14 @@ export default function ContactsPage() {
             size="sm"
             onClick={() => setActiveView('kanban')}
           >
-            Kanban
+            {ui('viewKanban')}
           </Button>
           <Button
             variant={activeView === 'list' ? 'default' : 'ghost'}
             size="sm"
             onClick={() => setActiveView('list')}
           >
-            List
+            {ui('viewList')}
           </Button>
         </div>
 

--- a/tools/app-shell/src/pages/CrmPage.jsx
+++ b/tools/app-shell/src/pages/CrmPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import { useUI } from '@/i18n';
 import { useNavigate } from 'react-router-dom';
 import { KPIHeader, KanbanBoard, DataTable } from '@/components/contract-ui';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
@@ -42,6 +43,7 @@ const STATUS_VARIANT = {
 
 export default function CrmPage() {
   const navigate = useNavigate();
+  const ui = useUI();
   const [cards, setCards] = useState(INITIAL_CARDS);
 
   const handleDragEnd = useCallback((cardId, _fromColumnId, toColumnId) => {
@@ -79,7 +81,7 @@ export default function CrmPage() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Activity className="h-5 w-5 text-muted-foreground" />
-                Recent Activities
+                {ui('recentActivities')}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -98,7 +100,7 @@ export default function CrmPage() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2 text-base">
                 <Users className="h-5 w-5 text-muted-foreground" />
-                Team Activity
+                {ui('teamActivity')}
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">

--- a/tools/app-shell/src/pages/FirstStepsPage.jsx
+++ b/tools/app-shell/src/pages/FirstStepsPage.jsx
@@ -11,21 +11,22 @@ import {
   Users,
   Receipt,
 } from 'lucide-react';
+import { useUI } from '@/i18n';
 import TopBar from '@/components/layout/TopBar/TopBar.jsx';
 
 const STEPS = [
   {
     id: 1,
     icon: Users,
-    title: 'Crear cuenta',
+    titleKey: 'firstStepsCreateAccount',
     time: null,
     done: true,
   },
   {
     id: 2,
     icon: Building2,
-    title: 'Datos de tu empresa',
-    description: 'Añade la información básica para emitir documentos.',
+    titleKey: 'firstStepsCompanyData',
+    descKey: 'firstStepsCompanyDataDesc',
     time: 2,
     done: false,
     expanded: true,
@@ -33,35 +34,35 @@ const STEPS = [
   {
     id: 3,
     icon: FileText,
-    title: 'Personaliza tus facturas',
+    titleKey: 'firstStepsCustomizeInvoices',
     time: 3,
     done: false,
   },
   {
     id: 4,
     icon: Landmark,
-    title: 'Conecta tu banco',
+    titleKey: 'firstStepsConnectBank',
     time: 4,
     done: false,
   },
   {
     id: 5,
     icon: CreditCard,
-    title: 'Configura métodos de pago',
+    titleKey: 'firstStepsSetupPayments',
     time: 2,
     done: false,
   },
   {
     id: 6,
     icon: Users,
-    title: 'Invita a tu equipo',
+    titleKey: 'firstStepsInviteTeam',
     time: 2,
     done: false,
   },
   {
     id: 7,
     icon: Receipt,
-    title: 'Crea tu primera factura',
+    titleKey: 'firstStepsFirstInvoice',
     time: 2,
     done: false,
   },
@@ -71,9 +72,10 @@ const completed = STEPS.filter(s => s.done).length;
 const total = STEPS.length;
 
 export default function FirstStepsPage() {
+  const ui = useUI();
   return (
     <div className="flex flex-col h-full">
-      <TopBar title="Primeros pasos" />
+      <TopBar title={ui("firstStepsPageTitle")} />
 
       <div className="flex-1 overflow-auto bg-page-bg">
         <div className="mx-auto max-w-2xl px-6 py-8 space-y-6">
@@ -82,7 +84,7 @@ export default function FirstStepsPage() {
           <div className="flex items-center justify-between rounded-xl border bg-card px-5 py-3.5 shadow-sm">
             <div className="flex items-center gap-3 text-sm text-muted-foreground">
               <Settings className="h-5 w-5 shrink-0" />
-              <span>Copilot puede ayudarte a configurarlo</span>
+              <span>{ui("firstStepsCopilotBanner")}</span>
             </div>
             <button
               type="button"
@@ -90,21 +92,21 @@ export default function FirstStepsPage() {
               className="flex items-center gap-1.5 rounded-lg bg-primary px-4 py-1.5 text-sm font-medium text-primary-foreground opacity-60 cursor-default"
             >
               <Sparkles className="h-4 w-4" />
-              Empezar
+              {ui("firstStepsStart")}
             </button>
           </div>
 
           {/* Header + progress */}
           <div className="space-y-2">
             <h1 className="text-3xl font-bold text-text-primary">
-              Vamos a preparar tu cuenta
+              {ui("firstStepsPrepareAccount")}
             </h1>
             <div className="flex items-center justify-between text-sm">
               <span className="text-muted-foreground">
-                Sigue estos pasos y en menos de 10 minutos tendrás todo listo para empezar.
+                {ui("firstStepsSubtitle")}
               </span>
               <span className="shrink-0 ml-4 font-medium text-muted-foreground">
-                {completed}/{total} Completados
+                {completed}/{total} {ui("firstStepsCompleted")}
               </span>
             </div>
             <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">
@@ -133,28 +135,28 @@ export default function FirstStepsPage() {
                     {/* Content */}
                     <div className="flex-1 min-w-0">
                       <p className={`text-sm font-semibold ${step.done ? 'line-through text-muted-foreground' : 'text-text-primary'}`}>
-                        {step.title}
+                        {ui(step.titleKey)}
                       </p>
 
-                      {step.expanded && step.description && (
+                      {step.expanded && step.descKey && (
                         <div className="mt-1 space-y-3">
-                          <p className="text-xs text-muted-foreground">{step.description}</p>
+                          <p className="text-xs text-muted-foreground">{ui(step.descKey)}</p>
                           <div className="flex items-center gap-3">
                             <button
                               type="button"
                               disabled
                               className="rounded-md border px-3 py-1 text-xs font-medium text-foreground cursor-default hover:bg-muted/50"
                             >
-                              Configurar
+                              {ui("firstStepsConfigure")}
                             </button>
                             <span className="flex items-center gap-1 text-xs text-muted-foreground">
                               <Clock className="h-3.5 w-3.5" />
-                              {step.time} min
+                              {step.time} {ui("minutes")}
                             </span>
                           </div>
                           <label className="flex items-center gap-2 text-xs text-muted-foreground cursor-default select-none">
                             <span className="flex h-4 w-4 shrink-0 items-center justify-center rounded border border-border" />
-                            Marcar como completado
+                            {ui("markAsCompleted")}
                           </label>
                         </div>
                       )}

--- a/tools/app-shell/src/pages/HrPage.jsx
+++ b/tools/app-shell/src/pages/HrPage.jsx
@@ -4,6 +4,7 @@ import { KPIHeader, KanbanBoard, DataTable } from '@/components/contract-ui';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
 import { Users, Calendar, UserPlus, Clock, Bell, ArrowUp, ArrowDown } from 'lucide-react';
+import { useUI } from '@/i18n';
 
 import { sections } from '@generated/hr/generated/config';
 import * as mockData from '@generated/hr/generated/mockData';
@@ -34,6 +35,7 @@ const HR_FEED = mockData.hrUpdates;
 
 export default function HrPage() {
   const navigate = useNavigate();
+  const ui = useUI();
   const [cards, setCards] = useState(INITIAL_CARDS);
 
   const handleDragEnd = useCallback((cardId, _fromColumnId, toColumnId) => {
@@ -62,7 +64,7 @@ export default function HrPage() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Users className="h-5 w-5 text-muted-foreground" />
-                Employee Directory
+                {ui('employeeDirectory')}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -92,7 +94,7 @@ export default function HrPage() {
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base">
             <Bell className="h-5 w-5 text-muted-foreground" />
-            HR Updates
+            {ui('hrUpdates')}
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-3">

--- a/tools/app-shell/src/pages/InventoryPage.jsx
+++ b/tools/app-shell/src/pages/InventoryPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useUI } from '@/i18n';
 import { KPIHeader, DataTable } from '@/components/contract-ui';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
@@ -30,6 +31,7 @@ const RECENT_MOVEMENTS = mockData.recentMovements;
 // -- Component -----------------------------------------------------------------
 
 export default function InventoryPage() {
+  const ui = useUI();
   return (
     <div className="space-y-6">
       {/* KPIs */}
@@ -43,7 +45,7 @@ export default function InventoryPage() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
                 <Search className="h-5 w-5 text-muted-foreground" />
-                Stock Levels
+                {ui('stockLevels')}
               </CardTitle>
             </CardHeader>
             <CardContent>
@@ -63,7 +65,7 @@ export default function InventoryPage() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2 text-base">
                 <AlertTriangle className="h-5 w-5 text-amber-500" />
-                Low Stock Alerts
+                {ui('lowStockAlerts')}
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
@@ -74,7 +76,7 @@ export default function InventoryPage() {
                     <div className="min-w-0">
                       <p className="text-sm font-medium truncate">{alert.name}</p>
                       <p className="text-xs text-muted-foreground mt-0.5">
-                        {alert.current} / {alert.minimum} minimum
+                        {alert.current} / {alert.minimum} {ui('minimum')}
                       </p>
                     </div>
                     <Badge
@@ -96,7 +98,7 @@ export default function InventoryPage() {
           {/* Recent Movements */}
           <Card>
             <CardHeader>
-              <CardTitle className="text-base">Recent Movements</CardTitle>
+              <CardTitle className="text-base">{ui('recentMovements')}</CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
               {RECENT_MOVEMENTS.map((movement, idx) => (
@@ -116,7 +118,7 @@ export default function InventoryPage() {
                     <div className="flex-1 min-w-0">
                       <p className="text-sm font-medium truncate">{movement.product}</p>
                       <p className="text-xs text-muted-foreground">
-                        {movement.qty} units &middot; {movement.warehouse}
+                        {movement.qty} {ui('units')} · {movement.warehouse}
                       </p>
                     </div>
                     <span className="text-xs text-muted-foreground whitespace-nowrap">

--- a/tools/app-shell/src/pages/OAuth2ClientsPage.jsx
+++ b/tools/app-shell/src/pages/OAuth2ClientsPage.jsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Shield, Plus, RefreshCw, Trash2, Key, MoreHorizontal, Copy, Ban, Pencil } from 'lucide-react';
+import { useUI } from '@/i18n';
 import { toast } from 'sonner';
 
 function detectBaseUrl() {
@@ -26,6 +27,7 @@ function detectBaseUrl() {
 
 export default function OAuth2ClientsPage() {
   const { token, logout } = useAuth();
+  const ui = useUI();
   const [clients, setClients] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -84,8 +86,7 @@ export default function OAuth2ClientsPage() {
     setConfirmState({
       open: true,
       title: `Delete "${client.name}"?`,
-      description:
-        'This will permanently delete the client and revoke all its tokens. This action cannot be undone.',
+      description: ui('oauthDeleteDesc'),
       confirmLabel: 'Delete',
       variant: 'destructive',
       onConfirm: async () => {
@@ -108,8 +109,7 @@ export default function OAuth2ClientsPage() {
     setConfirmState({
       open: true,
       title: `Regenerate secret for "${client.name}"?`,
-      description:
-        'Are you sure? The current secret will be invalidated immediately. Any agents using the old secret will stop working.',
+      description: ui('oauthRegenerateDesc'),
       confirmLabel: 'Regenerate',
       variant: 'destructive',
       onConfirm: async () => {
@@ -138,8 +138,7 @@ export default function OAuth2ClientsPage() {
     setConfirmState({
       open: true,
       title: `Revoke tokens for "${client.name}"?`,
-      description:
-        'This will invalidate all active tokens for this client. Agents will need to re-authenticate.',
+      description: ui('oauthRevokeDesc'),
       confirmLabel: 'Revoke All',
       variant: 'destructive',
       onConfirm: async () => {
@@ -172,8 +171,8 @@ export default function OAuth2ClientsPage() {
     <div className="space-y-6 p-6">
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-2xl font-bold tracking-tight">OAuth2 Clients</h2>
-          <p className="text-muted-foreground">Manage MCP agent credentials</p>
+          <h2 className="text-2xl font-bold tracking-tight">{ui("oauth2Clients")}</h2>
+          <p className="text-muted-foreground">{ui("oauthClientManage")}</p>
         </div>
         <div className="flex items-center gap-2">
           <Button variant="outline" size="icon" onClick={fetchClients} disabled={loading}>
@@ -181,7 +180,7 @@ export default function OAuth2ClientsPage() {
           </Button>
           <Button onClick={handleCreate}>
             <Plus className="h-4 w-4 mr-2" />
-            New Client
+            {ui("oauthClientNew")}
           </Button>
         </div>
       </div>
@@ -191,30 +190,30 @@ export default function OAuth2ClientsPage() {
           {loading ? (
             <div className="flex items-center justify-center py-12 text-muted-foreground">
               <RefreshCw className="h-5 w-5 animate-spin mr-2" />
-              Loading clients...
+              {ui("loadingClients")}
             </div>
           ) : clients.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-16 text-center">
               <Shield className="h-12 w-12 text-muted-foreground/40 mb-4" />
-              <h3 className="text-lg font-medium text-foreground mb-1">No OAuth2 clients</h3>
+              <h3 className="text-lg font-medium text-foreground mb-1">{ui("oauthClientNoClients")}</h3>
               <p className="text-sm text-muted-foreground mb-4">
-                Create a client to allow MCP agents to authenticate with Etendo.
+                {ui("oauthClientNoClientsDesc")}
               </p>
               <Button onClick={handleCreate}>
                 <Plus className="h-4 w-4 mr-2" />
-                Create First Client
+                {ui("oauthClientCreateFirst")}
               </Button>
             </div>
           ) : (
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Name</TableHead>
-                  <TableHead>Client ID</TableHead>
-                  <TableHead>User</TableHead>
-                  <TableHead>Role</TableHead>
-                  <TableHead>Scopes</TableHead>
-                  <TableHead>Active</TableHead>
+                  <TableHead>{ui("name")}</TableHead>
+                  <TableHead>{ui("oauthClientId")}</TableHead>
+                  <TableHead>{ui("user")}</TableHead>
+                  <TableHead>{ui("role")}</TableHead>
+                  <TableHead>{ui("oauthScopes")}</TableHead>
+                  <TableHead>{ui("oauthActive")}</TableHead>
                   <TableHead className="w-[60px]" />
                 </TableRow>
               </TableHeader>
@@ -226,7 +225,7 @@ export default function OAuth2ClientsPage() {
                       <button
                         onClick={() => copyClientId(client.clientId)}
                         className="inline-flex items-center gap-1.5 font-mono text-xs text-muted-foreground hover:text-foreground transition-colors"
-                        title="Click to copy"
+                        title={ui("oauthClickToCopy")}
                       >
                         {client.clientId?.slice(0, 12)}...
                         <Copy className="h-3 w-3" />
@@ -252,7 +251,7 @@ export default function OAuth2ClientsPage() {
                     </TableCell>
                     <TableCell>
                       <Badge variant={client.isActive ? 'default' : 'outline'}>
-                        {client.isActive ? 'Active' : 'Inactive'}
+                        {client.isActive ? ui('oauthActive') : ui('oauthInactive')}
                       </Badge>
                     </TableCell>
                     <TableCell>
@@ -265,15 +264,15 @@ export default function OAuth2ClientsPage() {
                         <DropdownMenuContent align="end">
                           <DropdownMenuItem onClick={() => handleEdit(client)}>
                             <Pencil className="h-4 w-4 mr-2" />
-                            Edit
+                            {ui("edit")}
                           </DropdownMenuItem>
                           <DropdownMenuItem onClick={() => handleRegenerateSecret(client)}>
                             <Key className="h-4 w-4 mr-2" />
-                            Regenerate Secret
+                            {ui("oauthRegenerateSecret")}
                           </DropdownMenuItem>
                           <DropdownMenuItem onClick={() => handleRevokeTokens(client)}>
                             <Ban className="h-4 w-4 mr-2" />
-                            Revoke Tokens
+                            {ui("oauthRevokeTokens")}
                           </DropdownMenuItem>
                           <DropdownMenuSeparator />
                           <DropdownMenuItem
@@ -281,7 +280,7 @@ export default function OAuth2ClientsPage() {
                             className="text-destructive focus:text-destructive"
                           >
                             <Trash2 className="h-4 w-4 mr-2" />
-                            Delete
+                            {ui("delete")}
                           </DropdownMenuItem>
                         </DropdownMenuContent>
                       </DropdownMenu>

--- a/tools/app-shell/src/pages/ProjectsPage.jsx
+++ b/tools/app-shell/src/pages/ProjectsPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { KPIHeader, KanbanBoard, DataTable } from '@/components/contract-ui';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { FolderKanban, Clock, PieChart, FileText } from 'lucide-react';
+import { useUI } from '@/i18n';
 
 import { sections } from '@generated/projects/generated/config';
 import * as mockData from '@generated/projects/generated/mockData';
@@ -35,6 +36,7 @@ const DOC_DATA = mockData.recentDocuments;
 
 export default function ProjectsPage() {
   const navigate = useNavigate();
+  const ui = useUI();
   const [cards, setCards] = useState(INITIAL_CARDS);
 
   const handleDragEnd = useCallback((cardId, _fromColumnId, toColumnId) => {
@@ -71,7 +73,7 @@ export default function ProjectsPage() {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <Clock className="h-5 w-5 text-muted-foreground" />
-              Recent Time Entries
+              {ui('recentTimeEntries')}
             </CardTitle>
           </CardHeader>
           <CardContent>
@@ -88,7 +90,7 @@ export default function ProjectsPage() {
           <CardHeader>
             <CardTitle className="flex items-center gap-2">
               <FileText className="h-5 w-5 text-muted-foreground" />
-              Recent Documents
+              {ui('recentDocuments')}
             </CardTitle>
           </CardHeader>
           <CardContent>

--- a/tools/app-shell/src/pages/PurchasesPage.jsx
+++ b/tools/app-shell/src/pages/PurchasesPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import { useUI } from '@/i18n';
 import { useNavigate } from 'react-router-dom';
 import { KPIHeader, KanbanBoard } from '@/components/contract-ui';
 import { Badge } from '@/components/ui/badge';
@@ -46,6 +47,7 @@ function formatCurrency(value) {
 
 export default function PurchasesPage() {
   const navigate = useNavigate();
+  const ui = useUI();
   const [activeTab, setActiveTab] = useState('kanban');
   const [cards, setCards] = useState(INITIAL_CARDS);
 
@@ -74,14 +76,14 @@ export default function PurchasesPage() {
           size="sm"
           onClick={() => setActiveTab('kanban')}
         >
-          Kanban
+          {ui("viewKanban")}
         </Button>
         <Button
           variant={activeTab === 'list' ? 'default' : 'outline'}
           size="sm"
           onClick={() => setActiveTab('list')}
         >
-          List
+          {ui("viewList")}
         </Button>
       </div>
 
@@ -92,25 +94,25 @@ export default function PurchasesPage() {
           cards={cards}
           onDragEnd={handleDragEnd}
           onCardClick={handleCardClick}
-          emptyMessage="No purchase orders"
+          emptyMessage={ui("noResults")}
         />
       )}
 
       {activeTab === 'list' && (
         <Card>
           <CardHeader>
-            <CardTitle>Purchase Orders</CardTitle>
+            <CardTitle>{ui("purchaseOrders")}</CardTitle>
           </CardHeader>
           <CardContent className="p-0">
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b bg-muted/50">
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">Doc No</th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">Vendor</th>
-                    <th className="px-4 py-3 text-right font-medium text-muted-foreground">Amount</th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">Status</th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">Date</th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">{ui("docNo")}</th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">{ui("vendor")}</th>
+                    <th className="px-4 py-3 text-right font-medium text-muted-foreground">{ui("amount")}</th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">{ui("statusColumn")}</th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">{ui("date")}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -128,6 +130,7 @@ export default function PurchasesPage() {
                           {STATUS_LABEL[card.columnId] || card.columnId}
                         </Badge>
                       </td>
+                      {/* i18n-allowlist: ["2026-03-09"] */}
                       <td className="px-4 py-3 text-muted-foreground">2026-03-09</td>
                     </tr>
                   ))}

--- a/tools/app-shell/src/pages/ReportViewerPage.jsx
+++ b/tools/app-shell/src/pages/ReportViewerPage.jsx
@@ -10,13 +10,6 @@ import ProductSearchDrawer from '@/components/contract-ui/ProductSearchDrawer.js
 import { useSetPageMeta } from '@/components/layout/PageMetaContext';
 import { useFavorites } from '@/components/layout/FavoritesContext';
 
-const FORMATS = [
-  { id: 'preview', label: 'Preview', icon: Eye },
-  { id: 'pdf', label: 'PDF', icon: FileDown },
-  { id: 'xlsx', label: 'Excel', icon: FileSpreadsheet },
-  { id: 'csv', label: 'CSV', icon: FileText },
-];
-
 // Etendo context path prefix (e.g. "/etendo" in production, "" in local dev where
 // Vite proxies /sws/* directly). Same logic as auth/api.js detectBaseUrl().
 function getEtendoBase() {
@@ -161,7 +154,7 @@ function SelectorPopup({ open, onClose, onSelect, selector, title, extraParams =
             </button>
           ))}
           <div ref={sentinelRef} className="py-1 flex justify-center">
-            {loadingMore && <span className="text-xs text-muted-foreground">Loading more...</span>}
+            {loadingMore && <span className="text-xs text-muted-foreground">{ui('loadingMore')}</span>}
           </div>
         </div>
       </div>
@@ -496,7 +489,7 @@ function PopupMultiSelector({ selector, label, onChange }) {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30" onClick={e => { if (e.target === e.currentTarget) setOpen(false); }}>
           <div className="bg-white rounded-xl shadow-2xl w-[480px] max-h-[560px] flex flex-col">
             <div className="flex items-center justify-between px-4 py-3 border-b border-border/50">
-              <h3 className="text-sm font-semibold">Select {label}</h3>
+              <h3 className="text-sm font-semibold">{ui('selectLabelPrefix')} {label}</h3>
               <button onClick={() => setOpen(false)} className="text-lg leading-none text-muted-foreground hover:text-foreground">&times;</button>
             </div>
             <div className="px-4 py-2 border-b border-border/30">
@@ -613,7 +606,7 @@ function SingleSelectModal({ selector, label, value, displayValue, onChange, has
                 type="text"
                 value={query}
                 onChange={e => setQuery(e.target.value)}
-                placeholder="Search..."
+                placeholder={ui('searchPlaceholder')}
                 className="w-full h-8 px-2 text-sm border border-border rounded-md focus:outline-none focus:ring-1 focus:ring-primary/30"
               />
             </div>
@@ -642,9 +635,9 @@ function SingleSelectModal({ selector, label, value, displayValue, onChange, has
 }
 
 const SIDEBAR_SECTIONS = [
-  { key: 'primary', label: 'reportScope' },
-  { key: 'dimensions', label: 'refineDimensions' },
-  { key: 'options', label: 'displayOptions' },
+  { key: 'primary', labelKey: 'reportScope' },
+  { key: 'dimensions', labelKey: 'refineDimensions' },
+  { key: 'options', labelKey: 'displayOptions' },
 ];
 
 function ReportSidebar({ report, params, onChange, onSubmit, onReset, loading, resetKey, token, selectedOrgId, roleOrgIds }) {
@@ -737,7 +730,7 @@ function ReportSidebar({ report, params, onChange, onSubmit, onReset, loading, r
                 ><X className="h-3.5 w-3.5" /></button>
               )}
             </div>
-            {hasError && <p className="text-[10px] text-destructive mt-1">Required</p>}
+            {hasError && <p className="text-[10px] text-destructive mt-1">{ui('required')}</p>}
           </div>
         );
       }
@@ -765,7 +758,7 @@ function ReportSidebar({ report, params, onChange, onSubmit, onReset, loading, r
             roleOrgIds={roleOrgIds}
             selectedWarehouseId={params.M_Warehouse_ID || ''}
           />
-          {hasError && <p className="text-[10px] text-destructive mt-1">Required</p>}
+          {hasError && <p className="text-[10px] text-destructive mt-1">{ui('required')}</p>}
         </div>
       );
     }
@@ -824,7 +817,7 @@ function ReportSidebar({ report, params, onChange, onSubmit, onReset, loading, r
             onChange={(iso) => handleChange(p.name, iso)}
             className={errorBorder}
           />
-          {hasError && <p className="text-[10px] text-destructive mt-1">Required</p>}
+          {hasError && <p className="text-[10px] text-destructive mt-1">{ui('required')}</p>}
         </div>
       );
     }
@@ -839,7 +832,7 @@ function ReportSidebar({ report, params, onChange, onSubmit, onReset, loading, r
           onChange={e => handleChange(p.name, e.target.value)}
           className={`w-full h-9 px-2 text-sm rounded-md bg-white focus:outline-none focus:ring-1 focus:ring-primary/30 border ${errorBorder}`}
         />
-        {hasError && <p className="text-[10px] text-destructive mt-1">Required</p>}
+        {hasError && <p className="text-[10px] text-destructive mt-1">{ui('required')}</p>}
       </div>
     );
   };
@@ -883,12 +876,12 @@ function ReportSidebar({ report, params, onChange, onSubmit, onReset, loading, r
 
       <div className="flex-1 overflow-y-auto">
         <div className="px-4 py-4 space-y-6">
-          {SIDEBAR_SECTIONS.map(({ key, label }) => {
+          {SIDEBAR_SECTIONS.map(({ key, labelKey }) => {
             const sectionParams = grouped[key];
             if (!sectionParams?.length) return null;
             return (
               <div key={key}>
-                <h4 className="text-xs font-semibold text-foreground mb-3">{ui(label)}</h4>
+                <h4 className="text-xs font-semibold text-foreground mb-3">{ui(labelKey)}</h4>
                 {renderSection(key, sectionParams)}
               </div>
             );
@@ -966,23 +959,23 @@ function DrillDownViewer({ report, token, baseParams, bpId, targetReportId, extr
   return (
     <div className="flex flex-col flex-1 min-h-0 gap-2">
       <div className="flex items-center gap-2 px-1">
-        {[{ id: 'preview', label: 'Preview', icon: Eye }, { id: 'pdf', label: 'PDF', icon: FileDown }, { id: 'xlsx', label: 'Excel', icon: FileSpreadsheet }].map(f => (
+        {[{ id: 'preview', labelKey: 'preview', icon: Eye }, { id: 'pdf', labelKey: 'PDF', icon: FileDown }, { id: 'xlsx', labelKey: 'Excel', icon: FileSpreadsheet }].map(f => (
           <button key={f.id} onClick={() => fetchFormat(f.id)} disabled={loading}
             className="inline-flex items-center gap-1.5 h-7 px-2.5 rounded-md text-xs font-medium border border-border bg-background hover:bg-muted disabled:opacity-50">
-            <f.icon className="h-3.5 w-3.5" />{f.label}
+            <f.icon className="h-3.5 w-3.5" />{ui(f.labelKey)}
           </button>
         ))}
       </div>
       <div className="flex-1 bg-white rounded-lg border border-border/30 overflow-hidden relative">
         {loading && (
           <div className="absolute inset-0 flex items-center justify-center bg-white/80 z-10 gap-2 text-muted-foreground">
-            <Loader2 className="h-5 w-5 animate-spin" /><span>Loading details...</span>
+            <Loader2 className="h-5 w-5 animate-spin" /><span>{ui('loadingDetails')}</span>
           </div>
         )}
         {error && (
           <div className="absolute inset-0 flex items-center justify-center text-destructive text-sm px-8 text-center">{error}</div>
         )}
-        <iframe ref={iframeRef} title="Detail Report" className="w-full h-full border-0" />
+        <iframe ref={iframeRef} title={ui('detailReport')} className="w-full h-full border-0" />
       </div>
     </div>
   );
@@ -1151,10 +1144,10 @@ function ReportViewer({ report, onBack, token, selectedOrgId, roleOrgIds, catego
   useSetPageMeta({ title, breadcrumb, onBack, onAddToFavorites: () => toggleFavorite(favKey, favLabel, favLabels), isFavorite: favActive }, [favActive]);
 
   const DOWNLOAD_FORMATS = [
-    { id: 'html', label: 'preview', icon: Eye },
-    { id: 'pdf', label: 'PDF', icon: FileDown },
-    { id: 'xlsx', label: 'Excel', icon: FileSpreadsheet },
-    { id: 'csv', label: 'CSV', icon: FileText },
+    { id: 'html', labelKey: 'preview', icon: Eye },
+    { id: 'pdf', labelKey: 'PDF', icon: FileDown },
+    { id: 'xlsx', labelKey: 'Excel', icon: FileSpreadsheet },
+    { id: 'csv', labelKey: 'CSV', icon: FileText },
   ];
 
   return (
@@ -1192,7 +1185,7 @@ function ReportViewer({ report, onBack, token, selectedOrgId, roleOrgIds, catego
                   return (
                     <button key={fmt.id} onClick={() => renderReport(fmt.id)} disabled={loading}
                       className="inline-flex items-center gap-1.5 h-8 px-3 rounded-lg text-xs font-medium border border-border bg-white text-foreground hover:bg-muted/50 disabled:opacity-40">
-                      <Icon className="h-3.5 w-3.5" />{ui(fmt.label)}
+                      <Icon className="h-3.5 w-3.5" />{ui(fmt.labelKey)}
                     </button>
                   );
                 })}
@@ -1209,7 +1202,7 @@ function ReportViewer({ report, onBack, token, selectedOrgId, roleOrgIds, catego
             <div className="bg-white rounded-lg shadow-sm h-full overflow-hidden relative border border-border/30">
               {loading && (
                 <div className="absolute inset-0 flex items-center justify-center bg-white/80 z-10 gap-2 text-muted-foreground">
-                  <Loader2 className="h-5 w-5 animate-spin" /><span>Rendering report...</span>
+                  <Loader2 className="h-5 w-5 animate-spin" /><span>{ui('renderingReport')}</span>
                 </div>
               )}
               {error && (
@@ -1244,7 +1237,7 @@ function ReportViewer({ report, onBack, token, selectedOrgId, roleOrgIds, catego
                   </div>
                 </div>
               )}
-              <iframe ref={iframeRef} title="Report" className="w-full h-full border-0" />
+              <iframe ref={iframeRef} title={ui('report')} className="w-full h-full border-0" />
             </div>
           </div>
         </div>
@@ -1255,7 +1248,7 @@ function ReportViewer({ report, onBack, token, selectedOrgId, roleOrgIds, catego
       <Dialog open={!!drillDownBp} onOpenChange={(o) => !o && setDrillDownBp(null)}>
         <DialogContent className="max-w-5xl w-[85vw] h-[70vh] flex flex-col gap-3 p-4">
           <DialogHeader className="shrink-0">
-            <DialogTitle>{drillDownBp?.name} — Details</DialogTitle>
+            <DialogTitle>{drillDownBp?.name}{ui('detailsSuffix')}</DialogTitle>
           </DialogHeader>
           {drillDownBp && (
             <DrillDownViewer

--- a/tools/app-shell/src/pages/ReportsPage.jsx
+++ b/tools/app-shell/src/pages/ReportsPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useUI } from '@/i18n';
 import { DataTable } from '@/components/contract-ui';
 import { Button } from '@/components/ui/button';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
@@ -8,16 +9,16 @@ import * as mockData from '@generated/reports/generated/mockData';
 
 // -- Tab definitions ----------------------------------------------------------
 
-const TABS = [
-  { id: 'balanceSheet', label: 'Balance Sheet', title: 'Balance Sheet' },
-  { id: 'profitLoss', label: 'P&L', title: 'Profit & Loss' },
-  { id: 'agingReceivable', label: 'Aging Receivable', title: 'Aging of Receivables' },
-  { id: 'agingPayable', label: 'Aging Payable', title: 'Aging of Payables' },
-];
-
 // -- Component ----------------------------------------------------------------
 
 export default function ReportsPage() {
+  const ui = useUI();
+  const TABS = [
+    { id: 'balanceSheet', label: ui('balanceSheet'), title: ui('balanceSheet') },
+    { id: 'profitLoss', label: ui('profitLoss'), title: ui('profitLossTitle') },
+    { id: 'agingReceivable', label: ui('agingReceivable'), title: ui('agingReceivableTitle') },
+    { id: 'agingPayable', label: ui('agingPayable'), title: ui('agingPayableTitle') },
+  ];
   const [activeTab, setActiveTab] = useState('balanceSheet');
 
   const currentTab = TABS.find((t) => t.id === activeTab);

--- a/tools/app-shell/src/pages/SalesPage.jsx
+++ b/tools/app-shell/src/pages/SalesPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback } from 'react';
+import { useUI } from '@/i18n';
 import { useNavigate } from 'react-router-dom';
 import { KPIHeader, KanbanBoard } from '@/components/contract-ui';
 import { Badge } from '@/components/ui/badge';
@@ -49,6 +50,7 @@ function formatCurrency(value) {
 
 export default function SalesPage() {
   const navigate = useNavigate();
+  const ui = useUI();
   const [activeTab, setActiveTab] = useState('kanban');
   const [cards, setCards] = useState(INITIAL_CARDS);
 
@@ -77,14 +79,14 @@ export default function SalesPage() {
           size="sm"
           onClick={() => setActiveTab('kanban')}
         >
-          Kanban
+          {ui("viewKanban")}
         </Button>
         <Button
           variant={activeTab === 'list' ? 'default' : 'outline'}
           size="sm"
           onClick={() => setActiveTab('list')}
         >
-          List
+          {ui("viewList")}
         </Button>
       </div>
 
@@ -95,25 +97,25 @@ export default function SalesPage() {
           cards={cards}
           onDragEnd={handleDragEnd}
           onCardClick={handleCardClick}
-          emptyMessage="No quotations"
+          emptyMessage={ui("noResults")}
         />
       )}
 
       {activeTab === 'list' && (
         <Card>
           <CardHeader>
-            <CardTitle>Quotations</CardTitle>
+            <CardTitle>{ui("quotations")}</CardTitle>
           </CardHeader>
           <CardContent className="p-0">
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b bg-muted/50">
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">Document No</th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">Customer</th>
-                    <th className="px-4 py-3 text-right font-medium text-muted-foreground">Amount</th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">Status</th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">Date</th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">{ui("documentNo")}</th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">{ui("customer")}</th>
+                    <th className="px-4 py-3 text-right font-medium text-muted-foreground">{ui("amount")}</th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">{ui("statusColumn")}</th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">{ui("date")}</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -131,6 +133,7 @@ export default function SalesPage() {
                           {STATUS_LABEL[card.columnId] || card.columnId}
                         </Badge>
                       </td>
+                      {/* i18n-allowlist: ["2026-03-09"] */}
                       <td className="px-4 py-3 text-muted-foreground">2026-03-09</td>
                     </tr>
                   ))}

--- a/tools/app-shell/src/pages/SettingsPage.jsx
+++ b/tools/app-shell/src/pages/SettingsPage.jsx
@@ -1,33 +1,35 @@
 import { useAuth } from '@/auth/AuthContext.jsx';
 import { Building2, Shield } from 'lucide-react';
+import { useUI } from '@/i18n';
 
 // TODO ETP-3690: switchContext removed — revisit if Settings UI is resurrected
 export default function SettingsPage() {
   const { username, selectedRole, selectedOrg } = useAuth();
+  const ui = useUI();
 
   return (
     <div className="max-w-2xl mx-auto py-10 px-6">
-      <h1 className="text-2xl font-bold text-foreground mb-1">Settings</h1>
+      <h1 className="text-2xl font-bold text-foreground mb-1">{ui('settings')}</h1>
       <p className="text-sm text-muted-foreground mb-8">
-        Manage your session context. Changing role or organization will re-authenticate your session.
+        {ui('settingsDescription')}
       </p>
 
       {/* Current context card */}
       <div className="rounded-lg border bg-card p-5 mb-6">
         <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-3">
-          Current Session
+          {ui('currentSession')}
         </h2>
         <div className="grid grid-cols-3 gap-4 text-sm">
           <div>
-            <span className="text-muted-foreground">User</span>
+            <span className="text-muted-foreground">{ui('user')}</span>
             <p className="font-medium text-foreground mt-0.5">{username || '\u2014'}</p>
           </div>
           <div>
-            <span className="text-muted-foreground">Role</span>
+            <span className="text-muted-foreground">{ui('role')}</span>
             <p className="font-medium text-foreground mt-0.5">{selectedRole?.name || selectedRole?.id || '\u2014'}</p>
           </div>
           <div>
-            <span className="text-muted-foreground">Organization</span>
+            <span className="text-muted-foreground">{ui('organization')}</span>
             <p className="font-medium text-foreground mt-0.5">{selectedOrg?.name || selectedOrg?.id || '\u2014'}</p>
           </div>
         </div>
@@ -36,17 +38,17 @@ export default function SettingsPage() {
       {/* Role & Org display (read-only — context switching removed in ETP-3690) */}
       <div className="rounded-lg border bg-card p-5">
         <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wide mb-4">
-          Active Context
+          {ui('activeContext')}
         </h2>
         <div className="space-y-3 text-sm">
           <div className="flex items-center gap-2">
             <Shield className="h-4 w-4 text-muted-foreground" />
-            <span className="text-muted-foreground">Role:</span>
+            <span className="text-muted-foreground">{ui('role')}:</span>
             <span className="font-medium">{selectedRole?.name || selectedRole?.id || '\u2014'}</span>
           </div>
           <div className="flex items-center gap-2">
             <Building2 className="h-4 w-4 text-muted-foreground" />
-            <span className="text-muted-foreground">Organization:</span>
+            <span className="text-muted-foreground">{ui('organization')}:</span>
             <span className="font-medium">{selectedOrg?.name || selectedOrg?.id || '\u2014'}</span>
           </div>
         </div>

--- a/tools/app-shell/test/OAuth2ClientsPage.test.js
+++ b/tools/app-shell/test/OAuth2ClientsPage.test.js
@@ -76,15 +76,15 @@ describe('OAuth2ClientsPage source', () => {
 
   it('empty state shows prompt to create first client', () => {
     const src = readFileSync(SOURCE, 'utf8');
-    assert.ok(src.includes('No OAuth2 clients'), 'empty state should display no-clients message');
-    assert.ok(src.includes('Create First Client'), 'empty state should show create CTA');
+    assert.ok(src.includes("ui(\"oauthClientNoClients\")"), 'empty state should display no-clients message via i18n');
+    assert.ok(src.includes("ui(\"oauthClientCreateFirst\")"), 'empty state should show create CTA via i18n');
   });
 
   it('table shows correct columns', () => {
     const src = readFileSync(SOURCE, 'utf8');
-    const expectedHeaders = ['Name', 'Client ID', 'User', 'Role', 'Scopes', 'Active'];
-    for (const header of expectedHeaders) {
-      assert.ok(src.includes(`>${header}<`), `table should have "${header}" column`);
+    const expectedKeys = ['name', 'oauthClientId', 'user', 'role', 'oauthScopes', 'oauthActive'];
+    for (const key of expectedKeys) {
+      assert.ok(src.includes(`ui("${key}")`), `table should have "${key}" column via i18n`);
     }
   });
 


### PR DESCRIPTION
Replace all hardcoded English/Spanish strings in pages/ with useUI() hook calls. Add missing genericLabels keys to en_US.json and es_ES.json.

Affected pages: AccountingPage, AppStorePage, ArtifactViewerPage, ContactsPage, CrmPage, FirstStepsPage, HrPage, InventoryPage, OAuth2ClientsPage, ProjectsPage, PurchasesPage, ReportViewerPage, ReportsPage, SalesPage, SettingsPage.