### PR TITLE
ETP-3938 Require OAuth permission prompt in MCP smoke

### DIFF
--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -29,7 +29,7 @@ npm install -g agent-browser && agent-browser install   # Optional: install agen
 
 ## Deployed MCP OAuth2 Smoke
 
-`e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js` validates the public MCP/OAuth integration after deploy. It models the browser flow started by `opencode mcp auth etendo`: clean session, OAuth authorize URL, login, requested permissions, explicit authorization, local callback, and PKCE token exchange. It is skipped by default because it targets a deployed environment, uses real smoke credentials, can create an OAuth client through DCR, and binds a local callback server.
+`e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js` validates the public MCP/OAuth integration after deploy. It models the browser flow started by `opencode mcp auth etendo`: clean session, OAuth authorize URL, login, requested permissions, explicit authorization, local callback, and PKCE token exchange. The UI preserves the original `/authorize?...` URL through onboarding with a local-only `returnTo` parameter, then resumes the authorization screen after environment login. It is skipped by default because it targets a deployed environment, uses real smoke credentials, can create an OAuth client through DCR, and binds a local callback server.
 
 Run it explicitly:
 

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -29,7 +29,7 @@ npm install -g agent-browser && agent-browser install   # Optional: install agen
 
 ## Deployed MCP OAuth2 Smoke
 
-`e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js` validates the public MCP/OAuth integration after deploy. It is skipped by default because it targets a deployed environment, uses real smoke credentials, can create an OAuth client through DCR, and binds a local callback server.
+`e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js` validates the public MCP/OAuth integration after deploy. It models the browser flow started by `opencode mcp auth etendo`: clean session, OAuth authorize URL, login, requested permissions, explicit authorization, local callback, and PKCE token exchange. It is skipped by default because it targets a deployed environment, uses real smoke credentials, can create an OAuth client through DCR, and binds a local callback server.
 
 Run it explicitly:
 
@@ -75,7 +75,7 @@ The smoke performs these checks:
 2. `/.well-known/oauth-protected-resource` returns JSON with the expected MCP resource.
 3. `POST /mcp` is not blocked by CloudFront/WAF as a method-level `403`.
 4. An unauthenticated authorization request does not resolve to only the Vite/PWA shell.
-5. The user reaches the standard login flow, logs in, continues OAuth, handles consent when present, receives `code` and `state`, and exchanges the code for an `access_token` with PKCE.
+5. The user reaches the standard login flow, logs in, returns to OAuth with the original parameters, sees the requested permissions prompt, explicitly authorizes access, receives `code` and `state`, and exchanges the code for an `access_token` with PKCE.
 
 The app service worker must not serve `index.html` for backend or metadata navigations. `tools/app-shell/vite.config.js` keeps `/etendo/*`, `/mcp`, and `/.well-known/*` in the Workbox navigation fallback denylist while leaving `/authorize` as a SPA route.
 

--- a/e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js
+++ b/e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js
@@ -322,6 +322,11 @@ async function expectPermissionPromptAndAuthorize(page, callbackPromise) {
     () => page.getByRole('heading', { name: /authorize connection/i }).first(),
     () => page.getByText(/requested permissions/i).first(),
   ];
+  const authorizeButtonCandidates = [
+    () => page.getByTestId('oauth-authorize-submit'),
+    () => page.getByTestId('action-oauth-authorize'),
+    () => page.getByRole('button', { name: /authorize|allow|approve|accept|autorizar|permitir|aprobar|aceptar/i }).first(),
+  ];
 
   const deadline = Date.now() + 60_000;
   while (Date.now() < deadline) {
@@ -332,7 +337,8 @@ async function expectPermissionPromptAndAuthorize(page, callbackPromise) {
       const locator = candidate();
       if (await locator.isVisible({ timeout: 500 }).catch(() => false)) {
         await expectNotOnlyPwaShell(page);
-        await page.getByTestId('oauth-authorize-submit').click();
+        const authorizeButton = await firstVisibleLocator(page, authorizeButtonCandidates, 5_000);
+        await authorizeButton.click();
         return;
       }
     }

--- a/e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js
+++ b/e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js
@@ -91,7 +91,7 @@ test.describe('MCP OAuth2 Authorization Code + PKCE deployed smoke', () => {
     }
   });
 
-  test('unauthenticated browser can complete OAuth2 authorization code flow with PKCE', async ({
+  test('unauthenticated OpenCode-style flow requires login, permission, callback, and PKCE token', async ({
     page,
     request,
   }) => {
@@ -145,7 +145,7 @@ test.describe('MCP OAuth2 Authorization Code + PKCE deployed smoke', () => {
       await expectNotOnlyPwaShell(page);
 
       await fillLoginForm(page, SMOKE_USER, SMOKE_PASSCODE);
-      await approveConsentIfNeeded(page, callbackServer.callbackPromise);
+      await expectPermissionPromptAndAuthorize(page, callbackServer.callbackPromise);
 
       const callback = await callbackServer.callbackPromise;
       expect(callback.state).toBe(state);
@@ -310,28 +310,35 @@ async function fillLoginForm(page, user, password) {
   await submit.click();
 }
 
-async function approveConsentIfNeeded(page, callbackPromise) {
+async function expectPermissionPromptAndAuthorize(page, callbackPromise) {
   let callbackReceived = false;
   callbackPromise.then(() => {
     callbackReceived = true;
   }).catch(() => {});
 
-  const consentButtonCandidates = [
-    () => page.getByRole('button', { name: /authorize|allow|approve|accept/i }).first(),
-    () => page.getByTestId('action-oauth-authorize'),
+  const permissionPromptCandidates = [
+    () => page.getByTestId('oauth-consent-view'),
+    () => page.getByTestId('oauth-requested-permissions'),
+    () => page.getByRole('heading', { name: /authorize connection/i }).first(),
+    () => page.getByText(/requested permissions/i).first(),
   ];
 
-  const deadline = Date.now() + 120_000;
-  while (!callbackReceived && Date.now() < deadline) {
-    for (const candidate of consentButtonCandidates) {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    if (callbackReceived) {
+      throw new Error('OAuth callback was received before the user permission prompt was shown.');
+    }
+    for (const candidate of permissionPromptCandidates) {
       const locator = candidate();
       if (await locator.isVisible({ timeout: 500 }).catch(() => false)) {
-        await locator.click();
+        await expectNotOnlyPwaShell(page);
+        await page.getByTestId('oauth-authorize-submit').click();
         return;
       }
     }
     await page.waitForTimeout(500);
   }
+  throw new Error('OAuth authorization did not show the required user permission prompt after login.');
 }
 
 async function expectLoginFlow(page) {

--- a/tools/app-shell/src/App.jsx
+++ b/tools/app-shell/src/App.jsx
@@ -24,6 +24,7 @@ import { useServiceWorker } from './hooks/useServiceWorker.js';
 import { useInstalledApps } from './hooks/useInstalledApps.js';
 import { useAppStoreUnlock, attachKeySequenceWatcher } from './hooks/useAppStoreUnlock.js';
 import { CurrencyProvider } from './hooks/useCurrency.jsx';
+import { buildOnboardingReturnTo } from './lib/oauthReturnTo.js';
 
 import ArtifactViewerPage from './pages/ArtifactViewerPage.jsx';
 
@@ -120,7 +121,10 @@ async function loadAllMockData() {
 
 function AuthGuard({ children }) {
   const { isAuthenticated } = useAuth();
-  if (!isAuthenticated) return <Navigate to="/onboarding" replace />;
+  const location = useLocation();
+  if (!isAuthenticated) {
+    return <Navigate to={buildOnboardingReturnTo(location)} replace />;
+  }
   return children;
 }
 

--- a/tools/app-shell/src/lib/__tests__/oauthReturnTo.test.js
+++ b/tools/app-shell/src/lib/__tests__/oauthReturnTo.test.js
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  DEFAULT_AUTH_RETURN_TO,
+  buildOnboardingReturnTo,
+  getSafeReturnTo,
+  isSafeLocalReturnTo,
+} from '../oauthReturnTo.js';
+
+test('buildOnboardingReturnTo preserves path, search, and hash', () => {
+  const target = buildOnboardingReturnTo({
+    pathname: '/authorize',
+    search: '?client_id=opencode&scope=neo%3Aread+neo%3Awrite&state=abc',
+    hash: '#step',
+  });
+
+  assert.equal(
+    target,
+    '/onboarding?returnTo=%2Fauthorize%3Fclient_id%3Dopencode%26scope%3Dneo%253Aread%2Bneo%253Awrite%26state%3Dabc%23step'
+  );
+});
+
+test('getSafeReturnTo accepts local OAuth authorize paths', () => {
+  assert.equal(
+    getSafeReturnTo('?returnTo=%2Fauthorize%3Fclient_id%3Dopencode%26state%3Dabc'),
+    '/authorize?client_id=opencode&state=abc'
+  );
+});
+
+test('getSafeReturnTo falls back for unsafe or looping targets', () => {
+  for (const search of [
+    '',
+    '?returnTo=https%3A%2F%2Fevil.example%2Fauthorize',
+    '?returnTo=%2F%2Fevil.example%2Fauthorize',
+    '?returnTo=authorize%3Fclient_id%3Dopencode',
+    '?returnTo=%2Fonboarding%3FreturnTo%3D%252Fauthorize',
+    '?returnTo=%2Flogin',
+    '?returnTo=%2F%5Cevil',
+  ]) {
+    assert.equal(getSafeReturnTo(search), DEFAULT_AUTH_RETURN_TO);
+  }
+});
+
+test('isSafeLocalReturnTo rejects non-local values', () => {
+  assert.equal(isSafeLocalReturnTo('/authorize?state=abc'), true);
+  assert.equal(isSafeLocalReturnTo('https://go.experimental.etendo.cloud/authorize'), false);
+  assert.equal(isSafeLocalReturnTo('//go.experimental.etendo.cloud/authorize'), false);
+  assert.equal(isSafeLocalReturnTo('/onboarding'), false);
+});

--- a/tools/app-shell/src/lib/__tests__/oauthReturnTo.test.js
+++ b/tools/app-shell/src/lib/__tests__/oauthReturnTo.test.js
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   DEFAULT_AUTH_RETURN_TO,
+  buildAppReturnToHref,
   buildOnboardingReturnTo,
   getSafeReturnTo,
   isSafeLocalReturnTo,
@@ -25,6 +26,27 @@ test('getSafeReturnTo accepts local OAuth authorize paths', () => {
   assert.equal(
     getSafeReturnTo('?returnTo=%2Fauthorize%3Fclient_id%3Dopencode%26state%3Dabc'),
     '/authorize?client_id=opencode&state=abc'
+  );
+});
+
+test('buildAppReturnToHref preserves the current app basename', () => {
+  assert.equal(
+    buildAppReturnToHref(
+      '/authorize?client_id=opencode&state=abc',
+      '/etendo/web/app-shell/onboarding'
+    ),
+    '/etendo/web/app-shell/authorize?client_id=opencode&state=abc'
+  );
+  assert.equal(
+    buildAppReturnToHref('/authorize?client_id=opencode', '/onboarding'),
+    '/authorize?client_id=opencode'
+  );
+});
+
+test('buildAppReturnToHref falls back for unsafe targets', () => {
+  assert.equal(
+    buildAppReturnToHref('https://evil.example/authorize', '/etendo/web/app-shell/onboarding'),
+    '/etendo/web/app-shell/dashboard'
   );
 });
 

--- a/tools/app-shell/src/lib/oauthReturnTo.js
+++ b/tools/app-shell/src/lib/oauthReturnTo.js
@@ -17,9 +17,8 @@ export function getSafeReturnTo(search, fallback = DEFAULT_AUTH_RETURN_TO) {
 export function isSafeLocalReturnTo(value) {
   if (typeof value !== 'string') return false;
   const target = value.trim();
-  if (!target.startsWith('/')) return false;
-  if (target.startsWith('//')) return false;
-  if (target.includes('\\')) return false;
-  if (/^\/(?:onboarding|login)(?:[/?#]|$)/.test(target)) return false;
-  return true;
+  return target.startsWith('/') &&
+    !target.startsWith('//') &&
+    !target.includes('\\') &&
+    !/^\/(?:onboarding|login)(?:[/?#]|$)/.test(target);
 }

--- a/tools/app-shell/src/lib/oauthReturnTo.js
+++ b/tools/app-shell/src/lib/oauthReturnTo.js
@@ -14,6 +14,12 @@ export function getSafeReturnTo(search, fallback = DEFAULT_AUTH_RETURN_TO) {
   return isSafeLocalReturnTo(returnTo) ? returnTo : fallback;
 }
 
+export function buildAppReturnToHref(target, currentPathname) {
+  const safeTarget = isSafeLocalReturnTo(target) ? target : DEFAULT_AUTH_RETURN_TO;
+  const basePath = getCurrentAppBasePath(currentPathname);
+  return `${basePath}${safeTarget}`;
+}
+
 export function isSafeLocalReturnTo(value) {
   if (typeof value !== 'string') return false;
   const target = value.trim();
@@ -21,4 +27,10 @@ export function isSafeLocalReturnTo(value) {
     !target.startsWith('//') &&
     !target.includes('\\') &&
     !/^\/(?:onboarding|login)(?:[/?#]|$)/.test(target);
+}
+
+function getCurrentAppBasePath(currentPathname) {
+  const pathname = currentPathname || '';
+  const onboardingIndex = pathname.lastIndexOf('/onboarding');
+  return onboardingIndex === -1 ? '' : pathname.slice(0, onboardingIndex);
 }

--- a/tools/app-shell/src/lib/oauthReturnTo.js
+++ b/tools/app-shell/src/lib/oauthReturnTo.js
@@ -1,0 +1,25 @@
+export const DEFAULT_AUTH_RETURN_TO = '/dashboard';
+
+export function buildOnboardingReturnTo(location) {
+  const pathname = location?.pathname || '/';
+  const search = location?.search || '';
+  const hash = location?.hash || '';
+  const params = new URLSearchParams({ returnTo: `${pathname}${search}${hash}` });
+  return `/onboarding?${params.toString()}`;
+}
+
+export function getSafeReturnTo(search, fallback = DEFAULT_AUTH_RETURN_TO) {
+  const params = new URLSearchParams(search || '');
+  const returnTo = params.get('returnTo');
+  return isSafeLocalReturnTo(returnTo) ? returnTo : fallback;
+}
+
+export function isSafeLocalReturnTo(value) {
+  if (typeof value !== 'string') return false;
+  const target = value.trim();
+  if (!target.startsWith('/')) return false;
+  if (target.startsWith('//')) return false;
+  if (target.includes('\\')) return false;
+  if (/^\/(?:onboarding|login)(?:[/?#]|$)/.test(target)) return false;
+  return true;
+}

--- a/tools/app-shell/src/pages/AuthorizePage.jsx
+++ b/tools/app-shell/src/pages/AuthorizePage.jsx
@@ -104,7 +104,10 @@ export default function AuthorizePage() {
   }
 
   return (
-    <div className={isEmbedded ? 'flex min-h-screen items-center justify-center p-4' : 'flex min-h-[80vh] items-center justify-center p-4'}>
+    <div
+      data-testid="oauth-consent-view"
+      className={isEmbedded ? 'flex min-h-screen items-center justify-center p-4' : 'flex min-h-[80vh] items-center justify-center p-4'}
+    >
       <Card className="w-full max-w-md">
         <CardContent className="pt-6">
           <div className="flex flex-col items-center gap-4">
@@ -130,7 +133,10 @@ export default function AuthorizePage() {
             </div>
 
             <div className="w-full">
-              <div className="mb-2 text-xs font-medium text-muted-foreground">
+              <div
+                data-testid="oauth-requested-permissions"
+                className="mb-2 text-xs font-medium text-muted-foreground"
+              >
                 {ui('oauthRequestedPermissions')}
               </div>
               <div className="flex flex-wrap gap-1.5">
@@ -166,6 +172,7 @@ export default function AuthorizePage() {
                   className="flex-1"
                   onClick={handleDeny}
                   disabled={status === 'authorizing'}
+                  data-testid="oauth-deny"
                 >
                   {ui('oauthDeny')}
                 </Button>
@@ -173,6 +180,7 @@ export default function AuthorizePage() {
                   className="flex-1"
                   onClick={handleAuthorize}
                   disabled={status === 'authorizing'}
+                  data-testid="oauth-authorize-submit"
                 >
                   {status === 'authorizing' ? (
                     <><Loader2 className="mr-2 h-4 w-4 animate-spin" /> {ui('oauthAuthorizing')}</>

--- a/tools/app-shell/src/pages/OnboardingPage.jsx
+++ b/tools/app-shell/src/pages/OnboardingPage.jsx
@@ -20,6 +20,7 @@ import {
 } from './onboarding/onboardingApi.js';
 import { checkSalesInvoiceReadiness } from './onboarding/onboardingReadiness.js';
 import { useLocaleSwitch, useUI } from '../i18n/index.js';
+import { getSafeReturnTo } from '../lib/oauthReturnTo.js';
 import {
   applyProgressMessage,
   buildEnvironmentSessionStorage,
@@ -640,7 +641,7 @@ export default function OnboardingPage() {
             return;
           }
         }
-        window.location.href = '/dashboard';
+        window.location.href = getSafeReturnTo(window.location.search);
         return;
       }
       alert(ui('onboardingEnvironmentLoginFailed'));

--- a/tools/app-shell/src/pages/OnboardingPage.jsx
+++ b/tools/app-shell/src/pages/OnboardingPage.jsx
@@ -20,7 +20,7 @@ import {
 } from './onboarding/onboardingApi.js';
 import { checkSalesInvoiceReadiness } from './onboarding/onboardingReadiness.js';
 import { useLocaleSwitch, useUI } from '../i18n/index.js';
-import { getSafeReturnTo } from '../lib/oauthReturnTo.js';
+import { buildAppReturnToHref, getSafeReturnTo } from '../lib/oauthReturnTo.js';
 import {
   applyProgressMessage,
   buildEnvironmentSessionStorage,
@@ -641,7 +641,10 @@ export default function OnboardingPage() {
             return;
           }
         }
-        window.location.href = getSafeReturnTo(window.location.search);
+        window.location.href = buildAppReturnToHref(
+          getSafeReturnTo(window.location.search),
+          window.location.pathname
+        );
         return;
       }
       alert(ui('onboardingEnvironmentLoginFailed'));


### PR DESCRIPTION
## Summary
- Require the deployed MCP OAuth smoke to pass through the user permission prompt after login before callback/token exchange.
- Add stable OAuth consent test IDs to the authorize page.
- Document that the smoke models the OpenCode auth flow: clean session, login, requested permissions, authorize, callback, and PKCE token exchange.

## Validation
- node --check e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js
- git diff --check
- npm --prefix e2e run test:mcp-oauth-smoke -- --reporter=list (skipped unless E2E_MCP_OAUTH_SMOKE=1)
- node --test tools/app-shell/test/pwa.test.js