### PR TITLE
Feature ETP-3957: Add Form State Metadata

### DIFF
--- a/artifacts/assets/contract.json
+++ b/artifacts/assets/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.2.0",
   "generatedAt": "2026-04-29T19:06:30.936Z",
-  "updatedAt": "2026-05-12T19:44:17.750Z",
-  "checksum": "8c7c01cd5d0bc19e",
+  "updatedAt": "2026-05-15T16:28:11.413Z",
+  "checksum": "dec6704ae8f567a8",
   "frontendContract": {
     "window": {
       "id": "800027",
@@ -1820,18 +1820,52 @@
     ],
     "actions": [
       {
+        "name": "processed",
+        "label": "Create Amortization",
+        "actionType": "utilityAction",
         "entity": "assets",
-        "field": "processed",
         "column": "Processed",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/assets/assets/{id}/action/processed",
+        "method": "POST",
         "url": "/sws/neo/assets/assets/{id}/action/processed",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "800125",
         "processType": "classic"
       },
       {
+        "name": "processAsset",
+        "label": "Generate Amortization Plan",
+        "actionType": "utilityAction",
         "entity": "assets",
-        "field": "processAsset",
         "column": "Process_Asset",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/assets/assets/{id}/action/processAsset",
+        "method": "POST",
         "url": "/sws/neo/assets/assets/{id}/action/processAsset",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "85601427EAEE401FA0250FF0A6DD62EF",
         "processType": "classic"
       }

--- a/artifacts/assets/contract.json
+++ b/artifacts/assets/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.2.0",
   "generatedAt": "2026-04-29T19:06:30.936Z",
-  "updatedAt": "2026-05-15T16:28:11.413Z",
-  "checksum": "dec6704ae8f567a8",
+  "updatedAt": "2026-05-15T16:33:40.192Z",
+  "checksum": "0861dc952c5f0eef",
   "frontendContract": {
     "window": {
       "id": "800027",
@@ -1886,6 +1886,364 @@
     "window": {
       "category": "finance"
     }
+  },
+  "formState": {
+    "entities": {
+      "assets": {
+        "fields": {
+          "searchKey": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "name": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "assetCategory": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@existAmortizationLines@ = 'Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@C_Currency_ID@",
+            "provenance": "extracted"
+          },
+          "depreciate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "depreciationType": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "calculateType": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "annualDepreciation": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "amortize": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "usableLifeYears": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "usableLifeMonths": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "everyMonthIs30Days": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "purchaseDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cancellationDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "depreciationStartDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "depreciationEndDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "assetValue": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "residualAssetValue": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "depreciationAmt": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "previouslyDepreciatedAmt": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "processed": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "depreciatedValue": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "depreciatedPlan": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "fullyDepreciated": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "processAsset": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "amortizationLine": {
+        "fields": {
+          "sEQNoAsset": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(SEQ_No_Asset),0)+10 AS DefaultValue FROM A_AMORTIZATIONLINE WHERE A_ASSET_ID=@A_ASSET_ID@",
+            "provenance": "extracted"
+          },
+          "amortization": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "amortizationPercentage": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "amortizationAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "assetAcct": {
+        "fields": {
+          "accountingSchema": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "accumulatedDepreciation": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "depreciation": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/assets/generated/web/assets/AssetsPage.jsx
+++ b/artifacts/assets/generated/web/assets/AssetsPage.jsx
@@ -145,18 +145,52 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "processed",
+      "label": "Create Amortization",
+      "actionType": "utilityAction",
       "entity": "assets",
-      "field": "processed",
       "column": "Processed",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/assets/assets/{id}/action/processed",
+      "method": "POST",
       "url": "/sws/neo/assets/assets/{id}/action/processed",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "800125",
       "processType": "classic"
     },
     {
+      "name": "processAsset",
+      "label": "Generate Amortization Plan",
+      "actionType": "utilityAction",
       "entity": "assets",
-      "field": "processAsset",
       "column": "Process_Asset",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/assets/assets/{id}/action/processAsset",
+      "method": "POST",
       "url": "/sws/neo/assets/assets/{id}/action/processAsset",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "85601427EAEE401FA0250FF0A6DD62EF",
       "processType": "classic"
     }

--- a/artifacts/contacts/contract.json
+++ b/artifacts/contacts/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.8.1",
   "generatedAt": "2026-05-06T15:52:09.982Z",
-  "updatedAt": "2026-05-15T16:28:09.254Z",
-  "checksum": "dc21a0dd8688e1af",
+  "updatedAt": "2026-05-15T16:33:38.056Z",
+  "checksum": "9f44204a9101aa79",
   "frontendContract": {
     "window": {
       "id": "123",
@@ -10407,6 +10407,1492 @@
         "EM_Etgo_Lastname": "Apellidos"
       }
     }
+  },
+  "formState": {
+    "entities": {
+      "businessPartner": {
+        "fields": {
+          "etgoIdentifier": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "searchKey": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "name": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etgoFirstname": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etgoLastname": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "oBTIKTaxIDKey": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "'1'",
+            "provenance": "extracted"
+          },
+          "taxID": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etgoWeb": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etgoEmail": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etgoPhone": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "businessPartnerCategory": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT MAX(C_BP_GROUP_ID) FROM C_BP_GROUP WHERE AD_ISORGINCLUDED(@AD_ORG_ID@, AD_ORG_ID, @#AD_CLIENT_ID@) <> -1 AND ISDEFAULT = 'Y' AND AD_CLIENT_ID = @#AD_CLIENT_ID@",
+            "provenance": "extracted"
+          },
+          "name2": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "uRL": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "referenceNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "consumptionDays": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "1000",
+            "provenance": "extracted"
+          },
+          "active": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "greeting": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "customer": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "vendor": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "employee": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "setNewCurrency": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "creditLimit": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "bPCurrencyID": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "isCustomerConsent": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "etgoIsperson": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "operator": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "creditUsed": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentTerms": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "salaryCategory": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "customerBlocking": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "account": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "isSalesRepresentative": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "priceList": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "pOFinancialAccount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "pOPaymentMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "pOPaymentTerms": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "purchasePricelist": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "vendorBlocking": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "eTGOLocation": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "customer": {
+        "fields": {
+          "customer": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "priceList": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentTerms": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "account": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "salesRepresentative": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoiceTerms": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "I",
+            "provenance": "extracted"
+          },
+          "invoiceSchedule": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxExempt": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "customerBlocking": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "salesOrder": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "goodsShipment": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "salesInvoice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "paymentIn": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "sOBPTaxCategory": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "maturityDate1": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "maturityDate2": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "maturityDate3": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "birthDay": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "birthPlace": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "aeatsiiDefaultsiikey": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "aeatsiiSiikeylist": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "F1",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "customerAccounting": {
+        "fields": {
+          "accountingSchema": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "customerReceivablesNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "customerPrepayment": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "intrastatShipments": {
+        "fields": {
+          "businessPartner": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "sOTransportationType": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "port": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "statisticalAmtPercentSo": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "privateCustomer": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "vendorCreditor": {
+        "fields": {
+          "vendor": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "purchasePricelist": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "pOPaymentMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "pOPaymentTerms": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "pOFinancialAccount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "pOMaturityDate1": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "pOMaturityDate2": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "pOMaturityDate3": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxCategory": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cashVAT": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "vendorBlocking": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "purchaseOrder": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "goodsReceipt": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "purchaseInvoice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "paymentOut": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "vendorAccounting": {
+        "fields": {
+          "accountingSchema": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "vendorLiability": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "vendorPrepayment": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "intrastatAdquisitions": {
+        "fields": {
+          "businessPartner": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "country": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "transportationType": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "portAirport": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "statisticalAmtPercentPo": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "employee": {
+        "fields": {
+          "employee": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "isSalesRepresentative": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "operator": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "salaryCategory": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "employeeAccounting": {
+        "fields": {
+          "accountingSchema": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "costSalaryCategory": {
+        "fields": {
+          "startingDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "salaryCategory": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "bankAccount": {
+        "fields": {
+          "bankName": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "country": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@COUNTRYDEF@",
+            "provenance": "extracted"
+          },
+          "userContact": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "bankFormat": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "GENERIC",
+            "provenance": "extracted"
+          },
+          "accountNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "iBAN": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "swiftCode": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "displayedAccount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "documentType": {
+        "fields": {
+          "documentcategory": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "issotrx": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "cDoctypeID": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "active": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "locationAddress": {
+        "fields": {
+          "locationAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "phone": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "alternativePhone": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "name": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": ".",
+            "provenance": "extracted"
+          },
+          "fax": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "shipToAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "invoiceToAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "active": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxLocation": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "contact": {
+        "fields": {
+          "firstName": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "lastName": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "name": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "email": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "phone": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "alternativePhone": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "position": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "comments": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "active": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "isdefaultfordocs": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "grantPortalAccess": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "commercialauth": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "viasms": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "viaemail": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "basicDiscount": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(LINE),0)+10 AS DefaultValue FROM C_BPARTNER_DISCOUNT WHERE C_BPARTNER_ID=@C_BPARTNER_ID@",
+            "provenance": "extracted"
+          },
+          "discount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "customer": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "vendor": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "applyInOrder": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "cascade": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/contacts/contract.json
+++ b/artifacts/contacts/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.8.1",
   "generatedAt": "2026-05-06T15:52:09.982Z",
-  "updatedAt": "2026-05-12T18:38:10.922Z",
-  "checksum": "c151e452e1f559fe",
+  "updatedAt": "2026-05-15T16:28:09.254Z",
+  "checksum": "dc21a0dd8688e1af",
   "frontendContract": {
     "window": {
       "id": "123",
@@ -10168,7 +10168,16 @@
         "column": "AD_User_ID",
         "reference": "User",
         "inputMode": "selector",
-        "url": "/sws/neo/contacts/bankAccount/selectors/userContact"
+        "url": "/sws/neo/contacts/bankAccount/selectors/userContact",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "documentType",
@@ -10197,50 +10206,170 @@
     ],
     "actions": [
       {
+        "name": "setNewCurrency",
+        "label": "Set New Currency",
+        "actionType": "utilityAction",
         "entity": "businessPartner",
-        "field": "setNewCurrency",
         "column": "Update_Currency",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/contacts/businessPartner/{id}/action/setNewCurrency",
+        "method": "POST",
         "url": "/sws/neo/contacts/businessPartner/{id}/action/setNewCurrency",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "B5C942145F354ABEBC9F16235D80D776",
         "processType": "obuiapp"
       },
       {
+        "name": "setNewCurrency",
+        "label": "Update_Currency",
+        "actionType": "utilityAction",
         "entity": "customer",
-        "field": "setNewCurrency",
         "column": "Update_Currency",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/contacts/customer/{id}/action/setNewCurrency",
+        "method": "POST",
         "url": "/sws/neo/contacts/customer/{id}/action/setNewCurrency",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "B5C942145F354ABEBC9F16235D80D776",
         "processType": "obuiapp"
       },
       {
+        "name": "setNewCurrency",
+        "label": "Update_Currency",
+        "actionType": "utilityAction",
         "entity": "vendorCreditor",
-        "field": "setNewCurrency",
         "column": "Update_Currency",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/contacts/vendorCreditor/{id}/action/setNewCurrency",
+        "method": "POST",
         "url": "/sws/neo/contacts/vendorCreditor/{id}/action/setNewCurrency",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "B5C942145F354ABEBC9F16235D80D776",
         "processType": "obuiapp"
       },
       {
+        "name": "setNewCurrency",
+        "label": "Update_Currency",
+        "actionType": "utilityAction",
         "entity": "employee",
-        "field": "setNewCurrency",
         "column": "Update_Currency",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/contacts/employee/{id}/action/setNewCurrency",
+        "method": "POST",
         "url": "/sws/neo/contacts/employee/{id}/action/setNewCurrency",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "B5C942145F354ABEBC9F16235D80D776",
         "processType": "obuiapp"
       },
       {
+        "name": "grantPortalAccess",
+        "label": "Grant Portal Access",
+        "actionType": "utilityAction",
         "entity": "contact",
-        "field": "grantPortalAccess",
         "column": "Grant_Portal_Access",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/contacts/contact/{id}/action/grantPortalAccess",
+        "method": "POST",
         "url": "/sws/neo/contacts/contact/{id}/action/grantPortalAccess",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "97FFD59B991D49BFB5153C309B009272",
         "processType": "obuiapp"
       },
       {
+        "name": "processNow",
+        "label": "Process Now",
+        "actionType": "documentAction",
         "entity": "contact",
-        "field": "processNow",
         "column": "Processing",
-        "url": "/sws/neo/contacts/contact/{id}/action/processNow"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/contacts/contact/{id}/action/processNow",
+        "method": "POST",
+        "url": "/sws/neo/contacts/contact/{id}/action/processNow",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted"
       }
     ],
     "queryParams": {

--- a/artifacts/contacts/generated/web/contacts/BusinessPartnerPage.jsx
+++ b/artifacts/contacts/generated/web/contacts/BusinessPartnerPage.jsx
@@ -546,7 +546,16 @@ export const api = {
       "column": "AD_User_ID",
       "reference": "User",
       "inputMode": "selector",
-      "url": "/sws/neo/contacts/bankAccount/selectors/userContact"
+      "url": "/sws/neo/contacts/bankAccount/selectors/userContact",
+      "context": {
+        "required": [
+          {
+            "param": "C_BPartner_ID",
+            "source": "parentField",
+            "field": "businessPartner"
+          }
+        ]
+      }
     },
     {
       "entity": "documentType",
@@ -575,50 +584,170 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "setNewCurrency",
+      "label": "Set New Currency",
+      "actionType": "utilityAction",
       "entity": "businessPartner",
-      "field": "setNewCurrency",
       "column": "Update_Currency",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/contacts/businessPartner/{id}/action/setNewCurrency",
+      "method": "POST",
       "url": "/sws/neo/contacts/businessPartner/{id}/action/setNewCurrency",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "B5C942145F354ABEBC9F16235D80D776",
       "processType": "obuiapp"
     },
     {
+      "name": "setNewCurrency",
+      "label": "Update_Currency",
+      "actionType": "utilityAction",
       "entity": "customer",
-      "field": "setNewCurrency",
       "column": "Update_Currency",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/contacts/customer/{id}/action/setNewCurrency",
+      "method": "POST",
       "url": "/sws/neo/contacts/customer/{id}/action/setNewCurrency",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "B5C942145F354ABEBC9F16235D80D776",
       "processType": "obuiapp"
     },
     {
+      "name": "setNewCurrency",
+      "label": "Update_Currency",
+      "actionType": "utilityAction",
       "entity": "vendorCreditor",
-      "field": "setNewCurrency",
       "column": "Update_Currency",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/contacts/vendorCreditor/{id}/action/setNewCurrency",
+      "method": "POST",
       "url": "/sws/neo/contacts/vendorCreditor/{id}/action/setNewCurrency",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "B5C942145F354ABEBC9F16235D80D776",
       "processType": "obuiapp"
     },
     {
+      "name": "setNewCurrency",
+      "label": "Update_Currency",
+      "actionType": "utilityAction",
       "entity": "employee",
-      "field": "setNewCurrency",
       "column": "Update_Currency",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/contacts/employee/{id}/action/setNewCurrency",
+      "method": "POST",
       "url": "/sws/neo/contacts/employee/{id}/action/setNewCurrency",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "B5C942145F354ABEBC9F16235D80D776",
       "processType": "obuiapp"
     },
     {
+      "name": "grantPortalAccess",
+      "label": "Grant Portal Access",
+      "actionType": "utilityAction",
       "entity": "contact",
-      "field": "grantPortalAccess",
       "column": "Grant_Portal_Access",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/contacts/contact/{id}/action/grantPortalAccess",
+      "method": "POST",
       "url": "/sws/neo/contacts/contact/{id}/action/grantPortalAccess",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "97FFD59B991D49BFB5153C309B009272",
       "processType": "obuiapp"
     },
     {
+      "name": "processNow",
+      "label": "Process Now",
+      "actionType": "documentAction",
       "entity": "contact",
-      "field": "processNow",
       "column": "Processing",
-      "url": "/sws/neo/contacts/contact/{id}/action/processNow"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/contacts/contact/{id}/action/processNow",
+      "method": "POST",
+      "url": "/sws/neo/contacts/contact/{id}/action/processNow",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted"
     }
   ],
   "queryParams": {

--- a/artifacts/goods-movements/contract.json
+++ b/artifacts/goods-movements/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T19:05:48.778Z",
-  "updatedAt": "2026-05-15T16:28:10.888Z",
-  "checksum": "88255395011d7d55",
+  "updatedAt": "2026-05-15T16:33:39.675Z",
+  "checksum": "1e2c7281b4a8708d",
   "frontendContract": {
     "window": {
       "id": "170",
@@ -1034,6 +1034,150 @@
     "window": {
       "category": "inventory"
     }
+  },
+  "formState": {
+    "entities": {
+      "movement": {
+        "fields": {
+          "name": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "movementDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "processNow": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "processed": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "movementLine": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM M_MovementLine WHERE M_Movement_ID=@M_Movement_ID@",
+            "provenance": "extracted"
+          },
+          "product": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "1",
+            "provenance": "extracted"
+          },
+          "uOM": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "storageBin": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "newStorageBin": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/goods-movements/contract.json
+++ b/artifacts/goods-movements/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T19:05:48.778Z",
-  "updatedAt": "2026-05-11T16:22:46.452Z",
-  "checksum": "c9c20297c85666a0",
+  "updatedAt": "2026-05-15T16:28:10.888Z",
+  "checksum": "88255395011d7d55",
   "frontendContract": {
     "window": {
       "id": "170",
@@ -909,26 +909,113 @@
     ],
     "actions": [
       {
+        "name": "moveBetweenLocators",
+        "label": "Move a Storage Bin",
+        "actionType": "utilityAction",
         "entity": "movement",
-        "field": "moveBetweenLocators",
         "column": "Move_FromTo_Locator",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-movements/movement/{id}/action/moveBetweenLocators",
+        "method": "POST",
         "url": "/sws/neo/goods-movements/movement/{id}/action/moveBetweenLocators",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "800048",
         "processType": "classic"
       },
       {
+        "name": "processNow",
+        "label": "Process Movements",
+        "actionType": "documentAction",
         "entity": "movement",
-        "field": "processNow",
         "column": "Processing",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-movements/movement/{id}/action/processNow",
+        "method": "POST",
         "url": "/sws/neo/goods-movements/movement/{id}/action/processNow",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "122",
         "processType": "classic"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "movement",
-        "field": "posted",
         "column": "Posted",
-        "url": "/sws/neo/goods-movements/movement/{id}/action/posted"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-movements/movement/{id}/action/posted",
+        "method": "POST",
+        "url": "/sws/neo/goods-movements/movement/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted"
       }
     ],
     "queryParams": {

--- a/artifacts/goods-movements/generated/web/goods-movements/MovementPage.jsx
+++ b/artifacts/goods-movements/generated/web/goods-movements/MovementPage.jsx
@@ -126,26 +126,113 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "moveBetweenLocators",
+      "label": "Move a Storage Bin",
+      "actionType": "utilityAction",
       "entity": "movement",
-      "field": "moveBetweenLocators",
       "column": "Move_FromTo_Locator",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-movements/movement/{id}/action/moveBetweenLocators",
+      "method": "POST",
       "url": "/sws/neo/goods-movements/movement/{id}/action/moveBetweenLocators",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "800048",
       "processType": "classic"
     },
     {
+      "name": "processNow",
+      "label": "Process Movements",
+      "actionType": "documentAction",
       "entity": "movement",
-      "field": "processNow",
       "column": "Processing",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-movements/movement/{id}/action/processNow",
+      "method": "POST",
       "url": "/sws/neo/goods-movements/movement/{id}/action/processNow",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "122",
       "processType": "classic"
     },
     {
+      "name": "posted",
+      "label": "Posted",
+      "actionType": "documentAction",
       "entity": "movement",
-      "field": "posted",
       "column": "Posted",
-      "url": "/sws/neo/goods-movements/movement/{id}/action/posted"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-movements/movement/{id}/action/posted",
+      "method": "POST",
+      "url": "/sws/neo/goods-movements/movement/{id}/action/posted",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted"
     }
   ],
   "queryParams": {

--- a/artifacts/goods-receipt/contract.json
+++ b/artifacts/goods-receipt/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.4.0",
   "generatedAt": "2026-04-29T19:05:20.719Z",
-  "updatedAt": "2026-05-12T19:44:00.759Z",
-  "checksum": "e9f9e44061d83f00",
+  "updatedAt": "2026-05-15T16:28:10.122Z",
+  "checksum": "3dc28a7c97984ce2",
   "frontendContract": {
     "window": {
       "id": "184",
@@ -1837,7 +1837,16 @@
         "column": "C_BPartner_Location_ID",
         "reference": "BusinessPartnerLocation",
         "inputMode": "dependent",
-        "url": "/sws/neo/goods-receipt/goodsReceipt/selectors/partnerAddress"
+        "url": "/sws/neo/goods-receipt/goodsReceipt/selectors/partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "goodsReceipt",
@@ -1853,7 +1862,20 @@
         "column": "C_Project_ID",
         "reference": "Project",
         "inputMode": "search",
-        "url": "/sws/neo/goods-receipt/goodsReceipt/selectors/project"
+        "url": "/sws/neo/goods-receipt/goodsReceipt/selectors/project",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "goodsReceipt",
@@ -1901,7 +1923,15 @@
         "column": "C_Aum",
         "reference": "UOM",
         "inputMode": "selector",
-        "url": "/sws/neo/goods-receipt/goodsReceiptLine/selectors/operativeUOM"
+        "url": "/sws/neo/goods-receipt/goodsReceiptLine/selectors/operativeUOM",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "goodsReceiptLine",
@@ -1978,94 +2008,338 @@
     ],
     "actions": [
       {
+        "name": "createLinesFrom",
+        "label": "Create Lines From",
+        "actionType": "createFrom",
         "entity": "goodsReceipt",
-        "field": "createLinesFrom",
         "column": "CreateFrom",
-        "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/createLinesFrom"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/createLinesFrom",
+        "method": "POST",
+        "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/createLinesFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "generateTo",
+        "label": "Generate Invoice from Receipt",
+        "actionType": "createFrom",
         "entity": "goodsReceipt",
-        "field": "generateTo",
         "column": "GenerateTo",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/generateTo",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/generateTo",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "154",
         "processType": "classic"
       },
       {
+        "name": "documentAction",
+        "label": "Process Shipment",
+        "actionType": "documentAction",
         "entity": "goodsReceipt",
-        "field": "documentAction",
         "column": "DocAction",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/documentAction",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/documentAction",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "109",
         "processType": "classic"
       },
       {
+        "name": "processGoodsJava",
+        "label": "Process Shipment Java",
+        "actionType": "utilityAction",
         "entity": "goodsReceipt",
-        "field": "processGoodsJava",
         "column": "Process_Goods_Java",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/processGoodsJava",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/processGoodsJava",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "49DEE812BF0545269781FCEBF2235924",
         "processType": "classic"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "goodsReceipt",
-        "field": "posted",
         "column": "Posted",
-        "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/posted"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/posted",
+        "method": "POST",
+        "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "calculateFreight",
+        "label": "Calculate Freight Amount",
+        "actionType": "utilityAction",
         "entity": "goodsReceipt",
-        "field": "calculateFreight",
         "column": "Calculate_Freight",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/calculateFreight",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/calculateFreight",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "800141",
         "processType": "classic"
       },
       {
+        "name": "receiveMaterials",
+        "label": "Receive Materials",
+        "actionType": "createFrom",
         "entity": "goodsReceipt",
-        "field": "receiveMaterials",
         "column": "RM_Receipt_PickEdit",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/receiveMaterials",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/receiveMaterials",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "5E9F9D7EECC24E4FBB2C60840FF613BE",
         "processType": "obuiapp"
       },
       {
+        "name": "updateLines",
+        "label": "Update Attributes from Shipment",
+        "actionType": "utilityAction",
         "entity": "goodsReceipt",
-        "field": "updateLines",
         "column": "UpdateLines",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/updateLines",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/updateLines",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "800010",
         "processType": "classic"
       },
       {
+        "name": "sendMaterials",
+        "label": "Send Materials",
+        "actionType": "createFrom",
         "entity": "goodsReceipt",
-        "field": "sendMaterials",
         "column": "RM_Shipment_Pickedit",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/sendMaterials",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/sendMaterials",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "4AD70293357245AB96E59C2CDB43A35D",
         "processType": "obuiapp"
       },
       {
+        "name": "invoicefromshipment",
+        "label": "Invoicefromshipment",
+        "actionType": "utilityAction",
         "entity": "goodsReceipt",
-        "field": "invoicefromshipment",
         "column": "Invoicefromshipment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/invoicefromshipment",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/invoicefromshipment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "62250E8866EA4D96A66C309878DC039E",
         "processType": "obuiapp"
       },
       {
+        "name": "managePrereservation",
+        "label": "Manage Prereservation",
+        "actionType": "utilityAction",
         "entity": "goodsReceiptLine",
-        "field": "managePrereservation",
         "column": "Manage_Prereservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceiptLine/{id}/action/managePrereservation",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceiptLine/{id}/action/managePrereservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
         "processType": "obuiapp"
       },
       {
+        "name": "explode",
+        "label": "Explode",
+        "actionType": "utilityAction",
         "entity": "goodsReceiptLine",
-        "field": "explode",
         "column": "Explode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceiptLine/{id}/action/explode",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceiptLine/{id}/action/explode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "DAE719940FE9463F8A3E3C401BBAFC53",
         "processType": "classic"
       }

--- a/artifacts/goods-receipt/contract.json
+++ b/artifacts/goods-receipt/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.4.0",
   "generatedAt": "2026-04-29T19:05:20.719Z",
-  "updatedAt": "2026-05-15T16:28:10.122Z",
-  "checksum": "3dc28a7c97984ce2",
+  "updatedAt": "2026-05-15T16:33:38.923Z",
+  "checksum": "6574f880394951b7",
   "frontendContract": {
     "window": {
       "id": "184",
@@ -2360,6 +2360,350 @@
     "window": {
       "category": "purchases"
     }
+  },
+  "formState": {
+    "entities": {
+      "goodsReceipt": {
+        "fields": {
+          "documentNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "warehouse": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "partnerAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "accountingDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "salesOrder": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderReference": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "DR",
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "asset": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoiceStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "goodsReceiptLine": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM M_InOutLine WHERE M_InOut_ID=@M_InOut_ID@",
+            "provenance": "extracted"
+          },
+          "product": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "attributeSetValue": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "operativeQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "operativeUOM": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "uOM": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "storageBin": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@OnHandLocatorDefault@",
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "salesOrderLine": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "asset": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoiceQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/goods-receipt/contract.prev.json
+++ b/artifacts/goods-receipt/contract.prev.json
@@ -1,8 +1,8 @@
 {
   "version": "0.4.0",
   "generatedAt": "2026-04-29T19:05:20.719Z",
-  "updatedAt": "2026-05-12T19:44:00.759Z",
-  "checksum": "e9f9e44061d83f00",
+  "updatedAt": "2026-05-15T16:28:10.122Z",
+  "checksum": "3dc28a7c97984ce2",
   "frontendContract": {
     "window": {
       "id": "184",
@@ -1837,7 +1837,16 @@
         "column": "C_BPartner_Location_ID",
         "reference": "BusinessPartnerLocation",
         "inputMode": "dependent",
-        "url": "/sws/neo/goods-receipt/goodsReceipt/selectors/partnerAddress"
+        "url": "/sws/neo/goods-receipt/goodsReceipt/selectors/partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "goodsReceipt",
@@ -1853,7 +1862,20 @@
         "column": "C_Project_ID",
         "reference": "Project",
         "inputMode": "search",
-        "url": "/sws/neo/goods-receipt/goodsReceipt/selectors/project"
+        "url": "/sws/neo/goods-receipt/goodsReceipt/selectors/project",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "goodsReceipt",
@@ -1901,7 +1923,15 @@
         "column": "C_Aum",
         "reference": "UOM",
         "inputMode": "selector",
-        "url": "/sws/neo/goods-receipt/goodsReceiptLine/selectors/operativeUOM"
+        "url": "/sws/neo/goods-receipt/goodsReceiptLine/selectors/operativeUOM",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "goodsReceiptLine",
@@ -1978,94 +2008,338 @@
     ],
     "actions": [
       {
+        "name": "createLinesFrom",
+        "label": "Create Lines From",
+        "actionType": "createFrom",
         "entity": "goodsReceipt",
-        "field": "createLinesFrom",
         "column": "CreateFrom",
-        "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/createLinesFrom"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/createLinesFrom",
+        "method": "POST",
+        "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/createLinesFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "generateTo",
+        "label": "Generate Invoice from Receipt",
+        "actionType": "createFrom",
         "entity": "goodsReceipt",
-        "field": "generateTo",
         "column": "GenerateTo",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/generateTo",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/generateTo",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "154",
         "processType": "classic"
       },
       {
+        "name": "documentAction",
+        "label": "Process Shipment",
+        "actionType": "documentAction",
         "entity": "goodsReceipt",
-        "field": "documentAction",
         "column": "DocAction",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/documentAction",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/documentAction",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "109",
         "processType": "classic"
       },
       {
+        "name": "processGoodsJava",
+        "label": "Process Shipment Java",
+        "actionType": "utilityAction",
         "entity": "goodsReceipt",
-        "field": "processGoodsJava",
         "column": "Process_Goods_Java",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/processGoodsJava",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/processGoodsJava",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "49DEE812BF0545269781FCEBF2235924",
         "processType": "classic"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "goodsReceipt",
-        "field": "posted",
         "column": "Posted",
-        "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/posted"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/posted",
+        "method": "POST",
+        "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "calculateFreight",
+        "label": "Calculate Freight Amount",
+        "actionType": "utilityAction",
         "entity": "goodsReceipt",
-        "field": "calculateFreight",
         "column": "Calculate_Freight",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/calculateFreight",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/calculateFreight",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "800141",
         "processType": "classic"
       },
       {
+        "name": "receiveMaterials",
+        "label": "Receive Materials",
+        "actionType": "createFrom",
         "entity": "goodsReceipt",
-        "field": "receiveMaterials",
         "column": "RM_Receipt_PickEdit",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/receiveMaterials",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/receiveMaterials",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "5E9F9D7EECC24E4FBB2C60840FF613BE",
         "processType": "obuiapp"
       },
       {
+        "name": "updateLines",
+        "label": "Update Attributes from Shipment",
+        "actionType": "utilityAction",
         "entity": "goodsReceipt",
-        "field": "updateLines",
         "column": "UpdateLines",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/updateLines",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/updateLines",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "800010",
         "processType": "classic"
       },
       {
+        "name": "sendMaterials",
+        "label": "Send Materials",
+        "actionType": "createFrom",
         "entity": "goodsReceipt",
-        "field": "sendMaterials",
         "column": "RM_Shipment_Pickedit",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/sendMaterials",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/sendMaterials",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "4AD70293357245AB96E59C2CDB43A35D",
         "processType": "obuiapp"
       },
       {
+        "name": "invoicefromshipment",
+        "label": "Invoicefromshipment",
+        "actionType": "utilityAction",
         "entity": "goodsReceipt",
-        "field": "invoicefromshipment",
         "column": "Invoicefromshipment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/invoicefromshipment",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/invoicefromshipment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "62250E8866EA4D96A66C309878DC039E",
         "processType": "obuiapp"
       },
       {
+        "name": "managePrereservation",
+        "label": "Manage Prereservation",
+        "actionType": "utilityAction",
         "entity": "goodsReceiptLine",
-        "field": "managePrereservation",
         "column": "Manage_Prereservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceiptLine/{id}/action/managePrereservation",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceiptLine/{id}/action/managePrereservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
         "processType": "obuiapp"
       },
       {
+        "name": "explode",
+        "label": "Explode",
+        "actionType": "utilityAction",
         "entity": "goodsReceiptLine",
-        "field": "explode",
         "column": "Explode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-receipt/goodsReceiptLine/{id}/action/explode",
+        "method": "POST",
         "url": "/sws/neo/goods-receipt/goodsReceiptLine/{id}/action/explode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "DAE719940FE9463F8A3E3C401BBAFC53",
         "processType": "classic"
       }

--- a/artifacts/goods-receipt/contract.prev.json
+++ b/artifacts/goods-receipt/contract.prev.json
@@ -1,8 +1,8 @@
 {
   "version": "0.4.0",
   "generatedAt": "2026-04-29T19:05:20.719Z",
-  "updatedAt": "2026-05-15T16:28:10.122Z",
-  "checksum": "3dc28a7c97984ce2",
+  "updatedAt": "2026-05-15T16:33:38.923Z",
+  "checksum": "6574f880394951b7",
   "frontendContract": {
     "window": {
       "id": "184",
@@ -2360,6 +2360,350 @@
     "window": {
       "category": "purchases"
     }
+  },
+  "formState": {
+    "entities": {
+      "goodsReceipt": {
+        "fields": {
+          "documentNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "warehouse": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "partnerAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "accountingDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "salesOrder": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderReference": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "DR",
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "asset": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoiceStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "goodsReceiptLine": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM M_InOutLine WHERE M_InOut_ID=@M_InOut_ID@",
+            "provenance": "extracted"
+          },
+          "product": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "attributeSetValue": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "operativeQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "operativeUOM": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "uOM": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "storageBin": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@OnHandLocatorDefault@",
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "salesOrderLine": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "asset": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoiceQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/goods-receipt/generated/web/goods-receipt/GoodsReceiptPage.jsx
+++ b/artifacts/goods-receipt/generated/web/goods-receipt/GoodsReceiptPage.jsx
@@ -118,7 +118,16 @@ export const api = {
       "column": "C_BPartner_Location_ID",
       "reference": "BusinessPartnerLocation",
       "inputMode": "dependent",
-      "url": "/sws/neo/goods-receipt/goodsReceipt/selectors/partnerAddress"
+      "url": "/sws/neo/goods-receipt/goodsReceipt/selectors/partnerAddress",
+      "context": {
+        "required": [
+          {
+            "param": "C_BPartner_ID",
+            "source": "field",
+            "field": "businessPartner"
+          }
+        ]
+      }
     },
     {
       "entity": "goodsReceipt",
@@ -134,7 +143,20 @@ export const api = {
       "column": "C_Project_ID",
       "reference": "Project",
       "inputMode": "search",
-      "url": "/sws/neo/goods-receipt/goodsReceipt/selectors/project"
+      "url": "/sws/neo/goods-receipt/goodsReceipt/selectors/project",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          },
+          {
+            "param": "C_BPartner_ID",
+            "source": "parentField",
+            "field": "businessPartner"
+          }
+        ]
+      }
     },
     {
       "entity": "goodsReceipt",
@@ -182,7 +204,15 @@ export const api = {
       "column": "C_Aum",
       "reference": "UOM",
       "inputMode": "selector",
-      "url": "/sws/neo/goods-receipt/goodsReceiptLine/selectors/operativeUOM"
+      "url": "/sws/neo/goods-receipt/goodsReceiptLine/selectors/operativeUOM",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          }
+        ]
+      }
     },
     {
       "entity": "goodsReceiptLine",
@@ -259,94 +289,338 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "createLinesFrom",
+      "label": "Create Lines From",
+      "actionType": "createFrom",
       "entity": "goodsReceipt",
-      "field": "createLinesFrom",
       "column": "CreateFrom",
-      "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/createLinesFrom"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/createLinesFrom",
+      "method": "POST",
+      "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/createLinesFrom",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "generateTo",
+      "label": "Generate Invoice from Receipt",
+      "actionType": "createFrom",
       "entity": "goodsReceipt",
-      "field": "generateTo",
       "column": "GenerateTo",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/generateTo",
+      "method": "POST",
       "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/generateTo",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "154",
       "processType": "classic"
     },
     {
+      "name": "documentAction",
+      "label": "Process Shipment",
+      "actionType": "documentAction",
       "entity": "goodsReceipt",
-      "field": "documentAction",
       "column": "DocAction",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/documentAction",
+      "method": "POST",
       "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/documentAction",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "109",
       "processType": "classic"
     },
     {
+      "name": "processGoodsJava",
+      "label": "Process Shipment Java",
+      "actionType": "utilityAction",
       "entity": "goodsReceipt",
-      "field": "processGoodsJava",
       "column": "Process_Goods_Java",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/processGoodsJava",
+      "method": "POST",
       "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/processGoodsJava",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "49DEE812BF0545269781FCEBF2235924",
       "processType": "classic"
     },
     {
+      "name": "posted",
+      "label": "Posted",
+      "actionType": "documentAction",
       "entity": "goodsReceipt",
-      "field": "posted",
       "column": "Posted",
-      "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/posted"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/posted",
+      "method": "POST",
+      "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/posted",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "calculateFreight",
+      "label": "Calculate Freight Amount",
+      "actionType": "utilityAction",
       "entity": "goodsReceipt",
-      "field": "calculateFreight",
       "column": "Calculate_Freight",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/calculateFreight",
+      "method": "POST",
       "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/calculateFreight",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "800141",
       "processType": "classic"
     },
     {
+      "name": "receiveMaterials",
+      "label": "Receive Materials",
+      "actionType": "createFrom",
       "entity": "goodsReceipt",
-      "field": "receiveMaterials",
       "column": "RM_Receipt_PickEdit",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/receiveMaterials",
+      "method": "POST",
       "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/receiveMaterials",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "5E9F9D7EECC24E4FBB2C60840FF613BE",
       "processType": "obuiapp"
     },
     {
+      "name": "updateLines",
+      "label": "Update Attributes from Shipment",
+      "actionType": "utilityAction",
       "entity": "goodsReceipt",
-      "field": "updateLines",
       "column": "UpdateLines",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/updateLines",
+      "method": "POST",
       "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/updateLines",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "800010",
       "processType": "classic"
     },
     {
+      "name": "sendMaterials",
+      "label": "Send Materials",
+      "actionType": "createFrom",
       "entity": "goodsReceipt",
-      "field": "sendMaterials",
       "column": "RM_Shipment_Pickedit",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/sendMaterials",
+      "method": "POST",
       "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/sendMaterials",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "4AD70293357245AB96E59C2CDB43A35D",
       "processType": "obuiapp"
     },
     {
+      "name": "invoicefromshipment",
+      "label": "Invoicefromshipment",
+      "actionType": "utilityAction",
       "entity": "goodsReceipt",
-      "field": "invoicefromshipment",
       "column": "Invoicefromshipment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/invoicefromshipment",
+      "method": "POST",
       "url": "/sws/neo/goods-receipt/goodsReceipt/{id}/action/invoicefromshipment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "62250E8866EA4D96A66C309878DC039E",
       "processType": "obuiapp"
     },
     {
+      "name": "managePrereservation",
+      "label": "Manage Prereservation",
+      "actionType": "utilityAction",
       "entity": "goodsReceiptLine",
-      "field": "managePrereservation",
       "column": "Manage_Prereservation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-receipt/goodsReceiptLine/{id}/action/managePrereservation",
+      "method": "POST",
       "url": "/sws/neo/goods-receipt/goodsReceiptLine/{id}/action/managePrereservation",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
       "processType": "obuiapp"
     },
     {
+      "name": "explode",
+      "label": "Explode",
+      "actionType": "utilityAction",
       "entity": "goodsReceiptLine",
-      "field": "explode",
       "column": "Explode",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-receipt/goodsReceiptLine/{id}/action/explode",
+      "method": "POST",
       "url": "/sws/neo/goods-receipt/goodsReceiptLine/{id}/action/explode",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "DAE719940FE9463F8A3E3C401BBAFC53",
       "processType": "classic"
     }

--- a/artifacts/goods-shipment/contract.json
+++ b/artifacts/goods-shipment/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.6.0",
   "generatedAt": "2026-04-29T19:04:55.657Z",
-  "updatedAt": "2026-05-15T16:28:09.581Z",
-  "checksum": "f87da5600eddd335",
+  "updatedAt": "2026-05-15T16:33:38.382Z",
+  "checksum": "999ccdc835bf9152",
   "frontendContract": {
     "window": {
       "id": "169",
@@ -1805,6 +1805,150 @@
     "window": {
       "category": "sales"
     }
+  },
+  "formState": {
+    "entities": {
+      "goodsShipment": {
+        "fields": {
+          "documentNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "warehouse": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "partnerAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "documentStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "DR",
+            "provenance": "extracted"
+          },
+          "invoiced": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "processed": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "goodsShipmentLine": {
+        "fields": {
+          "product": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/goods-shipment/contract.json
+++ b/artifacts/goods-shipment/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.6.0",
   "generatedAt": "2026-04-29T19:04:55.657Z",
-  "updatedAt": "2026-05-11T16:22:43.826Z",
-  "checksum": "86cc41085f28c4e2",
+  "updatedAt": "2026-05-15T16:28:09.581Z",
+  "checksum": "f87da5600eddd335",
   "frontendContract": {
     "window": {
       "id": "169",
@@ -1431,7 +1431,16 @@
         "column": "C_BPartner_Location_ID",
         "reference": "BusinessPartnerLocation",
         "inputMode": "dependent",
-        "url": "/sws/neo/goods-shipment/goodsShipment/selectors/partnerAddress"
+        "url": "/sws/neo/goods-shipment/goodsShipment/selectors/partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "goodsShipmentLine",
@@ -1444,94 +1453,338 @@
     ],
     "actions": [
       {
+        "name": "createLinesFrom",
+        "label": "Create Lines From",
+        "actionType": "createFrom",
         "entity": "goodsShipment",
-        "field": "createLinesFrom",
         "column": "CreateFrom",
-        "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/createLinesFrom"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/createLinesFrom",
+        "method": "POST",
+        "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/createLinesFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "processGoodsJava",
+        "label": "Process Shipment Java",
+        "actionType": "utilityAction",
         "entity": "goodsShipment",
-        "field": "processGoodsJava",
         "column": "Process_Goods_Java",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/processGoodsJava",
+        "method": "POST",
         "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/processGoodsJava",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "49DEE812BF0545269781FCEBF2235924",
         "processType": "classic"
       },
       {
+        "name": "documentAction",
+        "label": "Process Shipment",
+        "actionType": "documentAction",
         "entity": "goodsShipment",
-        "field": "documentAction",
         "column": "DocAction",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/documentAction",
+        "method": "POST",
         "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/documentAction",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "109",
         "processType": "classic"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "goodsShipment",
-        "field": "posted",
         "column": "Posted",
-        "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/posted"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/posted",
+        "method": "POST",
+        "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "calculateFreight",
+        "label": "Calculate Freight Amount",
+        "actionType": "utilityAction",
         "entity": "goodsShipment",
-        "field": "calculateFreight",
         "column": "Calculate_Freight",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/calculateFreight",
+        "method": "POST",
         "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/calculateFreight",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "800141",
         "processType": "classic"
       },
       {
+        "name": "invoicefromshipment",
+        "label": "Generate Invoice from Shipment",
+        "actionType": "utilityAction",
         "entity": "goodsShipment",
-        "field": "invoicefromshipment",
         "column": "Invoicefromshipment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/invoicefromshipment",
+        "method": "POST",
         "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/invoicefromshipment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "62250E8866EA4D96A66C309878DC039E",
         "processType": "obuiapp"
       },
       {
+        "name": "generateTo",
+        "label": "Generate Invoice from Receipt",
+        "actionType": "createFrom",
         "entity": "goodsShipment",
-        "field": "generateTo",
         "column": "GenerateTo",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/generateTo",
+        "method": "POST",
         "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/generateTo",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "154",
         "processType": "classic"
       },
       {
+        "name": "updateLines",
+        "label": "Update Attributes from Shipment",
+        "actionType": "utilityAction",
         "entity": "goodsShipment",
-        "field": "updateLines",
         "column": "UpdateLines",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/updateLines",
+        "method": "POST",
         "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/updateLines",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "800010",
         "processType": "classic"
       },
       {
+        "name": "receiveMaterials",
+        "label": "Receive Materials",
+        "actionType": "createFrom",
         "entity": "goodsShipment",
-        "field": "receiveMaterials",
         "column": "RM_Receipt_PickEdit",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/receiveMaterials",
+        "method": "POST",
         "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/receiveMaterials",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "5E9F9D7EECC24E4FBB2C60840FF613BE",
         "processType": "obuiapp"
       },
       {
+        "name": "sendMaterials",
+        "label": "Send Materials",
+        "actionType": "createFrom",
         "entity": "goodsShipment",
-        "field": "sendMaterials",
         "column": "RM_Shipment_Pickedit",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/sendMaterials",
+        "method": "POST",
         "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/sendMaterials",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "4AD70293357245AB96E59C2CDB43A35D",
         "processType": "obuiapp"
       },
       {
+        "name": "explode",
+        "label": "Explode",
+        "actionType": "utilityAction",
         "entity": "goodsShipmentLine",
-        "field": "explode",
         "column": "Explode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-shipment/goodsShipmentLine/{id}/action/explode",
+        "method": "POST",
         "url": "/sws/neo/goods-shipment/goodsShipmentLine/{id}/action/explode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "DAE719940FE9463F8A3E3C401BBAFC53",
         "processType": "classic"
       },
       {
+        "name": "managePrereservation",
+        "label": "Manage Prereservation",
+        "actionType": "utilityAction",
         "entity": "goodsShipmentLine",
-        "field": "managePrereservation",
         "column": "Manage_Prereservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/goods-shipment/goodsShipmentLine/{id}/action/managePrereservation",
+        "method": "POST",
         "url": "/sws/neo/goods-shipment/goodsShipmentLine/{id}/action/managePrereservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
         "processType": "obuiapp"
       }

--- a/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentPage.jsx
+++ b/artifacts/goods-shipment/generated/web/goods-shipment/GoodsShipmentPage.jsx
@@ -116,7 +116,16 @@ export const api = {
       "column": "C_BPartner_Location_ID",
       "reference": "BusinessPartnerLocation",
       "inputMode": "dependent",
-      "url": "/sws/neo/goods-shipment/goodsShipment/selectors/partnerAddress"
+      "url": "/sws/neo/goods-shipment/goodsShipment/selectors/partnerAddress",
+      "context": {
+        "required": [
+          {
+            "param": "C_BPartner_ID",
+            "source": "field",
+            "field": "businessPartner"
+          }
+        ]
+      }
     },
     {
       "entity": "goodsShipmentLine",
@@ -129,94 +138,338 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "createLinesFrom",
+      "label": "Create Lines From",
+      "actionType": "createFrom",
       "entity": "goodsShipment",
-      "field": "createLinesFrom",
       "column": "CreateFrom",
-      "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/createLinesFrom"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/createLinesFrom",
+      "method": "POST",
+      "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/createLinesFrom",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "processGoodsJava",
+      "label": "Process Shipment Java",
+      "actionType": "utilityAction",
       "entity": "goodsShipment",
-      "field": "processGoodsJava",
       "column": "Process_Goods_Java",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/processGoodsJava",
+      "method": "POST",
       "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/processGoodsJava",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "49DEE812BF0545269781FCEBF2235924",
       "processType": "classic"
     },
     {
+      "name": "documentAction",
+      "label": "Process Shipment",
+      "actionType": "documentAction",
       "entity": "goodsShipment",
-      "field": "documentAction",
       "column": "DocAction",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/documentAction",
+      "method": "POST",
       "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/documentAction",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "109",
       "processType": "classic"
     },
     {
+      "name": "posted",
+      "label": "Posted",
+      "actionType": "documentAction",
       "entity": "goodsShipment",
-      "field": "posted",
       "column": "Posted",
-      "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/posted"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/posted",
+      "method": "POST",
+      "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/posted",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "calculateFreight",
+      "label": "Calculate Freight Amount",
+      "actionType": "utilityAction",
       "entity": "goodsShipment",
-      "field": "calculateFreight",
       "column": "Calculate_Freight",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/calculateFreight",
+      "method": "POST",
       "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/calculateFreight",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "800141",
       "processType": "classic"
     },
     {
+      "name": "invoicefromshipment",
+      "label": "Generate Invoice from Shipment",
+      "actionType": "utilityAction",
       "entity": "goodsShipment",
-      "field": "invoicefromshipment",
       "column": "Invoicefromshipment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/invoicefromshipment",
+      "method": "POST",
       "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/invoicefromshipment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "62250E8866EA4D96A66C309878DC039E",
       "processType": "obuiapp"
     },
     {
+      "name": "generateTo",
+      "label": "Generate Invoice from Receipt",
+      "actionType": "createFrom",
       "entity": "goodsShipment",
-      "field": "generateTo",
       "column": "GenerateTo",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/generateTo",
+      "method": "POST",
       "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/generateTo",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "154",
       "processType": "classic"
     },
     {
+      "name": "updateLines",
+      "label": "Update Attributes from Shipment",
+      "actionType": "utilityAction",
       "entity": "goodsShipment",
-      "field": "updateLines",
       "column": "UpdateLines",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/updateLines",
+      "method": "POST",
       "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/updateLines",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "800010",
       "processType": "classic"
     },
     {
+      "name": "receiveMaterials",
+      "label": "Receive Materials",
+      "actionType": "createFrom",
       "entity": "goodsShipment",
-      "field": "receiveMaterials",
       "column": "RM_Receipt_PickEdit",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/receiveMaterials",
+      "method": "POST",
       "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/receiveMaterials",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "5E9F9D7EECC24E4FBB2C60840FF613BE",
       "processType": "obuiapp"
     },
     {
+      "name": "sendMaterials",
+      "label": "Send Materials",
+      "actionType": "createFrom",
       "entity": "goodsShipment",
-      "field": "sendMaterials",
       "column": "RM_Shipment_Pickedit",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-shipment/goodsShipment/{id}/action/sendMaterials",
+      "method": "POST",
       "url": "/sws/neo/goods-shipment/goodsShipment/{id}/action/sendMaterials",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "4AD70293357245AB96E59C2CDB43A35D",
       "processType": "obuiapp"
     },
     {
+      "name": "explode",
+      "label": "Explode",
+      "actionType": "utilityAction",
       "entity": "goodsShipmentLine",
-      "field": "explode",
       "column": "Explode",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-shipment/goodsShipmentLine/{id}/action/explode",
+      "method": "POST",
       "url": "/sws/neo/goods-shipment/goodsShipmentLine/{id}/action/explode",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "DAE719940FE9463F8A3E3C401BBAFC53",
       "processType": "classic"
     },
     {
+      "name": "managePrereservation",
+      "label": "Manage Prereservation",
+      "actionType": "utilityAction",
       "entity": "goodsShipmentLine",
-      "field": "managePrereservation",
       "column": "Manage_Prereservation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/goods-shipment/goodsShipmentLine/{id}/action/managePrereservation",
+      "method": "POST",
       "url": "/sws/neo/goods-shipment/goodsShipmentLine/{id}/action/managePrereservation",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
       "processType": "obuiapp"
     }

--- a/artifacts/internal-consumption/contract.json
+++ b/artifacts/internal-consumption/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.4.0",
   "generatedAt": "2026-04-29T19:05:49.589Z",
-  "updatedAt": "2026-05-13T17:58:43.876Z",
-  "checksum": "b2a99362d3bce3c7",
+  "updatedAt": "2026-05-15T16:28:10.988Z",
+  "checksum": "07a778d2913bf25d",
   "frontendContract": {
     "window": {
       "id": "800076",
@@ -731,18 +731,88 @@
     ],
     "actions": [
       {
+        "name": "processNow",
+        "label": "Process Internal Consumption",
+        "actionType": "documentAction",
         "entity": "internalConsumption",
-        "field": "processNow",
         "column": "Processing",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/internal-consumption/internalConsumption/{id}/action/processNow",
+        "method": "POST",
         "url": "/sws/neo/internal-consumption/internalConsumption/{id}/action/processNow",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "800131",
         "processType": "classic"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "internalConsumption",
-        "field": "posted",
         "column": "Posted",
-        "url": "/sws/neo/internal-consumption/internalConsumption/{id}/action/posted"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/internal-consumption/internalConsumption/{id}/action/posted",
+        "method": "POST",
+        "url": "/sws/neo/internal-consumption/internalConsumption/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted"
       }
     ],
     "queryParams": {

--- a/artifacts/internal-consumption/contract.json
+++ b/artifacts/internal-consumption/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.4.0",
   "generatedAt": "2026-04-29T19:05:49.589Z",
-  "updatedAt": "2026-05-15T16:28:10.988Z",
-  "checksum": "07a778d2913bf25d",
+  "updatedAt": "2026-05-15T16:33:39.775Z",
+  "checksum": "a5a39867d19d927b",
   "frontendContract": {
     "window": {
       "id": "800076",
@@ -831,6 +831,110 @@
     "window": {
       "category": "inventory"
     }
+  },
+  "formState": {
+    "entities": {
+      "internalConsumption": {
+        "fields": {
+          "movementDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "name": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "status": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "DR",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "internalConsumptionLine": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(LINE),0)+10 AS DefaultValue FROM M_INTERNAL_CONSUMPTIONLINE WHERE M_INTERNAL_CONSUMPTION_ID=@M_INTERNAL_CONSUMPTION_ID@",
+            "provenance": "extracted"
+          },
+          "product": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "uOM": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "storageBin": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/internal-consumption/generated/web/internal-consumption/InternalConsumptionPage.jsx
+++ b/artifacts/internal-consumption/generated/web/internal-consumption/InternalConsumptionPage.jsx
@@ -115,18 +115,88 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "processNow",
+      "label": "Process Internal Consumption",
+      "actionType": "documentAction",
       "entity": "internalConsumption",
-      "field": "processNow",
       "column": "Processing",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/internal-consumption/internalConsumption/{id}/action/processNow",
+      "method": "POST",
       "url": "/sws/neo/internal-consumption/internalConsumption/{id}/action/processNow",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "800131",
       "processType": "classic"
     },
     {
+      "name": "posted",
+      "label": "Posted",
+      "actionType": "documentAction",
       "entity": "internalConsumption",
-      "field": "posted",
       "column": "Posted",
-      "url": "/sws/neo/internal-consumption/internalConsumption/{id}/action/posted"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/internal-consumption/internalConsumption/{id}/action/posted",
+      "method": "POST",
+      "url": "/sws/neo/internal-consumption/internalConsumption/{id}/action/posted",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted"
     }
   ],
   "queryParams": {

--- a/artifacts/payment-in/contract.json
+++ b/artifacts/payment-in/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T19:05:52.312Z",
-  "updatedAt": "2026-05-13T15:59:17.665Z",
-  "checksum": "248e72bf83cc52c1",
+  "updatedAt": "2026-05-15T16:28:11.198Z",
+  "checksum": "4a568bfdb0c58739",
   "frontendContract": {
     "window": {
       "id": "E547CE89D4C04429B6340FFA44E70716",
@@ -1283,7 +1283,16 @@
         "column": "Fin_Financial_Account_ID",
         "reference": "Financial_Account",
         "inputMode": "dependent",
-        "url": "/sws/neo/payment-in/finPayment/selectors/account"
+        "url": "/sws/neo/payment-in/finPayment/selectors/account",
+        "context": {
+          "required": [
+            {
+              "param": "Fin_Paymentmethod_ID",
+              "source": "field",
+              "field": "paymentMethod"
+            }
+          ]
+        }
       },
       {
         "entity": "finPayment",
@@ -1291,7 +1300,16 @@
         "column": "C_Currency_ID",
         "reference": "Currency",
         "inputMode": "dependent",
-        "url": "/sws/neo/payment-in/finPayment/selectors/currency"
+        "url": "/sws/neo/payment-in/finPayment/selectors/currency",
+        "context": {
+          "required": [
+            {
+              "param": "FIN_Financial_Account_ID",
+              "source": "field",
+              "field": "account"
+            }
+          ]
+        }
       },
       {
         "entity": "finPaymentScheduleDetail",
@@ -1304,54 +1322,214 @@
     ],
     "actions": [
       {
+        "name": "aPRMAddScheduledpayments",
+        "label": "Add Details",
+        "actionType": "paymentAction",
         "entity": "finPayment",
-        "field": "aPRMAddScheduledpayments",
         "column": "EM_Aprm_Add_Scheduledpayments",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/payment-in/finPayment/{id}/action/aPRMAddScheduledpayments",
+        "method": "POST",
         "url": "/sws/neo/payment-in/finPayment/{id}/action/aPRMAddScheduledpayments",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "9BED7889E1034FE68BD85D5D16857320",
         "processType": "obuiapp"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "finPayment",
-        "field": "posted",
         "column": "Posted",
-        "url": "/sws/neo/payment-in/finPayment/{id}/action/posted"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/payment-in/finPayment/{id}/action/posted",
+        "method": "POST",
+        "url": "/sws/neo/payment-in/finPayment/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "aPRMProcessPayment",
+        "label": "Payment Process",
+        "actionType": "paymentAction",
         "entity": "finPayment",
-        "field": "aPRMProcessPayment",
         "column": "EM_APRM_Process_Payment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/payment-in/finPayment/{id}/action/aPRMProcessPayment",
+        "method": "POST",
         "url": "/sws/neo/payment-in/finPayment/{id}/action/aPRMProcessPayment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "6255BE488882480599C81284B70CD9B3",
         "processType": "classic"
       },
       {
+        "name": "aprmExecutepayment",
+        "label": "Execute Payment",
+        "actionType": "paymentAction",
         "entity": "finPayment",
-        "field": "aprmExecutepayment",
         "column": "EM_Aprm_Executepayment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/payment-in/finPayment/{id}/action/aprmExecutepayment",
+        "method": "POST",
         "url": "/sws/neo/payment-in/finPayment/{id}/action/aprmExecutepayment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "E011F492B0814A74B63CD1F3B9FF0526",
         "processType": "classic"
       },
       {
+        "name": "aPRMReversePayment",
+        "label": "Reverse Payment",
+        "actionType": "documentAction",
         "entity": "finPayment",
-        "field": "aPRMReversePayment",
         "column": "EM_APRM_ReversePayment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/payment-in/finPayment/{id}/action/aPRMReversePayment",
+        "method": "POST",
         "url": "/sws/neo/payment-in/finPayment/{id}/action/aPRMReversePayment",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "29D17F515727436DBCE32BC6CA28382B",
         "processType": "classic"
       },
       {
+        "name": "aPRMReconcilePayment",
+        "label": "Reconcile Payment",
+        "actionType": "paymentAction",
         "entity": "finPayment",
-        "field": "aPRMReconcilePayment",
         "column": "EM_APRM_Reconcile_Payment",
-        "url": "/sws/neo/payment-in/finPayment/{id}/action/aPRMReconcilePayment"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/payment-in/finPayment/{id}/action/aPRMReconcilePayment",
+        "method": "POST",
+        "url": "/sws/neo/payment-in/finPayment/{id}/action/aPRMReconcilePayment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "aeatsiiSend",
+        "label": "EM_Aeatsii_Send",
+        "actionType": "createFrom",
         "entity": "finPayment",
-        "field": "aeatsiiSend",
         "column": "EM_Aeatsii_Send",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/payment-in/finPayment/{id}/action/aeatsiiSend",
+        "method": "POST",
         "url": "/sws/neo/payment-in/finPayment/{id}/action/aeatsiiSend",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "EA02D79CA1DE4B46909EA6EF64A66B53",
         "processType": "obuiapp"
       }

--- a/artifacts/payment-in/contract.json
+++ b/artifacts/payment-in/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T19:05:52.312Z",
-  "updatedAt": "2026-05-15T16:28:11.198Z",
-  "checksum": "4a568bfdb0c58739",
+  "updatedAt": "2026-05-15T16:33:39.981Z",
+  "checksum": "6b7311c247a257c1",
   "frontendContract": {
     "window": {
       "id": "E547CE89D4C04429B6340FFA44E70716",
@@ -1550,6 +1550,150 @@
     "window": {
       "category": "finance"
     }
+  },
+  "formState": {
+    "entities": {
+      "finPayment": {
+        "fields": {
+          "documentNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "referenceNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' & @status@!'RPAE'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' & @status@!'RPAE'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "amount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "((@Processed@='Y' & @isReceipt@='Y') | @isReceipt@='N') | @Status@='RPAE'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "account": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' & @status@!'RPAE'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@IsMultiCurrencyEnabled@!'Y' | @Processed@='Y' | @Status@='RPAE'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "status": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "RPAP",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "finPaymentScheduleDetail": {
+        "fields": {
+          "dueDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "amount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "invoicePaymentSchedule": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/payment-in/generated/web/payment-in/FinPaymentPage.jsx
+++ b/artifacts/payment-in/generated/web/payment-in/FinPaymentPage.jsx
@@ -97,7 +97,16 @@ export const api = {
       "column": "Fin_Financial_Account_ID",
       "reference": "Financial_Account",
       "inputMode": "dependent",
-      "url": "/sws/neo/payment-in/finPayment/selectors/account"
+      "url": "/sws/neo/payment-in/finPayment/selectors/account",
+      "context": {
+        "required": [
+          {
+            "param": "Fin_Paymentmethod_ID",
+            "source": "field",
+            "field": "paymentMethod"
+          }
+        ]
+      }
     },
     {
       "entity": "finPayment",
@@ -105,7 +114,16 @@ export const api = {
       "column": "C_Currency_ID",
       "reference": "Currency",
       "inputMode": "dependent",
-      "url": "/sws/neo/payment-in/finPayment/selectors/currency"
+      "url": "/sws/neo/payment-in/finPayment/selectors/currency",
+      "context": {
+        "required": [
+          {
+            "param": "FIN_Financial_Account_ID",
+            "source": "field",
+            "field": "account"
+          }
+        ]
+      }
     },
     {
       "entity": "finPaymentScheduleDetail",
@@ -118,54 +136,214 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "aPRMAddScheduledpayments",
+      "label": "Add Details",
+      "actionType": "paymentAction",
       "entity": "finPayment",
-      "field": "aPRMAddScheduledpayments",
       "column": "EM_Aprm_Add_Scheduledpayments",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/payment-in/finPayment/{id}/action/aPRMAddScheduledpayments",
+      "method": "POST",
       "url": "/sws/neo/payment-in/finPayment/{id}/action/aPRMAddScheduledpayments",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "9BED7889E1034FE68BD85D5D16857320",
       "processType": "obuiapp"
     },
     {
+      "name": "posted",
+      "label": "Posted",
+      "actionType": "documentAction",
       "entity": "finPayment",
-      "field": "posted",
       "column": "Posted",
-      "url": "/sws/neo/payment-in/finPayment/{id}/action/posted"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/payment-in/finPayment/{id}/action/posted",
+      "method": "POST",
+      "url": "/sws/neo/payment-in/finPayment/{id}/action/posted",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "aPRMProcessPayment",
+      "label": "Payment Process",
+      "actionType": "paymentAction",
       "entity": "finPayment",
-      "field": "aPRMProcessPayment",
       "column": "EM_APRM_Process_Payment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/payment-in/finPayment/{id}/action/aPRMProcessPayment",
+      "method": "POST",
       "url": "/sws/neo/payment-in/finPayment/{id}/action/aPRMProcessPayment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "6255BE488882480599C81284B70CD9B3",
       "processType": "classic"
     },
     {
+      "name": "aprmExecutepayment",
+      "label": "Execute Payment",
+      "actionType": "paymentAction",
       "entity": "finPayment",
-      "field": "aprmExecutepayment",
       "column": "EM_Aprm_Executepayment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/payment-in/finPayment/{id}/action/aprmExecutepayment",
+      "method": "POST",
       "url": "/sws/neo/payment-in/finPayment/{id}/action/aprmExecutepayment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "E011F492B0814A74B63CD1F3B9FF0526",
       "processType": "classic"
     },
     {
+      "name": "aPRMReversePayment",
+      "label": "Reverse Payment",
+      "actionType": "documentAction",
       "entity": "finPayment",
-      "field": "aPRMReversePayment",
       "column": "EM_APRM_ReversePayment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/payment-in/finPayment/{id}/action/aPRMReversePayment",
+      "method": "POST",
       "url": "/sws/neo/payment-in/finPayment/{id}/action/aPRMReversePayment",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "29D17F515727436DBCE32BC6CA28382B",
       "processType": "classic"
     },
     {
+      "name": "aPRMReconcilePayment",
+      "label": "Reconcile Payment",
+      "actionType": "paymentAction",
       "entity": "finPayment",
-      "field": "aPRMReconcilePayment",
       "column": "EM_APRM_Reconcile_Payment",
-      "url": "/sws/neo/payment-in/finPayment/{id}/action/aPRMReconcilePayment"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/payment-in/finPayment/{id}/action/aPRMReconcilePayment",
+      "method": "POST",
+      "url": "/sws/neo/payment-in/finPayment/{id}/action/aPRMReconcilePayment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "aeatsiiSend",
+      "label": "EM_Aeatsii_Send",
+      "actionType": "createFrom",
       "entity": "finPayment",
-      "field": "aeatsiiSend",
       "column": "EM_Aeatsii_Send",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/payment-in/finPayment/{id}/action/aeatsiiSend",
+      "method": "POST",
       "url": "/sws/neo/payment-in/finPayment/{id}/action/aeatsiiSend",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "EA02D79CA1DE4B46909EA6EF64A66B53",
       "processType": "obuiapp"
     }

--- a/artifacts/payment-method/contract.json
+++ b/artifacts/payment-method/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.4.0",
   "generatedAt": "2026-04-29T18:12:23.942Z",
-  "updatedAt": "2026-05-13T15:59:19.480Z",
-  "checksum": "6fd7dae34dbc066e",
+  "updatedAt": "2026-05-15T16:33:40.490Z",
+  "checksum": "16dbff15b5a9da1c",
   "frontendContract": {
     "window": {
       "id": "3CAAC7D54593489384452416ACF356DD",
@@ -625,6 +625,96 @@
         "Automatic_Withdrawn": "Retiro automático"
       }
     }
+  },
+  "formState": {
+    "entities": {
+      "paymentMethod": {
+        "fields": {
+          "name": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "payinAllow": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "automaticReceipt": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "automaticDeposit": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "payoutAllow": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "automaticPayment": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "automaticWithdrawn": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/payment-out/contract.json
+++ b/artifacts/payment-out/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T18:11:46.137Z",
-  "updatedAt": "2026-05-11T16:22:46.850Z",
-  "checksum": "111d074327b02ffe",
+  "updatedAt": "2026-05-15T16:28:11.305Z",
+  "checksum": "9ae5caeb87263a14",
   "frontendContract": {
     "window": {
       "id": "6F8F913FA60F4CBD93DC1D3AA696E76E",
@@ -3752,54 +3752,214 @@
     ],
     "actions": [
       {
+        "name": "aPRMAddScheduledpayments",
+        "label": "Add Details",
+        "actionType": "paymentAction",
         "entity": "header",
-        "field": "aPRMAddScheduledpayments",
         "column": "EM_Aprm_Add_Scheduledpayments",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/payment-out/header/{id}/action/aPRMAddScheduledpayments",
+        "method": "POST",
         "url": "/sws/neo/payment-out/header/{id}/action/aPRMAddScheduledpayments",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "9BED7889E1034FE68BD85D5D16857320",
         "processType": "obuiapp"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "posted",
         "column": "Posted",
-        "url": "/sws/neo/payment-out/header/{id}/action/posted"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/payment-out/header/{id}/action/posted",
+        "method": "POST",
+        "url": "/sws/neo/payment-out/header/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "aPRMProcessPayment",
+        "label": "Payment Process",
+        "actionType": "paymentAction",
         "entity": "header",
-        "field": "aPRMProcessPayment",
         "column": "EM_APRM_Process_Payment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/payment-out/header/{id}/action/aPRMProcessPayment",
+        "method": "POST",
         "url": "/sws/neo/payment-out/header/{id}/action/aPRMProcessPayment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "6255BE488882480599C81284B70CD9B3",
         "processType": "classic"
       },
       {
+        "name": "aprmExecutepayment",
+        "label": "Execute Payment",
+        "actionType": "paymentAction",
         "entity": "header",
-        "field": "aprmExecutepayment",
         "column": "EM_Aprm_Executepayment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/payment-out/header/{id}/action/aprmExecutepayment",
+        "method": "POST",
         "url": "/sws/neo/payment-out/header/{id}/action/aprmExecutepayment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "E011F492B0814A74B63CD1F3B9FF0526",
         "processType": "classic"
       },
       {
+        "name": "aPRMReversePayment",
+        "label": "Reverse Payment",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "aPRMReversePayment",
         "column": "EM_APRM_ReversePayment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/payment-out/header/{id}/action/aPRMReversePayment",
+        "method": "POST",
         "url": "/sws/neo/payment-out/header/{id}/action/aPRMReversePayment",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "29D17F515727436DBCE32BC6CA28382B",
         "processType": "classic"
       },
       {
+        "name": "aPRMReconcilePayment",
+        "label": "Reconcile Payment",
+        "actionType": "paymentAction",
         "entity": "header",
-        "field": "aPRMReconcilePayment",
         "column": "EM_APRM_Reconcile_Payment",
-        "url": "/sws/neo/payment-out/header/{id}/action/aPRMReconcilePayment"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/payment-out/header/{id}/action/aPRMReconcilePayment",
+        "method": "POST",
+        "url": "/sws/neo/payment-out/header/{id}/action/aPRMReconcilePayment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "aeatsiiSend",
+        "label": "EM_Aeatsii_Send",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "aeatsiiSend",
         "column": "EM_Aeatsii_Send",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/payment-out/header/{id}/action/aeatsiiSend",
+        "method": "POST",
         "url": "/sws/neo/payment-out/header/{id}/action/aeatsiiSend",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "EA02D79CA1DE4B46909EA6EF64A66B53",
         "processType": "obuiapp"
       }

--- a/artifacts/payment-out/contract.json
+++ b/artifacts/payment-out/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T18:11:46.137Z",
-  "updatedAt": "2026-05-15T16:28:11.305Z",
-  "checksum": "9ae5caeb87263a14",
+  "updatedAt": "2026-05-15T16:33:40.086Z",
+  "checksum": "0d75aefbbf853e78",
   "frontendContract": {
     "window": {
       "id": "6F8F913FA60F4CBD93DC1D3AA696E76E",
@@ -3980,6 +3980,766 @@
     "window": {
       "category": "finance"
     }
+  },
+  "formState": {
+    "entities": {
+      "header": {
+        "fields": {
+          "documentType": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT C_DocType_ID from C_DocType WHERE AD_ISORGINCLUDED(@AD_Org_ID@,C_DocType.AD_Org_ID, @#AD_Client_ID@) <> -1 AND C_DocType.DocBaseType IN ('APP', 'ARR') AND C_DocType.IsSOTrx='@Isreceipt@'  ORDER BY C_DocType.isdefault DESC, AD_ISORGINCLUDED(@AD_Org_ID@,C_DocType.AD_Org_ID, @#AD_Client_ID@)",
+            "provenance": "extracted"
+          },
+          "documentNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "referenceNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' & @status@!'RPAE'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' & @status@!'RPAE'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "account": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' & @status@!'RPAE'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@IsMultiCurrencyEnabled@!'Y' | @Processed@='Y' | @Status@='RPAE'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "financialTransactionAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@NotAllowChangeExchange@='Y' | @Processed@='Y' | @status@='RPAE'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "financialTransactionConvertRate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@NotAllowChangeExchange@='Y' | (@Processed@='Y' & @status@!'RPAE' )",
+            "calloutTriggers": null,
+            "defaultValue": "1.0",
+            "provenance": "extracted"
+          },
+          "generatedCredit": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@isReceipt@='Y' | @status@!'RPAP'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "aPRMAddScheduledpayments": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "aPRMProcessPayment": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "P",
+            "provenance": "extracted"
+          },
+          "aprmExecutepayment": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "amount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "((@Processed@='Y' & @isReceipt@='Y') | @isReceipt@='N') | @Status@='RPAE'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "status": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "RPAP",
+            "provenance": "extracted"
+          },
+          "usedCredit": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "writeoffAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "reversedPayment": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costCenter": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "lines": {
+        "fields": {
+          "dueDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoiceAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "expected": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "amount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "orderNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderPaymentSchedule": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoiceNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoicePaymentSchedule": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "gLItem": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "canceled": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "activity": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "product": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "salesCampaign": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "salesRegion": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costCenter": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "executionHistory": {
+        "fields": {
+          "executionDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentRun": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentRunStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentRunMessage": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "sourceOfTheExecution": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentExecutionResult": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentExecutionMessage": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "exchangeRates": {
+        "fields": {
+          "active": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@HASREVERSEDINVOICESO@='Y' | @HASREVERSEDINVOICEPO@='Y' | @Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@HASREVERSEDINVOICESO@='Y' | @HASREVERSEDINVOICEPO@='Y' | @Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "toCurrency": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@HASREVERSEDINVOICESO@='Y' | @HASREVERSEDINVOICEPO@='Y' | @Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "rate": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@HASREVERSEDINVOICESO@='Y' | @HASREVERSEDINVOICEPO@='Y' | @Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "foreignAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@HASREVERSEDINVOICESO@='Y' | @HASREVERSEDINVOICEPO@='Y' | @Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "usedCreditSource": {
+        "fields": {
+          "creditPaymentUsed": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "amount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "accounting": {
+        "fields": {
+          "accountingSchema": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "period": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "accountingDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "account": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "debit": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "credit": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "product": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "asset": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/payment-out/generated/web/payment-out/HeaderPage.jsx
+++ b/artifacts/payment-out/generated/web/payment-out/HeaderPage.jsx
@@ -443,54 +443,214 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "aPRMAddScheduledpayments",
+      "label": "Add Details",
+      "actionType": "paymentAction",
       "entity": "header",
-      "field": "aPRMAddScheduledpayments",
       "column": "EM_Aprm_Add_Scheduledpayments",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/payment-out/header/{id}/action/aPRMAddScheduledpayments",
+      "method": "POST",
       "url": "/sws/neo/payment-out/header/{id}/action/aPRMAddScheduledpayments",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "9BED7889E1034FE68BD85D5D16857320",
       "processType": "obuiapp"
     },
     {
+      "name": "posted",
+      "label": "Posted",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "posted",
       "column": "Posted",
-      "url": "/sws/neo/payment-out/header/{id}/action/posted"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/payment-out/header/{id}/action/posted",
+      "method": "POST",
+      "url": "/sws/neo/payment-out/header/{id}/action/posted",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "aPRMProcessPayment",
+      "label": "Payment Process",
+      "actionType": "paymentAction",
       "entity": "header",
-      "field": "aPRMProcessPayment",
       "column": "EM_APRM_Process_Payment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/payment-out/header/{id}/action/aPRMProcessPayment",
+      "method": "POST",
       "url": "/sws/neo/payment-out/header/{id}/action/aPRMProcessPayment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "6255BE488882480599C81284B70CD9B3",
       "processType": "classic"
     },
     {
+      "name": "aprmExecutepayment",
+      "label": "Execute Payment",
+      "actionType": "paymentAction",
       "entity": "header",
-      "field": "aprmExecutepayment",
       "column": "EM_Aprm_Executepayment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/payment-out/header/{id}/action/aprmExecutepayment",
+      "method": "POST",
       "url": "/sws/neo/payment-out/header/{id}/action/aprmExecutepayment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "E011F492B0814A74B63CD1F3B9FF0526",
       "processType": "classic"
     },
     {
+      "name": "aPRMReversePayment",
+      "label": "Reverse Payment",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "aPRMReversePayment",
       "column": "EM_APRM_ReversePayment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/payment-out/header/{id}/action/aPRMReversePayment",
+      "method": "POST",
       "url": "/sws/neo/payment-out/header/{id}/action/aPRMReversePayment",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "29D17F515727436DBCE32BC6CA28382B",
       "processType": "classic"
     },
     {
+      "name": "aPRMReconcilePayment",
+      "label": "Reconcile Payment",
+      "actionType": "paymentAction",
       "entity": "header",
-      "field": "aPRMReconcilePayment",
       "column": "EM_APRM_Reconcile_Payment",
-      "url": "/sws/neo/payment-out/header/{id}/action/aPRMReconcilePayment"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/payment-out/header/{id}/action/aPRMReconcilePayment",
+      "method": "POST",
+      "url": "/sws/neo/payment-out/header/{id}/action/aPRMReconcilePayment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "aeatsiiSend",
+      "label": "EM_Aeatsii_Send",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "aeatsiiSend",
       "column": "EM_Aeatsii_Send",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/payment-out/header/{id}/action/aeatsiiSend",
+      "method": "POST",
       "url": "/sws/neo/payment-out/header/{id}/action/aeatsiiSend",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "EA02D79CA1DE4B46909EA6EF64A66B53",
       "processType": "obuiapp"
     }

--- a/artifacts/payment-term/contract.json
+++ b/artifacts/payment-term/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T19:06:55.269Z",
-  "updatedAt": "2026-05-12T19:44:32.752Z",
-  "checksum": "41bc87f1b0f35514",
+  "updatedAt": "2026-05-15T16:33:40.394Z",
+  "checksum": "d4c158ee909f6dc2",
   "frontendContract": {
     "window": {
       "id": "141",
@@ -421,6 +421,66 @@
         "IsActive": "Activo"
       }
     }
+  },
+  "formState": {
+    "entities": {
+      "header": {
+        "fields": {
+          "searchKey": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "name": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "offsetMonthDue": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "overduePaymentDaysRule": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "default": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/physical-inventory/contract.json
+++ b/artifacts/physical-inventory/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.17.0",
   "generatedAt": "2026-04-29T19:05:48.442Z",
-  "updatedAt": "2026-05-15T16:28:10.784Z",
-  "checksum": "4e6a1bf74992155a",
+  "updatedAt": "2026-05-15T16:33:39.571Z",
+  "checksum": "3e7936d659733fc1",
   "frontendContract": {
     "window": {
       "id": "168",
@@ -1179,6 +1179,190 @@
     "window": {
       "category": "inventory"
     }
+  },
+  "formState": {
+    "entities": {
+      "inventory": {
+        "fields": {
+          "movementDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "name": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "warehouse": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "processNow": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "inventoryType": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "processed": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "inventoryLine": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM M_InventoryLine WHERE M_Inventory_ID=@M_Inventory_ID@",
+            "provenance": "extracted"
+          },
+          "product": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "storageBin": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT M_LOCATOR_ID AS DEFAULTVALUE FROM M_LOCATOR WHERE AD_ISORGINCLUDED(@AD_Org_ID@, M_LOCATOR.AD_Org_ID, @#AD_Client_ID@) <> -1 AND ISACTIVE='Y' AND M_WAREHOUSE_ID=@M_WAREHOUSE_ID@  ORDER BY M_LOCATOR.ISDEFAULT DESC",
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "quantityOrderBook": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "quantityCount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "uOM": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "bookQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cost": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/physical-inventory/contract.json
+++ b/artifacts/physical-inventory/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.17.0",
   "generatedAt": "2026-04-29T19:05:48.442Z",
-  "updatedAt": "2026-05-11T16:22:46.243Z",
-  "checksum": "94f86c1d168d824b",
+  "updatedAt": "2026-05-15T16:28:10.784Z",
+  "checksum": "4e6a1bf74992155a",
   "frontendContract": {
     "window": {
       "id": "168",
@@ -1028,34 +1028,139 @@
     ],
     "actions": [
       {
+        "name": "generateList",
+        "label": "Create Inventory Count List",
+        "actionType": "createFrom",
         "entity": "inventory",
-        "field": "generateList",
         "column": "GenerateList",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/physical-inventory/inventory/{id}/action/generateList",
+        "method": "POST",
         "url": "/sws/neo/physical-inventory/inventory/{id}/action/generateList",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "105",
         "processType": "classic"
       },
       {
+        "name": "updateQuantities",
+        "label": "Update Quantity",
+        "actionType": "utilityAction",
         "entity": "inventory",
-        "field": "updateQuantities",
         "column": "UpdateQty",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/physical-inventory/inventory/{id}/action/updateQuantities",
+        "method": "POST",
         "url": "/sws/neo/physical-inventory/inventory/{id}/action/updateQuantities",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "106",
         "processType": "classic"
       },
       {
+        "name": "processNow",
+        "label": "Process Inventory Count",
+        "actionType": "documentAction",
         "entity": "inventory",
-        "field": "processNow",
         "column": "Processing",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/physical-inventory/inventory/{id}/action/processNow",
+        "method": "POST",
         "url": "/sws/neo/physical-inventory/inventory/{id}/action/processNow",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "107",
         "processType": "classic"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "inventory",
-        "field": "posted",
         "column": "Posted",
-        "url": "/sws/neo/physical-inventory/inventory/{id}/action/posted"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/physical-inventory/inventory/{id}/action/posted",
+        "method": "POST",
+        "url": "/sws/neo/physical-inventory/inventory/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted"
       }
     ],
     "queryParams": {

--- a/artifacts/physical-inventory/generated/web/physical-inventory/InventoryPage.jsx
+++ b/artifacts/physical-inventory/generated/web/physical-inventory/InventoryPage.jsx
@@ -132,34 +132,139 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "generateList",
+      "label": "Create Inventory Count List",
+      "actionType": "createFrom",
       "entity": "inventory",
-      "field": "generateList",
       "column": "GenerateList",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/physical-inventory/inventory/{id}/action/generateList",
+      "method": "POST",
       "url": "/sws/neo/physical-inventory/inventory/{id}/action/generateList",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "105",
       "processType": "classic"
     },
     {
+      "name": "updateQuantities",
+      "label": "Update Quantity",
+      "actionType": "utilityAction",
       "entity": "inventory",
-      "field": "updateQuantities",
       "column": "UpdateQty",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/physical-inventory/inventory/{id}/action/updateQuantities",
+      "method": "POST",
       "url": "/sws/neo/physical-inventory/inventory/{id}/action/updateQuantities",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "106",
       "processType": "classic"
     },
     {
+      "name": "processNow",
+      "label": "Process Inventory Count",
+      "actionType": "documentAction",
       "entity": "inventory",
-      "field": "processNow",
       "column": "Processing",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/physical-inventory/inventory/{id}/action/processNow",
+      "method": "POST",
       "url": "/sws/neo/physical-inventory/inventory/{id}/action/processNow",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "107",
       "processType": "classic"
     },
     {
+      "name": "posted",
+      "label": "Posted",
+      "actionType": "documentAction",
       "entity": "inventory",
-      "field": "posted",
       "column": "Posted",
-      "url": "/sws/neo/physical-inventory/inventory/{id}/action/posted"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/physical-inventory/inventory/{id}/action/posted",
+      "method": "POST",
+      "url": "/sws/neo/physical-inventory/inventory/{id}/action/posted",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted"
     }
   ],
   "queryParams": {

--- a/artifacts/price-list/contract.json
+++ b/artifacts/price-list/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.2.0",
   "generatedAt": "2026-04-29T18:12:11.134Z",
-  "updatedAt": "2026-05-12T19:44:24.001Z",
-  "checksum": "f660c4f25f448e0b",
+  "updatedAt": "2026-05-15T16:28:11.516Z",
+  "checksum": "2fffe47ceb47ae09",
   "frontendContract": {
     "window": {
       "id": "146",
@@ -1025,18 +1025,54 @@
     ],
     "actions": [
       {
+        "name": "create",
+        "label": "Create Price List",
+        "actionType": "createFrom",
         "entity": "priceListVersion",
-        "field": "create",
         "column": "ProcCreate",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/price-list/priceListVersion/{id}/action/create",
+        "method": "POST",
         "url": "/sws/neo/price-list/priceListVersion/{id}/action/create",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "103",
         "processType": "classic"
       },
       {
+        "name": "generatePriceListVersion",
+        "label": "Create Price List Version",
+        "actionType": "createFrom",
         "entity": "priceListVersion",
-        "field": "generatePriceListVersion",
         "column": "M_Pricelist_Version_Generate",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/price-list/priceListVersion/{id}/action/generatePriceListVersion",
+        "method": "POST",
         "url": "/sws/neo/price-list/priceListVersion/{id}/action/generatePriceListVersion",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "800069",
         "processType": "classic"
       }

--- a/artifacts/price-list/contract.json
+++ b/artifacts/price-list/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.2.0",
   "generatedAt": "2026-04-29T18:12:11.134Z",
-  "updatedAt": "2026-05-15T16:28:11.516Z",
-  "checksum": "2fffe47ceb47ae09",
+  "updatedAt": "2026-05-15T16:33:40.294Z",
+  "checksum": "a32f5e13b735ef1d",
   "frontendContract": {
     "window": {
       "id": "146",
@@ -1102,6 +1102,204 @@
         "IsDefault": "Por defecto"
       }
     }
+  },
+  "formState": {
+    "entities": {
+      "priceList": {
+        "fields": {
+          "name": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "salesPriceList": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costBasedPriceList": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "priceIncludesTax": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "default": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "priceListVersion": {
+        "fields": {
+          "name": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "validFromDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "priceListSchema": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "basePriceListVersion": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "create": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "productPrice": {
+        "fields": {
+          "product": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "standardPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "listPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cost": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "algorithm": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "S",
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/price-list/generated/web/price-list/PriceListPage.jsx
+++ b/artifacts/price-list/generated/web/price-list/PriceListPage.jsx
@@ -142,18 +142,54 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "create",
+      "label": "Create Price List",
+      "actionType": "createFrom",
       "entity": "priceListVersion",
-      "field": "create",
       "column": "ProcCreate",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/price-list/priceListVersion/{id}/action/create",
+      "method": "POST",
       "url": "/sws/neo/price-list/priceListVersion/{id}/action/create",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "103",
       "processType": "classic"
     },
     {
+      "name": "generatePriceListVersion",
+      "label": "Create Price List Version",
+      "actionType": "createFrom",
       "entity": "priceListVersion",
-      "field": "generatePriceListVersion",
       "column": "M_Pricelist_Version_Generate",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/price-list/priceListVersion/{id}/action/generatePriceListVersion",
+      "method": "POST",
       "url": "/sws/neo/price-list/priceListVersion/{id}/action/generatePriceListVersion",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "800069",
       "processType": "classic"
     }

--- a/artifacts/product-category/contract.json
+++ b/artifacts/product-category/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T18:11:26.703Z",
-  "updatedAt": "2026-05-12T19:44:04.462Z",
-  "checksum": "74f6fa4c44a9e396",
+  "updatedAt": "2026-05-15T16:28:10.683Z",
+  "checksum": "14f761cdaf5aefc3",
   "frontendContract": {
     "window": {
       "id": "144",
@@ -1452,66 +1452,221 @@
     "selectors": [],
     "actions": [
       {
+        "name": "processNow",
+        "label": "Verify BOM",
+        "actionType": "documentAction",
         "entity": "assignedProducts",
-        "field": "processNow",
         "column": "Processing",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product-category/assignedProducts/{id}/action/processNow",
+        "method": "POST",
         "url": "/sws/neo/product-category/assignedProducts/{id}/action/processNow",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "136",
         "processType": "classic"
       },
       {
+        "name": "copyservicemodifytaxconfig",
+        "label": "Copyservicemodifytaxconfig",
+        "actionType": "utilityAction",
         "entity": "assignedProducts",
-        "field": "copyservicemodifytaxconfig",
         "column": "Copyservicemodifytaxconfig",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product-category/assignedProducts/{id}/action/copyservicemodifytaxconfig",
+        "method": "POST",
         "url": "/sws/neo/product-category/assignedProducts/{id}/action/copyservicemodifytaxconfig",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "CBBD7BB6BDFE4705B68DD3D9FF788D4E",
         "processType": "obuiapp"
       },
       {
+        "name": "createVariants",
+        "label": "CreateVariants",
+        "actionType": "createFrom",
         "entity": "assignedProducts",
-        "field": "createVariants",
         "column": "CreateVariants",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product-category/assignedProducts/{id}/action/createVariants",
+        "method": "POST",
         "url": "/sws/neo/product-category/assignedProducts/{id}/action/createVariants",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "3C386BC12832466790E50F2F8C5EBD85",
         "processType": "classic"
       },
       {
+        "name": "manageVariants",
+        "label": "ManageVariants",
+        "actionType": "utilityAction",
         "entity": "assignedProducts",
-        "field": "manageVariants",
         "column": "ManageVariants",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product-category/assignedProducts/{id}/action/manageVariants",
+        "method": "POST",
         "url": "/sws/neo/product-category/assignedProducts/{id}/action/manageVariants",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "FE3A8C134D41488DB3A69837BD54B56A",
         "processType": "obuiapp"
       },
       {
+        "name": "relateprodcattaxtoservice",
+        "label": "Relateprodcattaxtoservice",
+        "actionType": "utilityAction",
         "entity": "assignedProducts",
-        "field": "relateprodcattaxtoservice",
         "column": "Relateprodcattaxtoservice",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product-category/assignedProducts/{id}/action/relateprodcattaxtoservice",
+        "method": "POST",
         "url": "/sws/neo/product-category/assignedProducts/{id}/action/relateprodcattaxtoservice",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "E0870062F05F4DC88E589ABC6A45DF4C",
         "processType": "obuiapp"
       },
       {
+        "name": "relateprodcattoservice",
+        "label": "Relateprodcattoservice",
+        "actionType": "utilityAction",
         "entity": "assignedProducts",
-        "field": "relateprodcattoservice",
         "column": "Relateprodcattoservice",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product-category/assignedProducts/{id}/action/relateprodcattoservice",
+        "method": "POST",
         "url": "/sws/neo/product-category/assignedProducts/{id}/action/relateprodcattoservice",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "8E5996F1F3154B498468938B5341A0CB",
         "processType": "obuiapp"
       },
       {
+        "name": "relateprodtoservice",
+        "label": "Relateprodtoservice",
+        "actionType": "utilityAction",
         "entity": "assignedProducts",
-        "field": "relateprodtoservice",
         "column": "Relateprodtoservice",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product-category/assignedProducts/{id}/action/relateprodtoservice",
+        "method": "POST",
         "url": "/sws/neo/product-category/assignedProducts/{id}/action/relateprodtoservice",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "E66C669B0B01498C8EB3F99CD371CF9A",
         "processType": "obuiapp"
       },
       {
+        "name": "updateInvariants",
+        "label": "Updateinvariants",
+        "actionType": "utilityAction",
         "entity": "assignedProducts",
-        "field": "updateInvariants",
         "column": "Updateinvariants",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product-category/assignedProducts/{id}/action/updateInvariants",
+        "method": "POST",
         "url": "/sws/neo/product-category/assignedProducts/{id}/action/updateInvariants",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "7DC2C8DC186B4C1DB18E147911950861",
         "processType": "obuiapp"
       }

--- a/artifacts/product-category/contract.json
+++ b/artifacts/product-category/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T18:11:26.703Z",
-  "updatedAt": "2026-05-15T16:28:10.683Z",
-  "checksum": "14f761cdaf5aefc3",
+  "updatedAt": "2026-05-15T16:33:39.468Z",
+  "checksum": "aefa9396313175e8",
   "frontendContract": {
     "window": {
       "id": "144",
@@ -1687,6 +1687,110 @@
     "window": {
       "category": "inventory"
     }
+  },
+  "formState": {
+    "entities": {
+      "productCategory": {
+        "fields": {
+          "searchKey": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "name": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "default": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "summaryLevel": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "image": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "assignedProducts": {
+        "fields": {
+          "searchKey": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "name": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "productType": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "I",
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/product-category/generated/web/product-category/ProductCategoryPage.jsx
+++ b/artifacts/product-category/generated/web/product-category/ProductCategoryPage.jsx
@@ -88,66 +88,221 @@ export const api = {
   "selectors": [],
   "actions": [
     {
+      "name": "processNow",
+      "label": "Verify BOM",
+      "actionType": "documentAction",
       "entity": "assignedProducts",
-      "field": "processNow",
       "column": "Processing",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product-category/assignedProducts/{id}/action/processNow",
+      "method": "POST",
       "url": "/sws/neo/product-category/assignedProducts/{id}/action/processNow",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "136",
       "processType": "classic"
     },
     {
+      "name": "copyservicemodifytaxconfig",
+      "label": "Copyservicemodifytaxconfig",
+      "actionType": "utilityAction",
       "entity": "assignedProducts",
-      "field": "copyservicemodifytaxconfig",
       "column": "Copyservicemodifytaxconfig",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product-category/assignedProducts/{id}/action/copyservicemodifytaxconfig",
+      "method": "POST",
       "url": "/sws/neo/product-category/assignedProducts/{id}/action/copyservicemodifytaxconfig",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "CBBD7BB6BDFE4705B68DD3D9FF788D4E",
       "processType": "obuiapp"
     },
     {
+      "name": "createVariants",
+      "label": "CreateVariants",
+      "actionType": "createFrom",
       "entity": "assignedProducts",
-      "field": "createVariants",
       "column": "CreateVariants",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product-category/assignedProducts/{id}/action/createVariants",
+      "method": "POST",
       "url": "/sws/neo/product-category/assignedProducts/{id}/action/createVariants",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "3C386BC12832466790E50F2F8C5EBD85",
       "processType": "classic"
     },
     {
+      "name": "manageVariants",
+      "label": "ManageVariants",
+      "actionType": "utilityAction",
       "entity": "assignedProducts",
-      "field": "manageVariants",
       "column": "ManageVariants",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product-category/assignedProducts/{id}/action/manageVariants",
+      "method": "POST",
       "url": "/sws/neo/product-category/assignedProducts/{id}/action/manageVariants",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "FE3A8C134D41488DB3A69837BD54B56A",
       "processType": "obuiapp"
     },
     {
+      "name": "relateprodcattaxtoservice",
+      "label": "Relateprodcattaxtoservice",
+      "actionType": "utilityAction",
       "entity": "assignedProducts",
-      "field": "relateprodcattaxtoservice",
       "column": "Relateprodcattaxtoservice",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product-category/assignedProducts/{id}/action/relateprodcattaxtoservice",
+      "method": "POST",
       "url": "/sws/neo/product-category/assignedProducts/{id}/action/relateprodcattaxtoservice",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "E0870062F05F4DC88E589ABC6A45DF4C",
       "processType": "obuiapp"
     },
     {
+      "name": "relateprodcattoservice",
+      "label": "Relateprodcattoservice",
+      "actionType": "utilityAction",
       "entity": "assignedProducts",
-      "field": "relateprodcattoservice",
       "column": "Relateprodcattoservice",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product-category/assignedProducts/{id}/action/relateprodcattoservice",
+      "method": "POST",
       "url": "/sws/neo/product-category/assignedProducts/{id}/action/relateprodcattoservice",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "8E5996F1F3154B498468938B5341A0CB",
       "processType": "obuiapp"
     },
     {
+      "name": "relateprodtoservice",
+      "label": "Relateprodtoservice",
+      "actionType": "utilityAction",
       "entity": "assignedProducts",
-      "field": "relateprodtoservice",
       "column": "Relateprodtoservice",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product-category/assignedProducts/{id}/action/relateprodtoservice",
+      "method": "POST",
       "url": "/sws/neo/product-category/assignedProducts/{id}/action/relateprodtoservice",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "E66C669B0B01498C8EB3F99CD371CF9A",
       "processType": "obuiapp"
     },
     {
+      "name": "updateInvariants",
+      "label": "Updateinvariants",
+      "actionType": "utilityAction",
       "entity": "assignedProducts",
-      "field": "updateInvariants",
       "column": "Updateinvariants",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product-category/assignedProducts/{id}/action/updateInvariants",
+      "method": "POST",
       "url": "/sws/neo/product-category/assignedProducts/{id}/action/updateInvariants",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "7DC2C8DC186B4C1DB18E147911950861",
       "processType": "obuiapp"
     }

--- a/artifacts/product/contract.json
+++ b/artifacts/product/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.2.0",
   "generatedAt": "2026-04-29T18:11:24.842Z",
-  "updatedAt": "2026-05-13T15:59:15.914Z",
-  "checksum": "a601a27239580ae0",
+  "updatedAt": "2026-05-15T16:28:10.571Z",
+  "checksum": "c94bc58c8c611d68",
   "frontendContract": {
     "window": {
       "id": "140",
@@ -4915,74 +4915,246 @@
     ],
     "actions": [
       {
+        "name": "manageVariants",
+        "label": "Manage Variants",
+        "actionType": "utilityAction",
         "entity": "product",
-        "field": "manageVariants",
         "column": "ManageVariants",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product/product/{id}/action/manageVariants",
+        "method": "POST",
         "url": "/sws/neo/product/product/{id}/action/manageVariants",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "FE3A8C134D41488DB3A69837BD54B56A",
         "processType": "obuiapp"
       },
       {
+        "name": "processNow",
+        "label": "Verify BOM",
+        "actionType": "documentAction",
         "entity": "product",
-        "field": "processNow",
         "column": "Processing",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product/product/{id}/action/processNow",
+        "method": "POST",
         "url": "/sws/neo/product/product/{id}/action/processNow",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "136",
         "processType": "classic"
       },
       {
+        "name": "createVariants",
+        "label": "Create Variants",
+        "actionType": "createFrom",
         "entity": "product",
-        "field": "createVariants",
         "column": "CreateVariants",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product/product/{id}/action/createVariants",
+        "method": "POST",
         "url": "/sws/neo/product/product/{id}/action/createVariants",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "3C386BC12832466790E50F2F8C5EBD85",
         "processType": "classic"
       },
       {
+        "name": "updateInvariants",
+        "label": "Update Characteristics",
+        "actionType": "utilityAction",
         "entity": "product",
-        "field": "updateInvariants",
         "column": "Updateinvariants",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product/product/{id}/action/updateInvariants",
+        "method": "POST",
         "url": "/sws/neo/product/product/{id}/action/updateInvariants",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "7DC2C8DC186B4C1DB18E147911950861",
         "processType": "obuiapp"
       },
       {
+        "name": "relateprodcattoservice",
+        "label": "Relate Prod Categories",
+        "actionType": "utilityAction",
         "entity": "product",
-        "field": "relateprodcattoservice",
         "column": "Relateprodcattoservice",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product/product/{id}/action/relateprodcattoservice",
+        "method": "POST",
         "url": "/sws/neo/product/product/{id}/action/relateprodcattoservice",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "8E5996F1F3154B498468938B5341A0CB",
         "processType": "obuiapp"
       },
       {
+        "name": "relateprodtoservice",
+        "label": "Relate Products",
+        "actionType": "utilityAction",
         "entity": "product",
-        "field": "relateprodtoservice",
         "column": "Relateprodtoservice",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product/product/{id}/action/relateprodtoservice",
+        "method": "POST",
         "url": "/sws/neo/product/product/{id}/action/relateprodtoservice",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "E66C669B0B01498C8EB3F99CD371CF9A",
         "processType": "obuiapp"
       },
       {
+        "name": "relateprodcattaxtoservice",
+        "label": "Modify Tax for Product Category",
+        "actionType": "utilityAction",
         "entity": "product",
-        "field": "relateprodcattaxtoservice",
         "column": "Relateprodcattaxtoservice",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product/product/{id}/action/relateprodcattaxtoservice",
+        "method": "POST",
         "url": "/sws/neo/product/product/{id}/action/relateprodcattaxtoservice",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "E0870062F05F4DC88E589ABC6A45DF4C",
         "processType": "obuiapp"
       },
       {
+        "name": "copyservicemodifytaxconfig",
+        "label": "Copy Service Modify Tax Configuration",
+        "actionType": "utilityAction",
         "entity": "product",
-        "field": "copyservicemodifytaxconfig",
         "column": "Copyservicemodifytaxconfig",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product/product/{id}/action/copyservicemodifytaxconfig",
+        "method": "POST",
         "url": "/sws/neo/product/product/{id}/action/copyservicemodifytaxconfig",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "CBBD7BB6BDFE4705B68DD3D9FF788D4E",
         "processType": "obuiapp"
       },
       {
+        "name": "manualcostadjustment",
+        "label": "Manual Cost Adjustment",
+        "actionType": "utilityAction",
         "entity": "transactions",
-        "field": "manualcostadjustment",
         "column": "Manualcostadjustment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/product/transactions/{id}/action/manualcostadjustment",
+        "method": "POST",
         "url": "/sws/neo/product/transactions/{id}/action/manualcostadjustment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "D395B727675C45C98320F8A40E0768E7",
         "processType": "obuiapp"
       }

--- a/artifacts/product/contract.json
+++ b/artifacts/product/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.2.0",
   "generatedAt": "2026-04-29T18:11:24.842Z",
-  "updatedAt": "2026-05-15T16:28:10.571Z",
-  "checksum": "c94bc58c8c611d68",
+  "updatedAt": "2026-05-15T16:33:39.363Z",
+  "checksum": "6b1df83415e79717",
   "frontendContract": {
     "window": {
       "id": "140",
@@ -5175,6 +5175,806 @@
     "window": {
       "category": "inventory"
     }
+  },
+  "formState": {
+    "entities": {
+      "product": {
+        "fields": {
+          "searchKey": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "name": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "image": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "uOM": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "productCategory": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT MAX(M_PRODUCT_CATEGORY_ID) FROM M_PRODUCT_CATEGORY WHERE AD_ISORGINCLUDED(@AD_ORG_ID@, AD_ORG_ID, @#AD_CLIENT_ID@) <> -1 AND ISDEFAULT = 'Y' AND AD_CLIENT_ID = @#AD_CLIENT_ID@ AND ISSUMMARY='N'",
+            "provenance": "extracted"
+          },
+          "taxCategory": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "purchase": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "sale": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "productType": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "I",
+            "provenance": "extracted"
+          },
+          "stocked": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@ProductType@='R' | @ProductType@='E' | @ProductType@='O'",
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "weight": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "uOMForWeight": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "attributeSet": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "uPCEAN": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "brand": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "returnable": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "mProductStatusID": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "price": {
+        "fields": {
+          "priceListVersion": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "standardPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "listPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cost": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "priceRuleVersion": {
+        "fields": {
+          "active": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "validFromDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "servicePriceRule": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "billOfMaterials": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM M_Product_BOM WHERE M_Product_ID=@M_Product_ID@",
+            "provenance": "extracted"
+          },
+          "bOMProduct": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "bOMQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "1",
+            "provenance": "extracted"
+          },
+          "bomprice": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "costing": {
+        "fields": {
+          "costType": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cost": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "startingDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "endingDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "quantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "warehouse": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cCurrencyID": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "100",
+            "provenance": "extracted"
+          },
+          "originalCost": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "transactionAdjustments": {
+        "fields": {
+          "costDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cost": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cCurrencyID": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costAdjustmentLine": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "unitCost": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "accountingDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "transactions": {
+        "fields": {
+          "organization": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@AD_Org_ID@",
+            "provenance": "extracted"
+          },
+          "storageBin": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementType": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "totalCost": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "uOM": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "productCharacteristic": {
+        "fields": {
+          "sequenceNumber": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(SEQNO),0)+10 AS DefaultValue FROM M_PRODUCT_CH WHERE m_product_id=@m_product_id@",
+            "provenance": "extracted"
+          },
+          "characteristic": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "variant": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "explodeConfigurationTab": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "definesPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "priceListType": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "SALES",
+            "provenance": "extracted"
+          },
+          "definesImage": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "characteristicSubset": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "active": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "stock": {
+        "fields": {
+          "storageBin": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "attributeSetValue": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "uOM": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "quantityOnHand": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "reservedQty": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "allocatedQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "categoryPriceRuleVersion": {
+        "fields": {
+          "active": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "validFromDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "servicePriceRule": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "alternateUom": {
+        "fields": {
+          "uOM": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "conversionRate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@EXISTS_CONVERSION@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "gtin": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "sales": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "S",
+            "provenance": "extracted"
+          },
+          "purchase": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "S",
+            "provenance": "extracted"
+          },
+          "logistics": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "S",
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/product/generated/web/product/ProductPage.jsx
+++ b/artifacts/product/generated/web/product/ProductPage.jsx
@@ -360,74 +360,246 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "manageVariants",
+      "label": "Manage Variants",
+      "actionType": "utilityAction",
       "entity": "product",
-      "field": "manageVariants",
       "column": "ManageVariants",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product/product/{id}/action/manageVariants",
+      "method": "POST",
       "url": "/sws/neo/product/product/{id}/action/manageVariants",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "FE3A8C134D41488DB3A69837BD54B56A",
       "processType": "obuiapp"
     },
     {
+      "name": "processNow",
+      "label": "Verify BOM",
+      "actionType": "documentAction",
       "entity": "product",
-      "field": "processNow",
       "column": "Processing",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product/product/{id}/action/processNow",
+      "method": "POST",
       "url": "/sws/neo/product/product/{id}/action/processNow",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "136",
       "processType": "classic"
     },
     {
+      "name": "createVariants",
+      "label": "Create Variants",
+      "actionType": "createFrom",
       "entity": "product",
-      "field": "createVariants",
       "column": "CreateVariants",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product/product/{id}/action/createVariants",
+      "method": "POST",
       "url": "/sws/neo/product/product/{id}/action/createVariants",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "3C386BC12832466790E50F2F8C5EBD85",
       "processType": "classic"
     },
     {
+      "name": "updateInvariants",
+      "label": "Update Characteristics",
+      "actionType": "utilityAction",
       "entity": "product",
-      "field": "updateInvariants",
       "column": "Updateinvariants",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product/product/{id}/action/updateInvariants",
+      "method": "POST",
       "url": "/sws/neo/product/product/{id}/action/updateInvariants",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "7DC2C8DC186B4C1DB18E147911950861",
       "processType": "obuiapp"
     },
     {
+      "name": "relateprodcattoservice",
+      "label": "Relate Prod Categories",
+      "actionType": "utilityAction",
       "entity": "product",
-      "field": "relateprodcattoservice",
       "column": "Relateprodcattoservice",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product/product/{id}/action/relateprodcattoservice",
+      "method": "POST",
       "url": "/sws/neo/product/product/{id}/action/relateprodcattoservice",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "8E5996F1F3154B498468938B5341A0CB",
       "processType": "obuiapp"
     },
     {
+      "name": "relateprodtoservice",
+      "label": "Relate Products",
+      "actionType": "utilityAction",
       "entity": "product",
-      "field": "relateprodtoservice",
       "column": "Relateprodtoservice",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product/product/{id}/action/relateprodtoservice",
+      "method": "POST",
       "url": "/sws/neo/product/product/{id}/action/relateprodtoservice",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "E66C669B0B01498C8EB3F99CD371CF9A",
       "processType": "obuiapp"
     },
     {
+      "name": "relateprodcattaxtoservice",
+      "label": "Modify Tax for Product Category",
+      "actionType": "utilityAction",
       "entity": "product",
-      "field": "relateprodcattaxtoservice",
       "column": "Relateprodcattaxtoservice",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product/product/{id}/action/relateprodcattaxtoservice",
+      "method": "POST",
       "url": "/sws/neo/product/product/{id}/action/relateprodcattaxtoservice",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "E0870062F05F4DC88E589ABC6A45DF4C",
       "processType": "obuiapp"
     },
     {
+      "name": "copyservicemodifytaxconfig",
+      "label": "Copy Service Modify Tax Configuration",
+      "actionType": "utilityAction",
       "entity": "product",
-      "field": "copyservicemodifytaxconfig",
       "column": "Copyservicemodifytaxconfig",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product/product/{id}/action/copyservicemodifytaxconfig",
+      "method": "POST",
       "url": "/sws/neo/product/product/{id}/action/copyservicemodifytaxconfig",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "CBBD7BB6BDFE4705B68DD3D9FF788D4E",
       "processType": "obuiapp"
     },
     {
+      "name": "manualcostadjustment",
+      "label": "Manual Cost Adjustment",
+      "actionType": "utilityAction",
       "entity": "transactions",
-      "field": "manualcostadjustment",
       "column": "Manualcostadjustment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/product/transactions/{id}/action/manualcostadjustment",
+      "method": "POST",
       "url": "/sws/neo/product/transactions/{id}/action/manualcostadjustment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "D395B727675C45C98320F8A40E0768E7",
       "processType": "obuiapp"
     }

--- a/artifacts/purchase-invoice/contract.json
+++ b/artifacts/purchase-invoice/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.27.0",
   "generatedAt": "2026-04-30T15:42:46.722Z",
-  "updatedAt": "2026-05-15T16:28:10.238Z",
-  "checksum": "a27657ddfa2fe628",
+  "updatedAt": "2026-05-15T16:33:39.037Z",
+  "checksum": "f566b73d953107c3",
   "frontendContract": {
     "window": {
       "id": "183",
@@ -9189,6 +9189,1490 @@
         "em_etgo_delivery_status": "Delivery Status"
       }
     }
+  },
+  "formState": {
+    "entities": {
+      "header": {
+        "fields": {
+          "transactionDocument": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoiceDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y' | (@Processed@='Y' & (@DocStatus@!'VO'))",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @HAS_C_INVOICELINES@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "partnerAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "priceList": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "accountingDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "paymentTerms": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "salesOrder": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderReference": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "DR",
+            "provenance": "extracted"
+          },
+          "grandTotalAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "summedLineAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@C_Currency_ID@",
+            "provenance": "extracted"
+          },
+          "paymentComplete": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "userContact": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "totalPaid": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "outstandingAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "dueAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "salesRepresentative": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "chargeAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "charge": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "prepaymentAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "etsgDateOperation": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@DateInvoiced@",
+            "provenance": "extracted"
+          },
+          "aeatsiiIssent": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "true",
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "aeatsiiFechaRegCont": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@AEATSII_InSIIAndPostedInvoices@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT CASE WHEN ((SELECT c.insiisystem FROM aeatsii_config c WHERE c.ad_org_id = (SELECT ad_get_org_le_bu(@AD_Org_ID@,'LE') FROM dual))='Y' AND (SELECT c.posted_invoices FROM aeatsii_config c WHERE c.ad_org_id = (SELECT ad_get_org_le_bu(@AD_Org_ID@,'LE') FROM dual))='Y') THEN null ELSE now() END FROM dual",
+            "provenance": "extracted"
+          },
+          "aeatsiiClaveTipoFc": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "(@em_aeatsii_estado@='CO' | @em_aeatsii_estado@='AE' | @DocStatus@='VO') & @Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT CASE WHEN ((SELECT c.insiisystem FROM aeatsii_config c WHERE c.ad_org_id = (SELECT ad_get_org_le_bu(@AD_Org_ID@,'LE') FROM dual))='Y') THEN 'F1' ELSE null END FROM dual",
+            "provenance": "extracted"
+          },
+          "aeatsiiPurDescription": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "(@em_aeatsii_estado@='CO' | @em_aeatsii_estado@='AE' | (@DocStatus@='VO' & @em_aeatsii_issent@='N')) & @Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=\n\tSELECT\n\t\tCASE\n\t\t\tWHEN\n\t\t\t\t(\n\t\t\t\t\t(\n\t\t\t\t\t\tSELECT c.insiisystem\n\t\t\t\t\t\tFROM aeatsii_config c\n\t\t\t\t\t\tWHERE c.ad_org_id = (\n\t\t\t\t\t\t\tSELECT ad_get_org_le_bu(@AD_Org_ID@,'LE')\n\t\t\t\t\t\t\tFROM dual\n\t\t\t\t\t\t)\n\t\t\t\t\t)='Y'\n\t\t\t\t)\n\t\t\tTHEN\n\t\t\t\t(\n\t\t\t\t\tSELECT\n\t\t\t\t\t\t(\n\t\t\t\t\t\t\tCASE\n\t\t\t\t\t\t\t\tWHEN (@issotrx@ = 'Y')\n\t\t\t\t\t\t\t\tTHEN (null)\n\t\t\t\t\t\t\t\tELSE (\n\t\t\t\t\t\t\t\t\tSELECT aeatsii_description_id\n\t\t\t\t\t\t\t\t\tFROM aeatsii_description\n\t\t\t\t\t\t\t\t\tWHERE isdefault = 'Y'\n\t\t\t\t\t\t\t\t\tAND ispurchase = 'Y'\n\t\t\t\t\t\t\t\t\tAND ad_org_id = @AD_Org_ID@\n\t\t\t\t\t\t\t\t\tAND ad_client_id = @ad_client_id@\n\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\tEND\n\t\t\t\t\t\t)\n\t\t\t\t\tFROM dual\n\t\t\t\t)\n\t\t\tELSE null\n\t\tEND\n\tFROM dual",
+            "provenance": "extracted"
+          },
+          "aeatsiiDescripcionSii": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "(@em_aeatsii_estado@='CO' | @em_aeatsii_estado@='AE' | (@DocStatus@='VO' & @em_aeatsii_issent@='Y')) & @Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=\n\tSELECT\n\t\tCASE\n\t\t\tWHEN\n\t\t\t\t(\n\t\t\t\t\t(\n\t\t\t\t\t\tSELECT c.insiisystem\n\t\t\t\t\t\tFROM aeatsii_config c\n\t\t\t\t\t\tWHERE c.ad_org_id = (\n\t\t\t\t\t\t\tSELECT ad_get_org_le_bu(@AD_Org_ID@,'LE')\n\t\t\t\t\t\t\tFROM dual\n\t\t\t\t\t\t)\n\t\t\t\t\t)='Y'\n\t\t\t\t)\n\t\t\tTHEN\n\t\t\t\t(\n\t\t\t\t\tSELECT\n\t\t\t\t\t\t(\n\t\t\t\t\t\t\tCASE\n\t\t\t\t\t\t\t\tWHEN(@issotrx@ = 'Y')\n\t\t\t\t\t\t\t\tTHEN (\n\t\t\t\t\t\t\t\t\tSELECT description\n\t\t\t\t\t\t\t\t\tFROM aeatsii_description\n\t\t\t\t\t\t\t\t\tWHERE isdefault = 'Y'\n\t\t\t\t\t\t\t\t\tAND issales = 'Y'\n\t\t\t\t\t\t\t\t\tAND ad_org_id = @AD_Org_ID@\n\t\t\t\t\t\t\t\t\tAND ad_client_id = @ad_client_id@\n\t\t\t\t\t\t\t\t) ELSE (\n\t\t\t\t\t\t\t\t\tSELECT description\n\t\t\t\t\t\t\t\t\tFROM aeatsii_description\n\t\t\t\t\t\t\t\t\tWHERE isdefault = 'Y'\n\t\t\t\t\t\t\t\t\tAND ispurchase = 'Y'\n\t\t\t\t\t\t\t\t\tAND ad_org_id = @AD_Org_ID@\n\t\t\t\t\t\t\t\t\tAND ad_client_id = @ad_client_id@\n\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\tEND\n\t\t\t\t\t\t)\n\t\t\t\t\tFROM dual\n\t\t\t\t)\n\t\t\tELSE null\n\t\tEND\n\tFROM dual",
+            "provenance": "extracted"
+          },
+          "aeatsiiEstado": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "true",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT CASE WHEN ((SELECT c.insiisystem FROM aeatsii_config c WHERE c.ad_org_id = (SELECT ad_get_org_le_bu(@AD_Org_ID@,'LE') FROM dual))='Y') THEN 'PE' ELSE null END FROM dual",
+            "provenance": "extracted"
+          },
+          "aeatsiiEjercicio": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "true",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "aeatsiiPeriodo": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "true",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "aeatsiiIsauthorization": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "tbaiIssent": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "aeatsiiCauseExemption": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etvfacDateIssue": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etvfacHash": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etvfacInvoiceStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etvfacIssueDescription": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etvfacQRURL": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etvfacSentToVerifac": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "etgoTotalDiscount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "eTGODueDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "eTGODeliveryStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "lines": {
+        "fields": {
+          "product": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoicedQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | (@UomManagement@='Y' & @Financial_Invoice_Line@='N')",
+            "calloutTriggers": null,
+            "defaultValue": "1",
+            "provenance": "extracted"
+          },
+          "listPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etgoDiscount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "tax": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "account": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "operativeQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "unitPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'|@GROSSPRICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "grossUnitPrice": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'|@GROSSPRICE@='N'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "grossAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "attributeSetValue": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "salesOrderLine": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "goodsShipmentLine": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxableAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "asset": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "intrastat": {
+        "fields": {
+          "invoiceLine": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "product": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "incoterms": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "transactionType": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "transportationType": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "portAirport": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "statisticalRegime": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "origCountry": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "nC8Code": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "netMassKg": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "hasSuplementaryUnit": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "conversionRate": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "staticalValue": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "supplementaryUOM": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "tax": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(LINE),0)+10 AS DefaultValue FROM C_INVOICETAX WHERE C_Invoice_ID=@C_Invoice_ID@",
+            "provenance": "extracted"
+          },
+          "tax": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @Recalculate@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @Recalculate@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxableAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @Recalculate@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "basicDiscounts": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(LINE),0)+10 AS DefaultValue FROM C_INVOICE_DISCOUNT WHERE C_INVOICE_ID=@C_INVOICE_ID@",
+            "provenance": "extracted"
+          },
+          "discount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cascade": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "cashVat": {
+        "fields": {
+          "paymentDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "percentage": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxableAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "canceled": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "payment": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "status": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "isManualSettlement": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "accountingDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "paymentPlan": {
+        "fields": {
+          "dueDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "expectedDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "amount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "paidAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "outstandingAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "lastPaymentDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "daysOverdue": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "numberOfPayments": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "paymentDetails": {
+        "fields": {
+          "amount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "writeoffAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "amount2": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "canceled": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "finPaymentID": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoicePaid": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "reversedInvoices": {
+        "fields": {
+          "reversedInvoice": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "accounting": {
+        "fields": {
+          "accountingSchema": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "period": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "accountingDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "account": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "debit": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "credit": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "product": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "asset": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "postingType": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "siiData": {
+        "fields": {
+          "conexinSII": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cdigoCSV": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "estadoRegistro": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "comunicacion": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "motivo": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "estadoCuadre": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "fechaCuadre": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "fechaltimaModificacinSII": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "batuz": {
+        "fields": {
+          "active": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "estado": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "descripcion": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoice": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/purchase-invoice/contract.json
+++ b/artifacts/purchase-invoice/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.27.0",
   "generatedAt": "2026-04-30T15:42:46.722Z",
-  "updatedAt": "2026-05-12T19:44:01.275Z",
-  "checksum": "819b8cb2efc41b2d",
+  "updatedAt": "2026-05-15T16:28:10.238Z",
+  "checksum": "a27657ddfa2fe628",
   "frontendContract": {
     "window": {
       "id": "183",
@@ -8022,7 +8022,15 @@
         "column": "C_DocTypeTarget_ID",
         "reference": "DocumentType",
         "inputMode": "selector",
-        "url": "/sws/neo/purchase-invoice/header/selectors/transactionDocument"
+        "url": "/sws/neo/purchase-invoice/header/selectors/transactionDocument",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -8038,7 +8046,16 @@
         "column": "C_BPartner_Location_ID",
         "reference": "BusinessPartnerLocation",
         "inputMode": "dependent",
-        "url": "/sws/neo/purchase-invoice/header/selectors/partnerAddress"
+        "url": "/sws/neo/purchase-invoice/header/selectors/partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -8046,7 +8063,15 @@
         "column": "M_PriceList_ID",
         "reference": "PriceList",
         "inputMode": "selector",
-        "url": "/sws/neo/purchase-invoice/header/selectors/priceList"
+        "url": "/sws/neo/purchase-invoice/header/selectors/priceList",
+        "context": {
+          "required": [
+            {
+              "param": "isSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -8062,7 +8087,15 @@
         "column": "FIN_Paymentmethod_ID",
         "reference": "PaymentMethod",
         "inputMode": "selector",
-        "url": "/sws/neo/purchase-invoice/header/selectors/paymentMethod"
+        "url": "/sws/neo/purchase-invoice/header/selectors/paymentMethod",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -8086,7 +8119,16 @@
         "column": "AD_User_ID",
         "reference": "User",
         "inputMode": "search",
-        "url": "/sws/neo/purchase-invoice/header/selectors/userContact"
+        "url": "/sws/neo/purchase-invoice/header/selectors/userContact",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -8110,7 +8152,20 @@
         "column": "C_Project_ID",
         "reference": "Project",
         "inputMode": "search",
-        "url": "/sws/neo/purchase-invoice/header/selectors/project"
+        "url": "/sws/neo/purchase-invoice/header/selectors/project",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -8142,7 +8197,22 @@
         "column": "C_Tax_ID",
         "reference": "Tax",
         "inputMode": "selector",
-        "url": "/sws/neo/purchase-invoice/lines/selectors/tax"
+        "url": "/sws/neo/purchase-invoice/lines/selectors/tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
       },
       {
         "entity": "lines",
@@ -8409,190 +8479,682 @@
     ],
     "actions": [
       {
+        "name": "generateTo",
+        "label": "Generate Receipt from Invoice",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "generateTo",
         "column": "GenerateTo",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/generateTo",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/generateTo",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "142",
         "processType": "classic"
       },
       {
+        "name": "aPRMAddpayment",
+        "label": "Add Payment",
+        "actionType": "paymentAction",
         "entity": "header",
-        "field": "aPRMAddpayment",
         "column": "EM_APRM_Addpayment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aPRMAddpayment",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/aPRMAddpayment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "9BED7889E1034FE68BD85D5D16857320",
         "processType": "obuiapp"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "posted",
         "column": "Posted",
-        "url": "/sws/neo/purchase-invoice/header/{id}/action/posted"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/posted",
+        "method": "POST",
+        "url": "/sws/neo/purchase-invoice/header/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "aPRMProcessinvoice",
+        "label": "Process Invoices",
+        "actionType": "paymentAction",
         "entity": "header",
-        "field": "aPRMProcessinvoice",
         "column": "EM_APRM_Processinvoice",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aPRMProcessinvoice",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/aPRMProcessinvoice",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "B54318B49E984B9CB855AEFB1F474CD6",
         "processType": "classic"
       },
       {
+        "name": "documentAction",
+        "label": "Process Invoice",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "documentAction",
         "column": "DocAction",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/documentAction",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/documentAction",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "111",
         "processType": "classic"
       },
       {
+        "name": "createLinesFromOrder",
+        "label": "Create Lines From Order",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createLinesFromOrder",
         "column": "Createfromorders",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFromOrder",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFromOrder",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "AB2EFCAABB7B4EC0A9B30CFB82963FB6",
         "processType": "obuiapp"
       },
       {
+        "name": "createLinesFromShipment",
+        "label": "Create Lines From Receipt",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createLinesFromShipment",
         "column": "Createfrominouts",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFromShipment",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFromShipment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "7737CA7330FD49FBA7EBC225E85F2BC9",
         "processType": "obuiapp"
       },
       {
+        "name": "copyFrom",
+        "label": "Copy Lines",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "copyFrom",
         "column": "CopyFrom",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/copyFrom",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/copyFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "210",
         "processType": "classic"
       },
       {
+        "name": "calculatePromotions",
+        "label": "Calculate_Promotions",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "calculatePromotions",
         "column": "Calculate_Promotions",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/calculatePromotions",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/calculatePromotions",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "9EB2228A60684C0DBEC12D5CD8D85218",
         "processType": "classic"
       },
       {
+        "name": "aeatsiiSend",
+        "label": "Send to SII",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "aeatsiiSend",
         "column": "EM_Aeatsii_Send",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiSend",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiSend",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "2ECF46DAAEEB486EAF79D3594D50DE5F",
         "processType": "obuiapp"
       },
       {
+        "name": "aeatsiiModif",
+        "label": "Modification in SII",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "aeatsiiModif",
         "column": "EM_Aeatsii_Modif",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiModif",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiModif",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "BAAECFDF9FF144E8A610E9F1EF3E5FBE",
         "processType": "obuiapp"
       },
       {
+        "name": "tbaiXmlgenerator",
+        "label": "Registrar Factura en Batuz",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "tbaiXmlgenerator",
         "column": "EM_Tbai_Xmlgenerator",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/tbaiXmlgenerator",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/tbaiXmlgenerator",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "BE2486102F2C41779B760609FD69A225",
         "processType": "obuiapp"
       },
       {
+        "name": "processNow",
+        "label": "Process Invoice",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "processNow",
         "column": "Processing",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/processNow",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/processNow",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "111",
         "processType": "classic"
       },
       {
+        "name": "createLinesFrom",
+        "label": "CreateFrom",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createLinesFrom",
         "column": "CreateFrom",
-        "url": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFrom"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFrom",
+        "method": "POST",
+        "url": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "aeatsiiDup",
+        "label": "EM_Aeatsii_Dup",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "aeatsiiDup",
         "column": "EM_Aeatsii_Dup",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiDup",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiDup",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "92C02F9A367140C085D1EE3BD27C4E96",
         "processType": "obuiapp"
       },
       {
+        "name": "aeatsiiUnsubscribe",
+        "label": "EM_Aeatsii_Unsubscribe",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "aeatsiiUnsubscribe",
         "column": "EM_Aeatsii_Unsubscribe",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiUnsubscribe",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiUnsubscribe",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "BE564945CB2D4892AC0EE51204C5DB7D",
         "processType": "obuiapp"
       },
       {
+        "name": "etvfacRectCreate",
+        "label": "EM_Etvfac_Rect_Create",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "etvfacRectCreate",
         "column": "EM_Etvfac_Rect_Create",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/etvfacRectCreate",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/etvfacRectCreate",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "E36A8BA259164E78AFDDC760172C18F5",
         "processType": "obuiapp"
       },
       {
+        "name": "tBAIQRcode",
+        "label": "em_tbai_qrcode",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "tBAIQRcode",
         "column": "em_tbai_qrcode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/tBAIQRcode",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/tBAIQRcode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "12FECC9DF1F4418AB7DAA46D6A05FEC6",
         "processType": "obuiapp"
       },
       {
+        "name": "tbaiVoidxmlgenerator",
+        "label": "EM_Tbai_Voidxmlgenerator",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "tbaiVoidxmlgenerator",
         "column": "EM_Tbai_Voidxmlgenerator",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/tbaiVoidxmlgenerator",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/tbaiVoidxmlgenerator",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "535A8BAE44A34759A7C8FF40D62A5070",
         "processType": "obuiapp"
       },
       {
+        "name": "explode",
+        "label": "Explode",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "explode",
         "column": "Explode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/lines/{id}/action/explode",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/lines/{id}/action/explode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "6E1ADD5C8B6B4ACB82237DAA8114451E",
         "processType": "classic"
       },
       {
+        "name": "matchLCCosts",
+        "label": "Match LC Costs",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "matchLCCosts",
         "column": "Match_Lccosts",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/lines/{id}/action/matchLCCosts",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/lines/{id}/action/matchLCCosts",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "281FFDFAB31C4394A2EAA73A6F9F3A3F",
         "processType": "obuiapp"
       },
       {
+        "name": "updatePaymentPlan",
+        "label": "Update Payment Plan",
+        "actionType": "paymentAction",
         "entity": "paymentPlan",
-        "field": "updatePaymentPlan",
         "column": "Update_Payment_Plan",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/updatePaymentPlan",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/updatePaymentPlan",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "FB740AB61B0E42B198D2C88D3A0D0CE6",
         "processType": "classic"
       },
       {
+        "name": "aprmModifPaymentOUTPlan",
+        "label": "Modify Payment Plan",
+        "actionType": "paymentAction",
         "entity": "paymentPlan",
-        "field": "aprmModifPaymentOUTPlan",
         "column": "EM_Aprm_Modif_Paym_Out_Sched",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/aprmModifPaymentOUTPlan",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/aprmModifPaymentOUTPlan",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "6F87442DF7BC43AB8A666BDED2F7D64E",
         "processType": "obuiapp"
       },
       {
+        "name": "aprmModifPaymentINPlan",
+        "label": "EM_Aprm_Modif_Paym_Sched",
+        "actionType": "paymentAction",
         "entity": "paymentPlan",
-        "field": "aprmModifPaymentINPlan",
         "column": "EM_Aprm_Modif_Paym_Sched",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/aprmModifPaymentINPlan",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/aprmModifPaymentINPlan",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "4EEB3497082C4F2182E16A4371CD5D96",
         "processType": "obuiapp"
       }

--- a/artifacts/purchase-invoice/contract.prev.json
+++ b/artifacts/purchase-invoice/contract.prev.json
@@ -1,8 +1,8 @@
 {
   "version": "0.27.0",
   "generatedAt": "2026-04-30T15:42:46.722Z",
-  "updatedAt": "2026-05-15T16:28:10.238Z",
-  "checksum": "a27657ddfa2fe628",
+  "updatedAt": "2026-05-15T16:33:39.037Z",
+  "checksum": "f566b73d953107c3",
   "frontendContract": {
     "window": {
       "id": "183",
@@ -9189,6 +9189,1490 @@
         "em_etgo_delivery_status": "Delivery Status"
       }
     }
+  },
+  "formState": {
+    "entities": {
+      "header": {
+        "fields": {
+          "transactionDocument": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoiceDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y' | (@Processed@='Y' & (@DocStatus@!'VO'))",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @HAS_C_INVOICELINES@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "partnerAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "priceList": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "accountingDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "paymentTerms": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "salesOrder": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderReference": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "DR",
+            "provenance": "extracted"
+          },
+          "grandTotalAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "summedLineAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@C_Currency_ID@",
+            "provenance": "extracted"
+          },
+          "paymentComplete": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "userContact": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "totalPaid": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "outstandingAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "dueAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "salesRepresentative": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "chargeAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "charge": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "prepaymentAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "etsgDateOperation": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@DateInvoiced@",
+            "provenance": "extracted"
+          },
+          "aeatsiiIssent": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "true",
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "aeatsiiFechaRegCont": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@AEATSII_InSIIAndPostedInvoices@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT CASE WHEN ((SELECT c.insiisystem FROM aeatsii_config c WHERE c.ad_org_id = (SELECT ad_get_org_le_bu(@AD_Org_ID@,'LE') FROM dual))='Y' AND (SELECT c.posted_invoices FROM aeatsii_config c WHERE c.ad_org_id = (SELECT ad_get_org_le_bu(@AD_Org_ID@,'LE') FROM dual))='Y') THEN null ELSE now() END FROM dual",
+            "provenance": "extracted"
+          },
+          "aeatsiiClaveTipoFc": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "(@em_aeatsii_estado@='CO' | @em_aeatsii_estado@='AE' | @DocStatus@='VO') & @Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT CASE WHEN ((SELECT c.insiisystem FROM aeatsii_config c WHERE c.ad_org_id = (SELECT ad_get_org_le_bu(@AD_Org_ID@,'LE') FROM dual))='Y') THEN 'F1' ELSE null END FROM dual",
+            "provenance": "extracted"
+          },
+          "aeatsiiPurDescription": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "(@em_aeatsii_estado@='CO' | @em_aeatsii_estado@='AE' | (@DocStatus@='VO' & @em_aeatsii_issent@='N')) & @Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=\n\tSELECT\n\t\tCASE\n\t\t\tWHEN\n\t\t\t\t(\n\t\t\t\t\t(\n\t\t\t\t\t\tSELECT c.insiisystem\n\t\t\t\t\t\tFROM aeatsii_config c\n\t\t\t\t\t\tWHERE c.ad_org_id = (\n\t\t\t\t\t\t\tSELECT ad_get_org_le_bu(@AD_Org_ID@,'LE')\n\t\t\t\t\t\t\tFROM dual\n\t\t\t\t\t\t)\n\t\t\t\t\t)='Y'\n\t\t\t\t)\n\t\t\tTHEN\n\t\t\t\t(\n\t\t\t\t\tSELECT\n\t\t\t\t\t\t(\n\t\t\t\t\t\t\tCASE\n\t\t\t\t\t\t\t\tWHEN (@issotrx@ = 'Y')\n\t\t\t\t\t\t\t\tTHEN (null)\n\t\t\t\t\t\t\t\tELSE (\n\t\t\t\t\t\t\t\t\tSELECT aeatsii_description_id\n\t\t\t\t\t\t\t\t\tFROM aeatsii_description\n\t\t\t\t\t\t\t\t\tWHERE isdefault = 'Y'\n\t\t\t\t\t\t\t\t\tAND ispurchase = 'Y'\n\t\t\t\t\t\t\t\t\tAND ad_org_id = @AD_Org_ID@\n\t\t\t\t\t\t\t\t\tAND ad_client_id = @ad_client_id@\n\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\tEND\n\t\t\t\t\t\t)\n\t\t\t\t\tFROM dual\n\t\t\t\t)\n\t\t\tELSE null\n\t\tEND\n\tFROM dual",
+            "provenance": "extracted"
+          },
+          "aeatsiiDescripcionSii": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "(@em_aeatsii_estado@='CO' | @em_aeatsii_estado@='AE' | (@DocStatus@='VO' & @em_aeatsii_issent@='Y')) & @Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=\n\tSELECT\n\t\tCASE\n\t\t\tWHEN\n\t\t\t\t(\n\t\t\t\t\t(\n\t\t\t\t\t\tSELECT c.insiisystem\n\t\t\t\t\t\tFROM aeatsii_config c\n\t\t\t\t\t\tWHERE c.ad_org_id = (\n\t\t\t\t\t\t\tSELECT ad_get_org_le_bu(@AD_Org_ID@,'LE')\n\t\t\t\t\t\t\tFROM dual\n\t\t\t\t\t\t)\n\t\t\t\t\t)='Y'\n\t\t\t\t)\n\t\t\tTHEN\n\t\t\t\t(\n\t\t\t\t\tSELECT\n\t\t\t\t\t\t(\n\t\t\t\t\t\t\tCASE\n\t\t\t\t\t\t\t\tWHEN(@issotrx@ = 'Y')\n\t\t\t\t\t\t\t\tTHEN (\n\t\t\t\t\t\t\t\t\tSELECT description\n\t\t\t\t\t\t\t\t\tFROM aeatsii_description\n\t\t\t\t\t\t\t\t\tWHERE isdefault = 'Y'\n\t\t\t\t\t\t\t\t\tAND issales = 'Y'\n\t\t\t\t\t\t\t\t\tAND ad_org_id = @AD_Org_ID@\n\t\t\t\t\t\t\t\t\tAND ad_client_id = @ad_client_id@\n\t\t\t\t\t\t\t\t) ELSE (\n\t\t\t\t\t\t\t\t\tSELECT description\n\t\t\t\t\t\t\t\t\tFROM aeatsii_description\n\t\t\t\t\t\t\t\t\tWHERE isdefault = 'Y'\n\t\t\t\t\t\t\t\t\tAND ispurchase = 'Y'\n\t\t\t\t\t\t\t\t\tAND ad_org_id = @AD_Org_ID@\n\t\t\t\t\t\t\t\t\tAND ad_client_id = @ad_client_id@\n\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\tEND\n\t\t\t\t\t\t)\n\t\t\t\t\tFROM dual\n\t\t\t\t)\n\t\t\tELSE null\n\t\tEND\n\tFROM dual",
+            "provenance": "extracted"
+          },
+          "aeatsiiEstado": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "true",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT CASE WHEN ((SELECT c.insiisystem FROM aeatsii_config c WHERE c.ad_org_id = (SELECT ad_get_org_le_bu(@AD_Org_ID@,'LE') FROM dual))='Y') THEN 'PE' ELSE null END FROM dual",
+            "provenance": "extracted"
+          },
+          "aeatsiiEjercicio": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "true",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "aeatsiiPeriodo": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "true",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "aeatsiiIsauthorization": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "tbaiIssent": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "aeatsiiCauseExemption": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etvfacDateIssue": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etvfacHash": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etvfacInvoiceStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etvfacIssueDescription": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etvfacQRURL": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etvfacSentToVerifac": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "etgoTotalDiscount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "eTGODueDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "eTGODeliveryStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "lines": {
+        "fields": {
+          "product": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoicedQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | (@UomManagement@='Y' & @Financial_Invoice_Line@='N')",
+            "calloutTriggers": null,
+            "defaultValue": "1",
+            "provenance": "extracted"
+          },
+          "listPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etgoDiscount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "tax": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "account": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "operativeQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "unitPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'|@GROSSPRICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "grossUnitPrice": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'|@GROSSPRICE@='N'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "grossAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "attributeSetValue": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "salesOrderLine": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "goodsShipmentLine": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxableAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "asset": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "intrastat": {
+        "fields": {
+          "invoiceLine": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "product": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "incoterms": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "transactionType": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "transportationType": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "portAirport": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "statisticalRegime": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "origCountry": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "nC8Code": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "netMassKg": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "hasSuplementaryUnit": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "conversionRate": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "staticalValue": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "supplementaryUOM": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@INTR_INVOICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "tax": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(LINE),0)+10 AS DefaultValue FROM C_INVOICETAX WHERE C_Invoice_ID=@C_Invoice_ID@",
+            "provenance": "extracted"
+          },
+          "tax": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @Recalculate@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @Recalculate@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxableAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @Recalculate@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "basicDiscounts": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(LINE),0)+10 AS DefaultValue FROM C_INVOICE_DISCOUNT WHERE C_INVOICE_ID=@C_INVOICE_ID@",
+            "provenance": "extracted"
+          },
+          "discount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cascade": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "cashVat": {
+        "fields": {
+          "paymentDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "percentage": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxableAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "canceled": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "payment": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "status": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "isManualSettlement": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "accountingDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "paymentPlan": {
+        "fields": {
+          "dueDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "expectedDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "amount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "paidAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "outstandingAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "lastPaymentDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "daysOverdue": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "numberOfPayments": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "paymentDetails": {
+        "fields": {
+          "amount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "writeoffAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "amount2": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "canceled": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "finPaymentID": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoicePaid": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "reversedInvoices": {
+        "fields": {
+          "reversedInvoice": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "accounting": {
+        "fields": {
+          "accountingSchema": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "period": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "accountingDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "account": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "debit": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "credit": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "product": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "asset": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "postingType": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "siiData": {
+        "fields": {
+          "conexinSII": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cdigoCSV": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "estadoRegistro": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "comunicacion": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "motivo": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "estadoCuadre": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "fechaCuadre": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "fechaltimaModificacinSII": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "batuz": {
+        "fields": {
+          "active": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          },
+          "estado": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "descripcion": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoice": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/purchase-invoice/contract.prev.json
+++ b/artifacts/purchase-invoice/contract.prev.json
@@ -1,8 +1,8 @@
 {
   "version": "0.27.0",
   "generatedAt": "2026-04-30T15:42:46.722Z",
-  "updatedAt": "2026-05-12T19:44:01.275Z",
-  "checksum": "819b8cb2efc41b2d",
+  "updatedAt": "2026-05-15T16:28:10.238Z",
+  "checksum": "a27657ddfa2fe628",
   "frontendContract": {
     "window": {
       "id": "183",
@@ -8022,7 +8022,15 @@
         "column": "C_DocTypeTarget_ID",
         "reference": "DocumentType",
         "inputMode": "selector",
-        "url": "/sws/neo/purchase-invoice/header/selectors/transactionDocument"
+        "url": "/sws/neo/purchase-invoice/header/selectors/transactionDocument",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -8038,7 +8046,16 @@
         "column": "C_BPartner_Location_ID",
         "reference": "BusinessPartnerLocation",
         "inputMode": "dependent",
-        "url": "/sws/neo/purchase-invoice/header/selectors/partnerAddress"
+        "url": "/sws/neo/purchase-invoice/header/selectors/partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -8046,7 +8063,15 @@
         "column": "M_PriceList_ID",
         "reference": "PriceList",
         "inputMode": "selector",
-        "url": "/sws/neo/purchase-invoice/header/selectors/priceList"
+        "url": "/sws/neo/purchase-invoice/header/selectors/priceList",
+        "context": {
+          "required": [
+            {
+              "param": "isSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -8062,7 +8087,15 @@
         "column": "FIN_Paymentmethod_ID",
         "reference": "PaymentMethod",
         "inputMode": "selector",
-        "url": "/sws/neo/purchase-invoice/header/selectors/paymentMethod"
+        "url": "/sws/neo/purchase-invoice/header/selectors/paymentMethod",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -8086,7 +8119,16 @@
         "column": "AD_User_ID",
         "reference": "User",
         "inputMode": "search",
-        "url": "/sws/neo/purchase-invoice/header/selectors/userContact"
+        "url": "/sws/neo/purchase-invoice/header/selectors/userContact",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -8110,7 +8152,20 @@
         "column": "C_Project_ID",
         "reference": "Project",
         "inputMode": "search",
-        "url": "/sws/neo/purchase-invoice/header/selectors/project"
+        "url": "/sws/neo/purchase-invoice/header/selectors/project",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -8142,7 +8197,22 @@
         "column": "C_Tax_ID",
         "reference": "Tax",
         "inputMode": "selector",
-        "url": "/sws/neo/purchase-invoice/lines/selectors/tax"
+        "url": "/sws/neo/purchase-invoice/lines/selectors/tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
       },
       {
         "entity": "lines",
@@ -8409,190 +8479,682 @@
     ],
     "actions": [
       {
+        "name": "generateTo",
+        "label": "Generate Receipt from Invoice",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "generateTo",
         "column": "GenerateTo",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/generateTo",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/generateTo",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "142",
         "processType": "classic"
       },
       {
+        "name": "aPRMAddpayment",
+        "label": "Add Payment",
+        "actionType": "paymentAction",
         "entity": "header",
-        "field": "aPRMAddpayment",
         "column": "EM_APRM_Addpayment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aPRMAddpayment",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/aPRMAddpayment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "9BED7889E1034FE68BD85D5D16857320",
         "processType": "obuiapp"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "posted",
         "column": "Posted",
-        "url": "/sws/neo/purchase-invoice/header/{id}/action/posted"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/posted",
+        "method": "POST",
+        "url": "/sws/neo/purchase-invoice/header/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "aPRMProcessinvoice",
+        "label": "Process Invoices",
+        "actionType": "paymentAction",
         "entity": "header",
-        "field": "aPRMProcessinvoice",
         "column": "EM_APRM_Processinvoice",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aPRMProcessinvoice",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/aPRMProcessinvoice",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "B54318B49E984B9CB855AEFB1F474CD6",
         "processType": "classic"
       },
       {
+        "name": "documentAction",
+        "label": "Process Invoice",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "documentAction",
         "column": "DocAction",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/documentAction",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/documentAction",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "111",
         "processType": "classic"
       },
       {
+        "name": "createLinesFromOrder",
+        "label": "Create Lines From Order",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createLinesFromOrder",
         "column": "Createfromorders",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFromOrder",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFromOrder",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "AB2EFCAABB7B4EC0A9B30CFB82963FB6",
         "processType": "obuiapp"
       },
       {
+        "name": "createLinesFromShipment",
+        "label": "Create Lines From Receipt",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createLinesFromShipment",
         "column": "Createfrominouts",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFromShipment",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFromShipment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "7737CA7330FD49FBA7EBC225E85F2BC9",
         "processType": "obuiapp"
       },
       {
+        "name": "copyFrom",
+        "label": "Copy Lines",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "copyFrom",
         "column": "CopyFrom",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/copyFrom",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/copyFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "210",
         "processType": "classic"
       },
       {
+        "name": "calculatePromotions",
+        "label": "Calculate_Promotions",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "calculatePromotions",
         "column": "Calculate_Promotions",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/calculatePromotions",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/calculatePromotions",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "9EB2228A60684C0DBEC12D5CD8D85218",
         "processType": "classic"
       },
       {
+        "name": "aeatsiiSend",
+        "label": "Send to SII",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "aeatsiiSend",
         "column": "EM_Aeatsii_Send",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiSend",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiSend",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "2ECF46DAAEEB486EAF79D3594D50DE5F",
         "processType": "obuiapp"
       },
       {
+        "name": "aeatsiiModif",
+        "label": "Modification in SII",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "aeatsiiModif",
         "column": "EM_Aeatsii_Modif",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiModif",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiModif",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "BAAECFDF9FF144E8A610E9F1EF3E5FBE",
         "processType": "obuiapp"
       },
       {
+        "name": "tbaiXmlgenerator",
+        "label": "Registrar Factura en Batuz",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "tbaiXmlgenerator",
         "column": "EM_Tbai_Xmlgenerator",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/tbaiXmlgenerator",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/tbaiXmlgenerator",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "BE2486102F2C41779B760609FD69A225",
         "processType": "obuiapp"
       },
       {
+        "name": "processNow",
+        "label": "Process Invoice",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "processNow",
         "column": "Processing",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/processNow",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/processNow",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "111",
         "processType": "classic"
       },
       {
+        "name": "createLinesFrom",
+        "label": "CreateFrom",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createLinesFrom",
         "column": "CreateFrom",
-        "url": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFrom"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFrom",
+        "method": "POST",
+        "url": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "aeatsiiDup",
+        "label": "EM_Aeatsii_Dup",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "aeatsiiDup",
         "column": "EM_Aeatsii_Dup",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiDup",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiDup",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "92C02F9A367140C085D1EE3BD27C4E96",
         "processType": "obuiapp"
       },
       {
+        "name": "aeatsiiUnsubscribe",
+        "label": "EM_Aeatsii_Unsubscribe",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "aeatsiiUnsubscribe",
         "column": "EM_Aeatsii_Unsubscribe",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiUnsubscribe",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiUnsubscribe",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "BE564945CB2D4892AC0EE51204C5DB7D",
         "processType": "obuiapp"
       },
       {
+        "name": "etvfacRectCreate",
+        "label": "EM_Etvfac_Rect_Create",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "etvfacRectCreate",
         "column": "EM_Etvfac_Rect_Create",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/etvfacRectCreate",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/etvfacRectCreate",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "E36A8BA259164E78AFDDC760172C18F5",
         "processType": "obuiapp"
       },
       {
+        "name": "tBAIQRcode",
+        "label": "em_tbai_qrcode",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "tBAIQRcode",
         "column": "em_tbai_qrcode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/tBAIQRcode",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/tBAIQRcode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "12FECC9DF1F4418AB7DAA46D6A05FEC6",
         "processType": "obuiapp"
       },
       {
+        "name": "tbaiVoidxmlgenerator",
+        "label": "EM_Tbai_Voidxmlgenerator",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "tbaiVoidxmlgenerator",
         "column": "EM_Tbai_Voidxmlgenerator",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/tbaiVoidxmlgenerator",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/header/{id}/action/tbaiVoidxmlgenerator",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "535A8BAE44A34759A7C8FF40D62A5070",
         "processType": "obuiapp"
       },
       {
+        "name": "explode",
+        "label": "Explode",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "explode",
         "column": "Explode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/lines/{id}/action/explode",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/lines/{id}/action/explode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "6E1ADD5C8B6B4ACB82237DAA8114451E",
         "processType": "classic"
       },
       {
+        "name": "matchLCCosts",
+        "label": "Match LC Costs",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "matchLCCosts",
         "column": "Match_Lccosts",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/lines/{id}/action/matchLCCosts",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/lines/{id}/action/matchLCCosts",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "281FFDFAB31C4394A2EAA73A6F9F3A3F",
         "processType": "obuiapp"
       },
       {
+        "name": "updatePaymentPlan",
+        "label": "Update Payment Plan",
+        "actionType": "paymentAction",
         "entity": "paymentPlan",
-        "field": "updatePaymentPlan",
         "column": "Update_Payment_Plan",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/updatePaymentPlan",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/updatePaymentPlan",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "FB740AB61B0E42B198D2C88D3A0D0CE6",
         "processType": "classic"
       },
       {
+        "name": "aprmModifPaymentOUTPlan",
+        "label": "Modify Payment Plan",
+        "actionType": "paymentAction",
         "entity": "paymentPlan",
-        "field": "aprmModifPaymentOUTPlan",
         "column": "EM_Aprm_Modif_Paym_Out_Sched",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/aprmModifPaymentOUTPlan",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/aprmModifPaymentOUTPlan",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "6F87442DF7BC43AB8A666BDED2F7D64E",
         "processType": "obuiapp"
       },
       {
+        "name": "aprmModifPaymentINPlan",
+        "label": "EM_Aprm_Modif_Paym_Sched",
+        "actionType": "paymentAction",
         "entity": "paymentPlan",
-        "field": "aprmModifPaymentINPlan",
         "column": "EM_Aprm_Modif_Paym_Sched",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/aprmModifPaymentINPlan",
+        "method": "POST",
         "url": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/aprmModifPaymentINPlan",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "4EEB3497082C4F2182E16A4371CD5D96",
         "processType": "obuiapp"
       }

--- a/artifacts/purchase-invoice/generated/web/purchase-invoice/HeaderPage.jsx
+++ b/artifacts/purchase-invoice/generated/web/purchase-invoice/HeaderPage.jsx
@@ -239,7 +239,15 @@ export const api = {
       "column": "C_DocTypeTarget_ID",
       "reference": "DocumentType",
       "inputMode": "selector",
-      "url": "/sws/neo/purchase-invoice/header/selectors/transactionDocument"
+      "url": "/sws/neo/purchase-invoice/header/selectors/transactionDocument",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -255,7 +263,16 @@ export const api = {
       "column": "C_BPartner_Location_ID",
       "reference": "BusinessPartnerLocation",
       "inputMode": "dependent",
-      "url": "/sws/neo/purchase-invoice/header/selectors/partnerAddress"
+      "url": "/sws/neo/purchase-invoice/header/selectors/partnerAddress",
+      "context": {
+        "required": [
+          {
+            "param": "C_BPartner_ID",
+            "source": "field",
+            "field": "businessPartner"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -263,7 +280,15 @@ export const api = {
       "column": "M_PriceList_ID",
       "reference": "PriceList",
       "inputMode": "selector",
-      "url": "/sws/neo/purchase-invoice/header/selectors/priceList"
+      "url": "/sws/neo/purchase-invoice/header/selectors/priceList",
+      "context": {
+        "required": [
+          {
+            "param": "isSOTrx",
+            "source": "windowCategory"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -279,7 +304,15 @@ export const api = {
       "column": "FIN_Paymentmethod_ID",
       "reference": "PaymentMethod",
       "inputMode": "selector",
-      "url": "/sws/neo/purchase-invoice/header/selectors/paymentMethod"
+      "url": "/sws/neo/purchase-invoice/header/selectors/paymentMethod",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -303,7 +336,16 @@ export const api = {
       "column": "AD_User_ID",
       "reference": "User",
       "inputMode": "search",
-      "url": "/sws/neo/purchase-invoice/header/selectors/userContact"
+      "url": "/sws/neo/purchase-invoice/header/selectors/userContact",
+      "context": {
+        "required": [
+          {
+            "param": "C_BPartner_ID",
+            "source": "parentField",
+            "field": "businessPartner"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -327,7 +369,20 @@ export const api = {
       "column": "C_Project_ID",
       "reference": "Project",
       "inputMode": "search",
-      "url": "/sws/neo/purchase-invoice/header/selectors/project"
+      "url": "/sws/neo/purchase-invoice/header/selectors/project",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          },
+          {
+            "param": "C_BPartner_ID",
+            "source": "parentField",
+            "field": "businessPartner"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -359,7 +414,22 @@ export const api = {
       "column": "C_Tax_ID",
       "reference": "Tax",
       "inputMode": "selector",
-      "url": "/sws/neo/purchase-invoice/lines/selectors/tax"
+      "url": "/sws/neo/purchase-invoice/lines/selectors/tax",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          },
+          {
+            "param": "DateInvoiced",
+            "source": "parentField",
+            "field": "invoiceDate",
+            "fallbackField": "orderDate",
+            "format": "DD-MM-YYYY"
+          }
+        ]
+      }
     },
     {
       "entity": "lines",
@@ -626,190 +696,682 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "generateTo",
+      "label": "Generate Receipt from Invoice",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "generateTo",
       "column": "GenerateTo",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/generateTo",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/generateTo",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "142",
       "processType": "classic"
     },
     {
+      "name": "aPRMAddpayment",
+      "label": "Add Payment",
+      "actionType": "paymentAction",
       "entity": "header",
-      "field": "aPRMAddpayment",
       "column": "EM_APRM_Addpayment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aPRMAddpayment",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/aPRMAddpayment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "9BED7889E1034FE68BD85D5D16857320",
       "processType": "obuiapp"
     },
     {
+      "name": "posted",
+      "label": "Posted",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "posted",
       "column": "Posted",
-      "url": "/sws/neo/purchase-invoice/header/{id}/action/posted"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/posted",
+      "method": "POST",
+      "url": "/sws/neo/purchase-invoice/header/{id}/action/posted",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "aPRMProcessinvoice",
+      "label": "Process Invoices",
+      "actionType": "paymentAction",
       "entity": "header",
-      "field": "aPRMProcessinvoice",
       "column": "EM_APRM_Processinvoice",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aPRMProcessinvoice",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/aPRMProcessinvoice",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "B54318B49E984B9CB855AEFB1F474CD6",
       "processType": "classic"
     },
     {
+      "name": "documentAction",
+      "label": "Process Invoice",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "documentAction",
       "column": "DocAction",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/documentAction",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/documentAction",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "111",
       "processType": "classic"
     },
     {
+      "name": "createLinesFromOrder",
+      "label": "Create Lines From Order",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "createLinesFromOrder",
       "column": "Createfromorders",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFromOrder",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFromOrder",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "AB2EFCAABB7B4EC0A9B30CFB82963FB6",
       "processType": "obuiapp"
     },
     {
+      "name": "createLinesFromShipment",
+      "label": "Create Lines From Receipt",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "createLinesFromShipment",
       "column": "Createfrominouts",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFromShipment",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFromShipment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "7737CA7330FD49FBA7EBC225E85F2BC9",
       "processType": "obuiapp"
     },
     {
+      "name": "copyFrom",
+      "label": "Copy Lines",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "copyFrom",
       "column": "CopyFrom",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/copyFrom",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/copyFrom",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "210",
       "processType": "classic"
     },
     {
+      "name": "calculatePromotions",
+      "label": "Calculate_Promotions",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "calculatePromotions",
       "column": "Calculate_Promotions",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/calculatePromotions",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/calculatePromotions",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "9EB2228A60684C0DBEC12D5CD8D85218",
       "processType": "classic"
     },
     {
+      "name": "aeatsiiSend",
+      "label": "Send to SII",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "aeatsiiSend",
       "column": "EM_Aeatsii_Send",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiSend",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiSend",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "2ECF46DAAEEB486EAF79D3594D50DE5F",
       "processType": "obuiapp"
     },
     {
+      "name": "aeatsiiModif",
+      "label": "Modification in SII",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "aeatsiiModif",
       "column": "EM_Aeatsii_Modif",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiModif",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiModif",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "BAAECFDF9FF144E8A610E9F1EF3E5FBE",
       "processType": "obuiapp"
     },
     {
+      "name": "tbaiXmlgenerator",
+      "label": "Registrar Factura en Batuz",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "tbaiXmlgenerator",
       "column": "EM_Tbai_Xmlgenerator",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/tbaiXmlgenerator",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/tbaiXmlgenerator",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "BE2486102F2C41779B760609FD69A225",
       "processType": "obuiapp"
     },
     {
+      "name": "processNow",
+      "label": "Process Invoice",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "processNow",
       "column": "Processing",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/processNow",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/processNow",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "111",
       "processType": "classic"
     },
     {
+      "name": "createLinesFrom",
+      "label": "CreateFrom",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "createLinesFrom",
       "column": "CreateFrom",
-      "url": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFrom"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFrom",
+      "method": "POST",
+      "url": "/sws/neo/purchase-invoice/header/{id}/action/createLinesFrom",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "aeatsiiDup",
+      "label": "EM_Aeatsii_Dup",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "aeatsiiDup",
       "column": "EM_Aeatsii_Dup",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiDup",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiDup",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "92C02F9A367140C085D1EE3BD27C4E96",
       "processType": "obuiapp"
     },
     {
+      "name": "aeatsiiUnsubscribe",
+      "label": "EM_Aeatsii_Unsubscribe",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "aeatsiiUnsubscribe",
       "column": "EM_Aeatsii_Unsubscribe",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiUnsubscribe",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/aeatsiiUnsubscribe",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "BE564945CB2D4892AC0EE51204C5DB7D",
       "processType": "obuiapp"
     },
     {
+      "name": "etvfacRectCreate",
+      "label": "EM_Etvfac_Rect_Create",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "etvfacRectCreate",
       "column": "EM_Etvfac_Rect_Create",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/etvfacRectCreate",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/etvfacRectCreate",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "E36A8BA259164E78AFDDC760172C18F5",
       "processType": "obuiapp"
     },
     {
+      "name": "tBAIQRcode",
+      "label": "em_tbai_qrcode",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "tBAIQRcode",
       "column": "em_tbai_qrcode",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/tBAIQRcode",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/tBAIQRcode",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "12FECC9DF1F4418AB7DAA46D6A05FEC6",
       "processType": "obuiapp"
     },
     {
+      "name": "tbaiVoidxmlgenerator",
+      "label": "EM_Tbai_Voidxmlgenerator",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "tbaiVoidxmlgenerator",
       "column": "EM_Tbai_Voidxmlgenerator",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/header/{id}/action/tbaiVoidxmlgenerator",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/header/{id}/action/tbaiVoidxmlgenerator",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "535A8BAE44A34759A7C8FF40D62A5070",
       "processType": "obuiapp"
     },
     {
+      "name": "explode",
+      "label": "Explode",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "explode",
       "column": "Explode",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/lines/{id}/action/explode",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/lines/{id}/action/explode",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "6E1ADD5C8B6B4ACB82237DAA8114451E",
       "processType": "classic"
     },
     {
+      "name": "matchLCCosts",
+      "label": "Match LC Costs",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "matchLCCosts",
       "column": "Match_Lccosts",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/lines/{id}/action/matchLCCosts",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/lines/{id}/action/matchLCCosts",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "281FFDFAB31C4394A2EAA73A6F9F3A3F",
       "processType": "obuiapp"
     },
     {
+      "name": "updatePaymentPlan",
+      "label": "Update Payment Plan",
+      "actionType": "paymentAction",
       "entity": "paymentPlan",
-      "field": "updatePaymentPlan",
       "column": "Update_Payment_Plan",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/updatePaymentPlan",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/updatePaymentPlan",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "FB740AB61B0E42B198D2C88D3A0D0CE6",
       "processType": "classic"
     },
     {
+      "name": "aprmModifPaymentOUTPlan",
+      "label": "Modify Payment Plan",
+      "actionType": "paymentAction",
       "entity": "paymentPlan",
-      "field": "aprmModifPaymentOUTPlan",
       "column": "EM_Aprm_Modif_Paym_Out_Sched",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/aprmModifPaymentOUTPlan",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/aprmModifPaymentOUTPlan",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "6F87442DF7BC43AB8A666BDED2F7D64E",
       "processType": "obuiapp"
     },
     {
+      "name": "aprmModifPaymentINPlan",
+      "label": "EM_Aprm_Modif_Paym_Sched",
+      "actionType": "paymentAction",
       "entity": "paymentPlan",
-      "field": "aprmModifPaymentINPlan",
       "column": "EM_Aprm_Modif_Paym_Sched",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/aprmModifPaymentINPlan",
+      "method": "POST",
       "url": "/sws/neo/purchase-invoice/paymentPlan/{id}/action/aprmModifPaymentINPlan",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "4EEB3497082C4F2182E16A4371CD5D96",
       "processType": "obuiapp"
     }

--- a/artifacts/purchase-order/contract.json
+++ b/artifacts/purchase-order/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.19.0",
   "generatedAt": "2026-04-30T15:42:46.497Z",
-  "updatedAt": "2026-05-15T16:28:10.014Z",
-  "checksum": "59183bea09725569",
+  "updatedAt": "2026-05-15T16:33:38.817Z",
+  "checksum": "db2af24b1a59c801",
   "frontendContract": {
     "window": {
       "id": "181",
@@ -5541,6 +5541,972 @@
         "InvoiceStatus": "Invoicing Status"
       }
     }
+  },
+  "formState": {
+    "entities": {
+      "header": {
+        "fields": {
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "partnerAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "scheduledDeliveryDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "transactionDocument": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "warehouse": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentTerms": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "priceList": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "DR",
+            "provenance": "extracted"
+          },
+          "grandTotalAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "summedLineAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@C_Currency_ID@",
+            "provenance": "extracted"
+          },
+          "deliveryNotes": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderReference": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cashVAT": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "companyAgent": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoiceFrom": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "incoterms": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "iNCOTERMSDescription": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "freightAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "deliveryMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "P",
+            "provenance": "extracted"
+          },
+          "shippingCompany": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "priority": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "5",
+            "provenance": "extracted"
+          },
+          "chargeAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "charge": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "priceIncludesTax": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "asset": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "deliveryStatusPurchase": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoiceStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etgoTotalDiscount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "accountingDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "deliveryTerms": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "A",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "lines": {
+        "fields": {
+          "product": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderedQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | (@IsSOTrx@='Y' & @ISLINKEDTOPRODUCT@='Y' & @PRODUCTTYPE@='S') | @UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "1",
+            "provenance": "extracted"
+          },
+          "listPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "discount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "tax": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "lineGrossAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "operativeQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "operativeUOM": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "uOM": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "attributeSetValue": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @ATTRIBUTESETINSTANCIABLE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "unitPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @GROSSPRICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "grossUnitPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @GROSSPRICE@='N'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "lineNetAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Iseditlinenetamt@='N'|@GROSSPRICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "grossListPrice": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxableAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "warehouse": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@OrderType@!'SO'",
+            "calloutTriggers": null,
+            "defaultValue": "@M_Warehouse_ID@",
+            "provenance": "extracted"
+          },
+          "reservedQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "deliveredQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoicedQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "shippingCompany": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@M_Shipper_ID@",
+            "provenance": "extracted"
+          },
+          "orderDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@DateOrdered@",
+            "provenance": "extracted"
+          },
+          "scheduledDeliveryDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@DatePromised@",
+            "provenance": "extracted"
+          },
+          "freightAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "partnerAddress": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@C_BPartner_Location_ID@",
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "asset": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@C_Currency_ID@",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "lineTax": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(LINE),0)+10 AS DefaultValue FROM C_ORDERLINETAX WHERE C_ORDERLINE_ID=@C_OrderLine_ID@",
+            "provenance": "extracted"
+          },
+          "tax": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxableAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "taxAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "reservedStock": {
+        "fields": {
+          "reservation": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT C_BPartner_ID AS DefaultValue FROM C_Order WHERE C_Order_ID=@C_Order_ID@",
+            "provenance": "extracted"
+          },
+          "storageBin": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "attributeSetValue": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "allocated": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "quantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "released": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "paymentDetails": {
+        "fields": {
+          "payment": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "dueDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "finFinancialAccountID": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "expected": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paidAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "writeoffAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "expectedConverted": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paidConverted": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "finaccTxnConvertRate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "canceled": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "status": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/purchase-order/contract.json
+++ b/artifacts/purchase-order/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.19.0",
   "generatedAt": "2026-04-30T15:42:46.497Z",
-  "updatedAt": "2026-05-11T16:08:18.213Z",
-  "checksum": "602fefe58d6a786d",
+  "updatedAt": "2026-05-15T16:28:10.014Z",
+  "checksum": "59183bea09725569",
   "frontendContract": {
     "window": {
       "id": "181",
@@ -4566,14 +4566,31 @@
         "column": "C_BPartner_Location_ID",
         "reference": "BusinessPartnerLocation",
         "inputMode": "dependent",
-        "url": "/sws/neo/purchase-order/header/selectors/partnerAddress"
+        "url": "/sws/neo/purchase-order/header/selectors/partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
         "field": "transactionDocument",
         "column": "C_DocTypeTarget_ID",
         "reference": "DocumentType",
-        "url": "/sws/neo/purchase-order/header/selectors/transactionDocument"
+        "url": "/sws/neo/purchase-order/header/selectors/transactionDocument",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -4589,7 +4606,15 @@
         "column": "FIN_Paymentmethod_ID",
         "reference": "PaymentMethod",
         "inputMode": "selector",
-        "url": "/sws/neo/purchase-order/header/selectors/paymentMethod"
+        "url": "/sws/neo/purchase-order/header/selectors/paymentMethod",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -4605,7 +4630,15 @@
         "column": "M_PriceList_ID",
         "reference": "PriceList",
         "inputMode": "selector",
-        "url": "/sws/neo/purchase-order/header/selectors/priceList"
+        "url": "/sws/neo/purchase-order/header/selectors/priceList",
+        "context": {
+          "required": [
+            {
+              "param": "isSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -4625,7 +4658,16 @@
         "column": "BillTo_ID",
         "reference": "BusinessPartnerLocation",
         "inputMode": "dependent",
-        "url": "/sws/neo/purchase-order/header/selectors/invoiceFrom"
+        "url": "/sws/neo/purchase-order/header/selectors/invoiceFrom",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -4652,7 +4694,20 @@
         "column": "C_Project_ID",
         "reference": "Project",
         "inputMode": "search",
-        "url": "/sws/neo/purchase-order/header/selectors/project"
+        "url": "/sws/neo/purchase-order/header/selectors/project",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -4700,7 +4755,22 @@
         "column": "C_Tax_ID",
         "reference": "Tax",
         "inputMode": "selector",
-        "url": "/sws/neo/purchase-order/lines/selectors/tax"
+        "url": "/sws/neo/purchase-order/lines/selectors/tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
       },
       {
         "entity": "lines",
@@ -4708,7 +4778,15 @@
         "column": "C_Aum",
         "reference": "UOM",
         "inputMode": "selector",
-        "url": "/sws/neo/purchase-order/lines/selectors/operativeUOM"
+        "url": "/sws/neo/purchase-order/lines/selectors/operativeUOM",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "lines",
@@ -4736,7 +4814,16 @@
         "field": "partnerAddress",
         "column": "C_BPartner_Location_ID",
         "reference": "BusinessPartnerLocation",
-        "url": "/sws/neo/purchase-order/lines/selectors/partnerAddress"
+        "url": "/sws/neo/purchase-order/lines/selectors/partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "lines",
@@ -4837,168 +4924,589 @@
     ],
     "actions": [
       {
+        "name": "generateTemplate",
+        "label": "Generate template",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "generateTemplate",
         "column": "Generatetemplate",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/generateTemplate",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/generateTemplate",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "800022",
         "processType": "classic"
       },
       {
+        "name": "rMPickFromShipment",
+        "label": "RM_PickFromShipment",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "rMPickFromShipment",
         "column": "RM_PickFromShipment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/rMPickFromShipment",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/rMPickFromShipment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
         "processType": "obuiapp"
       },
       {
+        "name": "rMReceiveMaterials",
+        "label": "RM_ReceiveMaterials",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "rMReceiveMaterials",
         "column": "RM_ReceiveMaterials",
-        "url": "/sws/neo/purchase-order/header/{id}/action/rMReceiveMaterials"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/rMReceiveMaterials",
+        "method": "POST",
+        "url": "/sws/neo/purchase-order/header/{id}/action/rMReceiveMaterials",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "rMCreateInvoice",
+        "label": "Create Invoice",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "rMCreateInvoice",
         "column": "RM_CreateInvoice",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/rMCreateInvoice",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/rMCreateInvoice",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "FF80808133362F6A013336781FCE0066",
         "processType": "classic"
       },
       {
+        "name": "aPRMAddPayment",
+        "label": "Add Payment",
+        "actionType": "paymentAction",
         "entity": "header",
-        "field": "aPRMAddPayment",
         "column": "EM_APRM_AddPayment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/aPRMAddPayment",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/aPRMAddPayment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "9BED7889E1034FE68BD85D5D16857320",
         "processType": "obuiapp"
       },
       {
+        "name": "documentAction",
+        "label": "Process Order",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "documentAction",
         "column": "DocAction",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/documentAction",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/documentAction",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "104",
         "processType": "classic"
       },
       {
+        "name": "copyFrom",
+        "label": "Copy Lines",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "copyFrom",
         "column": "CopyFrom",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/copyFrom",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/copyFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "211",
         "processType": "classic"
       },
       {
+        "name": "copyFromPO",
+        "label": "Copy from Orders",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "copyFromPO",
         "column": "CopyFromPO",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/copyFromPO",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/copyFromPO",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "8B81D80B06364566B87853FEECAB5DE0",
         "processType": "obuiapp"
       },
       {
+        "name": "rMAddOrphanLine",
+        "label": "RM_AddOrphanLine",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "rMAddOrphanLine",
         "column": "RM_AddOrphanLine",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/rMAddOrphanLine",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/rMAddOrphanLine",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "23D1B163EC0B41F790CE39BF01DA320E",
         "processType": "classic"
       },
       {
+        "name": "createOrder",
+        "label": "Create Order",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createOrder",
         "column": "Convertquotation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/createOrder",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/createOrder",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A3FE1F9892394386A49FB707AA50A0FA",
         "processType": "classic"
       },
       {
+        "name": "calculatePromotions",
+        "label": "Calculate_Promotions",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "calculatePromotions",
         "column": "Calculate_Promotions",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/calculatePromotions",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/calculatePromotions",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "9EB2228A60684C0DBEC12D5CD8D85218",
         "processType": "classic"
       },
       {
+        "name": "createPOLines",
+        "label": "Create Lines",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createPOLines",
         "column": "Create_POLines",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/createPOLines",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/createPOLines",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "6995A4C2592D434A9E16B71E1694CBCA",
         "processType": "obuiapp"
       },
       {
+        "name": "processNow",
+        "label": "Process Order",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "processNow",
         "column": "Processing",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/processNow",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/processNow",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "104",
         "processType": "classic"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "posted",
         "column": "Posted",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/posted",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "57496FB9CF9E4E8F847224017941570E",
         "processType": "obuiapp"
       },
       {
+        "name": "cancelandreplace",
+        "label": "Cancelandreplace",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "cancelandreplace",
         "column": "Cancelandreplace",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/cancelandreplace",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/cancelandreplace",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "A2FAF49712D1445ABE750315CE1B473A",
         "processType": "obuiapp"
       },
       {
+        "name": "confirmcancelandreplace",
+        "label": "Confirmcancelandreplace",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "confirmcancelandreplace",
         "column": "Confirmcancelandreplace",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/confirmcancelandreplace",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/confirmcancelandreplace",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "0C2AFAEFB67B4CB8A1429195EB119A49",
         "processType": "obuiapp"
       },
       {
+        "name": "rMPickfromreceipt",
+        "label": "RM_Pickfromreceipt",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "rMPickfromreceipt",
         "column": "RM_Pickfromreceipt",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/rMPickfromreceipt",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/rMPickfromreceipt",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
         "processType": "obuiapp"
       },
       {
+        "name": "managePrereservation",
+        "label": "Manage Prereservation",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "managePrereservation",
         "column": "Manage_Prereservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/lines/{id}/action/managePrereservation",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/lines/{id}/action/managePrereservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
         "processType": "obuiapp"
       },
       {
+        "name": "explode",
+        "label": "Explode",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "explode",
         "column": "Explode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/lines/{id}/action/explode",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/lines/{id}/action/explode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "DFC78024B1F54CBB95DC73425BA6687F",
         "processType": "classic"
       },
       {
+        "name": "manageReservation",
+        "label": "Manage Reservation",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "manageReservation",
         "column": "Manage_Reservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/lines/{id}/action/manageReservation",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/lines/{id}/action/manageReservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "5F547560D3DE401AA0B570F22E2C6C06",
         "processType": "obuiapp"
       },
       {
+        "name": "selectOrderLine",
+        "label": "Relate_Orderline",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "selectOrderLine",
         "column": "Relate_Orderline",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/lines/{id}/action/selectOrderLine",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/lines/{id}/action/selectOrderLine",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "C4265E27C8134096B49DFBF69369DFC6",
         "processType": "obuiapp"
       }

--- a/artifacts/purchase-order/contract.prev.json
+++ b/artifacts/purchase-order/contract.prev.json
@@ -1,8 +1,8 @@
 {
   "version": "0.19.0",
   "generatedAt": "2026-04-30T15:42:46.497Z",
-  "updatedAt": "2026-05-15T16:28:10.014Z",
-  "checksum": "59183bea09725569",
+  "updatedAt": "2026-05-15T16:33:38.817Z",
+  "checksum": "db2af24b1a59c801",
   "frontendContract": {
     "window": {
       "id": "181",
@@ -5541,6 +5541,972 @@
         "InvoiceStatus": "Invoicing Status"
       }
     }
+  },
+  "formState": {
+    "entities": {
+      "header": {
+        "fields": {
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "partnerAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "scheduledDeliveryDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "transactionDocument": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "warehouse": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentTerms": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "priceList": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "DR",
+            "provenance": "extracted"
+          },
+          "grandTotalAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "summedLineAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@C_Currency_ID@",
+            "provenance": "extracted"
+          },
+          "deliveryNotes": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderReference": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cashVAT": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "companyAgent": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoiceFrom": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "incoterms": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "iNCOTERMSDescription": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "freightAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "deliveryMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "P",
+            "provenance": "extracted"
+          },
+          "shippingCompany": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "priority": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "5",
+            "provenance": "extracted"
+          },
+          "chargeAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "charge": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "priceIncludesTax": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "asset": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "deliveryStatusPurchase": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoiceStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etgoTotalDiscount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "accountingDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "deliveryTerms": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "A",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "lines": {
+        "fields": {
+          "product": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderedQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | (@IsSOTrx@='Y' & @ISLINKEDTOPRODUCT@='Y' & @PRODUCTTYPE@='S') | @UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "1",
+            "provenance": "extracted"
+          },
+          "listPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "discount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "tax": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "lineGrossAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "operativeQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "operativeUOM": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "uOM": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "attributeSetValue": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @ATTRIBUTESETINSTANCIABLE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "unitPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @GROSSPRICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "grossUnitPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @GROSSPRICE@='N'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "lineNetAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Iseditlinenetamt@='N'|@GROSSPRICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "grossListPrice": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxableAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "warehouse": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@OrderType@!'SO'",
+            "calloutTriggers": null,
+            "defaultValue": "@M_Warehouse_ID@",
+            "provenance": "extracted"
+          },
+          "reservedQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "deliveredQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoicedQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "shippingCompany": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@M_Shipper_ID@",
+            "provenance": "extracted"
+          },
+          "orderDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@DateOrdered@",
+            "provenance": "extracted"
+          },
+          "scheduledDeliveryDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@DatePromised@",
+            "provenance": "extracted"
+          },
+          "freightAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "partnerAddress": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@C_BPartner_Location_ID@",
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "asset": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@C_Currency_ID@",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "lineTax": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(LINE),0)+10 AS DefaultValue FROM C_ORDERLINETAX WHERE C_ORDERLINE_ID=@C_OrderLine_ID@",
+            "provenance": "extracted"
+          },
+          "tax": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxableAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "taxAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "reservedStock": {
+        "fields": {
+          "reservation": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT C_BPartner_ID AS DefaultValue FROM C_Order WHERE C_Order_ID=@C_Order_ID@",
+            "provenance": "extracted"
+          },
+          "storageBin": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "attributeSetValue": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "allocated": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "quantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "released": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "paymentDetails": {
+        "fields": {
+          "payment": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "dueDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "finFinancialAccountID": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "expected": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paidAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "writeoffAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "expectedConverted": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paidConverted": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "finaccTxnConvertRate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "canceled": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "status": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/purchase-order/contract.prev.json
+++ b/artifacts/purchase-order/contract.prev.json
@@ -1,8 +1,8 @@
 {
   "version": "0.19.0",
   "generatedAt": "2026-04-30T15:42:46.497Z",
-  "updatedAt": "2026-05-11T16:08:18.213Z",
-  "checksum": "602fefe58d6a786d",
+  "updatedAt": "2026-05-15T16:28:10.014Z",
+  "checksum": "59183bea09725569",
   "frontendContract": {
     "window": {
       "id": "181",
@@ -4566,14 +4566,31 @@
         "column": "C_BPartner_Location_ID",
         "reference": "BusinessPartnerLocation",
         "inputMode": "dependent",
-        "url": "/sws/neo/purchase-order/header/selectors/partnerAddress"
+        "url": "/sws/neo/purchase-order/header/selectors/partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
         "field": "transactionDocument",
         "column": "C_DocTypeTarget_ID",
         "reference": "DocumentType",
-        "url": "/sws/neo/purchase-order/header/selectors/transactionDocument"
+        "url": "/sws/neo/purchase-order/header/selectors/transactionDocument",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -4589,7 +4606,15 @@
         "column": "FIN_Paymentmethod_ID",
         "reference": "PaymentMethod",
         "inputMode": "selector",
-        "url": "/sws/neo/purchase-order/header/selectors/paymentMethod"
+        "url": "/sws/neo/purchase-order/header/selectors/paymentMethod",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -4605,7 +4630,15 @@
         "column": "M_PriceList_ID",
         "reference": "PriceList",
         "inputMode": "selector",
-        "url": "/sws/neo/purchase-order/header/selectors/priceList"
+        "url": "/sws/neo/purchase-order/header/selectors/priceList",
+        "context": {
+          "required": [
+            {
+              "param": "isSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -4625,7 +4658,16 @@
         "column": "BillTo_ID",
         "reference": "BusinessPartnerLocation",
         "inputMode": "dependent",
-        "url": "/sws/neo/purchase-order/header/selectors/invoiceFrom"
+        "url": "/sws/neo/purchase-order/header/selectors/invoiceFrom",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -4652,7 +4694,20 @@
         "column": "C_Project_ID",
         "reference": "Project",
         "inputMode": "search",
-        "url": "/sws/neo/purchase-order/header/selectors/project"
+        "url": "/sws/neo/purchase-order/header/selectors/project",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -4700,7 +4755,22 @@
         "column": "C_Tax_ID",
         "reference": "Tax",
         "inputMode": "selector",
-        "url": "/sws/neo/purchase-order/lines/selectors/tax"
+        "url": "/sws/neo/purchase-order/lines/selectors/tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
       },
       {
         "entity": "lines",
@@ -4708,7 +4778,15 @@
         "column": "C_Aum",
         "reference": "UOM",
         "inputMode": "selector",
-        "url": "/sws/neo/purchase-order/lines/selectors/operativeUOM"
+        "url": "/sws/neo/purchase-order/lines/selectors/operativeUOM",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "lines",
@@ -4736,7 +4814,16 @@
         "field": "partnerAddress",
         "column": "C_BPartner_Location_ID",
         "reference": "BusinessPartnerLocation",
-        "url": "/sws/neo/purchase-order/lines/selectors/partnerAddress"
+        "url": "/sws/neo/purchase-order/lines/selectors/partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "lines",
@@ -4837,168 +4924,589 @@
     ],
     "actions": [
       {
+        "name": "generateTemplate",
+        "label": "Generate template",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "generateTemplate",
         "column": "Generatetemplate",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/generateTemplate",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/generateTemplate",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "800022",
         "processType": "classic"
       },
       {
+        "name": "rMPickFromShipment",
+        "label": "RM_PickFromShipment",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "rMPickFromShipment",
         "column": "RM_PickFromShipment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/rMPickFromShipment",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/rMPickFromShipment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
         "processType": "obuiapp"
       },
       {
+        "name": "rMReceiveMaterials",
+        "label": "RM_ReceiveMaterials",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "rMReceiveMaterials",
         "column": "RM_ReceiveMaterials",
-        "url": "/sws/neo/purchase-order/header/{id}/action/rMReceiveMaterials"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/rMReceiveMaterials",
+        "method": "POST",
+        "url": "/sws/neo/purchase-order/header/{id}/action/rMReceiveMaterials",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "rMCreateInvoice",
+        "label": "Create Invoice",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "rMCreateInvoice",
         "column": "RM_CreateInvoice",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/rMCreateInvoice",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/rMCreateInvoice",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "FF80808133362F6A013336781FCE0066",
         "processType": "classic"
       },
       {
+        "name": "aPRMAddPayment",
+        "label": "Add Payment",
+        "actionType": "paymentAction",
         "entity": "header",
-        "field": "aPRMAddPayment",
         "column": "EM_APRM_AddPayment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/aPRMAddPayment",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/aPRMAddPayment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "9BED7889E1034FE68BD85D5D16857320",
         "processType": "obuiapp"
       },
       {
+        "name": "documentAction",
+        "label": "Process Order",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "documentAction",
         "column": "DocAction",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/documentAction",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/documentAction",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "104",
         "processType": "classic"
       },
       {
+        "name": "copyFrom",
+        "label": "Copy Lines",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "copyFrom",
         "column": "CopyFrom",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/copyFrom",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/copyFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "211",
         "processType": "classic"
       },
       {
+        "name": "copyFromPO",
+        "label": "Copy from Orders",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "copyFromPO",
         "column": "CopyFromPO",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/copyFromPO",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/copyFromPO",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "8B81D80B06364566B87853FEECAB5DE0",
         "processType": "obuiapp"
       },
       {
+        "name": "rMAddOrphanLine",
+        "label": "RM_AddOrphanLine",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "rMAddOrphanLine",
         "column": "RM_AddOrphanLine",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/rMAddOrphanLine",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/rMAddOrphanLine",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "23D1B163EC0B41F790CE39BF01DA320E",
         "processType": "classic"
       },
       {
+        "name": "createOrder",
+        "label": "Create Order",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createOrder",
         "column": "Convertquotation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/createOrder",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/createOrder",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A3FE1F9892394386A49FB707AA50A0FA",
         "processType": "classic"
       },
       {
+        "name": "calculatePromotions",
+        "label": "Calculate_Promotions",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "calculatePromotions",
         "column": "Calculate_Promotions",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/calculatePromotions",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/calculatePromotions",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "9EB2228A60684C0DBEC12D5CD8D85218",
         "processType": "classic"
       },
       {
+        "name": "createPOLines",
+        "label": "Create Lines",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createPOLines",
         "column": "Create_POLines",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/createPOLines",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/createPOLines",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "6995A4C2592D434A9E16B71E1694CBCA",
         "processType": "obuiapp"
       },
       {
+        "name": "processNow",
+        "label": "Process Order",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "processNow",
         "column": "Processing",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/processNow",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/processNow",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "104",
         "processType": "classic"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "posted",
         "column": "Posted",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/posted",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "57496FB9CF9E4E8F847224017941570E",
         "processType": "obuiapp"
       },
       {
+        "name": "cancelandreplace",
+        "label": "Cancelandreplace",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "cancelandreplace",
         "column": "Cancelandreplace",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/cancelandreplace",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/cancelandreplace",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "A2FAF49712D1445ABE750315CE1B473A",
         "processType": "obuiapp"
       },
       {
+        "name": "confirmcancelandreplace",
+        "label": "Confirmcancelandreplace",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "confirmcancelandreplace",
         "column": "Confirmcancelandreplace",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/confirmcancelandreplace",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/confirmcancelandreplace",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "0C2AFAEFB67B4CB8A1429195EB119A49",
         "processType": "obuiapp"
       },
       {
+        "name": "rMPickfromreceipt",
+        "label": "RM_Pickfromreceipt",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "rMPickfromreceipt",
         "column": "RM_Pickfromreceipt",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/header/{id}/action/rMPickfromreceipt",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/header/{id}/action/rMPickfromreceipt",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
         "processType": "obuiapp"
       },
       {
+        "name": "managePrereservation",
+        "label": "Manage Prereservation",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "managePrereservation",
         "column": "Manage_Prereservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/lines/{id}/action/managePrereservation",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/lines/{id}/action/managePrereservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
         "processType": "obuiapp"
       },
       {
+        "name": "explode",
+        "label": "Explode",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "explode",
         "column": "Explode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/lines/{id}/action/explode",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/lines/{id}/action/explode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "DFC78024B1F54CBB95DC73425BA6687F",
         "processType": "classic"
       },
       {
+        "name": "manageReservation",
+        "label": "Manage Reservation",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "manageReservation",
         "column": "Manage_Reservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/lines/{id}/action/manageReservation",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/lines/{id}/action/manageReservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "5F547560D3DE401AA0B570F22E2C6C06",
         "processType": "obuiapp"
       },
       {
+        "name": "selectOrderLine",
+        "label": "Relate_Orderline",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "selectOrderLine",
         "column": "Relate_Orderline",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/purchase-order/lines/{id}/action/selectOrderLine",
+        "method": "POST",
         "url": "/sws/neo/purchase-order/lines/{id}/action/selectOrderLine",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "C4265E27C8134096B49DFBF69369DFC6",
         "processType": "obuiapp"
       }

--- a/artifacts/purchase-order/generated/web/purchase-order/HeaderPage.jsx
+++ b/artifacts/purchase-order/generated/web/purchase-order/HeaderPage.jsx
@@ -171,14 +171,31 @@ export const api = {
       "column": "C_BPartner_Location_ID",
       "reference": "BusinessPartnerLocation",
       "inputMode": "dependent",
-      "url": "/sws/neo/purchase-order/header/selectors/partnerAddress"
+      "url": "/sws/neo/purchase-order/header/selectors/partnerAddress",
+      "context": {
+        "required": [
+          {
+            "param": "C_BPartner_ID",
+            "source": "field",
+            "field": "businessPartner"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
       "field": "transactionDocument",
       "column": "C_DocTypeTarget_ID",
       "reference": "DocumentType",
-      "url": "/sws/neo/purchase-order/header/selectors/transactionDocument"
+      "url": "/sws/neo/purchase-order/header/selectors/transactionDocument",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -194,7 +211,15 @@ export const api = {
       "column": "FIN_Paymentmethod_ID",
       "reference": "PaymentMethod",
       "inputMode": "selector",
-      "url": "/sws/neo/purchase-order/header/selectors/paymentMethod"
+      "url": "/sws/neo/purchase-order/header/selectors/paymentMethod",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -210,7 +235,15 @@ export const api = {
       "column": "M_PriceList_ID",
       "reference": "PriceList",
       "inputMode": "selector",
-      "url": "/sws/neo/purchase-order/header/selectors/priceList"
+      "url": "/sws/neo/purchase-order/header/selectors/priceList",
+      "context": {
+        "required": [
+          {
+            "param": "isSOTrx",
+            "source": "windowCategory"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -230,7 +263,16 @@ export const api = {
       "column": "BillTo_ID",
       "reference": "BusinessPartnerLocation",
       "inputMode": "dependent",
-      "url": "/sws/neo/purchase-order/header/selectors/invoiceFrom"
+      "url": "/sws/neo/purchase-order/header/selectors/invoiceFrom",
+      "context": {
+        "required": [
+          {
+            "param": "C_BPartner_ID",
+            "source": "field",
+            "field": "businessPartner"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -257,7 +299,20 @@ export const api = {
       "column": "C_Project_ID",
       "reference": "Project",
       "inputMode": "search",
-      "url": "/sws/neo/purchase-order/header/selectors/project"
+      "url": "/sws/neo/purchase-order/header/selectors/project",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          },
+          {
+            "param": "C_BPartner_ID",
+            "source": "parentField",
+            "field": "businessPartner"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -305,7 +360,22 @@ export const api = {
       "column": "C_Tax_ID",
       "reference": "Tax",
       "inputMode": "selector",
-      "url": "/sws/neo/purchase-order/lines/selectors/tax"
+      "url": "/sws/neo/purchase-order/lines/selectors/tax",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          },
+          {
+            "param": "DateInvoiced",
+            "source": "parentField",
+            "field": "invoiceDate",
+            "fallbackField": "orderDate",
+            "format": "DD-MM-YYYY"
+          }
+        ]
+      }
     },
     {
       "entity": "lines",
@@ -313,7 +383,15 @@ export const api = {
       "column": "C_Aum",
       "reference": "UOM",
       "inputMode": "selector",
-      "url": "/sws/neo/purchase-order/lines/selectors/operativeUOM"
+      "url": "/sws/neo/purchase-order/lines/selectors/operativeUOM",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          }
+        ]
+      }
     },
     {
       "entity": "lines",
@@ -341,7 +419,16 @@ export const api = {
       "field": "partnerAddress",
       "column": "C_BPartner_Location_ID",
       "reference": "BusinessPartnerLocation",
-      "url": "/sws/neo/purchase-order/lines/selectors/partnerAddress"
+      "url": "/sws/neo/purchase-order/lines/selectors/partnerAddress",
+      "context": {
+        "required": [
+          {
+            "param": "C_BPartner_ID",
+            "source": "parentField",
+            "field": "businessPartner"
+          }
+        ]
+      }
     },
     {
       "entity": "lines",
@@ -442,168 +529,589 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "generateTemplate",
+      "label": "Generate template",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "generateTemplate",
       "column": "Generatetemplate",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/generateTemplate",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/header/{id}/action/generateTemplate",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "800022",
       "processType": "classic"
     },
     {
+      "name": "rMPickFromShipment",
+      "label": "RM_PickFromShipment",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "rMPickFromShipment",
       "column": "RM_PickFromShipment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/rMPickFromShipment",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/header/{id}/action/rMPickFromShipment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
       "processType": "obuiapp"
     },
     {
+      "name": "rMReceiveMaterials",
+      "label": "RM_ReceiveMaterials",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "rMReceiveMaterials",
       "column": "RM_ReceiveMaterials",
-      "url": "/sws/neo/purchase-order/header/{id}/action/rMReceiveMaterials"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/rMReceiveMaterials",
+      "method": "POST",
+      "url": "/sws/neo/purchase-order/header/{id}/action/rMReceiveMaterials",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "rMCreateInvoice",
+      "label": "Create Invoice",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "rMCreateInvoice",
       "column": "RM_CreateInvoice",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/rMCreateInvoice",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/header/{id}/action/rMCreateInvoice",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "FF80808133362F6A013336781FCE0066",
       "processType": "classic"
     },
     {
+      "name": "aPRMAddPayment",
+      "label": "Add Payment",
+      "actionType": "paymentAction",
       "entity": "header",
-      "field": "aPRMAddPayment",
       "column": "EM_APRM_AddPayment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/aPRMAddPayment",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/header/{id}/action/aPRMAddPayment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "9BED7889E1034FE68BD85D5D16857320",
       "processType": "obuiapp"
     },
     {
+      "name": "documentAction",
+      "label": "Process Order",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "documentAction",
       "column": "DocAction",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/documentAction",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/header/{id}/action/documentAction",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "104",
       "processType": "classic"
     },
     {
+      "name": "copyFrom",
+      "label": "Copy Lines",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "copyFrom",
       "column": "CopyFrom",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/copyFrom",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/header/{id}/action/copyFrom",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "211",
       "processType": "classic"
     },
     {
+      "name": "copyFromPO",
+      "label": "Copy from Orders",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "copyFromPO",
       "column": "CopyFromPO",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/copyFromPO",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/header/{id}/action/copyFromPO",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "8B81D80B06364566B87853FEECAB5DE0",
       "processType": "obuiapp"
     },
     {
+      "name": "rMAddOrphanLine",
+      "label": "RM_AddOrphanLine",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "rMAddOrphanLine",
       "column": "RM_AddOrphanLine",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/rMAddOrphanLine",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/header/{id}/action/rMAddOrphanLine",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "23D1B163EC0B41F790CE39BF01DA320E",
       "processType": "classic"
     },
     {
+      "name": "createOrder",
+      "label": "Create Order",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "createOrder",
       "column": "Convertquotation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/createOrder",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/header/{id}/action/createOrder",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "A3FE1F9892394386A49FB707AA50A0FA",
       "processType": "classic"
     },
     {
+      "name": "calculatePromotions",
+      "label": "Calculate_Promotions",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "calculatePromotions",
       "column": "Calculate_Promotions",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/calculatePromotions",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/header/{id}/action/calculatePromotions",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "9EB2228A60684C0DBEC12D5CD8D85218",
       "processType": "classic"
     },
     {
+      "name": "createPOLines",
+      "label": "Create Lines",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "createPOLines",
       "column": "Create_POLines",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/createPOLines",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/header/{id}/action/createPOLines",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "6995A4C2592D434A9E16B71E1694CBCA",
       "processType": "obuiapp"
     },
     {
+      "name": "processNow",
+      "label": "Process Order",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "processNow",
       "column": "Processing",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/processNow",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/header/{id}/action/processNow",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "104",
       "processType": "classic"
     },
     {
+      "name": "posted",
+      "label": "Posted",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "posted",
       "column": "Posted",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/posted",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/header/{id}/action/posted",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "57496FB9CF9E4E8F847224017941570E",
       "processType": "obuiapp"
     },
     {
+      "name": "cancelandreplace",
+      "label": "Cancelandreplace",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "cancelandreplace",
       "column": "Cancelandreplace",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/cancelandreplace",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/header/{id}/action/cancelandreplace",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "A2FAF49712D1445ABE750315CE1B473A",
       "processType": "obuiapp"
     },
     {
+      "name": "confirmcancelandreplace",
+      "label": "Confirmcancelandreplace",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "confirmcancelandreplace",
       "column": "Confirmcancelandreplace",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/confirmcancelandreplace",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/header/{id}/action/confirmcancelandreplace",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "0C2AFAEFB67B4CB8A1429195EB119A49",
       "processType": "obuiapp"
     },
     {
+      "name": "rMPickfromreceipt",
+      "label": "RM_Pickfromreceipt",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "rMPickfromreceipt",
       "column": "RM_Pickfromreceipt",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/header/{id}/action/rMPickfromreceipt",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/header/{id}/action/rMPickfromreceipt",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
       "processType": "obuiapp"
     },
     {
+      "name": "managePrereservation",
+      "label": "Manage Prereservation",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "managePrereservation",
       "column": "Manage_Prereservation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/lines/{id}/action/managePrereservation",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/lines/{id}/action/managePrereservation",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
       "processType": "obuiapp"
     },
     {
+      "name": "explode",
+      "label": "Explode",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "explode",
       "column": "Explode",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/lines/{id}/action/explode",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/lines/{id}/action/explode",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "DFC78024B1F54CBB95DC73425BA6687F",
       "processType": "classic"
     },
     {
+      "name": "manageReservation",
+      "label": "Manage Reservation",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "manageReservation",
       "column": "Manage_Reservation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/lines/{id}/action/manageReservation",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/lines/{id}/action/manageReservation",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "5F547560D3DE401AA0B570F22E2C6C06",
       "processType": "obuiapp"
     },
     {
+      "name": "selectOrderLine",
+      "label": "Relate_Orderline",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "selectOrderLine",
       "column": "Relate_Orderline",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/purchase-order/lines/{id}/action/selectOrderLine",
+      "method": "POST",
       "url": "/sws/neo/purchase-order/lines/{id}/action/selectOrderLine",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "C4265E27C8134096B49DFBF69369DFC6",
       "processType": "obuiapp"
     }

--- a/artifacts/return-from-customer/contract.json
+++ b/artifacts/return-from-customer/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T19:46:12.773Z",
-  "updatedAt": "2026-05-11T16:22:44.839Z",
-  "checksum": "7c63ffb4e39aacf3",
+  "updatedAt": "2026-05-15T16:28:09.800Z",
+  "checksum": "47401470893c7b94",
   "frontendContract": {
     "window": {
       "id": "FF808081330213E60133021822E40007",
@@ -2264,7 +2264,16 @@
         "column": "C_BPartner_Location_ID",
         "reference": "BPartner_Location",
         "inputMode": "dependent",
-        "url": "/sws/neo/returns/customerReturn/selectors/partnerAddress"
+        "url": "/sws/neo/returns/customerReturn/selectors/partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "customerReturn",
@@ -2320,7 +2329,22 @@
         "column": "C_Tax_ID",
         "reference": "Tax",
         "inputMode": "selector",
-        "url": "/sws/neo/returns/customerReturnLine/selectors/tax"
+        "url": "/sws/neo/returns/customerReturnLine/selectors/tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
       },
       {
         "entity": "customerReturnLine",
@@ -2333,168 +2357,589 @@
     ],
     "actions": [
       {
+        "name": "documentAction",
+        "label": "Process Order",
+        "actionType": "documentAction",
         "entity": "customerReturn",
-        "field": "documentAction",
         "column": "DocAction",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/documentAction",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturn/{id}/action/documentAction",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "104",
         "processType": "classic"
       },
       {
+        "name": "rMReceiveMaterials",
+        "label": "RM_ReceiveMaterials",
+        "actionType": "createFrom",
         "entity": "customerReturn",
-        "field": "rMReceiveMaterials",
         "column": "RM_ReceiveMaterials",
-        "url": "/sws/neo/returns/customerReturn/{id}/action/rMReceiveMaterials"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/rMReceiveMaterials",
+        "method": "POST",
+        "url": "/sws/neo/returns/customerReturn/{id}/action/rMReceiveMaterials",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "rMPickFromShipment",
+        "label": "Pick/Edit Lines",
+        "actionType": "createFrom",
         "entity": "customerReturn",
-        "field": "rMPickFromShipment",
         "column": "RM_PickFromShipment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/rMPickFromShipment",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturn/{id}/action/rMPickFromShipment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
         "processType": "obuiapp"
       },
       {
+        "name": "rMAddOrphanLine",
+        "label": "Insert Orphan Line",
+        "actionType": "utilityAction",
         "entity": "customerReturn",
-        "field": "rMAddOrphanLine",
         "column": "RM_AddOrphanLine",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/rMAddOrphanLine",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturn/{id}/action/rMAddOrphanLine",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "23D1B163EC0B41F790CE39BF01DA320E",
         "processType": "classic"
       },
       {
+        "name": "rMCreateInvoice",
+        "label": "Create Credit",
+        "actionType": "createFrom",
         "entity": "customerReturn",
-        "field": "rMCreateInvoice",
         "column": "RM_CreateInvoice",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/rMCreateInvoice",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturn/{id}/action/rMCreateInvoice",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "FF80808133362F6A013336781FCE0066",
         "processType": "classic"
       },
       {
+        "name": "processNow",
+        "label": "Process Order",
+        "actionType": "documentAction",
         "entity": "customerReturn",
-        "field": "processNow",
         "column": "Processing",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/processNow",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturn/{id}/action/processNow",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "104",
         "processType": "classic"
       },
       {
+        "name": "copyFrom",
+        "label": "Copy Lines",
+        "actionType": "createFrom",
         "entity": "customerReturn",
-        "field": "copyFrom",
         "column": "CopyFrom",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/copyFrom",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturn/{id}/action/copyFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "211",
         "processType": "classic"
       },
       {
+        "name": "generateTemplate",
+        "label": "Copy Product Template",
+        "actionType": "createFrom",
         "entity": "customerReturn",
-        "field": "generateTemplate",
         "column": "Generatetemplate",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/generateTemplate",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturn/{id}/action/generateTemplate",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "800022",
         "processType": "classic"
       },
       {
+        "name": "copyFromPO",
+        "label": "Copy from Order",
+        "actionType": "createFrom",
         "entity": "customerReturn",
-        "field": "copyFromPO",
         "column": "CopyFromPO",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/copyFromPO",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturn/{id}/action/copyFromPO",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "8B81D80B06364566B87853FEECAB5DE0",
         "processType": "obuiapp"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "customerReturn",
-        "field": "posted",
         "column": "Posted",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/posted",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturn/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "57496FB9CF9E4E8F847224017941570E",
         "processType": "obuiapp"
       },
       {
+        "name": "calculatePromotions",
+        "label": "Calculate_Promotions",
+        "actionType": "utilityAction",
         "entity": "customerReturn",
-        "field": "calculatePromotions",
         "column": "Calculate_Promotions",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/calculatePromotions",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturn/{id}/action/calculatePromotions",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "9EB2228A60684C0DBEC12D5CD8D85218",
         "processType": "classic"
       },
       {
+        "name": "cancelandreplace",
+        "label": "Cancelandreplace",
+        "actionType": "utilityAction",
         "entity": "customerReturn",
-        "field": "cancelandreplace",
         "column": "Cancelandreplace",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/cancelandreplace",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturn/{id}/action/cancelandreplace",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "A2FAF49712D1445ABE750315CE1B473A",
         "processType": "obuiapp"
       },
       {
+        "name": "confirmcancelandreplace",
+        "label": "Confirmcancelandreplace",
+        "actionType": "utilityAction",
         "entity": "customerReturn",
-        "field": "confirmcancelandreplace",
         "column": "Confirmcancelandreplace",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/confirmcancelandreplace",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturn/{id}/action/confirmcancelandreplace",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "0C2AFAEFB67B4CB8A1429195EB119A49",
         "processType": "obuiapp"
       },
       {
+        "name": "createOrder",
+        "label": "Convertquotation",
+        "actionType": "createFrom",
         "entity": "customerReturn",
-        "field": "createOrder",
         "column": "Convertquotation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/createOrder",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturn/{id}/action/createOrder",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A3FE1F9892394386A49FB707AA50A0FA",
         "processType": "classic"
       },
       {
+        "name": "createPOLines",
+        "label": "Create_POLines",
+        "actionType": "createFrom",
         "entity": "customerReturn",
-        "field": "createPOLines",
         "column": "Create_POLines",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/createPOLines",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturn/{id}/action/createPOLines",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "6995A4C2592D434A9E16B71E1694CBCA",
         "processType": "obuiapp"
       },
       {
+        "name": "aPRMAddPayment",
+        "label": "EM_APRM_AddPayment",
+        "actionType": "paymentAction",
         "entity": "customerReturn",
-        "field": "aPRMAddPayment",
         "column": "EM_APRM_AddPayment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/aPRMAddPayment",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturn/{id}/action/aPRMAddPayment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "9BED7889E1034FE68BD85D5D16857320",
         "processType": "obuiapp"
       },
       {
+        "name": "rMPickfromreceipt",
+        "label": "RM_Pickfromreceipt",
+        "actionType": "createFrom",
         "entity": "customerReturn",
-        "field": "rMPickfromreceipt",
         "column": "RM_Pickfromreceipt",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturn/{id}/action/rMPickfromreceipt",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturn/{id}/action/rMPickfromreceipt",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
         "processType": "obuiapp"
       },
       {
+        "name": "selectOrderLine",
+        "label": "Select Order Line",
+        "actionType": "utilityAction",
         "entity": "customerReturnLine",
-        "field": "selectOrderLine",
         "column": "Relate_Orderline",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturnLine/{id}/action/selectOrderLine",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturnLine/{id}/action/selectOrderLine",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "C4265E27C8134096B49DFBF69369DFC6",
         "processType": "obuiapp"
       },
       {
+        "name": "explode",
+        "label": "Explode",
+        "actionType": "utilityAction",
         "entity": "customerReturnLine",
-        "field": "explode",
         "column": "Explode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturnLine/{id}/action/explode",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturnLine/{id}/action/explode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "DFC78024B1F54CBB95DC73425BA6687F",
         "processType": "classic"
       },
       {
+        "name": "managePrereservation",
+        "label": "Manage_Prereservation",
+        "actionType": "utilityAction",
         "entity": "customerReturnLine",
-        "field": "managePrereservation",
         "column": "Manage_Prereservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturnLine/{id}/action/managePrereservation",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturnLine/{id}/action/managePrereservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
         "processType": "obuiapp"
       },
       {
+        "name": "manageReservation",
+        "label": "Manage_Reservation",
+        "actionType": "utilityAction",
         "entity": "customerReturnLine",
-        "field": "manageReservation",
         "column": "Manage_Reservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/returns/customerReturnLine/{id}/action/manageReservation",
+        "method": "POST",
         "url": "/sws/neo/returns/customerReturnLine/{id}/action/manageReservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "5F547560D3DE401AA0B570F22E2C6C06",
         "processType": "obuiapp"
       }

--- a/artifacts/return-from-customer/contract.json
+++ b/artifacts/return-from-customer/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T19:46:12.773Z",
-  "updatedAt": "2026-05-15T16:28:09.800Z",
-  "checksum": "47401470893c7b94",
+  "updatedAt": "2026-05-15T16:33:38.596Z",
+  "checksum": "ceb2e80134be71ca",
   "frontendContract": {
     "window": {
       "id": "FF808081330213E60133021822E40007",
@@ -2960,6 +2960,260 @@
     "window": {
       "category": "sales"
     }
+  },
+  "formState": {
+    "entities": {
+      "customerReturn": {
+        "fields": {
+          "documentStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "DR",
+            "provenance": "extracted"
+          },
+          "grandTotalAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "summedLineAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cReturnReasonID": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "partnerAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "warehouse": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etvfacReversedInvoice": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "salesRepresentative": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "customerReturnLine": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM C_OrderLine WHERE C_Order_ID=@C_Order_ID@",
+            "provenance": "extracted"
+          },
+          "product": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "attributeSetValue": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @ATTRIBUTESETINSTANCIABLE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cReturnReasonID": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderedQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | (@IsSOTrx@='Y' & @ISLINKEDTOPRODUCT@='Y' & @PRODUCTTYPE@='S') | @UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "1",
+            "provenance": "extracted"
+          },
+          "uOM": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "unitPrice": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @GROSSPRICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "lineNetAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Iseditlinenetamt@='N'|@GROSSPRICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "lineGrossAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "tax": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "goodsShipmentLine": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/return-from-customer/generated/web/return-from-customer/CustomerReturnPage.jsx
+++ b/artifacts/return-from-customer/generated/web/return-from-customer/CustomerReturnPage.jsx
@@ -117,7 +117,16 @@ export const api = {
       "column": "C_BPartner_Location_ID",
       "reference": "BPartner_Location",
       "inputMode": "dependent",
-      "url": "/sws/neo/returns/customerReturn/selectors/partnerAddress"
+      "url": "/sws/neo/returns/customerReturn/selectors/partnerAddress",
+      "context": {
+        "required": [
+          {
+            "param": "C_BPartner_ID",
+            "source": "field",
+            "field": "businessPartner"
+          }
+        ]
+      }
     },
     {
       "entity": "customerReturn",
@@ -173,7 +182,22 @@ export const api = {
       "column": "C_Tax_ID",
       "reference": "Tax",
       "inputMode": "selector",
-      "url": "/sws/neo/returns/customerReturnLine/selectors/tax"
+      "url": "/sws/neo/returns/customerReturnLine/selectors/tax",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          },
+          {
+            "param": "DateInvoiced",
+            "source": "parentField",
+            "field": "invoiceDate",
+            "fallbackField": "orderDate",
+            "format": "DD-MM-YYYY"
+          }
+        ]
+      }
     },
     {
       "entity": "customerReturnLine",
@@ -186,168 +210,589 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "documentAction",
+      "label": "Process Order",
+      "actionType": "documentAction",
       "entity": "customerReturn",
-      "field": "documentAction",
       "column": "DocAction",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/documentAction",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturn/{id}/action/documentAction",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "104",
       "processType": "classic"
     },
     {
+      "name": "rMReceiveMaterials",
+      "label": "RM_ReceiveMaterials",
+      "actionType": "createFrom",
       "entity": "customerReturn",
-      "field": "rMReceiveMaterials",
       "column": "RM_ReceiveMaterials",
-      "url": "/sws/neo/returns/customerReturn/{id}/action/rMReceiveMaterials"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/rMReceiveMaterials",
+      "method": "POST",
+      "url": "/sws/neo/returns/customerReturn/{id}/action/rMReceiveMaterials",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "rMPickFromShipment",
+      "label": "Pick/Edit Lines",
+      "actionType": "createFrom",
       "entity": "customerReturn",
-      "field": "rMPickFromShipment",
       "column": "RM_PickFromShipment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/rMPickFromShipment",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturn/{id}/action/rMPickFromShipment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
       "processType": "obuiapp"
     },
     {
+      "name": "rMAddOrphanLine",
+      "label": "Insert Orphan Line",
+      "actionType": "utilityAction",
       "entity": "customerReturn",
-      "field": "rMAddOrphanLine",
       "column": "RM_AddOrphanLine",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/rMAddOrphanLine",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturn/{id}/action/rMAddOrphanLine",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "23D1B163EC0B41F790CE39BF01DA320E",
       "processType": "classic"
     },
     {
+      "name": "rMCreateInvoice",
+      "label": "Create Credit",
+      "actionType": "createFrom",
       "entity": "customerReturn",
-      "field": "rMCreateInvoice",
       "column": "RM_CreateInvoice",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/rMCreateInvoice",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturn/{id}/action/rMCreateInvoice",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "FF80808133362F6A013336781FCE0066",
       "processType": "classic"
     },
     {
+      "name": "processNow",
+      "label": "Process Order",
+      "actionType": "documentAction",
       "entity": "customerReturn",
-      "field": "processNow",
       "column": "Processing",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/processNow",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturn/{id}/action/processNow",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "104",
       "processType": "classic"
     },
     {
+      "name": "copyFrom",
+      "label": "Copy Lines",
+      "actionType": "createFrom",
       "entity": "customerReturn",
-      "field": "copyFrom",
       "column": "CopyFrom",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/copyFrom",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturn/{id}/action/copyFrom",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "211",
       "processType": "classic"
     },
     {
+      "name": "generateTemplate",
+      "label": "Copy Product Template",
+      "actionType": "createFrom",
       "entity": "customerReturn",
-      "field": "generateTemplate",
       "column": "Generatetemplate",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/generateTemplate",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturn/{id}/action/generateTemplate",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "800022",
       "processType": "classic"
     },
     {
+      "name": "copyFromPO",
+      "label": "Copy from Order",
+      "actionType": "createFrom",
       "entity": "customerReturn",
-      "field": "copyFromPO",
       "column": "CopyFromPO",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/copyFromPO",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturn/{id}/action/copyFromPO",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "8B81D80B06364566B87853FEECAB5DE0",
       "processType": "obuiapp"
     },
     {
+      "name": "posted",
+      "label": "Posted",
+      "actionType": "documentAction",
       "entity": "customerReturn",
-      "field": "posted",
       "column": "Posted",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/posted",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturn/{id}/action/posted",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "57496FB9CF9E4E8F847224017941570E",
       "processType": "obuiapp"
     },
     {
+      "name": "calculatePromotions",
+      "label": "Calculate_Promotions",
+      "actionType": "utilityAction",
       "entity": "customerReturn",
-      "field": "calculatePromotions",
       "column": "Calculate_Promotions",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/calculatePromotions",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturn/{id}/action/calculatePromotions",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "9EB2228A60684C0DBEC12D5CD8D85218",
       "processType": "classic"
     },
     {
+      "name": "cancelandreplace",
+      "label": "Cancelandreplace",
+      "actionType": "utilityAction",
       "entity": "customerReturn",
-      "field": "cancelandreplace",
       "column": "Cancelandreplace",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/cancelandreplace",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturn/{id}/action/cancelandreplace",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "A2FAF49712D1445ABE750315CE1B473A",
       "processType": "obuiapp"
     },
     {
+      "name": "confirmcancelandreplace",
+      "label": "Confirmcancelandreplace",
+      "actionType": "utilityAction",
       "entity": "customerReturn",
-      "field": "confirmcancelandreplace",
       "column": "Confirmcancelandreplace",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/confirmcancelandreplace",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturn/{id}/action/confirmcancelandreplace",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "0C2AFAEFB67B4CB8A1429195EB119A49",
       "processType": "obuiapp"
     },
     {
+      "name": "createOrder",
+      "label": "Convertquotation",
+      "actionType": "createFrom",
       "entity": "customerReturn",
-      "field": "createOrder",
       "column": "Convertquotation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/createOrder",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturn/{id}/action/createOrder",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "A3FE1F9892394386A49FB707AA50A0FA",
       "processType": "classic"
     },
     {
+      "name": "createPOLines",
+      "label": "Create_POLines",
+      "actionType": "createFrom",
       "entity": "customerReturn",
-      "field": "createPOLines",
       "column": "Create_POLines",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/createPOLines",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturn/{id}/action/createPOLines",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "6995A4C2592D434A9E16B71E1694CBCA",
       "processType": "obuiapp"
     },
     {
+      "name": "aPRMAddPayment",
+      "label": "EM_APRM_AddPayment",
+      "actionType": "paymentAction",
       "entity": "customerReturn",
-      "field": "aPRMAddPayment",
       "column": "EM_APRM_AddPayment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/aPRMAddPayment",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturn/{id}/action/aPRMAddPayment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "9BED7889E1034FE68BD85D5D16857320",
       "processType": "obuiapp"
     },
     {
+      "name": "rMPickfromreceipt",
+      "label": "RM_Pickfromreceipt",
+      "actionType": "createFrom",
       "entity": "customerReturn",
-      "field": "rMPickfromreceipt",
       "column": "RM_Pickfromreceipt",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturn/{id}/action/rMPickfromreceipt",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturn/{id}/action/rMPickfromreceipt",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
       "processType": "obuiapp"
     },
     {
+      "name": "selectOrderLine",
+      "label": "Select Order Line",
+      "actionType": "utilityAction",
       "entity": "customerReturnLine",
-      "field": "selectOrderLine",
       "column": "Relate_Orderline",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturnLine/{id}/action/selectOrderLine",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturnLine/{id}/action/selectOrderLine",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "C4265E27C8134096B49DFBF69369DFC6",
       "processType": "obuiapp"
     },
     {
+      "name": "explode",
+      "label": "Explode",
+      "actionType": "utilityAction",
       "entity": "customerReturnLine",
-      "field": "explode",
       "column": "Explode",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturnLine/{id}/action/explode",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturnLine/{id}/action/explode",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "DFC78024B1F54CBB95DC73425BA6687F",
       "processType": "classic"
     },
     {
+      "name": "managePrereservation",
+      "label": "Manage_Prereservation",
+      "actionType": "utilityAction",
       "entity": "customerReturnLine",
-      "field": "managePrereservation",
       "column": "Manage_Prereservation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturnLine/{id}/action/managePrereservation",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturnLine/{id}/action/managePrereservation",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
       "processType": "obuiapp"
     },
     {
+      "name": "manageReservation",
+      "label": "Manage_Reservation",
+      "actionType": "utilityAction",
       "entity": "customerReturnLine",
-      "field": "manageReservation",
       "column": "Manage_Reservation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/returns/customerReturnLine/{id}/action/manageReservation",
+      "method": "POST",
       "url": "/sws/neo/returns/customerReturnLine/{id}/action/manageReservation",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "5F547560D3DE401AA0B570F22E2C6C06",
       "processType": "obuiapp"
     }

--- a/artifacts/return-material-receipt/contract.json
+++ b/artifacts/return-material-receipt/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.2.0",
   "generatedAt": "2026-04-29T18:11:05.114Z",
-  "updatedAt": "2026-05-11T16:22:45.010Z",
-  "checksum": "963d5b3618f4484b",
+  "updatedAt": "2026-05-15T16:28:09.904Z",
+  "checksum": "70fbf883e1ef6b3f",
   "frontendContract": {
     "window": {
       "id": "123271B9AD60469BAE8A924841456B63",
@@ -1459,7 +1459,16 @@
         "column": "C_BPartner_Location_ID",
         "reference": "BusinessPartnerLocation",
         "inputMode": "dependent",
-        "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/selectors/partnerAddress"
+        "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/selectors/partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "returnMaterialReceipt",
@@ -1496,94 +1505,338 @@
     ],
     "actions": [
       {
+        "name": "receiveMaterials",
+        "label": "Pick/Edit Lines",
+        "actionType": "createFrom",
         "entity": "returnMaterialReceipt",
-        "field": "receiveMaterials",
         "column": "RM_Receipt_PickEdit",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/receiveMaterials",
+        "method": "POST",
         "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/receiveMaterials",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "5E9F9D7EECC24E4FBB2C60840FF613BE",
         "processType": "obuiapp"
       },
       {
+        "name": "createLinesFrom",
+        "label": "Create Lines From",
+        "actionType": "createFrom",
         "entity": "returnMaterialReceipt",
-        "field": "createLinesFrom",
         "column": "CreateFrom",
-        "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/createLinesFrom"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/createLinesFrom",
+        "method": "POST",
+        "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/createLinesFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "documentAction",
+        "label": "Process Shipment",
+        "actionType": "documentAction",
         "entity": "returnMaterialReceipt",
-        "field": "documentAction",
         "column": "DocAction",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/documentAction",
+        "method": "POST",
         "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/documentAction",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "109",
         "processType": "classic"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "returnMaterialReceipt",
-        "field": "posted",
         "column": "Posted",
-        "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/posted"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/posted",
+        "method": "POST",
+        "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "calculateFreight",
+        "label": "Calculate Freight Amount",
+        "actionType": "utilityAction",
         "entity": "returnMaterialReceipt",
-        "field": "calculateFreight",
         "column": "Calculate_Freight",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/calculateFreight",
+        "method": "POST",
         "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/calculateFreight",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "800141",
         "processType": "classic"
       },
       {
+        "name": "sendMaterials",
+        "label": "Send Materials",
+        "actionType": "createFrom",
         "entity": "returnMaterialReceipt",
-        "field": "sendMaterials",
         "column": "RM_Shipment_Pickedit",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/sendMaterials",
+        "method": "POST",
         "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/sendMaterials",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "4AD70293357245AB96E59C2CDB43A35D",
         "processType": "obuiapp"
       },
       {
+        "name": "generateTo",
+        "label": "Generate Invoice from Receipt",
+        "actionType": "createFrom",
         "entity": "returnMaterialReceipt",
-        "field": "generateTo",
         "column": "GenerateTo",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/generateTo",
+        "method": "POST",
         "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/generateTo",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "154",
         "processType": "classic"
       },
       {
+        "name": "updateLines",
+        "label": "Update Attributes from Shipment",
+        "actionType": "utilityAction",
         "entity": "returnMaterialReceipt",
-        "field": "updateLines",
         "column": "UpdateLines",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/updateLines",
+        "method": "POST",
         "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/updateLines",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "800010",
         "processType": "classic"
       },
       {
+        "name": "invoicefromshipment",
+        "label": "Invoicefromshipment",
+        "actionType": "utilityAction",
         "entity": "returnMaterialReceipt",
-        "field": "invoicefromshipment",
         "column": "Invoicefromshipment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/invoicefromshipment",
+        "method": "POST",
         "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/invoicefromshipment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "62250E8866EA4D96A66C309878DC039E",
         "processType": "obuiapp"
       },
       {
+        "name": "processGoodsJava",
+        "label": "Process_Goods_Java",
+        "actionType": "utilityAction",
         "entity": "returnMaterialReceipt",
-        "field": "processGoodsJava",
         "column": "Process_Goods_Java",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/processGoodsJava",
+        "method": "POST",
         "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/processGoodsJava",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "49DEE812BF0545269781FCEBF2235924",
         "processType": "classic"
       },
       {
+        "name": "explode",
+        "label": "Explode",
+        "actionType": "utilityAction",
         "entity": "returnMaterialReceiptLine",
-        "field": "explode",
         "column": "Explode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceiptLine/{id}/action/explode",
+        "method": "POST",
         "url": "/sws/neo/return-material-receipt/returnMaterialReceiptLine/{id}/action/explode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "DAE719940FE9463F8A3E3C401BBAFC53",
         "processType": "classic"
       },
       {
+        "name": "managePrereservation",
+        "label": "Manage_Prereservation",
+        "actionType": "utilityAction",
         "entity": "returnMaterialReceiptLine",
-        "field": "managePrereservation",
         "column": "Manage_Prereservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceiptLine/{id}/action/managePrereservation",
+        "method": "POST",
         "url": "/sws/neo/return-material-receipt/returnMaterialReceiptLine/{id}/action/managePrereservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
         "processType": "obuiapp"
       }

--- a/artifacts/return-material-receipt/contract.json
+++ b/artifacts/return-material-receipt/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.2.0",
   "generatedAt": "2026-04-29T18:11:05.114Z",
-  "updatedAt": "2026-05-15T16:28:09.904Z",
-  "checksum": "70fbf883e1ef6b3f",
+  "updatedAt": "2026-05-15T16:33:38.706Z",
+  "checksum": "c30ce521fb63c8e3",
   "frontendContract": {
     "window": {
       "id": "123271B9AD60469BAE8A924841456B63",
@@ -1857,6 +1857,180 @@
     "window": {
       "category": "sales"
     }
+  },
+  "formState": {
+    "entities": {
+      "returnMaterialReceipt": {
+        "fields": {
+          "documentNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @HAS_M_INOUTLINES@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "warehouse": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "partnerAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "DR",
+            "provenance": "extracted"
+          },
+          "salesOrder": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "trackingNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "returnMaterialReceiptLine": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM M_InOutLine WHERE M_InOut_ID=@M_InOut_ID@",
+            "provenance": "extracted"
+          },
+          "product": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "uOM": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "salesOrderLine": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/return-material-receipt/generated/web/return-material-receipt/ReturnMaterialReceiptPage.jsx
+++ b/artifacts/return-material-receipt/generated/web/return-material-receipt/ReturnMaterialReceiptPage.jsx
@@ -111,7 +111,16 @@ export const api = {
       "column": "C_BPartner_Location_ID",
       "reference": "BusinessPartnerLocation",
       "inputMode": "dependent",
-      "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/selectors/partnerAddress"
+      "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/selectors/partnerAddress",
+      "context": {
+        "required": [
+          {
+            "param": "C_BPartner_ID",
+            "source": "field",
+            "field": "businessPartner"
+          }
+        ]
+      }
     },
     {
       "entity": "returnMaterialReceipt",
@@ -148,94 +157,338 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "receiveMaterials",
+      "label": "Pick/Edit Lines",
+      "actionType": "createFrom",
       "entity": "returnMaterialReceipt",
-      "field": "receiveMaterials",
       "column": "RM_Receipt_PickEdit",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/receiveMaterials",
+      "method": "POST",
       "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/receiveMaterials",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "5E9F9D7EECC24E4FBB2C60840FF613BE",
       "processType": "obuiapp"
     },
     {
+      "name": "createLinesFrom",
+      "label": "Create Lines From",
+      "actionType": "createFrom",
       "entity": "returnMaterialReceipt",
-      "field": "createLinesFrom",
       "column": "CreateFrom",
-      "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/createLinesFrom"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/createLinesFrom",
+      "method": "POST",
+      "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/createLinesFrom",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "documentAction",
+      "label": "Process Shipment",
+      "actionType": "documentAction",
       "entity": "returnMaterialReceipt",
-      "field": "documentAction",
       "column": "DocAction",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/documentAction",
+      "method": "POST",
       "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/documentAction",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "109",
       "processType": "classic"
     },
     {
+      "name": "posted",
+      "label": "Posted",
+      "actionType": "documentAction",
       "entity": "returnMaterialReceipt",
-      "field": "posted",
       "column": "Posted",
-      "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/posted"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/posted",
+      "method": "POST",
+      "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/posted",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "calculateFreight",
+      "label": "Calculate Freight Amount",
+      "actionType": "utilityAction",
       "entity": "returnMaterialReceipt",
-      "field": "calculateFreight",
       "column": "Calculate_Freight",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/calculateFreight",
+      "method": "POST",
       "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/calculateFreight",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "800141",
       "processType": "classic"
     },
     {
+      "name": "sendMaterials",
+      "label": "Send Materials",
+      "actionType": "createFrom",
       "entity": "returnMaterialReceipt",
-      "field": "sendMaterials",
       "column": "RM_Shipment_Pickedit",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/sendMaterials",
+      "method": "POST",
       "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/sendMaterials",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "4AD70293357245AB96E59C2CDB43A35D",
       "processType": "obuiapp"
     },
     {
+      "name": "generateTo",
+      "label": "Generate Invoice from Receipt",
+      "actionType": "createFrom",
       "entity": "returnMaterialReceipt",
-      "field": "generateTo",
       "column": "GenerateTo",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/generateTo",
+      "method": "POST",
       "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/generateTo",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "154",
       "processType": "classic"
     },
     {
+      "name": "updateLines",
+      "label": "Update Attributes from Shipment",
+      "actionType": "utilityAction",
       "entity": "returnMaterialReceipt",
-      "field": "updateLines",
       "column": "UpdateLines",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/updateLines",
+      "method": "POST",
       "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/updateLines",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "800010",
       "processType": "classic"
     },
     {
+      "name": "invoicefromshipment",
+      "label": "Invoicefromshipment",
+      "actionType": "utilityAction",
       "entity": "returnMaterialReceipt",
-      "field": "invoicefromshipment",
       "column": "Invoicefromshipment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/invoicefromshipment",
+      "method": "POST",
       "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/invoicefromshipment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "62250E8866EA4D96A66C309878DC039E",
       "processType": "obuiapp"
     },
     {
+      "name": "processGoodsJava",
+      "label": "Process_Goods_Java",
+      "actionType": "utilityAction",
       "entity": "returnMaterialReceipt",
-      "field": "processGoodsJava",
       "column": "Process_Goods_Java",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/processGoodsJava",
+      "method": "POST",
       "url": "/sws/neo/return-material-receipt/returnMaterialReceipt/{id}/action/processGoodsJava",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "49DEE812BF0545269781FCEBF2235924",
       "processType": "classic"
     },
     {
+      "name": "explode",
+      "label": "Explode",
+      "actionType": "utilityAction",
       "entity": "returnMaterialReceiptLine",
-      "field": "explode",
       "column": "Explode",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceiptLine/{id}/action/explode",
+      "method": "POST",
       "url": "/sws/neo/return-material-receipt/returnMaterialReceiptLine/{id}/action/explode",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "DAE719940FE9463F8A3E3C401BBAFC53",
       "processType": "classic"
     },
     {
+      "name": "managePrereservation",
+      "label": "Manage_Prereservation",
+      "actionType": "utilityAction",
       "entity": "returnMaterialReceiptLine",
-      "field": "managePrereservation",
       "column": "Manage_Prereservation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-material-receipt/returnMaterialReceiptLine/{id}/action/managePrereservation",
+      "method": "POST",
       "url": "/sws/neo/return-material-receipt/returnMaterialReceiptLine/{id}/action/managePrereservation",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
       "processType": "obuiapp"
     }

--- a/artifacts/return-to-vendor-shipment/contract.json
+++ b/artifacts/return-to-vendor-shipment/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.4.0",
   "generatedAt": "2026-04-29T18:11:17.025Z",
-  "updatedAt": "2026-05-15T16:28:10.460Z",
-  "checksum": "676b9b16eeba9d69",
+  "updatedAt": "2026-05-15T16:33:39.256Z",
+  "checksum": "db9da5faf9c4e661",
   "frontendContract": {
     "window": {
       "id": "273673D2ED914C399A6C51DB758BE0F9",
@@ -2241,6 +2241,300 @@
     "window": {
       "category": "purchases"
     }
+  },
+  "formState": {
+    "entities": {
+      "header": {
+        "fields": {
+          "sendMaterials": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderReference": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @HAS_M_INOUTLINES@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "partnerAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "accountingDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "warehouse": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "DR",
+            "provenance": "extracted"
+          },
+          "documentAction": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "CO",
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "lines": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM M_InOutLine WHERE M_InOut_ID=@M_InOut_ID@",
+            "provenance": "extracted"
+          },
+          "product": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "attributeSetValue": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "operativeQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "operativeUOM": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "uOM": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "storageBin": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@OnHandLocatorDefault@",
+            "provenance": "extracted"
+          },
+          "salesOrderLine": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/return-to-vendor-shipment/contract.json
+++ b/artifacts/return-to-vendor-shipment/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.4.0",
   "generatedAt": "2026-04-29T18:11:17.025Z",
-  "updatedAt": "2026-05-14T16:16:15.734Z",
-  "checksum": "8980dcc59fe7ae11",
+  "updatedAt": "2026-05-15T16:28:10.460Z",
+  "checksum": "676b9b16eeba9d69",
   "frontendContract": {
     "window": {
       "id": "273673D2ED914C399A6C51DB758BE0F9",
@@ -1889,94 +1889,338 @@
     ],
     "actions": [
       {
+        "name": "sendMaterials",
+        "label": "Pick/Edit Lines",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "sendMaterials",
         "column": "RM_Shipment_Pickedit",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/sendMaterials",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/sendMaterials",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "4AD70293357245AB96E59C2CDB43A35D",
         "processType": "obuiapp"
       },
       {
+        "name": "createLinesFrom",
+        "label": "Create Lines From",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createLinesFrom",
         "column": "CreateFrom",
-        "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/createLinesFrom"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/createLinesFrom",
+        "method": "POST",
+        "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/createLinesFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "generateTo",
+        "label": "Generate Invoice from Receipt",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "generateTo",
         "column": "GenerateTo",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/generateTo",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/generateTo",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "154",
         "processType": "classic"
       },
       {
+        "name": "documentAction",
+        "label": "Process Shipment",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "documentAction",
         "column": "DocAction",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/documentAction",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/documentAction",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "109",
         "processType": "classic"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "posted",
         "column": "Posted",
-        "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/posted"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/posted",
+        "method": "POST",
+        "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "calculateFreight",
+        "label": "Calculate Freight Amount",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "calculateFreight",
         "column": "Calculate_Freight",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/calculateFreight",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/calculateFreight",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "800141",
         "processType": "classic"
       },
       {
+        "name": "receiveMaterials",
+        "label": "Receive Materials",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "receiveMaterials",
         "column": "RM_Receipt_PickEdit",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/receiveMaterials",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/receiveMaterials",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "5E9F9D7EECC24E4FBB2C60840FF613BE",
         "processType": "obuiapp"
       },
       {
+        "name": "updateLines",
+        "label": "Update Attributes from Shipment",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "updateLines",
         "column": "UpdateLines",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/updateLines",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/updateLines",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "800010",
         "processType": "classic"
       },
       {
+        "name": "invoicefromshipment",
+        "label": "Invoicefromshipment",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "invoicefromshipment",
         "column": "Invoicefromshipment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/invoicefromshipment",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/invoicefromshipment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "62250E8866EA4D96A66C309878DC039E",
         "processType": "obuiapp"
       },
       {
+        "name": "processGoodsJava",
+        "label": "Process_Goods_Java",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "processGoodsJava",
         "column": "Process_Goods_Java",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/processGoodsJava",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/processGoodsJava",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "49DEE812BF0545269781FCEBF2235924",
         "processType": "classic"
       },
       {
+        "name": "explode",
+        "label": "Explode",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "explode",
         "column": "Explode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor-shipment/lines/{id}/action/explode",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor-shipment/lines/{id}/action/explode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "DAE719940FE9463F8A3E3C401BBAFC53",
         "processType": "classic"
       },
       {
+        "name": "managePrereservation",
+        "label": "Manage_Prereservation",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "managePrereservation",
         "column": "Manage_Prereservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor-shipment/lines/{id}/action/managePrereservation",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor-shipment/lines/{id}/action/managePrereservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
         "processType": "obuiapp"
       }

--- a/artifacts/return-to-vendor-shipment/generated/web/return-to-vendor-shipment/HeaderPage.jsx
+++ b/artifacts/return-to-vendor-shipment/generated/web/return-to-vendor-shipment/HeaderPage.jsx
@@ -251,94 +251,338 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "sendMaterials",
+      "label": "Pick/Edit Lines",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "sendMaterials",
       "column": "RM_Shipment_Pickedit",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/sendMaterials",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/sendMaterials",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "4AD70293357245AB96E59C2CDB43A35D",
       "processType": "obuiapp"
     },
     {
+      "name": "createLinesFrom",
+      "label": "Create Lines From",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "createLinesFrom",
       "column": "CreateFrom",
-      "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/createLinesFrom"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/createLinesFrom",
+      "method": "POST",
+      "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/createLinesFrom",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "generateTo",
+      "label": "Generate Invoice from Receipt",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "generateTo",
       "column": "GenerateTo",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/generateTo",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/generateTo",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "154",
       "processType": "classic"
     },
     {
+      "name": "documentAction",
+      "label": "Process Shipment",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "documentAction",
       "column": "DocAction",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/documentAction",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/documentAction",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "109",
       "processType": "classic"
     },
     {
+      "name": "posted",
+      "label": "Posted",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "posted",
       "column": "Posted",
-      "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/posted"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/posted",
+      "method": "POST",
+      "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/posted",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "calculateFreight",
+      "label": "Calculate Freight Amount",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "calculateFreight",
       "column": "Calculate_Freight",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/calculateFreight",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/calculateFreight",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "800141",
       "processType": "classic"
     },
     {
+      "name": "receiveMaterials",
+      "label": "Receive Materials",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "receiveMaterials",
       "column": "RM_Receipt_PickEdit",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/receiveMaterials",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/receiveMaterials",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "5E9F9D7EECC24E4FBB2C60840FF613BE",
       "processType": "obuiapp"
     },
     {
+      "name": "updateLines",
+      "label": "Update Attributes from Shipment",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "updateLines",
       "column": "UpdateLines",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/updateLines",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/updateLines",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "800010",
       "processType": "classic"
     },
     {
+      "name": "invoicefromshipment",
+      "label": "Invoicefromshipment",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "invoicefromshipment",
       "column": "Invoicefromshipment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/invoicefromshipment",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/invoicefromshipment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "62250E8866EA4D96A66C309878DC039E",
       "processType": "obuiapp"
     },
     {
+      "name": "processGoodsJava",
+      "label": "Process_Goods_Java",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "processGoodsJava",
       "column": "Process_Goods_Java",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor-shipment/header/{id}/action/processGoodsJava",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor-shipment/header/{id}/action/processGoodsJava",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "49DEE812BF0545269781FCEBF2235924",
       "processType": "classic"
     },
     {
+      "name": "explode",
+      "label": "Explode",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "explode",
       "column": "Explode",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor-shipment/lines/{id}/action/explode",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor-shipment/lines/{id}/action/explode",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "DAE719940FE9463F8A3E3C401BBAFC53",
       "processType": "classic"
     },
     {
+      "name": "managePrereservation",
+      "label": "Manage_Prereservation",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "managePrereservation",
       "column": "Manage_Prereservation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor-shipment/lines/{id}/action/managePrereservation",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor-shipment/lines/{id}/action/managePrereservation",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
       "processType": "obuiapp"
     }

--- a/artifacts/return-to-vendor/contract.json
+++ b/artifacts/return-to-vendor/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.5.0",
   "generatedAt": "2026-04-29T19:46:13.628Z",
-  "updatedAt": "2026-05-15T16:28:10.352Z",
-  "checksum": "051aed5a17800f71",
+  "updatedAt": "2026-05-15T16:33:39.149Z",
+  "checksum": "9a5e40e7f48a00d9",
   "frontendContract": {
     "window": {
       "id": "C50A8AEE6F044825B5EF54FAAE76826F",
@@ -5257,6 +5257,800 @@
     "window": {
       "category": "purchases"
     }
+  },
+  "formState": {
+    "entities": {
+      "header": {
+        "fields": {
+          "documentAction": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "CO",
+            "provenance": "extracted"
+          },
+          "rMPickfromreceipt": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderReference": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "partnerAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cReturnReasonID": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "warehouse": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentTerms": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "priceList": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "DR",
+            "provenance": "extracted"
+          },
+          "grandTotalAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "summedLineAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@C_Currency_ID@",
+            "provenance": "extracted"
+          },
+          "deliveryNotes": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "rMAddOrphanLine": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "delivered": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "lines": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(Line),0)+10 AS DefaultValue FROM C_OrderLine WHERE C_Order_ID=@C_Order_ID@",
+            "provenance": "extracted"
+          },
+          "product": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "attributeSetValue": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @ATTRIBUTESETINSTANCIABLE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cReturnReasonID": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "operativeQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "operativeUOM": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderedQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | (@IsSOTrx@='Y' & @ISLINKEDTOPRODUCT@='Y' & @PRODUCTTYPE@='S') | @UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "1",
+            "provenance": "extracted"
+          },
+          "uOM": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "unitPrice": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @GROSSPRICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "grossUnitPrice": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @GROSSPRICE@='N'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "lineNetAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Iseditlinenetamt@='N'|@GROSSPRICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "lineGrossAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "goodsShipmentLine": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "tax": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "deliveredQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "project": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costcenter": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "ndDimension": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "lineTax": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(LINE),0)+10 AS DefaultValue FROM C_ORDERLINETAX WHERE C_ORDERLINE_ID=@C_OrderLine_ID@",
+            "provenance": "extracted"
+          },
+          "tax": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxableAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "taxAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "basicDiscounts": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(LINE),0)+10 AS DefaultValue FROM C_ORDER_DISCOUNT WHERE C_ORDER_ID=@C_ORDER_ID@",
+            "provenance": "extracted"
+          },
+          "discount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "cascade": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "active": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "Y",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "tax": {
+        "fields": {
+          "lineNo": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT COALESCE(MAX(LINE),0)+10 AS DefaultValue FROM C_ORDERTAX WHERE C_Order_ID=@C_Order_ID@",
+            "provenance": "extracted"
+          },
+          "tax": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "taxableAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "paymentOutPlan": {
+        "fields": {
+          "dueDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "expected": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "received": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "outstanding": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "lastPayment": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "numberOfPayments": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "paymentOutDetails": {
+        "fields": {
+          "payment": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "dueDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "finFinancialAccountID": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "expected": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paidAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "writeoffAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "expectedConverted": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paidConverted": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "finaccTxnConvertRate": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "canceled": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "status": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/return-to-vendor/contract.json
+++ b/artifacts/return-to-vendor/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.5.0",
   "generatedAt": "2026-04-29T19:46:13.628Z",
-  "updatedAt": "2026-05-14T16:16:11.606Z",
-  "checksum": "2457d6662aeaca75",
+  "updatedAt": "2026-05-15T16:28:10.352Z",
+  "checksum": "051aed5a17800f71",
   "frontendContract": {
     "window": {
       "id": "C50A8AEE6F044825B5EF54FAAE76826F",
@@ -4628,176 +4628,615 @@
     ],
     "actions": [
       {
+        "name": "documentAction",
+        "label": "Process Order",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "documentAction",
         "column": "DocAction",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/documentAction",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/header/{id}/action/documentAction",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "104",
         "processType": "classic"
       },
       {
+        "name": "rMPickfromreceipt",
+        "label": "Pick/Edit Lines",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "rMPickfromreceipt",
         "column": "RM_Pickfromreceipt",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/rMPickfromreceipt",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/header/{id}/action/rMPickfromreceipt",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
         "processType": "obuiapp"
       },
       {
+        "name": "generateTemplate",
+        "label": "Generate template",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "generateTemplate",
         "column": "Generatetemplate",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/generateTemplate",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/header/{id}/action/generateTemplate",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "800022",
         "processType": "classic"
       },
       {
+        "name": "rMReceiveMaterials",
+        "label": "RM_ReceiveMaterials",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "rMReceiveMaterials",
         "column": "RM_ReceiveMaterials",
-        "url": "/sws/neo/return-to-vendor/header/{id}/action/rMReceiveMaterials"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/rMReceiveMaterials",
+        "method": "POST",
+        "url": "/sws/neo/return-to-vendor/header/{id}/action/rMReceiveMaterials",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "rMCreateInvoice",
+        "label": "Create Invoice",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "rMCreateInvoice",
         "column": "RM_CreateInvoice",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/rMCreateInvoice",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/header/{id}/action/rMCreateInvoice",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "FF80808133362F6A013336781FCE0066",
         "processType": "classic"
       },
       {
+        "name": "copyFrom",
+        "label": "Copy Lines",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "copyFrom",
         "column": "CopyFrom",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/copyFrom",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/header/{id}/action/copyFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "211",
         "processType": "classic"
       },
       {
+        "name": "copyFromPO",
+        "label": "Copy from Order",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "copyFromPO",
         "column": "CopyFromPO",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/copyFromPO",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/header/{id}/action/copyFromPO",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "8B81D80B06364566B87853FEECAB5DE0",
         "processType": "obuiapp"
       },
       {
+        "name": "rMAddOrphanLine",
+        "label": "Insert Orphan Line",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "rMAddOrphanLine",
         "column": "RM_AddOrphanLine",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/rMAddOrphanLine",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/header/{id}/action/rMAddOrphanLine",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "23D1B163EC0B41F790CE39BF01DA320E",
         "processType": "classic"
       },
       {
+        "name": "processNow",
+        "label": "Process Order",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "processNow",
         "column": "Processing",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/processNow",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/header/{id}/action/processNow",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "104",
         "processType": "classic"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "posted",
         "column": "Posted",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/posted",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/header/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "57496FB9CF9E4E8F847224017941570E",
         "processType": "obuiapp"
       },
       {
+        "name": "calculatePromotions",
+        "label": "Calculate_Promotions",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "calculatePromotions",
         "column": "Calculate_Promotions",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/calculatePromotions",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/header/{id}/action/calculatePromotions",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "9EB2228A60684C0DBEC12D5CD8D85218",
         "processType": "classic"
       },
       {
+        "name": "cancelandreplace",
+        "label": "Cancelandreplace",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "cancelandreplace",
         "column": "Cancelandreplace",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/cancelandreplace",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/header/{id}/action/cancelandreplace",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "A2FAF49712D1445ABE750315CE1B473A",
         "processType": "obuiapp"
       },
       {
+        "name": "confirmcancelandreplace",
+        "label": "Confirmcancelandreplace",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "confirmcancelandreplace",
         "column": "Confirmcancelandreplace",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/confirmcancelandreplace",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/header/{id}/action/confirmcancelandreplace",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "0C2AFAEFB67B4CB8A1429195EB119A49",
         "processType": "obuiapp"
       },
       {
+        "name": "createOrder",
+        "label": "Convertquotation",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createOrder",
         "column": "Convertquotation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/createOrder",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/header/{id}/action/createOrder",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A3FE1F9892394386A49FB707AA50A0FA",
         "processType": "classic"
       },
       {
+        "name": "createPOLines",
+        "label": "Create_POLines",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createPOLines",
         "column": "Create_POLines",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/createPOLines",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/header/{id}/action/createPOLines",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "6995A4C2592D434A9E16B71E1694CBCA",
         "processType": "obuiapp"
       },
       {
+        "name": "aPRMAddPayment",
+        "label": "EM_APRM_AddPayment",
+        "actionType": "paymentAction",
         "entity": "header",
-        "field": "aPRMAddPayment",
         "column": "EM_APRM_AddPayment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/aPRMAddPayment",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/header/{id}/action/aPRMAddPayment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "9BED7889E1034FE68BD85D5D16857320",
         "processType": "obuiapp"
       },
       {
+        "name": "rMPickFromShipment",
+        "label": "RM_PickFromShipment",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "rMPickFromShipment",
         "column": "RM_PickFromShipment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/rMPickFromShipment",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/header/{id}/action/rMPickFromShipment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
         "processType": "obuiapp"
       },
       {
+        "name": "explode",
+        "label": "Explode",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "explode",
         "column": "Explode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/lines/{id}/action/explode",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/lines/{id}/action/explode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "DFC78024B1F54CBB95DC73425BA6687F",
         "processType": "classic"
       },
       {
+        "name": "managePrereservation",
+        "label": "Manage_Prereservation",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "managePrereservation",
         "column": "Manage_Prereservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/lines/{id}/action/managePrereservation",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/lines/{id}/action/managePrereservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
         "processType": "obuiapp"
       },
       {
+        "name": "manageReservation",
+        "label": "Manage_Reservation",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "manageReservation",
         "column": "Manage_Reservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/lines/{id}/action/manageReservation",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/lines/{id}/action/manageReservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "5F547560D3DE401AA0B570F22E2C6C06",
         "processType": "obuiapp"
       },
       {
+        "name": "selectOrderLine",
+        "label": "Relate_Orderline",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "selectOrderLine",
         "column": "Relate_Orderline",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/lines/{id}/action/selectOrderLine",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/lines/{id}/action/selectOrderLine",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "C4265E27C8134096B49DFBF69369DFC6",
         "processType": "obuiapp"
       },
       {
+        "name": "updatePaymentPlan",
+        "label": "Update_Payment_Plan",
+        "actionType": "paymentAction",
         "entity": "paymentOutPlan",
-        "field": "updatePaymentPlan",
         "column": "Update_Payment_Plan",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/return-to-vendor/paymentOutPlan/{id}/action/updatePaymentPlan",
+        "method": "POST",
         "url": "/sws/neo/return-to-vendor/paymentOutPlan/{id}/action/updatePaymentPlan",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "FB740AB61B0E42B198D2C88D3A0D0CE6",
         "processType": "classic"
       }

--- a/artifacts/return-to-vendor/generated/web/return-to-vendor/HeaderPage.jsx
+++ b/artifacts/return-to-vendor/generated/web/return-to-vendor/HeaderPage.jsx
@@ -457,176 +457,615 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "documentAction",
+      "label": "Process Order",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "documentAction",
       "column": "DocAction",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/documentAction",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/header/{id}/action/documentAction",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "104",
       "processType": "classic"
     },
     {
+      "name": "rMPickfromreceipt",
+      "label": "Pick/Edit Lines",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "rMPickfromreceipt",
       "column": "RM_Pickfromreceipt",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/rMPickfromreceipt",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/header/{id}/action/rMPickfromreceipt",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
       "processType": "obuiapp"
     },
     {
+      "name": "generateTemplate",
+      "label": "Generate template",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "generateTemplate",
       "column": "Generatetemplate",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/generateTemplate",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/header/{id}/action/generateTemplate",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "800022",
       "processType": "classic"
     },
     {
+      "name": "rMReceiveMaterials",
+      "label": "RM_ReceiveMaterials",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "rMReceiveMaterials",
       "column": "RM_ReceiveMaterials",
-      "url": "/sws/neo/return-to-vendor/header/{id}/action/rMReceiveMaterials"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/rMReceiveMaterials",
+      "method": "POST",
+      "url": "/sws/neo/return-to-vendor/header/{id}/action/rMReceiveMaterials",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "rMCreateInvoice",
+      "label": "Create Invoice",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "rMCreateInvoice",
       "column": "RM_CreateInvoice",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/rMCreateInvoice",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/header/{id}/action/rMCreateInvoice",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "FF80808133362F6A013336781FCE0066",
       "processType": "classic"
     },
     {
+      "name": "copyFrom",
+      "label": "Copy Lines",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "copyFrom",
       "column": "CopyFrom",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/copyFrom",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/header/{id}/action/copyFrom",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "211",
       "processType": "classic"
     },
     {
+      "name": "copyFromPO",
+      "label": "Copy from Order",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "copyFromPO",
       "column": "CopyFromPO",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/copyFromPO",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/header/{id}/action/copyFromPO",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "8B81D80B06364566B87853FEECAB5DE0",
       "processType": "obuiapp"
     },
     {
+      "name": "rMAddOrphanLine",
+      "label": "Insert Orphan Line",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "rMAddOrphanLine",
       "column": "RM_AddOrphanLine",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/rMAddOrphanLine",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/header/{id}/action/rMAddOrphanLine",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "23D1B163EC0B41F790CE39BF01DA320E",
       "processType": "classic"
     },
     {
+      "name": "processNow",
+      "label": "Process Order",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "processNow",
       "column": "Processing",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/processNow",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/header/{id}/action/processNow",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "104",
       "processType": "classic"
     },
     {
+      "name": "posted",
+      "label": "Posted",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "posted",
       "column": "Posted",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/posted",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/header/{id}/action/posted",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "57496FB9CF9E4E8F847224017941570E",
       "processType": "obuiapp"
     },
     {
+      "name": "calculatePromotions",
+      "label": "Calculate_Promotions",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "calculatePromotions",
       "column": "Calculate_Promotions",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/calculatePromotions",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/header/{id}/action/calculatePromotions",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "9EB2228A60684C0DBEC12D5CD8D85218",
       "processType": "classic"
     },
     {
+      "name": "cancelandreplace",
+      "label": "Cancelandreplace",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "cancelandreplace",
       "column": "Cancelandreplace",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/cancelandreplace",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/header/{id}/action/cancelandreplace",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "A2FAF49712D1445ABE750315CE1B473A",
       "processType": "obuiapp"
     },
     {
+      "name": "confirmcancelandreplace",
+      "label": "Confirmcancelandreplace",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "confirmcancelandreplace",
       "column": "Confirmcancelandreplace",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/confirmcancelandreplace",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/header/{id}/action/confirmcancelandreplace",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "0C2AFAEFB67B4CB8A1429195EB119A49",
       "processType": "obuiapp"
     },
     {
+      "name": "createOrder",
+      "label": "Convertquotation",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "createOrder",
       "column": "Convertquotation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/createOrder",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/header/{id}/action/createOrder",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "A3FE1F9892394386A49FB707AA50A0FA",
       "processType": "classic"
     },
     {
+      "name": "createPOLines",
+      "label": "Create_POLines",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "createPOLines",
       "column": "Create_POLines",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/createPOLines",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/header/{id}/action/createPOLines",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "6995A4C2592D434A9E16B71E1694CBCA",
       "processType": "obuiapp"
     },
     {
+      "name": "aPRMAddPayment",
+      "label": "EM_APRM_AddPayment",
+      "actionType": "paymentAction",
       "entity": "header",
-      "field": "aPRMAddPayment",
       "column": "EM_APRM_AddPayment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/aPRMAddPayment",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/header/{id}/action/aPRMAddPayment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "9BED7889E1034FE68BD85D5D16857320",
       "processType": "obuiapp"
     },
     {
+      "name": "rMPickFromShipment",
+      "label": "RM_PickFromShipment",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "rMPickFromShipment",
       "column": "RM_PickFromShipment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/header/{id}/action/rMPickFromShipment",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/header/{id}/action/rMPickFromShipment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
       "processType": "obuiapp"
     },
     {
+      "name": "explode",
+      "label": "Explode",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "explode",
       "column": "Explode",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/lines/{id}/action/explode",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/lines/{id}/action/explode",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "DFC78024B1F54CBB95DC73425BA6687F",
       "processType": "classic"
     },
     {
+      "name": "managePrereservation",
+      "label": "Manage_Prereservation",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "managePrereservation",
       "column": "Manage_Prereservation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/lines/{id}/action/managePrereservation",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/lines/{id}/action/managePrereservation",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
       "processType": "obuiapp"
     },
     {
+      "name": "manageReservation",
+      "label": "Manage_Reservation",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "manageReservation",
       "column": "Manage_Reservation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/lines/{id}/action/manageReservation",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/lines/{id}/action/manageReservation",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "5F547560D3DE401AA0B570F22E2C6C06",
       "processType": "obuiapp"
     },
     {
+      "name": "selectOrderLine",
+      "label": "Relate_Orderline",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "selectOrderLine",
       "column": "Relate_Orderline",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/lines/{id}/action/selectOrderLine",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/lines/{id}/action/selectOrderLine",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "C4265E27C8134096B49DFBF69369DFC6",
       "processType": "obuiapp"
     },
     {
+      "name": "updatePaymentPlan",
+      "label": "Update_Payment_Plan",
+      "actionType": "paymentAction",
       "entity": "paymentOutPlan",
-      "field": "updatePaymentPlan",
       "column": "Update_Payment_Plan",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/return-to-vendor/paymentOutPlan/{id}/action/updatePaymentPlan",
+      "method": "POST",
       "url": "/sws/neo/return-to-vendor/paymentOutPlan/{id}/action/updatePaymentPlan",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "FB740AB61B0E42B198D2C88D3A0D0CE6",
       "processType": "classic"
     }

--- a/artifacts/sales-invoice/contract.json
+++ b/artifacts/sales-invoice/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.24.0",
   "generatedAt": "2026-04-30T15:42:46.582Z",
-  "updatedAt": "2026-05-15T16:28:09.691Z",
-  "checksum": "2775df805b40b3ca",
+  "updatedAt": "2026-05-15T16:33:38.488Z",
+  "checksum": "8b4a080ff9f10555",
   "frontendContract": {
     "window": {
       "id": "167",
@@ -4564,6 +4564,586 @@
         "em_etgo_delivery_status": "Delivery Status"
       }
     }
+  },
+  "formState": {
+    "entities": {
+      "header": {
+        "fields": {
+          "adOrgId": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#AD_Org_ID@",
+            "provenance": "extracted"
+          },
+          "documentNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoiceDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Posted@='Y' | (@Processed@='Y' & (@DocStatus@!'VO'))",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "partnerAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentTerms": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "DR",
+            "provenance": "extracted"
+          },
+          "grandTotalAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "summedLineAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@C_Currency_ID@",
+            "provenance": "extracted"
+          },
+          "paymentComplete": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "posted": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "outstandingAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "priceList": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etsgDateOperation": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@DateInvoiced@",
+            "provenance": "extracted"
+          },
+          "tbaiSequence": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "tbaiInvoicenum": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "tbaiInvoiceseq": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "tbaiIssent": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "aeatsiiIssent": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "true",
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "aeatsiiClaveTipo": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "(@em_aeatsii_estado@='CO' | @em_aeatsii_estado@='AE' | @DocStatus@='VO') & @Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT CASE WHEN ((SELECT c.insiisystem FROM aeatsii_config c WHERE c.ad_org_id = (SELECT ad_get_org_le_bu(@AD_Org_ID@,'LE') FROM dual))='Y') THEN 'F1' ELSE null END FROM dual",
+            "provenance": "extracted"
+          },
+          "aeatsiiDescription": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "(@em_aeatsii_estado@='CO' | @em_aeatsii_estado@='AE' | (@DocStatus@='VO' & @em_aeatsii_issent@='Y')) & @Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=\n\tSELECT\n\t\tCASE\n\t\t\tWHEN\n\t\t\t\t(\n\t\t\t\t\t(\n\t\t\t\t\t\tSELECT c.insiisystem\n\t\t\t\t\t\tFROM aeatsii_config c\n\t\t\t\t\t\tWHERE c.ad_org_id = (\n\t\t\t\t\t\t\tSELECT ad_get_org_le_bu(@AD_Org_ID@,'LE')\n\t\t\t\t\t\t\tFROM dual\n\t\t\t\t\t\t)\n\t\t\t\t\t)='Y'\n\t\t\t\t)\n\t\t\tTHEN\n\t\t\t\t(\n\t\t\t\t\tSELECT\n\t\t\t\t\t\t(\n\t\t\t\t\t\t\tCASE\n\t\t\t\t\t\t\t\tWHEN ('Y' = 'Y')\n\t\t\t\t\t\t\t\tTHEN (\n\t\t\t\t\t\t\t\t\tSELECT aeatsii_description_id\n\t\t\t\t\t\t\t\t\tFROM aeatsii_description\n\t\t\t\t\t\t\t\t\tWHERE isdefault = 'Y'\n\t\t\t\t\t\t\t\t\tAND issales = 'Y'\n\t\t\t\t\t\t\t\t\tAND ad_org_id = @AD_Org_ID@\n\t\t\t\t\t\t\t\t\tAND ad_client_id = @ad_client_id@\n\t\t\t\t\t\t\t\t) ELSE (null)\n\t\t\t\t\t\t\tEND\n\t\t\t\t\t\t)\n\t\t\t\t\tFROM dual\n\t\t\t\t)\n\t\t\tELSE null\n\t\tEND\n\tFROM dual",
+            "provenance": "extracted"
+          },
+          "aeatsiiDescripcionSii": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "(@em_aeatsii_estado@='CO' | @em_aeatsii_estado@='AE' | (@DocStatus@='VO' & @em_aeatsii_issent@='Y')) & @Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=\n\tSELECT\n\t\tCASE\n\t\t\tWHEN\n\t\t\t\t(\n\t\t\t\t\t(\n\t\t\t\t\t\tSELECT c.insiisystem\n\t\t\t\t\t\tFROM aeatsii_config c\n\t\t\t\t\t\tWHERE c.ad_org_id = (\n\t\t\t\t\t\t\tSELECT ad_get_org_le_bu(@AD_Org_ID@,'LE')\n\t\t\t\t\t\t\tFROM dual\n\t\t\t\t\t\t)\n\t\t\t\t\t)='Y'\n\t\t\t\t)\n\t\t\tTHEN\n\t\t\t\t(\n\t\t\t\t\tSELECT\n\t\t\t\t\t\t(\n\t\t\t\t\t\t\tCASE\n\t\t\t\t\t\t\t\tWHEN(@issotrx@ = 'Y')\n\t\t\t\t\t\t\t\tTHEN (\n\t\t\t\t\t\t\t\t\tSELECT description\n\t\t\t\t\t\t\t\t\tFROM aeatsii_description\n\t\t\t\t\t\t\t\t\tWHERE isdefault = 'Y'\n\t\t\t\t\t\t\t\t\tAND issales = 'Y'\n\t\t\t\t\t\t\t\t\tAND ad_org_id = @AD_Org_ID@\n\t\t\t\t\t\t\t\t\tAND ad_client_id = @ad_client_id@\n\t\t\t\t\t\t\t\t) ELSE (\n\t\t\t\t\t\t\t\t\tSELECT description\n\t\t\t\t\t\t\t\t\tFROM aeatsii_description\n\t\t\t\t\t\t\t\t\tWHERE isdefault = 'Y'\n\t\t\t\t\t\t\t\t\tAND ispurchase = 'Y'\n\t\t\t\t\t\t\t\t\tAND ad_org_id = @AD_Org_ID@\n\t\t\t\t\t\t\t\t\tAND ad_client_id = @ad_client_id@\n\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\tEND\n\t\t\t\t\t\t)\n\t\t\t\t\tFROM dual\n\t\t\t\t)\n\t\t\tELSE null\n\t\tEND\n\tFROM dual",
+            "provenance": "extracted"
+          },
+          "aeatsiiEstado": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "true",
+            "calloutTriggers": null,
+            "defaultValue": "@SQL=SELECT CASE WHEN ((SELECT c.insiisystem FROM aeatsii_config c WHERE c.ad_org_id = (SELECT ad_get_org_le_bu(@AD_Org_ID@,'LE') FROM dual))='Y') THEN 'PE' ELSE null END FROM dual",
+            "provenance": "extracted"
+          },
+          "aeatsiiEjercicio": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "true",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "aeatsiiPeriodo": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "true",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "aeatsiiCauseExemption": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "aeatsiiIsauthorization": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "processed": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etgoTotalDiscount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "eTGODueDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "eTGODeliveryStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "lines": {
+        "fields": {
+          "product": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoicedQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | (@UomManagement@='Y' & @Financial_Invoice_Line@='N')",
+            "calloutTriggers": null,
+            "defaultValue": "1",
+            "provenance": "extracted"
+          },
+          "listPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etgoDiscount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "tax": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "unitPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'|@GROSSPRICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "grossUnitPrice": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'|@GROSSPRICE@='N'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "grossAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "paymentPlan": {
+        "fields": {
+          "dueDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "expectedDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "finPaymentmethodID": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "amount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "paidAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "outstandingAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "lastPaymentDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "daysOverdue": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "numberOfPayments": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "totalDebtAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "finPaymentScheduleID": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [
+      "#ShowAcct"
+    ],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/sales-invoice/contract.json
+++ b/artifacts/sales-invoice/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.24.0",
   "generatedAt": "2026-04-30T15:42:46.582Z",
-  "updatedAt": "2026-05-11T19:25:32.300Z",
-  "checksum": "f5ee265b656457b3",
+  "updatedAt": "2026-05-15T16:28:09.691Z",
+  "checksum": "2775df805b40b3ca",
   "frontendContract": {
     "window": {
       "id": "167",
@@ -3731,7 +3731,16 @@
         "column": "C_BPartner_Location_ID",
         "reference": "BusinessPartnerLocation",
         "inputMode": "dependent",
-        "url": "/sws/neo/sales-invoice/header/selectors/partnerAddress"
+        "url": "/sws/neo/sales-invoice/header/selectors/partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -3747,7 +3756,15 @@
         "column": "FIN_Paymentmethod_ID",
         "reference": "PaymentMethod",
         "inputMode": "selector",
-        "url": "/sws/neo/sales-invoice/header/selectors/paymentMethod"
+        "url": "/sws/neo/sales-invoice/header/selectors/paymentMethod",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -3763,7 +3780,15 @@
         "column": "M_PriceList_ID",
         "reference": "PriceList",
         "inputMode": "selector",
-        "url": "/sws/neo/sales-invoice/header/selectors/priceList"
+        "url": "/sws/neo/sales-invoice/header/selectors/priceList",
+        "context": {
+          "required": [
+            {
+              "param": "isSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -3795,7 +3820,22 @@
         "column": "C_Tax_ID",
         "reference": "Tax",
         "inputMode": "selector",
-        "url": "/sws/neo/sales-invoice/lines/selectors/tax"
+        "url": "/sws/neo/sales-invoice/lines/selectors/tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
       },
       {
         "entity": "paymentPlan",
@@ -3816,190 +3856,682 @@
     ],
     "actions": [
       {
+        "name": "aPRMAddpayment",
+        "label": "Add Payment",
+        "actionType": "paymentAction",
         "entity": "header",
-        "field": "aPRMAddpayment",
         "column": "EM_APRM_Addpayment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/aPRMAddpayment",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/aPRMAddpayment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "9BED7889E1034FE68BD85D5D16857320",
         "processType": "obuiapp"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "posted",
         "column": "Posted",
-        "url": "/sws/neo/sales-invoice/header/{id}/action/posted"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/posted",
+        "method": "POST",
+        "url": "/sws/neo/sales-invoice/header/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "aPRMProcessinvoice",
+        "label": "Process Invoices",
+        "actionType": "paymentAction",
         "entity": "header",
-        "field": "aPRMProcessinvoice",
         "column": "EM_APRM_Processinvoice",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/aPRMProcessinvoice",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/aPRMProcessinvoice",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "B54318B49E984B9CB855AEFB1F474CD6",
         "processType": "classic"
       },
       {
+        "name": "documentAction",
+        "label": "Process Invoice",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "documentAction",
         "column": "DocAction",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/documentAction",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/documentAction",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "111",
         "processType": "classic"
       },
       {
+        "name": "createLinesFromOrder",
+        "label": "Create Lines From Order",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createLinesFromOrder",
         "column": "Createfromorders",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/createLinesFromOrder",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/createLinesFromOrder",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "AB2EFCAABB7B4EC0A9B30CFB82963FB6",
         "processType": "obuiapp"
       },
       {
+        "name": "createLinesFromShipment",
+        "label": "Create Lines From Shipment",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createLinesFromShipment",
         "column": "Createfrominouts",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/createLinesFromShipment",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/createLinesFromShipment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "7737CA7330FD49FBA7EBC225E85F2BC9",
         "processType": "obuiapp"
       },
       {
+        "name": "copyFrom",
+        "label": "Copy Lines",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "copyFrom",
         "column": "CopyFrom",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/copyFrom",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/copyFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "210",
         "processType": "classic"
       },
       {
+        "name": "calculatePromotions",
+        "label": "Calculate Promotions",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "calculatePromotions",
         "column": "Calculate_Promotions",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/calculatePromotions",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/calculatePromotions",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "9EB2228A60684C0DBEC12D5CD8D85218",
         "processType": "classic"
       },
       {
+        "name": "tBAIQRcode",
+        "label": "Imprimir factura con QR",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "tBAIQRcode",
         "column": "em_tbai_qrcode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/tBAIQRcode",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/tBAIQRcode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "12FECC9DF1F4418AB7DAA46D6A05FEC6",
         "processType": "obuiapp"
       },
       {
+        "name": "etvfacRectCreate",
+        "label": "Crear Rectificación Importe Negativo",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "etvfacRectCreate",
         "column": "EM_Etvfac_Rect_Create",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/etvfacRectCreate",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/etvfacRectCreate",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "E36A8BA259164E78AFDDC760172C18F5",
         "processType": "obuiapp"
       },
       {
+        "name": "tbaiXmlgenerator",
+        "label": "Registrar Factura en TBAI",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "tbaiXmlgenerator",
         "column": "EM_Tbai_Xmlgenerator",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/tbaiXmlgenerator",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/tbaiXmlgenerator",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "BE2486102F2C41779B760609FD69A225",
         "processType": "obuiapp"
       },
       {
+        "name": "tbaiVoidxmlgenerator",
+        "label": "Enviar anulación a TIcketbai",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "tbaiVoidxmlgenerator",
         "column": "EM_Tbai_Voidxmlgenerator",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/tbaiVoidxmlgenerator",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/tbaiVoidxmlgenerator",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "535A8BAE44A34759A7C8FF40D62A5070",
         "processType": "obuiapp"
       },
       {
+        "name": "aeatsiiSend",
+        "label": "Send to SII",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "aeatsiiSend",
         "column": "EM_Aeatsii_Send",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/aeatsiiSend",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/aeatsiiSend",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "2ECF46DAAEEB486EAF79D3594D50DE5F",
         "processType": "obuiapp"
       },
       {
+        "name": "aeatsiiModif",
+        "label": "Modification in SII",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "aeatsiiModif",
         "column": "EM_Aeatsii_Modif",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/aeatsiiModif",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/aeatsiiModif",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "BAAECFDF9FF144E8A610E9F1EF3E5FBE",
         "processType": "obuiapp"
       },
       {
+        "name": "processNow",
+        "label": "Process Invoice",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "processNow",
         "column": "Processing",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/processNow",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/processNow",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "111",
         "processType": "classic"
       },
       {
+        "name": "generateTo",
+        "label": "Generate Receipt from Invoice",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "generateTo",
         "column": "GenerateTo",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/generateTo",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/generateTo",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "142",
         "processType": "classic"
       },
       {
+        "name": "createLinesFrom",
+        "label": "CreateFrom",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createLinesFrom",
         "column": "CreateFrom",
-        "url": "/sws/neo/sales-invoice/header/{id}/action/createLinesFrom"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/createLinesFrom",
+        "method": "POST",
+        "url": "/sws/neo/sales-invoice/header/{id}/action/createLinesFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "aeatsiiDup",
+        "label": "EM_Aeatsii_Dup",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "aeatsiiDup",
         "column": "EM_Aeatsii_Dup",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/aeatsiiDup",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/aeatsiiDup",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "92C02F9A367140C085D1EE3BD27C4E96",
         "processType": "obuiapp"
       },
       {
+        "name": "aeatsiiUnsubscribe",
+        "label": "EM_Aeatsii_Unsubscribe",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "aeatsiiUnsubscribe",
         "column": "EM_Aeatsii_Unsubscribe",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/header/{id}/action/aeatsiiUnsubscribe",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/header/{id}/action/aeatsiiUnsubscribe",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "BE564945CB2D4892AC0EE51204C5DB7D",
         "processType": "obuiapp"
       },
       {
+        "name": "explode",
+        "label": "Explode",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "explode",
         "column": "Explode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/lines/{id}/action/explode",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/lines/{id}/action/explode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "6E1ADD5C8B6B4ACB82237DAA8114451E",
         "processType": "classic"
       },
       {
+        "name": "matchLCCosts",
+        "label": "Match_Lccosts",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "matchLCCosts",
         "column": "Match_Lccosts",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/lines/{id}/action/matchLCCosts",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/lines/{id}/action/matchLCCosts",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "281FFDFAB31C4394A2EAA73A6F9F3A3F",
         "processType": "obuiapp"
       },
       {
+        "name": "updatePaymentPlan",
+        "label": "Update Payment Plan",
+        "actionType": "paymentAction",
         "entity": "paymentPlan",
-        "field": "updatePaymentPlan",
         "column": "Update_Payment_Plan",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/paymentPlan/{id}/action/updatePaymentPlan",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/paymentPlan/{id}/action/updatePaymentPlan",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "FB740AB61B0E42B198D2C88D3A0D0CE6",
         "processType": "classic"
       },
       {
+        "name": "aprmModifPaymentINPlan",
+        "label": "Modify Payment Plan",
+        "actionType": "paymentAction",
         "entity": "paymentPlan",
-        "field": "aprmModifPaymentINPlan",
         "column": "EM_Aprm_Modif_Paym_Sched",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/paymentPlan/{id}/action/aprmModifPaymentINPlan",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/paymentPlan/{id}/action/aprmModifPaymentINPlan",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "4EEB3497082C4F2182E16A4371CD5D96",
         "processType": "obuiapp"
       },
       {
+        "name": "aprmModifPaymentOUTPlan",
+        "label": "EM_Aprm_Modif_Paym_Out_Sched",
+        "actionType": "paymentAction",
         "entity": "paymentPlan",
-        "field": "aprmModifPaymentOUTPlan",
         "column": "EM_Aprm_Modif_Paym_Out_Sched",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-invoice/paymentPlan/{id}/action/aprmModifPaymentOUTPlan",
+        "method": "POST",
         "url": "/sws/neo/sales-invoice/paymentPlan/{id}/action/aprmModifPaymentOUTPlan",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "6F87442DF7BC43AB8A666BDED2F7D64E",
         "processType": "obuiapp"
       }

--- a/artifacts/sales-invoice/generated/web/sales-invoice/HeaderPage.jsx
+++ b/artifacts/sales-invoice/generated/web/sales-invoice/HeaderPage.jsx
@@ -150,7 +150,16 @@ export const api = {
       "column": "C_BPartner_Location_ID",
       "reference": "BusinessPartnerLocation",
       "inputMode": "dependent",
-      "url": "/sws/neo/sales-invoice/header/selectors/partnerAddress"
+      "url": "/sws/neo/sales-invoice/header/selectors/partnerAddress",
+      "context": {
+        "required": [
+          {
+            "param": "C_BPartner_ID",
+            "source": "field",
+            "field": "businessPartner"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -166,7 +175,15 @@ export const api = {
       "column": "FIN_Paymentmethod_ID",
       "reference": "PaymentMethod",
       "inputMode": "selector",
-      "url": "/sws/neo/sales-invoice/header/selectors/paymentMethod"
+      "url": "/sws/neo/sales-invoice/header/selectors/paymentMethod",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -182,7 +199,15 @@ export const api = {
       "column": "M_PriceList_ID",
       "reference": "PriceList",
       "inputMode": "selector",
-      "url": "/sws/neo/sales-invoice/header/selectors/priceList"
+      "url": "/sws/neo/sales-invoice/header/selectors/priceList",
+      "context": {
+        "required": [
+          {
+            "param": "isSOTrx",
+            "source": "windowCategory"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -214,7 +239,22 @@ export const api = {
       "column": "C_Tax_ID",
       "reference": "Tax",
       "inputMode": "selector",
-      "url": "/sws/neo/sales-invoice/lines/selectors/tax"
+      "url": "/sws/neo/sales-invoice/lines/selectors/tax",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          },
+          {
+            "param": "DateInvoiced",
+            "source": "parentField",
+            "field": "invoiceDate",
+            "fallbackField": "orderDate",
+            "format": "DD-MM-YYYY"
+          }
+        ]
+      }
     },
     {
       "entity": "paymentPlan",
@@ -235,190 +275,682 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "aPRMAddpayment",
+      "label": "Add Payment",
+      "actionType": "paymentAction",
       "entity": "header",
-      "field": "aPRMAddpayment",
       "column": "EM_APRM_Addpayment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/aPRMAddpayment",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/aPRMAddpayment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "9BED7889E1034FE68BD85D5D16857320",
       "processType": "obuiapp"
     },
     {
+      "name": "posted",
+      "label": "Posted",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "posted",
       "column": "Posted",
-      "url": "/sws/neo/sales-invoice/header/{id}/action/posted"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/posted",
+      "method": "POST",
+      "url": "/sws/neo/sales-invoice/header/{id}/action/posted",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "aPRMProcessinvoice",
+      "label": "Process Invoices",
+      "actionType": "paymentAction",
       "entity": "header",
-      "field": "aPRMProcessinvoice",
       "column": "EM_APRM_Processinvoice",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/aPRMProcessinvoice",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/aPRMProcessinvoice",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "B54318B49E984B9CB855AEFB1F474CD6",
       "processType": "classic"
     },
     {
+      "name": "documentAction",
+      "label": "Process Invoice",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "documentAction",
       "column": "DocAction",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/documentAction",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/documentAction",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "111",
       "processType": "classic"
     },
     {
+      "name": "createLinesFromOrder",
+      "label": "Create Lines From Order",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "createLinesFromOrder",
       "column": "Createfromorders",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/createLinesFromOrder",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/createLinesFromOrder",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "AB2EFCAABB7B4EC0A9B30CFB82963FB6",
       "processType": "obuiapp"
     },
     {
+      "name": "createLinesFromShipment",
+      "label": "Create Lines From Shipment",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "createLinesFromShipment",
       "column": "Createfrominouts",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/createLinesFromShipment",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/createLinesFromShipment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "7737CA7330FD49FBA7EBC225E85F2BC9",
       "processType": "obuiapp"
     },
     {
+      "name": "copyFrom",
+      "label": "Copy Lines",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "copyFrom",
       "column": "CopyFrom",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/copyFrom",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/copyFrom",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "210",
       "processType": "classic"
     },
     {
+      "name": "calculatePromotions",
+      "label": "Calculate Promotions",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "calculatePromotions",
       "column": "Calculate_Promotions",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/calculatePromotions",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/calculatePromotions",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "9EB2228A60684C0DBEC12D5CD8D85218",
       "processType": "classic"
     },
     {
+      "name": "tBAIQRcode",
+      "label": "Imprimir factura con QR",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "tBAIQRcode",
       "column": "em_tbai_qrcode",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/tBAIQRcode",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/tBAIQRcode",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "12FECC9DF1F4418AB7DAA46D6A05FEC6",
       "processType": "obuiapp"
     },
     {
+      "name": "etvfacRectCreate",
+      "label": "Crear Rectificación Importe Negativo",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "etvfacRectCreate",
       "column": "EM_Etvfac_Rect_Create",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/etvfacRectCreate",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/etvfacRectCreate",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "E36A8BA259164E78AFDDC760172C18F5",
       "processType": "obuiapp"
     },
     {
+      "name": "tbaiXmlgenerator",
+      "label": "Registrar Factura en TBAI",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "tbaiXmlgenerator",
       "column": "EM_Tbai_Xmlgenerator",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/tbaiXmlgenerator",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/tbaiXmlgenerator",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "BE2486102F2C41779B760609FD69A225",
       "processType": "obuiapp"
     },
     {
+      "name": "tbaiVoidxmlgenerator",
+      "label": "Enviar anulación a TIcketbai",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "tbaiVoidxmlgenerator",
       "column": "EM_Tbai_Voidxmlgenerator",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/tbaiVoidxmlgenerator",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/tbaiVoidxmlgenerator",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "535A8BAE44A34759A7C8FF40D62A5070",
       "processType": "obuiapp"
     },
     {
+      "name": "aeatsiiSend",
+      "label": "Send to SII",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "aeatsiiSend",
       "column": "EM_Aeatsii_Send",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/aeatsiiSend",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/aeatsiiSend",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "2ECF46DAAEEB486EAF79D3594D50DE5F",
       "processType": "obuiapp"
     },
     {
+      "name": "aeatsiiModif",
+      "label": "Modification in SII",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "aeatsiiModif",
       "column": "EM_Aeatsii_Modif",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/aeatsiiModif",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/aeatsiiModif",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "BAAECFDF9FF144E8A610E9F1EF3E5FBE",
       "processType": "obuiapp"
     },
     {
+      "name": "processNow",
+      "label": "Process Invoice",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "processNow",
       "column": "Processing",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/processNow",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/processNow",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "111",
       "processType": "classic"
     },
     {
+      "name": "generateTo",
+      "label": "Generate Receipt from Invoice",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "generateTo",
       "column": "GenerateTo",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/generateTo",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/generateTo",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "142",
       "processType": "classic"
     },
     {
+      "name": "createLinesFrom",
+      "label": "CreateFrom",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "createLinesFrom",
       "column": "CreateFrom",
-      "url": "/sws/neo/sales-invoice/header/{id}/action/createLinesFrom"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/createLinesFrom",
+      "method": "POST",
+      "url": "/sws/neo/sales-invoice/header/{id}/action/createLinesFrom",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "aeatsiiDup",
+      "label": "EM_Aeatsii_Dup",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "aeatsiiDup",
       "column": "EM_Aeatsii_Dup",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/aeatsiiDup",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/aeatsiiDup",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "92C02F9A367140C085D1EE3BD27C4E96",
       "processType": "obuiapp"
     },
     {
+      "name": "aeatsiiUnsubscribe",
+      "label": "EM_Aeatsii_Unsubscribe",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "aeatsiiUnsubscribe",
       "column": "EM_Aeatsii_Unsubscribe",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/header/{id}/action/aeatsiiUnsubscribe",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/header/{id}/action/aeatsiiUnsubscribe",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "BE564945CB2D4892AC0EE51204C5DB7D",
       "processType": "obuiapp"
     },
     {
+      "name": "explode",
+      "label": "Explode",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "explode",
       "column": "Explode",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/lines/{id}/action/explode",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/lines/{id}/action/explode",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "6E1ADD5C8B6B4ACB82237DAA8114451E",
       "processType": "classic"
     },
     {
+      "name": "matchLCCosts",
+      "label": "Match_Lccosts",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "matchLCCosts",
       "column": "Match_Lccosts",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/lines/{id}/action/matchLCCosts",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/lines/{id}/action/matchLCCosts",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "281FFDFAB31C4394A2EAA73A6F9F3A3F",
       "processType": "obuiapp"
     },
     {
+      "name": "updatePaymentPlan",
+      "label": "Update Payment Plan",
+      "actionType": "paymentAction",
       "entity": "paymentPlan",
-      "field": "updatePaymentPlan",
       "column": "Update_Payment_Plan",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/paymentPlan/{id}/action/updatePaymentPlan",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/paymentPlan/{id}/action/updatePaymentPlan",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "FB740AB61B0E42B198D2C88D3A0D0CE6",
       "processType": "classic"
     },
     {
+      "name": "aprmModifPaymentINPlan",
+      "label": "Modify Payment Plan",
+      "actionType": "paymentAction",
       "entity": "paymentPlan",
-      "field": "aprmModifPaymentINPlan",
       "column": "EM_Aprm_Modif_Paym_Sched",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/paymentPlan/{id}/action/aprmModifPaymentINPlan",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/paymentPlan/{id}/action/aprmModifPaymentINPlan",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "4EEB3497082C4F2182E16A4371CD5D96",
       "processType": "obuiapp"
     },
     {
+      "name": "aprmModifPaymentOUTPlan",
+      "label": "EM_Aprm_Modif_Paym_Out_Sched",
+      "actionType": "paymentAction",
       "entity": "paymentPlan",
-      "field": "aprmModifPaymentOUTPlan",
       "column": "EM_Aprm_Modif_Paym_Out_Sched",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-invoice/paymentPlan/{id}/action/aprmModifPaymentOUTPlan",
+      "method": "POST",
       "url": "/sws/neo/sales-invoice/paymentPlan/{id}/action/aprmModifPaymentOUTPlan",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "6F87442DF7BC43AB8A666BDED2F7D64E",
       "processType": "obuiapp"
     }

--- a/artifacts/sales-order/contract.json
+++ b/artifacts/sales-order/contract.json
@@ -1,7 +1,8 @@
 {
   "version": "0.1.0",
   "generatedAt": "2026-05-12T16:47:39.614Z",
-  "checksum": "6eee1b41fd22ef78",
+  "updatedAt": "2026-05-15T16:28:09.476Z",
+  "checksum": "482710ba309cc9b4",
   "frontendContract": {
     "window": {
       "id": "143",
@@ -2414,7 +2415,16 @@
         "column": "C_BPartner_Location_ID",
         "reference": "BusinessPartnerLocation",
         "inputMode": "dependent",
-        "url": "/sws/neo/sales-order/header/selectors/partnerAddress"
+        "url": "/sws/neo/sales-order/header/selectors/partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -2422,7 +2432,15 @@
         "column": "M_PriceList_ID",
         "reference": "PriceList",
         "inputMode": "selector",
-        "url": "/sws/neo/sales-order/header/selectors/priceList"
+        "url": "/sws/neo/sales-order/header/selectors/priceList",
+        "context": {
+          "required": [
+            {
+              "param": "isSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -2430,7 +2448,15 @@
         "column": "FIN_Paymentmethod_ID",
         "reference": "PaymentMethod",
         "inputMode": "selector",
-        "url": "/sws/neo/sales-order/header/selectors/paymentMethod"
+        "url": "/sws/neo/sales-order/header/selectors/paymentMethod",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "header",
@@ -2470,173 +2496,609 @@
         "column": "C_Tax_ID",
         "reference": "Tax",
         "inputMode": "selector",
-        "url": "/sws/neo/sales-order/lines/selectors/tax"
+        "url": "/sws/neo/sales-order/lines/selectors/tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
       }
     ],
     "actions": [
       {
+        "name": "rMPickFromShipment",
+        "label": "RM_PickFromShipment",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "rMPickFromShipment",
         "column": "RM_PickFromShipment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/rMPickFromShipment",
+        "method": "POST",
         "url": "/sws/neo/sales-order/header/{id}/action/rMPickFromShipment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
         "processType": "obuiapp"
       },
       {
+        "name": "rMReceiveMaterials",
+        "label": "RM_ReceiveMaterials",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "rMReceiveMaterials",
         "column": "RM_ReceiveMaterials",
-        "url": "/sws/neo/sales-order/header/{id}/action/rMReceiveMaterials"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/rMReceiveMaterials",
+        "method": "POST",
+        "url": "/sws/neo/sales-order/header/{id}/action/rMReceiveMaterials",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "rMCreateInvoice",
+        "label": "Create Invoice",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "rMCreateInvoice",
         "column": "RM_CreateInvoice",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/rMCreateInvoice",
+        "method": "POST",
         "url": "/sws/neo/sales-order/header/{id}/action/rMCreateInvoice",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "FF80808133362F6A013336781FCE0066",
         "processType": "classic"
       },
       {
+        "name": "aPRMAddPayment",
+        "label": "Add Payment",
+        "actionType": "paymentAction",
         "entity": "header",
-        "field": "aPRMAddPayment",
         "column": "EM_APRM_AddPayment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/aPRMAddPayment",
+        "method": "POST",
         "url": "/sws/neo/sales-order/header/{id}/action/aPRMAddPayment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "9BED7889E1034FE68BD85D5D16857320",
         "processType": "obuiapp"
       },
       {
+        "name": "documentAction",
+        "label": "Process Order",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "documentAction",
         "column": "DocAction",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/documentAction",
+        "method": "POST",
         "url": "/sws/neo/sales-order/header/{id}/action/documentAction",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "104",
         "processType": "classic"
       },
       {
+        "name": "copyFrom",
+        "label": "Copy Lines",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "copyFrom",
         "column": "CopyFrom",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/copyFrom",
+        "method": "POST",
         "url": "/sws/neo/sales-order/header/{id}/action/copyFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "211",
         "processType": "classic"
       },
       {
+        "name": "copyFromPO",
+        "label": "Copy from Orders",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "copyFromPO",
         "column": "CopyFromPO",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/copyFromPO",
+        "method": "POST",
         "url": "/sws/neo/sales-order/header/{id}/action/copyFromPO",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "8B81D80B06364566B87853FEECAB5DE0",
         "processType": "obuiapp"
       },
       {
+        "name": "calculatePromotions",
+        "label": "Calculate Promotions",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "calculatePromotions",
         "column": "Calculate_Promotions",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/calculatePromotions",
+        "method": "POST",
         "url": "/sws/neo/sales-order/header/{id}/action/calculatePromotions",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "9EB2228A60684C0DBEC12D5CD8D85218",
         "processType": "classic"
       },
       {
+        "name": "rMAddOrphanLine",
+        "label": "RM_AddOrphanLine",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "rMAddOrphanLine",
         "column": "RM_AddOrphanLine",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/rMAddOrphanLine",
+        "method": "POST",
         "url": "/sws/neo/sales-order/header/{id}/action/rMAddOrphanLine",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "23D1B163EC0B41F790CE39BF01DA320E",
         "processType": "classic"
       },
       {
+        "name": "createOrder",
+        "label": "Create Order",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createOrder",
         "column": "Convertquotation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/createOrder",
+        "method": "POST",
         "url": "/sws/neo/sales-order/header/{id}/action/createOrder",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A3FE1F9892394386A49FB707AA50A0FA",
         "processType": "classic"
       },
       {
+        "name": "cancelAndReplace",
+        "label": "Cancel and Replace",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "cancelAndReplace",
         "column": "Cancelandreplace",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/cancelAndReplace",
+        "method": "POST",
         "url": "/sws/neo/sales-order/header/{id}/action/cancelAndReplace",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "A2FAF49712D1445ABE750315CE1B473A",
         "processType": "obuiapp"
       },
       {
+        "name": "confirmCancelAndReplace",
+        "label": "Confirm Cancel and Replace",
+        "actionType": "utilityAction",
         "entity": "header",
-        "field": "confirmCancelAndReplace",
         "column": "Confirmcancelandreplace",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/confirmCancelAndReplace",
+        "method": "POST",
         "url": "/sws/neo/sales-order/header/{id}/action/confirmCancelAndReplace",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "0C2AFAEFB67B4CB8A1429195EB119A49",
         "processType": "obuiapp"
       },
       {
+        "name": "processNow",
+        "label": "Process Order",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "processNow",
         "column": "Processing",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/processNow",
+        "method": "POST",
         "url": "/sws/neo/sales-order/header/{id}/action/processNow",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "104",
         "processType": "classic"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "header",
-        "field": "posted",
         "column": "Posted",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/posted",
+        "method": "POST",
         "url": "/sws/neo/sales-order/header/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "57496FB9CF9E4E8F847224017941570E",
         "processType": "obuiapp"
       },
       {
+        "name": "generateTemplate",
+        "label": "Copy Product Template",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "generateTemplate",
         "column": "Generatetemplate",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/generateTemplate",
+        "method": "POST",
         "url": "/sws/neo/sales-order/header/{id}/action/generateTemplate",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "800022",
         "processType": "classic"
       },
       {
+        "name": "createPOLines",
+        "label": "Create_POLines",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "createPOLines",
         "column": "Create_POLines",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/createPOLines",
+        "method": "POST",
         "url": "/sws/neo/sales-order/header/{id}/action/createPOLines",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "6995A4C2592D434A9E16B71E1694CBCA",
         "processType": "obuiapp"
       },
       {
+        "name": "rMPickfromreceipt",
+        "label": "RM_Pickfromreceipt",
+        "actionType": "createFrom",
         "entity": "header",
-        "field": "rMPickfromreceipt",
         "column": "RM_Pickfromreceipt",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/header/{id}/action/rMPickfromreceipt",
+        "method": "POST",
         "url": "/sws/neo/sales-order/header/{id}/action/rMPickfromreceipt",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
         "processType": "obuiapp"
       },
       {
+        "name": "manageReservation",
+        "label": "Manage Reservation",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "manageReservation",
         "column": "Manage_Reservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/lines/{id}/action/manageReservation",
+        "method": "POST",
         "url": "/sws/neo/sales-order/lines/{id}/action/manageReservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "5F547560D3DE401AA0B570F22E2C6C06",
         "processType": "obuiapp"
       },
       {
+        "name": "explode",
+        "label": "Explode",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "explode",
         "column": "Explode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/lines/{id}/action/explode",
+        "method": "POST",
         "url": "/sws/neo/sales-order/lines/{id}/action/explode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "DFC78024B1F54CBB95DC73425BA6687F",
         "processType": "classic"
       },
       {
+        "name": "selectOrderLine",
+        "label": "Select Order Line",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "selectOrderLine",
         "column": "Relate_Orderline",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/lines/{id}/action/selectOrderLine",
+        "method": "POST",
         "url": "/sws/neo/sales-order/lines/{id}/action/selectOrderLine",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "C4265E27C8134096B49DFBF69369DFC6",
         "processType": "obuiapp"
       },
       {
+        "name": "managePrereservation",
+        "label": "Manage_Prereservation",
+        "actionType": "utilityAction",
         "entity": "lines",
-        "field": "managePrereservation",
         "column": "Manage_Prereservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-order/lines/{id}/action/managePrereservation",
+        "method": "POST",
         "url": "/sws/neo/sales-order/lines/{id}/action/managePrereservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
         "processType": "obuiapp"
       }

--- a/artifacts/sales-order/contract.json
+++ b/artifacts/sales-order/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.1.0",
   "generatedAt": "2026-05-12T16:47:39.614Z",
-  "updatedAt": "2026-05-15T16:28:09.476Z",
-  "checksum": "482710ba309cc9b4",
+  "updatedAt": "2026-05-15T16:33:38.278Z",
+  "checksum": "31fb4d3412c22037",
   "frontendContract": {
     "window": {
       "id": "143",
@@ -3131,6 +3131,280 @@
         "InvoiceStatus": "Invoicing Status"
       }
     }
+  },
+  "formState": {
+    "entities": {
+      "header": {
+        "fields": {
+          "documentNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "partnerAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "priceList": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentTerms": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "warehouse": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "DR",
+            "provenance": "extracted"
+          },
+          "grandTotalAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "summedLineAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@C_Currency_ID@",
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "deliveryStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "invoiceStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etgoTotalDiscount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "processed": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "lines": {
+        "fields": {
+          "product": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderedQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | (@IsSOTrx@='Y' & @ISLINKEDTOPRODUCT@='Y' & @PRODUCTTYPE@='S') | @UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "1",
+            "provenance": "extracted"
+          },
+          "listPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "discount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "tax": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "lineGrossAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "unitPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @GROSSPRICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "grossUnitPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @GROSSPRICE@='N'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/sales-order/generated/web/sales-order/HeaderPage.jsx
+++ b/artifacts/sales-order/generated/web/sales-order/HeaderPage.jsx
@@ -131,7 +131,16 @@ export const api = {
       "column": "C_BPartner_Location_ID",
       "reference": "BusinessPartnerLocation",
       "inputMode": "dependent",
-      "url": "/sws/neo/sales-order/header/selectors/partnerAddress"
+      "url": "/sws/neo/sales-order/header/selectors/partnerAddress",
+      "context": {
+        "required": [
+          {
+            "param": "C_BPartner_ID",
+            "source": "field",
+            "field": "businessPartner"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -139,7 +148,15 @@ export const api = {
       "column": "M_PriceList_ID",
       "reference": "PriceList",
       "inputMode": "selector",
-      "url": "/sws/neo/sales-order/header/selectors/priceList"
+      "url": "/sws/neo/sales-order/header/selectors/priceList",
+      "context": {
+        "required": [
+          {
+            "param": "isSOTrx",
+            "source": "windowCategory"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -147,7 +164,15 @@ export const api = {
       "column": "FIN_Paymentmethod_ID",
       "reference": "PaymentMethod",
       "inputMode": "selector",
-      "url": "/sws/neo/sales-order/header/selectors/paymentMethod"
+      "url": "/sws/neo/sales-order/header/selectors/paymentMethod",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          }
+        ]
+      }
     },
     {
       "entity": "header",
@@ -187,173 +212,609 @@ export const api = {
       "column": "C_Tax_ID",
       "reference": "Tax",
       "inputMode": "selector",
-      "url": "/sws/neo/sales-order/lines/selectors/tax"
+      "url": "/sws/neo/sales-order/lines/selectors/tax",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          },
+          {
+            "param": "DateInvoiced",
+            "source": "parentField",
+            "field": "invoiceDate",
+            "fallbackField": "orderDate",
+            "format": "DD-MM-YYYY"
+          }
+        ]
+      }
     }
   ],
   "actions": [
     {
+      "name": "rMPickFromShipment",
+      "label": "RM_PickFromShipment",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "rMPickFromShipment",
       "column": "RM_PickFromShipment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/rMPickFromShipment",
+      "method": "POST",
       "url": "/sws/neo/sales-order/header/{id}/action/rMPickFromShipment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
       "processType": "obuiapp"
     },
     {
+      "name": "rMReceiveMaterials",
+      "label": "RM_ReceiveMaterials",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "rMReceiveMaterials",
       "column": "RM_ReceiveMaterials",
-      "url": "/sws/neo/sales-order/header/{id}/action/rMReceiveMaterials"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/rMReceiveMaterials",
+      "method": "POST",
+      "url": "/sws/neo/sales-order/header/{id}/action/rMReceiveMaterials",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "rMCreateInvoice",
+      "label": "Create Invoice",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "rMCreateInvoice",
       "column": "RM_CreateInvoice",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/rMCreateInvoice",
+      "method": "POST",
       "url": "/sws/neo/sales-order/header/{id}/action/rMCreateInvoice",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "FF80808133362F6A013336781FCE0066",
       "processType": "classic"
     },
     {
+      "name": "aPRMAddPayment",
+      "label": "Add Payment",
+      "actionType": "paymentAction",
       "entity": "header",
-      "field": "aPRMAddPayment",
       "column": "EM_APRM_AddPayment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/aPRMAddPayment",
+      "method": "POST",
       "url": "/sws/neo/sales-order/header/{id}/action/aPRMAddPayment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "9BED7889E1034FE68BD85D5D16857320",
       "processType": "obuiapp"
     },
     {
+      "name": "documentAction",
+      "label": "Process Order",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "documentAction",
       "column": "DocAction",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/documentAction",
+      "method": "POST",
       "url": "/sws/neo/sales-order/header/{id}/action/documentAction",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "104",
       "processType": "classic"
     },
     {
+      "name": "copyFrom",
+      "label": "Copy Lines",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "copyFrom",
       "column": "CopyFrom",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/copyFrom",
+      "method": "POST",
       "url": "/sws/neo/sales-order/header/{id}/action/copyFrom",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "211",
       "processType": "classic"
     },
     {
+      "name": "copyFromPO",
+      "label": "Copy from Orders",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "copyFromPO",
       "column": "CopyFromPO",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/copyFromPO",
+      "method": "POST",
       "url": "/sws/neo/sales-order/header/{id}/action/copyFromPO",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "8B81D80B06364566B87853FEECAB5DE0",
       "processType": "obuiapp"
     },
     {
+      "name": "calculatePromotions",
+      "label": "Calculate Promotions",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "calculatePromotions",
       "column": "Calculate_Promotions",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/calculatePromotions",
+      "method": "POST",
       "url": "/sws/neo/sales-order/header/{id}/action/calculatePromotions",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "9EB2228A60684C0DBEC12D5CD8D85218",
       "processType": "classic"
     },
     {
+      "name": "rMAddOrphanLine",
+      "label": "RM_AddOrphanLine",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "rMAddOrphanLine",
       "column": "RM_AddOrphanLine",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/rMAddOrphanLine",
+      "method": "POST",
       "url": "/sws/neo/sales-order/header/{id}/action/rMAddOrphanLine",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "23D1B163EC0B41F790CE39BF01DA320E",
       "processType": "classic"
     },
     {
+      "name": "createOrder",
+      "label": "Create Order",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "createOrder",
       "column": "Convertquotation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/createOrder",
+      "method": "POST",
       "url": "/sws/neo/sales-order/header/{id}/action/createOrder",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "A3FE1F9892394386A49FB707AA50A0FA",
       "processType": "classic"
     },
     {
+      "name": "cancelAndReplace",
+      "label": "Cancel and Replace",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "cancelAndReplace",
       "column": "Cancelandreplace",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/cancelAndReplace",
+      "method": "POST",
       "url": "/sws/neo/sales-order/header/{id}/action/cancelAndReplace",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "A2FAF49712D1445ABE750315CE1B473A",
       "processType": "obuiapp"
     },
     {
+      "name": "confirmCancelAndReplace",
+      "label": "Confirm Cancel and Replace",
+      "actionType": "utilityAction",
       "entity": "header",
-      "field": "confirmCancelAndReplace",
       "column": "Confirmcancelandreplace",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/confirmCancelAndReplace",
+      "method": "POST",
       "url": "/sws/neo/sales-order/header/{id}/action/confirmCancelAndReplace",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "0C2AFAEFB67B4CB8A1429195EB119A49",
       "processType": "obuiapp"
     },
     {
+      "name": "processNow",
+      "label": "Process Order",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "processNow",
       "column": "Processing",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/processNow",
+      "method": "POST",
       "url": "/sws/neo/sales-order/header/{id}/action/processNow",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "104",
       "processType": "classic"
     },
     {
+      "name": "posted",
+      "label": "Posted",
+      "actionType": "documentAction",
       "entity": "header",
-      "field": "posted",
       "column": "Posted",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/posted",
+      "method": "POST",
       "url": "/sws/neo/sales-order/header/{id}/action/posted",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "57496FB9CF9E4E8F847224017941570E",
       "processType": "obuiapp"
     },
     {
+      "name": "generateTemplate",
+      "label": "Copy Product Template",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "generateTemplate",
       "column": "Generatetemplate",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/generateTemplate",
+      "method": "POST",
       "url": "/sws/neo/sales-order/header/{id}/action/generateTemplate",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "800022",
       "processType": "classic"
     },
     {
+      "name": "createPOLines",
+      "label": "Create_POLines",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "createPOLines",
       "column": "Create_POLines",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/createPOLines",
+      "method": "POST",
       "url": "/sws/neo/sales-order/header/{id}/action/createPOLines",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "6995A4C2592D434A9E16B71E1694CBCA",
       "processType": "obuiapp"
     },
     {
+      "name": "rMPickfromreceipt",
+      "label": "RM_Pickfromreceipt",
+      "actionType": "createFrom",
       "entity": "header",
-      "field": "rMPickfromreceipt",
       "column": "RM_Pickfromreceipt",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/header/{id}/action/rMPickfromreceipt",
+      "method": "POST",
       "url": "/sws/neo/sales-order/header/{id}/action/rMPickfromreceipt",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
       "processType": "obuiapp"
     },
     {
+      "name": "manageReservation",
+      "label": "Manage Reservation",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "manageReservation",
       "column": "Manage_Reservation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/lines/{id}/action/manageReservation",
+      "method": "POST",
       "url": "/sws/neo/sales-order/lines/{id}/action/manageReservation",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "5F547560D3DE401AA0B570F22E2C6C06",
       "processType": "obuiapp"
     },
     {
+      "name": "explode",
+      "label": "Explode",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "explode",
       "column": "Explode",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/lines/{id}/action/explode",
+      "method": "POST",
       "url": "/sws/neo/sales-order/lines/{id}/action/explode",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "DFC78024B1F54CBB95DC73425BA6687F",
       "processType": "classic"
     },
     {
+      "name": "selectOrderLine",
+      "label": "Select Order Line",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "selectOrderLine",
       "column": "Relate_Orderline",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/lines/{id}/action/selectOrderLine",
+      "method": "POST",
       "url": "/sws/neo/sales-order/lines/{id}/action/selectOrderLine",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "C4265E27C8134096B49DFBF69369DFC6",
       "processType": "obuiapp"
     },
     {
+      "name": "managePrereservation",
+      "label": "Manage_Prereservation",
+      "actionType": "utilityAction",
       "entity": "lines",
-      "field": "managePrereservation",
       "column": "Manage_Prereservation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-order/lines/{id}/action/managePrereservation",
+      "method": "POST",
       "url": "/sws/neo/sales-order/lines/{id}/action/managePrereservation",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
       "processType": "obuiapp"
     }

--- a/artifacts/sales-quotation/contract.json
+++ b/artifacts/sales-quotation/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.6.0",
   "generatedAt": "2026-04-30T15:42:46.907Z",
-  "updatedAt": "2026-05-08T12:44:37.431Z",
-  "checksum": "05c3dc4a9d755fb6",
+  "updatedAt": "2026-05-15T16:28:09.368Z",
+  "checksum": "43c7b4ae0c9d4a87",
   "frontendContract": {
     "window": {
       "id": "6CB5B67ED33F47DFA334079D3EA2340E",
@@ -2444,7 +2444,16 @@
         "column": "C_BPartner_Location_ID",
         "reference": "BusinessPartnerLocation",
         "inputMode": "dependent",
-        "url": "/sws/neo/sales-quotation/quotation/selectors/partnerAddress"
+        "url": "/sws/neo/sales-quotation/quotation/selectors/partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
       },
       {
         "entity": "quotation",
@@ -2452,7 +2461,15 @@
         "column": "M_PriceList_ID",
         "reference": "PriceList",
         "inputMode": "selector",
-        "url": "/sws/neo/sales-quotation/quotation/selectors/priceList"
+        "url": "/sws/neo/sales-quotation/quotation/selectors/priceList",
+        "context": {
+          "required": [
+            {
+              "param": "isSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "quotation",
@@ -2460,7 +2477,15 @@
         "column": "FIN_Paymentmethod_ID",
         "reference": "Paymentmethod",
         "inputMode": "selector",
-        "url": "/sws/neo/sales-quotation/quotation/selectors/paymentMethod"
+        "url": "/sws/neo/sales-quotation/quotation/selectors/paymentMethod",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
       },
       {
         "entity": "quotation",
@@ -2500,173 +2525,609 @@
         "column": "C_Tax_ID",
         "reference": "Tax",
         "inputMode": "selector",
-        "url": "/sws/neo/sales-quotation/quotationLine/selectors/tax"
+        "url": "/sws/neo/sales-quotation/quotationLine/selectors/tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
       }
     ],
     "actions": [
       {
+        "name": "rMPickFromShipment",
+        "label": "RM_PickFromShipment",
+        "actionType": "createFrom",
         "entity": "quotation",
-        "field": "rMPickFromShipment",
         "column": "RM_PickFromShipment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/rMPickFromShipment",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotation/{id}/action/rMPickFromShipment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
         "processType": "obuiapp"
       },
       {
+        "name": "rMReceiveMaterials",
+        "label": "RM_ReceiveMaterials",
+        "actionType": "createFrom",
         "entity": "quotation",
-        "field": "rMReceiveMaterials",
         "column": "RM_ReceiveMaterials",
-        "url": "/sws/neo/sales-quotation/quotation/{id}/action/rMReceiveMaterials"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/rMReceiveMaterials",
+        "method": "POST",
+        "url": "/sws/neo/sales-quotation/quotation/{id}/action/rMReceiveMaterials",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "rMCreateInvoice",
+        "label": "Create Invoice",
+        "actionType": "createFrom",
         "entity": "quotation",
-        "field": "rMCreateInvoice",
         "column": "RM_CreateInvoice",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/rMCreateInvoice",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotation/{id}/action/rMCreateInvoice",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "FF80808133362F6A013336781FCE0066",
         "processType": "classic"
       },
       {
+        "name": "copyFrom",
+        "label": "Copy Lines",
+        "actionType": "createFrom",
         "entity": "quotation",
-        "field": "copyFrom",
         "column": "CopyFrom",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/copyFrom",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotation/{id}/action/copyFrom",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "211",
         "processType": "classic"
       },
       {
+        "name": "copyFromPO",
+        "label": "Copy from Orders",
+        "actionType": "createFrom",
         "entity": "quotation",
-        "field": "copyFromPO",
         "column": "CopyFromPO",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/copyFromPO",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotation/{id}/action/copyFromPO",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "8B81D80B06364566B87853FEECAB5DE0",
         "processType": "obuiapp"
       },
       {
+        "name": "documentAction",
+        "label": "Process Order",
+        "actionType": "documentAction",
         "entity": "quotation",
-        "field": "documentAction",
         "column": "DocAction",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/documentAction",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotation/{id}/action/documentAction",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "104",
         "processType": "classic"
       },
       {
+        "name": "createOrder",
+        "label": "Create Order",
+        "actionType": "createFrom",
         "entity": "quotation",
-        "field": "createOrder",
         "column": "Convertquotation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/createOrder",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotation/{id}/action/createOrder",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A3FE1F9892394386A49FB707AA50A0FA",
         "processType": "classic"
       },
       {
+        "name": "calculatePromotions",
+        "label": "Calculate Promotions",
+        "actionType": "utilityAction",
         "entity": "quotation",
-        "field": "calculatePromotions",
         "column": "Calculate_Promotions",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/calculatePromotions",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotation/{id}/action/calculatePromotions",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "9EB2228A60684C0DBEC12D5CD8D85218",
         "processType": "classic"
       },
       {
+        "name": "generateTemplate",
+        "label": "Copy Product Template",
+        "actionType": "createFrom",
         "entity": "quotation",
-        "field": "generateTemplate",
         "column": "Generatetemplate",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/generateTemplate",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotation/{id}/action/generateTemplate",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "800022",
         "processType": "classic"
       },
       {
+        "name": "processNow",
+        "label": "Process Order",
+        "actionType": "documentAction",
         "entity": "quotation",
-        "field": "processNow",
         "column": "Processing",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/processNow",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotation/{id}/action/processNow",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "104",
         "processType": "classic"
       },
       {
+        "name": "posted",
+        "label": "Posted",
+        "actionType": "documentAction",
         "entity": "quotation",
-        "field": "posted",
         "column": "Posted",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/posted",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotation/{id}/action/posted",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted",
         "processId": "57496FB9CF9E4E8F847224017941570E",
         "processType": "obuiapp"
       },
       {
+        "name": "cancelandreplace",
+        "label": "Cancelandreplace",
+        "actionType": "utilityAction",
         "entity": "quotation",
-        "field": "cancelandreplace",
         "column": "Cancelandreplace",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/cancelandreplace",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotation/{id}/action/cancelandreplace",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "A2FAF49712D1445ABE750315CE1B473A",
         "processType": "obuiapp"
       },
       {
+        "name": "confirmcancelandreplace",
+        "label": "Confirmcancelandreplace",
+        "actionType": "utilityAction",
         "entity": "quotation",
-        "field": "confirmcancelandreplace",
         "column": "Confirmcancelandreplace",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/confirmcancelandreplace",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotation/{id}/action/confirmcancelandreplace",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "0C2AFAEFB67B4CB8A1429195EB119A49",
         "processType": "obuiapp"
       },
       {
+        "name": "createPOLines",
+        "label": "Create_POLines",
+        "actionType": "createFrom",
         "entity": "quotation",
-        "field": "createPOLines",
         "column": "Create_POLines",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/createPOLines",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotation/{id}/action/createPOLines",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "6995A4C2592D434A9E16B71E1694CBCA",
         "processType": "obuiapp"
       },
       {
+        "name": "aPRMAddPayment",
+        "label": "EM_APRM_AddPayment",
+        "actionType": "paymentAction",
         "entity": "quotation",
-        "field": "aPRMAddPayment",
         "column": "EM_APRM_AddPayment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/aPRMAddPayment",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotation/{id}/action/aPRMAddPayment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates or processes payment records",
+          "May update invoice/order payment status"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Payment amount exceeds remaining balance",
+          "Payment method is not configured for the business partner",
+          "Invoice is already fully paid"
+        ],
+        "provenance": "extracted",
         "processId": "9BED7889E1034FE68BD85D5D16857320",
         "processType": "obuiapp"
       },
       {
+        "name": "rMAddOrphanLine",
+        "label": "RM_AddOrphanLine",
+        "actionType": "utilityAction",
         "entity": "quotation",
-        "field": "rMAddOrphanLine",
         "column": "RM_AddOrphanLine",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/rMAddOrphanLine",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotation/{id}/action/rMAddOrphanLine",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "23D1B163EC0B41F790CE39BF01DA320E",
         "processType": "classic"
       },
       {
+        "name": "rMPickfromreceipt",
+        "label": "RM_Pickfromreceipt",
+        "actionType": "createFrom",
         "entity": "quotation",
-        "field": "rMPickfromreceipt",
         "column": "RM_Pickfromreceipt",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/rMPickfromreceipt",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotation/{id}/action/rMPickfromreceipt",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "Creates child or related records",
+          "May copy data from source document"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Source document has no valid lines to copy",
+          "Target entity already has linked records",
+          "Required reference data is missing (price list, warehouse, etc.)"
+        ],
+        "provenance": "extracted",
         "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
         "processType": "obuiapp"
       },
       {
+        "name": "explode",
+        "label": "Explode",
+        "actionType": "utilityAction",
         "entity": "quotationLine",
-        "field": "explode",
         "column": "Explode",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotationLine/{id}/action/explode",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotationLine/{id}/action/explode",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "DFC78024B1F54CBB95DC73425BA6687F",
         "processType": "classic"
       },
       {
+        "name": "managePrereservation",
+        "label": "Manage_Prereservation",
+        "actionType": "utilityAction",
         "entity": "quotationLine",
-        "field": "managePrereservation",
         "column": "Manage_Prereservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotationLine/{id}/action/managePrereservation",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotationLine/{id}/action/managePrereservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
         "processType": "obuiapp"
       },
       {
+        "name": "manageReservation",
+        "label": "Manage_Reservation",
+        "actionType": "utilityAction",
         "entity": "quotationLine",
-        "field": "manageReservation",
         "column": "Manage_Reservation",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotationLine/{id}/action/manageReservation",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotationLine/{id}/action/manageReservation",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "5F547560D3DE401AA0B570F22E2C6C06",
         "processType": "obuiapp"
       },
       {
+        "name": "selectOrderLine",
+        "label": "Relate_Orderline",
+        "actionType": "utilityAction",
         "entity": "quotationLine",
-        "field": "selectOrderLine",
         "column": "Relate_Orderline",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/sales-quotation/quotationLine/{id}/action/selectOrderLine",
+        "method": "POST",
         "url": "/sws/neo/sales-quotation/quotationLine/{id}/action/selectOrderLine",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "C4265E27C8134096B49DFBF69369DFC6",
         "processType": "obuiapp"
       }

--- a/artifacts/sales-quotation/contract.json
+++ b/artifacts/sales-quotation/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.6.0",
   "generatedAt": "2026-04-30T15:42:46.907Z",
-  "updatedAt": "2026-05-15T16:28:09.368Z",
-  "checksum": "43c7b4ae0c9d4a87",
+  "updatedAt": "2026-05-15T16:33:38.169Z",
+  "checksum": "5a05d01d48852d04",
   "frontendContract": {
     "window": {
       "id": "6CB5B67ED33F47DFA334079D3EA2340E",
@@ -3158,6 +3158,270 @@
         "C_Reject_Reason_ID": "Reject Reason"
       }
     }
+  },
+  "formState": {
+    "entities": {
+      "quotation": {
+        "fields": {
+          "documentNo": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "partnerAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "priceList": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @DocStatus@='TMP'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "validUntil": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentMethod": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "paymentTerms": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "rejectReason": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@DocStatus@='CJ'|@DocStatus@='CA'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "documentStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "DR",
+            "provenance": "extracted"
+          },
+          "grandTotalAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "summedLineAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "currency": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@C_Currency_ID@",
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "etgoTotalDiscount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "processed": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "quotationLine": {
+        "fields": {
+          "product": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderedQuantity": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | (@IsSOTrx@='Y' & @ISLINKEDTOPRODUCT@='Y' & @PRODUCTTYPE@='S') | @UomManagement@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "1",
+            "provenance": "extracted"
+          },
+          "listPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "discount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "tax": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "lineGrossAmount": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "0",
+            "provenance": "extracted"
+          },
+          "unitPrice": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Processed@='Y' | @GROSSPRICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "lineNetAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": "@Iseditlinenetamt@='N'|@GROSSPRICE@='Y'",
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/sales-quotation/generated/web/sales-quotation/QuotationPage.jsx
+++ b/artifacts/sales-quotation/generated/web/sales-quotation/QuotationPage.jsx
@@ -135,7 +135,16 @@ export const api = {
       "column": "C_BPartner_Location_ID",
       "reference": "BusinessPartnerLocation",
       "inputMode": "dependent",
-      "url": "/sws/neo/sales-quotation/quotation/selectors/partnerAddress"
+      "url": "/sws/neo/sales-quotation/quotation/selectors/partnerAddress",
+      "context": {
+        "required": [
+          {
+            "param": "C_BPartner_ID",
+            "source": "field",
+            "field": "businessPartner"
+          }
+        ]
+      }
     },
     {
       "entity": "quotation",
@@ -143,7 +152,15 @@ export const api = {
       "column": "M_PriceList_ID",
       "reference": "PriceList",
       "inputMode": "selector",
-      "url": "/sws/neo/sales-quotation/quotation/selectors/priceList"
+      "url": "/sws/neo/sales-quotation/quotation/selectors/priceList",
+      "context": {
+        "required": [
+          {
+            "param": "isSOTrx",
+            "source": "windowCategory"
+          }
+        ]
+      }
     },
     {
       "entity": "quotation",
@@ -151,7 +168,15 @@ export const api = {
       "column": "FIN_Paymentmethod_ID",
       "reference": "Paymentmethod",
       "inputMode": "selector",
-      "url": "/sws/neo/sales-quotation/quotation/selectors/paymentMethod"
+      "url": "/sws/neo/sales-quotation/quotation/selectors/paymentMethod",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          }
+        ]
+      }
     },
     {
       "entity": "quotation",
@@ -191,173 +216,609 @@ export const api = {
       "column": "C_Tax_ID",
       "reference": "Tax",
       "inputMode": "selector",
-      "url": "/sws/neo/sales-quotation/quotationLine/selectors/tax"
+      "url": "/sws/neo/sales-quotation/quotationLine/selectors/tax",
+      "context": {
+        "required": [
+          {
+            "param": "IsSOTrx",
+            "source": "windowCategory"
+          },
+          {
+            "param": "DateInvoiced",
+            "source": "parentField",
+            "field": "invoiceDate",
+            "fallbackField": "orderDate",
+            "format": "DD-MM-YYYY"
+          }
+        ]
+      }
     }
   ],
   "actions": [
     {
+      "name": "rMPickFromShipment",
+      "label": "RM_PickFromShipment",
+      "actionType": "createFrom",
       "entity": "quotation",
-      "field": "rMPickFromShipment",
       "column": "RM_PickFromShipment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/rMPickFromShipment",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotation/{id}/action/rMPickFromShipment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
       "processType": "obuiapp"
     },
     {
+      "name": "rMReceiveMaterials",
+      "label": "RM_ReceiveMaterials",
+      "actionType": "createFrom",
       "entity": "quotation",
-      "field": "rMReceiveMaterials",
       "column": "RM_ReceiveMaterials",
-      "url": "/sws/neo/sales-quotation/quotation/{id}/action/rMReceiveMaterials"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/rMReceiveMaterials",
+      "method": "POST",
+      "url": "/sws/neo/sales-quotation/quotation/{id}/action/rMReceiveMaterials",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "rMCreateInvoice",
+      "label": "Create Invoice",
+      "actionType": "createFrom",
       "entity": "quotation",
-      "field": "rMCreateInvoice",
       "column": "RM_CreateInvoice",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/rMCreateInvoice",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotation/{id}/action/rMCreateInvoice",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "FF80808133362F6A013336781FCE0066",
       "processType": "classic"
     },
     {
+      "name": "copyFrom",
+      "label": "Copy Lines",
+      "actionType": "createFrom",
       "entity": "quotation",
-      "field": "copyFrom",
       "column": "CopyFrom",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/copyFrom",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotation/{id}/action/copyFrom",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "211",
       "processType": "classic"
     },
     {
+      "name": "copyFromPO",
+      "label": "Copy from Orders",
+      "actionType": "createFrom",
       "entity": "quotation",
-      "field": "copyFromPO",
       "column": "CopyFromPO",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/copyFromPO",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotation/{id}/action/copyFromPO",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "8B81D80B06364566B87853FEECAB5DE0",
       "processType": "obuiapp"
     },
     {
+      "name": "documentAction",
+      "label": "Process Order",
+      "actionType": "documentAction",
       "entity": "quotation",
-      "field": "documentAction",
       "column": "DocAction",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/documentAction",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotation/{id}/action/documentAction",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "104",
       "processType": "classic"
     },
     {
+      "name": "createOrder",
+      "label": "Create Order",
+      "actionType": "createFrom",
       "entity": "quotation",
-      "field": "createOrder",
       "column": "Convertquotation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/createOrder",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotation/{id}/action/createOrder",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "A3FE1F9892394386A49FB707AA50A0FA",
       "processType": "classic"
     },
     {
+      "name": "calculatePromotions",
+      "label": "Calculate Promotions",
+      "actionType": "utilityAction",
       "entity": "quotation",
-      "field": "calculatePromotions",
       "column": "Calculate_Promotions",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/calculatePromotions",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotation/{id}/action/calculatePromotions",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "9EB2228A60684C0DBEC12D5CD8D85218",
       "processType": "classic"
     },
     {
+      "name": "generateTemplate",
+      "label": "Copy Product Template",
+      "actionType": "createFrom",
       "entity": "quotation",
-      "field": "generateTemplate",
       "column": "Generatetemplate",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/generateTemplate",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotation/{id}/action/generateTemplate",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "800022",
       "processType": "classic"
     },
     {
+      "name": "processNow",
+      "label": "Process Order",
+      "actionType": "documentAction",
       "entity": "quotation",
-      "field": "processNow",
       "column": "Processing",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/processNow",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotation/{id}/action/processNow",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "104",
       "processType": "classic"
     },
     {
+      "name": "posted",
+      "label": "Posted",
+      "actionType": "documentAction",
       "entity": "quotation",
-      "field": "posted",
       "column": "Posted",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/posted",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotation/{id}/action/posted",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted",
       "processId": "57496FB9CF9E4E8F847224017941570E",
       "processType": "obuiapp"
     },
     {
+      "name": "cancelandreplace",
+      "label": "Cancelandreplace",
+      "actionType": "utilityAction",
       "entity": "quotation",
-      "field": "cancelandreplace",
       "column": "Cancelandreplace",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/cancelandreplace",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotation/{id}/action/cancelandreplace",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "A2FAF49712D1445ABE750315CE1B473A",
       "processType": "obuiapp"
     },
     {
+      "name": "confirmcancelandreplace",
+      "label": "Confirmcancelandreplace",
+      "actionType": "utilityAction",
       "entity": "quotation",
-      "field": "confirmcancelandreplace",
       "column": "Confirmcancelandreplace",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/confirmcancelandreplace",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotation/{id}/action/confirmcancelandreplace",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "0C2AFAEFB67B4CB8A1429195EB119A49",
       "processType": "obuiapp"
     },
     {
+      "name": "createPOLines",
+      "label": "Create_POLines",
+      "actionType": "createFrom",
       "entity": "quotation",
-      "field": "createPOLines",
       "column": "Create_POLines",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/createPOLines",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotation/{id}/action/createPOLines",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "6995A4C2592D434A9E16B71E1694CBCA",
       "processType": "obuiapp"
     },
     {
+      "name": "aPRMAddPayment",
+      "label": "EM_APRM_AddPayment",
+      "actionType": "paymentAction",
       "entity": "quotation",
-      "field": "aPRMAddPayment",
       "column": "EM_APRM_AddPayment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/aPRMAddPayment",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotation/{id}/action/aPRMAddPayment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates or processes payment records",
+        "May update invoice/order payment status"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Payment amount exceeds remaining balance",
+        "Payment method is not configured for the business partner",
+        "Invoice is already fully paid"
+      ],
+      "provenance": "extracted",
       "processId": "9BED7889E1034FE68BD85D5D16857320",
       "processType": "obuiapp"
     },
     {
+      "name": "rMAddOrphanLine",
+      "label": "RM_AddOrphanLine",
+      "actionType": "utilityAction",
       "entity": "quotation",
-      "field": "rMAddOrphanLine",
       "column": "RM_AddOrphanLine",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/rMAddOrphanLine",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotation/{id}/action/rMAddOrphanLine",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "23D1B163EC0B41F790CE39BF01DA320E",
       "processType": "classic"
     },
     {
+      "name": "rMPickfromreceipt",
+      "label": "RM_Pickfromreceipt",
+      "actionType": "createFrom",
       "entity": "quotation",
-      "field": "rMPickfromreceipt",
       "column": "RM_Pickfromreceipt",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotation/{id}/action/rMPickfromreceipt",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotation/{id}/action/rMPickfromreceipt",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "Creates child or related records",
+        "May copy data from source document"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Source document has no valid lines to copy",
+        "Target entity already has linked records",
+        "Required reference data is missing (price list, warehouse, etc.)"
+      ],
+      "provenance": "extracted",
       "processId": "A2C19D0EF6594D14A64BC62E99A89CC3",
       "processType": "obuiapp"
     },
     {
+      "name": "explode",
+      "label": "Explode",
+      "actionType": "utilityAction",
       "entity": "quotationLine",
-      "field": "explode",
       "column": "Explode",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotationLine/{id}/action/explode",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotationLine/{id}/action/explode",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "DFC78024B1F54CBB95DC73425BA6687F",
       "processType": "classic"
     },
     {
+      "name": "managePrereservation",
+      "label": "Manage_Prereservation",
+      "actionType": "utilityAction",
       "entity": "quotationLine",
-      "field": "managePrereservation",
       "column": "Manage_Prereservation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotationLine/{id}/action/managePrereservation",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotationLine/{id}/action/managePrereservation",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "70E42AD47E5F4698A9ACCCAF3EB72B9E",
       "processType": "obuiapp"
     },
     {
+      "name": "manageReservation",
+      "label": "Manage_Reservation",
+      "actionType": "utilityAction",
       "entity": "quotationLine",
-      "field": "manageReservation",
       "column": "Manage_Reservation",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotationLine/{id}/action/manageReservation",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotationLine/{id}/action/manageReservation",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "5F547560D3DE401AA0B570F22E2C6C06",
       "processType": "obuiapp"
     },
     {
+      "name": "selectOrderLine",
+      "label": "Relate_Orderline",
+      "actionType": "utilityAction",
       "entity": "quotationLine",
-      "field": "selectOrderLine",
       "column": "Relate_Orderline",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/sales-quotation/quotationLine/{id}/action/selectOrderLine",
+      "method": "POST",
       "url": "/sws/neo/sales-quotation/quotationLine/{id}/action/selectOrderLine",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "C4265E27C8134096B49DFBF69369DFC6",
       "processType": "obuiapp"
     }

--- a/artifacts/tax/contract.json
+++ b/artifacts/tax/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.4.0",
   "generatedAt": "2026-04-27T19:18:32.198Z",
-  "updatedAt": "2026-05-12T19:44:34.781Z",
-  "checksum": "aa192c547dd1acc6",
+  "updatedAt": "2026-05-15T16:33:40.590Z",
+  "checksum": "a6db6ad31a9201b5",
   "frontendContract": {
     "window": {
       "id": "137",
@@ -842,6 +842,76 @@
         "Description": "Description"
       }
     }
+  },
+  "formState": {
+    "entities": {
+      "tax": {
+        "fields": {
+          "name": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "validFromDate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "rate": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "salesPurchaseType": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "B",
+            "provenance": "extracted"
+          },
+          "docTaxAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "D",
+            "provenance": "extracted"
+          },
+          "baseAmount": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "LNA",
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/unit-of-measure/contract.json
+++ b/artifacts/unit-of-measure/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.2.0",
   "generatedAt": "2026-04-29T18:12:30.399Z",
-  "updatedAt": "2026-05-12T19:44:36.969Z",
-  "checksum": "52c614394c00ad36",
+  "updatedAt": "2026-05-15T16:33:40.687Z",
+  "checksum": "ab05297826abf1f0",
   "frontendContract": {
     "window": {
       "id": "120",
@@ -681,6 +681,150 @@
     "window": {
       "category": "settings"
     }
+  },
+  "formState": {
+    "entities": {
+      "unitOfMeasure": {
+        "fields": {
+          "eDICode": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "name": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "standardPrecision": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "costingPrecision": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "symbol": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "uOMType": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "default": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "breakdown": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "useinproduction": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "conversion": {
+        "fields": {
+          "toUOM": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "multipleRateBy": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "divideRateBy": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/user/contract.json
+++ b/artifacts/user/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T18:12:34.035Z",
-  "updatedAt": "2026-05-12T19:44:45.365Z",
-  "checksum": "43eb66f58e0f74a8",
+  "updatedAt": "2026-05-15T16:28:12.021Z",
+  "checksum": "f6b7d022a1df77ce",
   "frontendContract": {
     "window": {
       "id": "108",
@@ -1600,7 +1600,16 @@
         "column": "Default_Ad_Client_ID",
         "reference": "Client",
         "inputMode": "dependent",
-        "url": "/sws/neo/user/user/selectors/defaultClient"
+        "url": "/sws/neo/user/user/selectors/defaultClient",
+        "context": {
+          "required": [
+            {
+              "param": "Default_AD_Role_ID",
+              "source": "field",
+              "field": "defaultRole"
+            }
+          ]
+        }
       },
       {
         "entity": "user",
@@ -1608,7 +1617,16 @@
         "column": "Default_Ad_Org_ID",
         "reference": "Organization",
         "inputMode": "dependent",
-        "url": "/sws/neo/user/user/selectors/defaultOrganization"
+        "url": "/sws/neo/user/user/selectors/defaultOrganization",
+        "context": {
+          "required": [
+            {
+              "param": "Default_AD_Role_ID",
+              "source": "field",
+              "field": "defaultRole"
+            }
+          ]
+        }
       },
       {
         "entity": "user",
@@ -1616,7 +1634,16 @@
         "column": "Default_M_Warehouse_ID",
         "reference": "Warehouse",
         "inputMode": "dependent",
-        "url": "/sws/neo/user/user/selectors/defaultWarehouse"
+        "url": "/sws/neo/user/user/selectors/defaultWarehouse",
+        "context": {
+          "required": [
+            {
+              "param": "Default_AD_Client_ID",
+              "source": "field",
+              "field": "defaultClient"
+            }
+          ]
+        }
       },
       {
         "entity": "userRoles",
@@ -1629,24 +1656,93 @@
     ],
     "actions": [
       {
+        "name": "processNow",
+        "label": "Process Now",
+        "actionType": "documentAction",
         "entity": "user",
-        "field": "processNow",
         "column": "Processing",
-        "url": "/sws/neo/user/user/{id}/action/processNow"
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/user/user/{id}/action/processNow",
+        "method": "POST",
+        "url": "/sws/neo/user/user/{id}/action/processNow",
+        "parameters": [
+          {
+            "name": "docAction",
+            "type": "string",
+            "required": true,
+            "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+          }
+        ],
+        "preconditions": [
+          {
+            "field": "documentStatus",
+            "operator": "in",
+            "values": [
+              "DR",
+              "IP"
+            ],
+            "description": "Document must be in draft or in-progress state"
+          }
+        ],
+        "effects": [
+          "Updates document status",
+          "May trigger workflow transitions"
+        ],
+        "dryRunSupported": true,
+        "edgeCases": [
+          "Document is already completed or closed",
+          "Document has pending lines or missing required fields",
+          "User lacks permission to execute the action"
+        ],
+        "provenance": "extracted"
       },
       {
+        "name": "grantPortalAccess",
+        "label": "Grant_Portal_Access",
+        "actionType": "utilityAction",
         "entity": "user",
-        "field": "grantPortalAccess",
         "column": "Grant_Portal_Access",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/user/user/{id}/action/grantPortalAccess",
+        "method": "POST",
         "url": "/sws/neo/user/user/{id}/action/grantPortalAccess",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "97FFD59B991D49BFB5153C309B009272",
         "processType": "obuiapp"
       },
       {
+        "name": "smtpconnectiontest",
+        "label": "Test SMTP Connection",
+        "actionType": "utilityAction",
         "entity": "emailConfiguration",
-        "field": "smtpconnectiontest",
         "column": "Smtpconnectiontest",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/user/emailConfiguration/{id}/action/smtpconnectiontest",
+        "method": "POST",
         "url": "/sws/neo/user/emailConfiguration/{id}/action/smtpconnectiontest",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "9AB8A39485BD4FB1B6BB38B27E707668",
         "processType": "obuiapp"
       }

--- a/artifacts/user/contract.json
+++ b/artifacts/user/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T18:12:34.035Z",
-  "updatedAt": "2026-05-15T16:28:12.021Z",
-  "checksum": "f6b7d022a1df77ce",
+  "updatedAt": "2026-05-15T16:33:40.789Z",
+  "checksum": "c8027686276fce34",
   "frontendContract": {
     "window": {
       "id": "108",
@@ -1763,6 +1763,384 @@
     "window": {
       "category": "settings"
     }
+  },
+  "formState": {
+    "entities": {
+      "user": {
+        "fields": {
+          "name": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "username": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "firstName": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "lastName": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "password": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "isPasswordExpired": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "email": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "locked": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "position": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "phone": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "supervisor": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "defaultRole": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "defaultLanguage": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "defaultClient": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "defaultOrganization": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "defaultWarehouse": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "lastPasswordUpdate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "@#Date@",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "userRoles": {
+        "fields": {
+          "role": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "roleAdmin": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "emailConfiguration": {
+        "fields": {
+          "active": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "smtpServer": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "sMTPAuthentification": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "smtpServerAccount": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "smtpServerPassword": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "smtpServerSenderAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "smtpConnectionSecurity": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "smtpPort": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "25",
+            "provenance": "extracted"
+          },
+          "smtpConnectionTimeout": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "600",
+            "provenance": "extracted"
+          },
+          "fromName": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "replyToAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "testSuccessful": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "lastTestDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "smtpconnectiontest": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          },
+          "defaultConfiguration": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/user/generated/web/user/UserPage.jsx
+++ b/artifacts/user/generated/web/user/UserPage.jsx
@@ -139,7 +139,16 @@ export const api = {
       "column": "Default_Ad_Client_ID",
       "reference": "Client",
       "inputMode": "dependent",
-      "url": "/sws/neo/user/user/selectors/defaultClient"
+      "url": "/sws/neo/user/user/selectors/defaultClient",
+      "context": {
+        "required": [
+          {
+            "param": "Default_AD_Role_ID",
+            "source": "field",
+            "field": "defaultRole"
+          }
+        ]
+      }
     },
     {
       "entity": "user",
@@ -147,7 +156,16 @@ export const api = {
       "column": "Default_Ad_Org_ID",
       "reference": "Organization",
       "inputMode": "dependent",
-      "url": "/sws/neo/user/user/selectors/defaultOrganization"
+      "url": "/sws/neo/user/user/selectors/defaultOrganization",
+      "context": {
+        "required": [
+          {
+            "param": "Default_AD_Role_ID",
+            "source": "field",
+            "field": "defaultRole"
+          }
+        ]
+      }
     },
     {
       "entity": "user",
@@ -155,7 +173,16 @@ export const api = {
       "column": "Default_M_Warehouse_ID",
       "reference": "Warehouse",
       "inputMode": "dependent",
-      "url": "/sws/neo/user/user/selectors/defaultWarehouse"
+      "url": "/sws/neo/user/user/selectors/defaultWarehouse",
+      "context": {
+        "required": [
+          {
+            "param": "Default_AD_Client_ID",
+            "source": "field",
+            "field": "defaultClient"
+          }
+        ]
+      }
     },
     {
       "entity": "userRoles",
@@ -168,24 +195,93 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "processNow",
+      "label": "Process Now",
+      "actionType": "documentAction",
       "entity": "user",
-      "field": "processNow",
       "column": "Processing",
-      "url": "/sws/neo/user/user/{id}/action/processNow"
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/user/user/{id}/action/processNow",
+      "method": "POST",
+      "url": "/sws/neo/user/user/{id}/action/processNow",
+      "parameters": [
+        {
+          "name": "docAction",
+          "type": "string",
+          "required": true,
+          "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+        }
+      ],
+      "preconditions": [
+        {
+          "field": "documentStatus",
+          "operator": "in",
+          "values": [
+            "DR",
+            "IP"
+          ],
+          "description": "Document must be in draft or in-progress state"
+        }
+      ],
+      "effects": [
+        "Updates document status",
+        "May trigger workflow transitions"
+      ],
+      "dryRunSupported": true,
+      "edgeCases": [
+        "Document is already completed or closed",
+        "Document has pending lines or missing required fields",
+        "User lacks permission to execute the action"
+      ],
+      "provenance": "extracted"
     },
     {
+      "name": "grantPortalAccess",
+      "label": "Grant_Portal_Access",
+      "actionType": "utilityAction",
       "entity": "user",
-      "field": "grantPortalAccess",
       "column": "Grant_Portal_Access",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/user/user/{id}/action/grantPortalAccess",
+      "method": "POST",
       "url": "/sws/neo/user/user/{id}/action/grantPortalAccess",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "97FFD59B991D49BFB5153C309B009272",
       "processType": "obuiapp"
     },
     {
+      "name": "smtpconnectiontest",
+      "label": "Test SMTP Connection",
+      "actionType": "utilityAction",
       "entity": "emailConfiguration",
-      "field": "smtpconnectiontest",
       "column": "Smtpconnectiontest",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/user/emailConfiguration/{id}/action/smtpconnectiontest",
+      "method": "POST",
       "url": "/sws/neo/user/emailConfiguration/{id}/action/smtpconnectiontest",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "9AB8A39485BD4FB1B6BB38B27E707668",
       "processType": "obuiapp"
     }

--- a/artifacts/warehouse/contract.json
+++ b/artifacts/warehouse/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.5.0",
   "generatedAt": "2026-04-29T18:11:37.816Z",
-  "updatedAt": "2026-05-12T19:44:08.766Z",
-  "checksum": "11eba872155a1db2",
+  "updatedAt": "2026-05-15T16:28:11.093Z",
+  "checksum": "bb549a76bf639ab7",
   "frontendContract": {
     "window": {
       "id": "139",
@@ -1747,18 +1747,52 @@
     ],
     "actions": [
       {
+        "name": "changeStatus",
+        "label": "Change Status",
+        "actionType": "utilityAction",
         "entity": "storageBin",
-        "field": "changeStatus",
         "column": "Change_Status",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/warehouse/storageBin/{id}/action/changeStatus",
+        "method": "POST",
         "url": "/sws/neo/warehouse/storageBin/{id}/action/changeStatus",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "3A4E13B0AB764F188CB062DDE2A9B685",
         "processType": "obuiapp"
       },
       {
+        "name": "manualcostadjustment",
+        "label": "Manualcostadjustment",
+        "actionType": "utilityAction",
         "entity": "productTransactions",
-        "field": "manualcostadjustment",
         "column": "Manualcostadjustment",
+        "requiresRecord": true,
+        "endpoint": "/sws/neo/warehouse/productTransactions/{id}/action/manualcostadjustment",
+        "method": "POST",
         "url": "/sws/neo/warehouse/productTransactions/{id}/action/manualcostadjustment",
+        "parameters": [],
+        "preconditions": [],
+        "effects": [
+          "May update related records"
+        ],
+        "dryRunSupported": false,
+        "edgeCases": [
+          "Required context is missing",
+          "User lacks permission",
+          "Record is in an incompatible state"
+        ],
+        "provenance": "extracted",
         "processId": "D395B727675C45C98320F8A40E0768E7",
         "processType": "obuiapp"
       }

--- a/artifacts/warehouse/contract.json
+++ b/artifacts/warehouse/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.5.0",
   "generatedAt": "2026-04-29T18:11:37.816Z",
-  "updatedAt": "2026-05-15T16:28:11.093Z",
-  "checksum": "bb549a76bf639ab7",
+  "updatedAt": "2026-05-15T16:33:39.878Z",
+  "checksum": "a18f761a13edd8d1",
   "frontendContract": {
     "window": {
       "id": "139",
@@ -1813,6 +1813,378 @@
     "window": {
       "category": "inventory"
     }
+  },
+  "formState": {
+    "entities": {
+      "warehouse": {
+        "fields": {
+          "searchKey": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "name": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "description": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "locationAddress": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "warehouseRule": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "allocated": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "storageBin": {
+        "fields": {
+          "searchKey": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "rowX": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "stackY": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "levelZ": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "relativePriority": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "50",
+            "provenance": "extracted"
+          },
+          "barcode": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "inventoryStatus": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "7B3DC15A20234C418D26EECDC5D59003",
+            "provenance": "extracted"
+          },
+          "default": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "changeStatus": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": "N",
+            "provenance": "extracted"
+          }
+        }
+      },
+      "productTransactions": {
+        "fields": {
+          "product": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "attributeSetValue": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementQuantity": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementType": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "goodsShipmentLine": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "physicalInventoryLine": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "movementLine": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "productionLine": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "projectIssue": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      },
+      "binContents": {
+        "fields": {
+          "product": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "attributeSetValue": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "lastInventoryCountDate": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "uOM": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "orderUOM": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "quantityOnHand": {
+            "visible": true,
+            "readOnly": true,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "onHandOrderQuanity": {
+            "visible": true,
+            "readOnly": false,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "quantityInDraftTransactions": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "quantityOrderInDraftTransactions": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          },
+          "referencedInventory": {
+            "visible": true,
+            "readOnly": true,
+            "required": false,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": null,
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
   },
   "testManifest": {
     "tests": [

--- a/artifacts/warehouse/generated/web/warehouse/WarehousePage.jsx
+++ b/artifacts/warehouse/generated/web/warehouse/WarehousePage.jsx
@@ -198,18 +198,52 @@ export const api = {
   ],
   "actions": [
     {
+      "name": "changeStatus",
+      "label": "Change Status",
+      "actionType": "utilityAction",
       "entity": "storageBin",
-      "field": "changeStatus",
       "column": "Change_Status",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/warehouse/storageBin/{id}/action/changeStatus",
+      "method": "POST",
       "url": "/sws/neo/warehouse/storageBin/{id}/action/changeStatus",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "3A4E13B0AB764F188CB062DDE2A9B685",
       "processType": "obuiapp"
     },
     {
+      "name": "manualcostadjustment",
+      "label": "Manualcostadjustment",
+      "actionType": "utilityAction",
       "entity": "productTransactions",
-      "field": "manualcostadjustment",
       "column": "Manualcostadjustment",
+      "requiresRecord": true,
+      "endpoint": "/sws/neo/warehouse/productTransactions/{id}/action/manualcostadjustment",
+      "method": "POST",
       "url": "/sws/neo/warehouse/productTransactions/{id}/action/manualcostadjustment",
+      "parameters": [],
+      "preconditions": [],
+      "effects": [
+        "May update related records"
+      ],
+      "dryRunSupported": false,
+      "edgeCases": [
+        "Required context is missing",
+        "User lacks permission",
+        "Record is in an incompatible state"
+      ],
+      "provenance": "extracted",
       "processId": "D395B727675C45C98320F8A40E0768E7",
       "processType": "obuiapp"
     }

--- a/cli/src/generate-contract.js
+++ b/cli/src/generate-contract.js
@@ -720,6 +720,167 @@ function buildSelectorContext(field, windowCategory) {
   return Object.keys(context).length > 0 ? context : null;
 }
 
+// ─── Action classification helpers for ETP-3956 ──────────────────────────────
+
+/**
+ * Infer action type from field name, column, and window category.
+ */
+function inferActionType(field, windowCategory) {
+  const name = (field.name || '').toLowerCase();
+  const column = (field.column || '').toLowerCase();
+
+  if (name === 'documentaction' || column === 'docaction') return 'documentAction';
+  if (name === 'processnow') return 'documentAction';
+
+  const lifecyclePatterns = ['complete', 'void', 'reactivate', 'close', 'reverse', 'post', 'approve', 'reject'];
+  if (lifecyclePatterns.some(p => name.includes(p))) return 'documentAction';
+
+  if (name.includes('aprm') || name.includes('payment')) return 'paymentAction';
+
+  if (name.includes('create') || name.includes('generate') || name.includes('copyfrom') ||
+      name.includes('pickfrom') || name.includes('receive') || name.includes('send')) return 'createFrom';
+
+  return 'utilityAction';
+}
+
+/**
+ * Infer action parameters from action type and field metadata.
+ */
+function inferActionParameters(field, actionType, curated) {
+  if (curated?.parameters) return curated.parameters;
+
+  const params = [];
+  if (actionType === 'documentAction') {
+    params.push({
+      name: 'docAction',
+      type: 'string',
+      required: true,
+      description: 'Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)',
+    });
+  }
+  return params;
+}
+
+/**
+ * Infer preconditions from action type and field metadata.
+ */
+function inferActionPreconditions(field, actionType, curated) {
+  if (curated?.preconditions) return curated.preconditions;
+
+  if (actionType === 'documentAction') {
+    return [{
+      field: 'documentStatus',
+      operator: 'in',
+      values: ['DR', 'IP'],
+      description: 'Document must be in draft or in-progress state',
+    }];
+  }
+  return [];
+}
+
+/**
+ * Infer side effects from action type.
+ */
+function inferActionEffects(field, actionType) {
+  switch (actionType) {
+    case 'documentAction':
+      return ['Updates document status', 'May trigger workflow transitions'];
+    case 'paymentAction':
+      return ['Creates or processes payment records', 'May update invoice/order payment status'];
+    case 'createFrom':
+      return ['Creates child or related records', 'May copy data from source document'];
+    default:
+      return ['May update related records'];
+  }
+}
+
+/**
+ * Infer edge cases for an action.
+ */
+function inferEdgeCases(field, actionType) {
+  switch (actionType) {
+    case 'documentAction':
+      return [
+        'Document is already completed or closed',
+        'Document has pending lines or missing required fields',
+        'User lacks permission to execute the action',
+      ];
+    case 'paymentAction':
+      return [
+        'Payment amount exceeds remaining balance',
+        'Payment method is not configured for the business partner',
+        'Invoice is already fully paid',
+      ];
+    case 'createFrom':
+      return [
+        'Source document has no valid lines to copy',
+        'Target entity already has linked records',
+        'Required reference data is missing (price list, warehouse, etc.)',
+      ];
+    default:
+      return [
+        'Required context is missing',
+        'User lacks permission',
+        'Record is in an incompatible state',
+      ];
+  }
+}
+
+/**
+ * Classify an action field into a structured action model for agents.
+ *
+ * @param {object} field - Button field from schema entity
+ * @param {string} entityName - Entity name (header, lines, etc.)
+ * @param {string} specName - Spec name (kebab-case)
+ * @param {string} windowCategory - Window category (sales, purchases, etc.)
+ * @param {object} decisionsActions - Curated action overrides from decisions.json
+ * @returns {object} Enriched action entry
+ */
+function classifyAction(field, entityName, specName, windowCategory, decisionsActions) {
+  const curated = decisionsActions?.[field.name] ?? decisionsActions?.[field.column] ?? null;
+  const actionType = inferActionType(field, windowCategory);
+  const label = curated?.label ?? field.label ?? field.name;
+  const endpoint = `/sws/neo/${specName}/${entityName}/{id}/action/${field.name}`;
+  const requiresRecord = true;
+  const parameters = inferActionParameters(field, actionType, curated);
+  const preconditions = inferActionPreconditions(field, actionType, curated);
+  const effects = curated?.effects ?? inferActionEffects(field, actionType);
+  const dryRunSupported = curated?.dryRunSupported ?? (actionType === 'documentAction');
+  const edgeCases = curated?.edgeCases ?? inferEdgeCases(field, actionType);
+
+  const action = {
+    name: field.name,
+    label,
+    actionType,
+    entity: entityName,
+    column: field.column,
+    requiresRecord,
+    endpoint,
+    method: 'POST',
+    url: endpoint,
+    parameters,
+    preconditions,
+    effects,
+    dryRunSupported,
+    edgeCases,
+    provenance: curated ? 'curated' : 'extracted',
+  };
+
+  if (field.processId) action.processId = field.processId;
+  if (field.processType) action.processType = field.processType;
+  if (curated?.description) action.description = curated.description;
+  if (curated?.allowedValues) {
+    const paramName = curated.paramName || 'docAction';
+    action.parameters = action.parameters.map(p =>
+      p.name === paramName ? { ...p, allowedValues: curated.allowedValues } : p
+    );
+  }
+
+  return action;
+}
+
+// ─── End action classification helpers ───────────────────────────────────────
+
 /**
  * Generate API prediction: predicts NEO Headless URLs, selectors, actions, and query params.
  */
@@ -769,16 +930,10 @@ export function generateApiPrediction(schema, frontendContract, backendContract)
     }
 
     // Actions — fields with type "button" (AD_Reference_ID = 28)
+    const decisionsActions = schema.window?.actions ?? {};
     for (const field of entity.fields) {
       if (field.type === 'button') {
-        const action = {
-          entity: entityName,
-          field: field.name,
-          column: field.column,
-          url: `${baseUrl}/${entityName}/{id}/action/${field.name}`,
-        };
-        if (field.processId) action.processId = field.processId;
-        if (field.processType) action.processType = field.processType;
+        const action = classifyAction(field, entityName, specName, windowCategory, decisionsActions);
         actions.push(action);
       }
     }
@@ -796,7 +951,7 @@ export function generateApiPrediction(schema, frontendContract, backendContract)
 
   const seenActions = new Set();
   const dedupedActions = actions.filter(a => {
-    const key = `${a.entity}:${a.field}`;
+    const key = `${a.entity}:${a.name}`;
     if (seenActions.has(key)) return false;
     seenActions.add(key);
     return true;
@@ -907,12 +1062,12 @@ export function generateContract(schema, rules = [], processes = [], previousVer
 
   for (const action of apiPrediction.actions) {
     testManifest.tests.push({
-      id: makeId('action-endpoint', action.entity, action.field),
+      id: makeId('action-endpoint', action.entity, action.name),
       category: 'action-endpoint',
       entity: action.entity,
-      field: action.field,
+      field: action.name,
       runner: 'node',
-      description: `Action endpoint for '${action.field}' in ${action.entity} should exist`,
+      description: `Action endpoint for '${action.name}' in ${action.entity} should exist`,
     });
   }
   delete testManifest._makeId;

--- a/cli/src/generate-contract.js
+++ b/cli/src/generate-contract.js
@@ -1026,6 +1026,116 @@ function reorderFieldsByPrev(currentFields, prevFields) {
   });
 }
 
+// ─── Form-state generation for ETP-3957 ──────────────────────────────────────
+
+/**
+ * Generate form-state metadata for an entity.
+ *
+ * Returns a structured object describing field visibility, read-only logic,
+ * requiredness, display logic, callout triggers, and default value provenance.
+ *
+ * @param {object} entity - Schema entity
+ * @param {object} rules - Business rules for the entity
+ * @returns {object} Form state for the entity
+ */
+function generateEntityFormState(entity, rules) {
+  const fields = {};
+  const allRules = Array.isArray(rules) ? rules : [];
+  const entityRules = allRules.filter(r => r.entity === entity.name);
+
+  for (const field of entity.fields ?? []) {
+    if (field.visibility === 'system' || field.visibility === 'discarded') continue;
+
+    const fieldRules = entityRules.filter(r => r.fieldName === field.name || r.fieldName === field.column);
+    const calloutTriggers = fieldRules.filter(r => r.type === 'callout').map(r => r.className ?? r.name).filter(Boolean);
+    const displayLogicRule = fieldRules.find(r => r.type === 'displayLogic');
+    const readOnlyRule = fieldRules.find(r => r.type === 'readOnlyLogic');
+
+    fields[field.name] = {
+      visible: field.visibility === 'editable' || field.visibility === 'readOnly',
+      readOnly: field.visibility === 'readOnly',
+      required: field.required ?? false,
+      displayLogic: displayLogicRule?.expression ?? null,
+      readOnlyLogic: readOnlyRule?.expression ?? field.readOnlyLogic ?? null,
+      calloutTriggers: calloutTriggers.length > 0 ? calloutTriggers : null,
+      defaultValue: field.defaultValue ?? null,
+      provenance: 'extracted',
+    };
+  }
+
+  return fields;
+}
+
+/**
+ * Extract required session variables from the schema.
+ *
+ * Scans fields for @#VAR@ patterns that indicate session-level context requirements.
+ *
+ * @param {object} schema - Full schema
+ * @returns {string[]} List of required session variable names
+ */
+function addSessionVariablesFromExpression(expression, sessionVars) {
+  if (typeof expression !== 'string') return;
+
+  const sessionPattern = /@#(\w+)@/g;
+  let match;
+  while ((match = sessionPattern.exec(expression)) !== null) {
+    sessionVars.add(`#${match[1]}`);
+  }
+}
+
+function extractRequiredSessionVariables(schema, rules = []) {
+  const sessionVars = new Set();
+
+  for (const entity of schema.entities ?? []) {
+    for (const field of entity.fields ?? []) {
+      const sources = [
+        field.displayLogic,
+        field.readOnlyLogic,
+        field.validationRule?.rawExpression,
+      ].filter(Boolean);
+
+      for (const src of sources) {
+        addSessionVariablesFromExpression(src, sessionVars);
+      }
+    }
+  }
+
+  const allRules = Array.isArray(rules) ? rules : [];
+  for (const rule of allRules) {
+    addSessionVariablesFromExpression(rule.expression, sessionVars);
+    addSessionVariablesFromExpression(rule.rawExpression, sessionVars);
+  }
+
+  return Array.from(sessionVars).sort();
+}
+
+/**
+ * Generate the full formState section for the contract.
+ *
+ * @param {object} schema - Full schema
+ * @param {object} rules - Business rules array
+ * @returns {object} formState contract section
+ */
+function generateFormState(schema, rules) {
+  const entities = {};
+
+  for (const entity of schema.entities ?? []) {
+    const entityFormState = generateEntityFormState(entity, rules);
+    if (Object.keys(entityFormState).length > 0) {
+      entities[entity.name] = { fields: entityFormState };
+    }
+  }
+
+  return {
+    entities,
+    requiredSessionVariables: extractRequiredSessionVariables(schema, rules),
+    evaluationMode: 'runtime',
+  };
+}
+
+// ─── End form-state generation ───────────────────────────────────────────────
+
 /**
  * Main orchestrator: generates the full contract object.
  */
@@ -1036,6 +1146,7 @@ export function generateContract(schema, rules = [], processes = [], previousVer
   const backendContract = generateBackendContract(schema, rules, processes);
   const testManifest = generateTestManifest(frontendContract, backendContract, rules, processes);
   const apiPrediction = generateApiPrediction(schema, frontendContract, backendContract);
+  const formState = generateFormState(schema, rules);
 
   // Append apiPrediction-based tests to testManifest using stable IDs
   const makeId = testManifest._makeId;
@@ -1088,7 +1199,7 @@ export function generateContract(schema, rules = [], processes = [], previousVer
     byRunner: updatedByRunner,
   };
 
-  const contractData = { frontendContract, backendContract, apiPrediction, testManifest };
+  const contractData = { frontendContract, backendContract, apiPrediction, formState, testManifest };
   const checksum = createHash('sha256')
     .update(JSON.stringify(contractData))
     .digest('hex')

--- a/cli/src/run-contract-tests.js
+++ b/cli/src/run-contract-tests.js
@@ -230,7 +230,7 @@ function checkSelectorEndpoint(contract, test) {
  */
 function checkActionEndpoint(contract, test) {
   const actions = contract.apiPrediction?.actions ?? [];
-  const match = actions.find(a => a.entity === test.entity && a.field === test.field);
+  const match = actions.find(a => a.entity === test.entity && (a.field ?? a.name) === test.field);
   return match
     ? { passed: true }
     : { passed: false, reason: `No action endpoint for button field '${test.field}' in entity '${test.entity}'` };

--- a/cli/test/generate-contract.test.js
+++ b/cli/test/generate-contract.test.js
@@ -864,10 +864,21 @@ describe('generateApiPrediction', () => {
     const bc = generateBackendContract(buttonSchema);
     const prediction = generateApiPrediction(buttonSchema, fc, bc);
     assert.equal(prediction.actions.length, 1);
-    assert.equal(prediction.actions[0].field, 'docAction');
-    assert.equal(prediction.actions[0].column, 'DocAction');
-    assert.equal(prediction.actions[0].url,
+    const action = prediction.actions[0];
+    assert.equal(action.name, 'docAction');
+    assert.equal(action.column, 'DocAction');
+    assert.equal(action.url,
       '/sws/neo/purchase-invoice/invoice/{id}/action/docAction');
+    assert.equal(action.actionType, 'documentAction');
+    assert.equal(action.entity, 'invoice');
+    assert.ok(action.requiresRecord);
+    assert.ok(Array.isArray(action.parameters));
+    assert.ok(Array.isArray(action.preconditions));
+    assert.ok(Array.isArray(action.effects));
+    assert.ok(Array.isArray(action.edgeCases));
+    assert.equal(action.edgeCases.length >= 3, true);
+    assert.equal(action.provenance, 'extracted');
+    assert.equal(action.dryRunSupported, true);
   });
 
   it('actions is empty array when no button fields exist', () => {
@@ -1278,5 +1289,165 @@ describe('generateApiPrediction — selector context metadata (ETP-3955)', () =>
     const catSelector = prediction.selectors.find(s => s.field === 'category');
     // No dependsOn, no validationRule cascade params, not a priceList -> no context
     assert.equal(catSelector.context, undefined, 'simple FK without context should have no context metadata');
+  });
+});
+
+// ─── Action Classification Metadata (ETP-3956) ────────────────────────────────
+
+describe('generateApiPrediction — action classification (ETP-3956)', () => {
+  const actionSchema = {
+    version: '0.1.0',
+    window: { id: '800', name: 'Action Test', primaryEntity: 'header', category: 'sales' },
+    entities: [{
+      name: 'header',
+      table: 'C_Test',
+      level: 'header',
+      fields: [
+        { name: 'documentAction', column: 'DocAction', type: 'button',
+          processId: '104', processType: 'classic', label: 'Document Action' },
+        { name: 'completeDocument', column: 'Complete', type: 'button',
+          processId: 'ABC123', processType: 'obuiapp' },
+        { name: 'aPRMAddPayment', column: 'EM_APRM_Add', type: 'button',
+          processId: 'PAY001', processType: 'obuiapp' },
+        { name: 'createLinesFrom', column: 'CreateLines', type: 'button',
+          processId: 'CL001', processType: 'classic' },
+        { name: 'recalculate', column: 'Recalculate', type: 'button' },
+      ],
+    }],
+  };
+
+  it('documentAction is classified as documentAction type', () => {
+    const fc = generateFrontendContract(actionSchema);
+    const bc = generateBackendContract(actionSchema);
+    const prediction = generateApiPrediction(actionSchema, fc, bc);
+    const docAction = prediction.actions.find(a => a.name === 'documentAction');
+    assert.ok(docAction);
+    assert.equal(docAction.actionType, 'documentAction');
+    assert.equal(docAction.dryRunSupported, true);
+    assert.equal(docAction.provenance, 'extracted');
+  });
+
+  it('complete pattern is classified as documentAction', () => {
+    const fc = generateFrontendContract(actionSchema);
+    const bc = generateBackendContract(actionSchema);
+    const prediction = generateApiPrediction(actionSchema, fc, bc);
+    const complete = prediction.actions.find(a => a.name === 'completeDocument');
+    assert.ok(complete);
+    assert.equal(complete.actionType, 'documentAction');
+  });
+
+  it('APRM pattern is classified as paymentAction', () => {
+    const fc = generateFrontendContract(actionSchema);
+    const bc = generateBackendContract(actionSchema);
+    const prediction = generateApiPrediction(actionSchema, fc, bc);
+    const payment = prediction.actions.find(a => a.name === 'aPRMAddPayment');
+    assert.ok(payment);
+    assert.equal(payment.actionType, 'paymentAction');
+  });
+
+  it('create pattern is classified as createFrom', () => {
+    const fc = generateFrontendContract(actionSchema);
+    const bc = generateBackendContract(actionSchema);
+    const prediction = generateApiPrediction(actionSchema, fc, bc);
+    const create = prediction.actions.find(a => a.name === 'createLinesFrom');
+    assert.ok(create);
+    assert.equal(create.actionType, 'createFrom');
+    assert.equal(create.requiresRecord, true);
+  });
+
+  it('unknown button is classified as utilityAction', () => {
+    const fc = generateFrontendContract(actionSchema);
+    const bc = generateBackendContract(actionSchema);
+    const prediction = generateApiPrediction(actionSchema, fc, bc);
+    const util = prediction.actions.find(a => a.name === 'recalculate');
+    assert.ok(util);
+    assert.equal(util.actionType, 'utilityAction');
+  });
+
+  it('every action has at least 3 edge cases', () => {
+    const fc = generateFrontendContract(actionSchema);
+    const bc = generateBackendContract(actionSchema);
+    const prediction = generateApiPrediction(actionSchema, fc, bc);
+    for (const action of prediction.actions) {
+      assert.ok(Array.isArray(action.edgeCases), `${action.name} should have edgeCases array`);
+      assert.ok(action.edgeCases.length >= 3, `${action.name} should have >= 3 edge cases, got ${action.edgeCases.length}`);
+    }
+  });
+
+  it('documentAction has docAction parameter', () => {
+    const fc = generateFrontendContract(actionSchema);
+    const bc = generateBackendContract(actionSchema);
+    const prediction = generateApiPrediction(actionSchema, fc, bc);
+    const docAction = prediction.actions.find(a => a.name === 'documentAction');
+    assert.ok(docAction.parameters.length > 0);
+    assert.equal(docAction.parameters[0].name, 'docAction');
+    assert.equal(docAction.parameters[0].required, true);
+  });
+
+  it('actions expose explicit POST endpoint metadata', () => {
+    const fc = generateFrontendContract(actionSchema);
+    const bc = generateBackendContract(actionSchema);
+    const prediction = generateApiPrediction(actionSchema, fc, bc);
+    const docAction = prediction.actions.find(a => a.name === 'documentAction');
+    assert.equal(docAction.method, 'POST');
+    assert.equal(docAction.endpoint, '/sws/neo/action-test/header/{id}/action/documentAction');
+    assert.equal(docAction.url, docAction.endpoint);
+  });
+
+  it('documentAction has preconditions on documentStatus', () => {
+    const fc = generateFrontendContract(actionSchema);
+    const bc = generateBackendContract(actionSchema);
+    const prediction = generateApiPrediction(actionSchema, fc, bc);
+    const docAction = prediction.actions.find(a => a.name === 'documentAction');
+    assert.ok(docAction.preconditions.length > 0);
+    const statusPre = docAction.preconditions.find(p => p.field === 'documentStatus');
+    assert.ok(statusPre);
+    assert.deepEqual(statusPre.values, ['DR', 'IP']);
+  });
+
+  it('curated action overrides are applied from window.actions', () => {
+    const curatedSchema = {
+      ...actionSchema,
+      window: {
+        ...actionSchema.window,
+        actions: {
+          documentAction: {
+            label: 'Complete Document',
+            description: 'Complete the sales order',
+            dryRunSupported: false,
+            effects: ['Locks the document', 'Creates accounting entries'],
+            edgeCases: ['Custom edge 1', 'Custom edge 2', 'Custom edge 3'],
+            allowedValues: ['CO', 'PR'],
+            paramName: 'docAction',
+          },
+        },
+      },
+    };
+    const fc = generateFrontendContract(curatedSchema);
+    const bc = generateBackendContract(curatedSchema);
+    const prediction = generateApiPrediction(curatedSchema, fc, bc);
+    const docAction = prediction.actions.find(a => a.name === 'documentAction');
+    assert.ok(docAction);
+    assert.equal(docAction.label, 'Complete Document');
+    assert.equal(docAction.description, 'Complete the sales order');
+    assert.equal(docAction.dryRunSupported, false);
+    assert.equal(docAction.provenance, 'curated');
+    assert.deepEqual(docAction.effects, ['Locks the document', 'Creates accounting entries']);
+    assert.deepEqual(docAction.edgeCases, ['Custom edge 1', 'Custom edge 2', 'Custom edge 3']);
+    const param = docAction.parameters.find(p => p.name === 'docAction');
+    assert.ok(param);
+    assert.deepEqual(param.allowedValues, ['CO', 'PR']);
+  });
+
+  it('action testManifest entries use action.name', () => {
+    const fc = generateFrontendContract(actionSchema);
+    const bc = generateBackendContract(actionSchema);
+    const contract = generateContract(actionSchema);
+    const actionTests = contract.testManifest.tests.filter(t => t.category === 'action-endpoint');
+    assert.ok(actionTests.length > 0);
+    for (const t of actionTests) {
+      assert.ok(t.field, 'test should have field property');
+      assert.ok(t.entity, 'test should have entity property');
+    }
   });
 });

--- a/cli/test/generate-contract.test.js
+++ b/cli/test/generate-contract.test.js
@@ -1451,3 +1451,132 @@ describe('generateApiPrediction — action classification (ETP-3956)', () => {
     }
   });
 });
+
+// ─── Form-State Metadata (ETP-3957) ──────────────────────────────────────────
+
+describe('generateContract — formState (ETP-3957)', () => {
+  const formStateSchema = {
+    version: '0.1.0',
+    window: { id: '900', name: 'Form State Test', primaryEntity: 'header', category: 'sales' },
+    entities: [{
+      name: 'header',
+      table: 'C_FormTest',
+      level: 'header',
+      fields: [
+        { name: 'documentNo', column: 'DocumentNo', type: 'string', visibility: 'readOnly', required: false, searchable: true, grid: true, form: true },
+        { name: 'businessPartner', column: 'C_BPartner_ID', type: 'foreignKey', visibility: 'editable', required: true, searchable: true, grid: true, form: true },
+        { name: 'orderDate', column: 'DateOrdered', type: 'date', visibility: 'editable', required: false, searchable: false, grid: true, form: true, defaultValue: 'today' },
+        { name: 'internalNote', column: 'Description', type: 'string', visibility: 'editable', required: false, searchable: false, grid: false, form: true },
+        { name: 'processed', column: 'Processed', type: 'boolean', visibility: 'system', required: false, searchable: false, grid: false, form: false },
+        { name: 'documentAction', column: 'DocAction', type: 'button', visibility: 'system', required: false, searchable: false, grid: false, form: false },
+      ],
+    }],
+  };
+
+  const formStateRules = [
+    { entity: 'header', fieldName: 'businessPartner', type: 'callout', className: 'BPartnerCallout', name: 'bpartnerCallout' },
+    { entity: 'header', fieldName: 'businessPartner', type: 'callout', className: 'PriceListCallout' },
+    { entity: 'header', fieldName: 'documentNo', type: 'readOnlyLogic', expression: "@Processed@='Y'" },
+    { entity: 'header', fieldName: 'internalNote', type: 'displayLogic', expression: "@DocumentStatus@='DR'" },
+  ];
+
+  it('contract includes formState section', () => {
+    const contract = generateContract(formStateSchema, formStateRules);
+    assert.ok(contract.formState, 'contract should have formState');
+    assert.ok(contract.formState.entities, 'formState should have entities');
+  });
+
+  it('formState fields include visibility, readOnly, required', () => {
+    const contract = generateContract(formStateSchema, formStateRules);
+    const bp = contract.formState.entities.header.fields.businessPartner;
+    assert.equal(bp.visible, true);
+    assert.equal(bp.readOnly, false);
+    assert.equal(bp.required, true);
+  });
+
+  it('readOnly fields are marked correctly', () => {
+    const contract = generateContract(formStateSchema, formStateRules);
+    const docNo = contract.formState.entities.header.fields.documentNo;
+    assert.equal(docNo.visible, true);
+    assert.equal(docNo.readOnly, true);
+    assert.equal(docNo.required, false);
+  });
+
+  it('system and discarded fields are excluded from formState', () => {
+    const contract = generateContract(formStateSchema, formStateRules);
+    assert.ok(!contract.formState.entities.header.fields.processed, 'system field should be excluded');
+    assert.ok(!contract.formState.entities.header.fields.documentAction, 'system button should be excluded');
+  });
+
+  it('callout triggers are collected from rules', () => {
+    const contract = generateContract(formStateSchema, formStateRules);
+    const bp = contract.formState.entities.header.fields.businessPartner;
+    assert.ok(Array.isArray(bp.calloutTriggers));
+    assert.equal(bp.calloutTriggers.length, 2);
+    assert.ok(bp.calloutTriggers.includes('BPartnerCallout'));
+    assert.ok(bp.calloutTriggers.includes('PriceListCallout'));
+  });
+
+  it('displayLogic is extracted from rules', () => {
+    const contract = generateContract(formStateSchema, formStateRules);
+    const note = contract.formState.entities.header.fields.internalNote;
+    assert.equal(note.displayLogic, "@DocumentStatus@='DR'");
+  });
+
+  it('readOnlyLogic is extracted from rules', () => {
+    const contract = generateContract(formStateSchema, formStateRules);
+    const docNo = contract.formState.entities.header.fields.documentNo;
+    assert.equal(docNo.readOnlyLogic, "@Processed@='Y'");
+  });
+
+  it('defaultValue is included when present', () => {
+    const contract = generateContract(formStateSchema, formStateRules);
+    const date = contract.formState.entities.header.fields.orderDate;
+    assert.equal(date.defaultValue, 'today');
+  });
+
+  it('requiredSessionVariables extracts @#VAR@ patterns', () => {
+    const sessionSchema = {
+      ...formStateSchema,
+      entities: [{
+        ...formStateSchema.entities[0],
+        fields: [
+          ...formStateSchema.entities[0].fields,
+          { name: 'orgField', column: 'AD_Org_ID', type: 'foreignKey', visibility: 'editable', required: false, searchable: false, grid: false, form: true,
+            validationRule: { rawExpression: "@#AD_Org_ID@ IS NOT NULL" } },
+        ],
+      }],
+    };
+    const contract = generateContract(sessionSchema, []);
+    assert.ok(contract.formState.requiredSessionVariables.includes('#AD_Org_ID'));
+  });
+
+  it('requiredSessionVariables extracts session variables from rule expressions', () => {
+    const contract = generateContract(formStateSchema, [
+      { entity: 'header', fieldName: 'internalNote', type: 'displayLogic', expression: "@#AD_Client_ID@ IS NOT NULL" },
+      { entity: 'header', fieldName: 'businessPartner', type: 'readOnlyLogic', rawExpression: "@#AD_Role_ID@ IS NOT NULL" },
+    ]);
+
+    assert.deepStrictEqual(contract.formState.requiredSessionVariables, [
+      '#AD_Client_ID',
+      '#AD_Role_ID',
+    ]);
+  });
+
+  it('evaluationMode is runtime', () => {
+    const contract = generateContract(formStateSchema, formStateRules);
+    assert.equal(contract.formState.evaluationMode, 'runtime');
+  });
+
+  it('empty schema produces empty formState entities', () => {
+    const emptySchema = {
+      version: '0.1.0',
+      window: { id: '999', name: 'Empty', primaryEntity: 'main', category: 'test' },
+      entities: [],
+    };
+    const contract = generateContract(emptySchema, []);
+    assert.ok(contract.formState);
+    assert.deepStrictEqual(contract.formState.entities, {});
+    assert.deepStrictEqual(contract.formState.requiredSessionVariables, []);
+  });
+});

--- a/docs/plans/2026-05-12-etp-3956-action-metadata.md
+++ b/docs/plans/2026-05-12-etp-3956-action-metadata.md
@@ -1,0 +1,103 @@
+# ETP-3956 Action Metadata
+
+## Purpose
+
+ETP-3956 makes generated contracts expose document and process actions in an
+agent-readable shape. The goal is to let MCP and NEO clients discover which
+record actions exist, where to call them, which payload fields are expected, and
+which preconditions or side effects an agent must consider before execution.
+
+## Jira Scope Mapping
+
+The Jira task asks for actions such as `documentAction`, `processNow`,
+`createLinesFrom`, `createLinesFromOrder`, `createLinesFromShipment`,
+`receiveMaterials`, `sendMaterials`, `invoicefromshipment`,
+`aPRMProcessPayment`, and `aprmExecutepayment` to become discoverable and
+operable by agents.
+
+This Schema Forge phase covers the contract discovery part:
+
+- classify button fields into `documentAction`, `paymentAction`, `createFrom`,
+  or `utilityAction`;
+- expose stable action metadata in `apiPrediction.actions`;
+- include the record-scoped POST endpoint, payload parameters, preconditions,
+  effects, dry-run support, edge cases, and provenance;
+- allow curated overrides through `window.actions` in `decisions.json` when
+  extracted metadata is not specific enough.
+
+Runtime validation and execution remain owned by NEO Headless in
+`com.etendoerp.go`. A Schema Forge contract can describe an action endpoint, but
+it must not emulate runtime permission checks, process execution, or
+window-specific action behavior.
+
+## Generated Action Shape
+
+Each generated action entry uses this shape:
+
+```json
+{
+  "name": "documentAction",
+  "label": "Document Action",
+  "actionType": "documentAction",
+  "entity": "header",
+  "column": "DocAction",
+  "requiresRecord": true,
+  "endpoint": "/sws/neo/sales-order/header/{id}/action/documentAction",
+  "method": "POST",
+  "url": "/sws/neo/sales-order/header/{id}/action/documentAction",
+  "parameters": [
+    {
+      "name": "docAction",
+      "type": "string",
+      "required": true,
+      "description": "Document action code (e.g. CO=Complete, VO=Void, RE=Reactivate)"
+    }
+  ],
+  "preconditions": [
+    {
+      "field": "documentStatus",
+      "operator": "in",
+      "values": ["DR", "IP"],
+      "description": "Document must be in draft or in-progress state"
+    }
+  ],
+  "effects": [
+    "Updates document status",
+    "May trigger workflow transitions"
+  ],
+  "dryRunSupported": true,
+  "edgeCases": [
+    "Document is already completed or closed",
+    "Document has pending lines or missing required fields",
+    "User lacks permission to execute the action"
+  ],
+  "provenance": "extracted"
+}
+```
+
+`url` is kept as a backwards-compatible alias for existing consumers; new agent
+clients should prefer `endpoint` plus `method`.
+
+## Current Limits
+
+- Generated metadata is inferred from button field names and columns unless a
+  curated override exists.
+- Document action values such as `CO`, `RE`, or `VO` should be curated when the
+  extractor cannot prove the valid set.
+- The contract does not prove that an action is executable for a specific user
+  or record state. Runtime tools must return structured `available`, `blocked`,
+  `unsupported`, or `forbidden` diagnostics.
+- Real artifact contracts must be regenerated before the new action shape is
+  visible in versioned `artifacts/*/contract.json` files.
+
+## Validation
+
+Generator coverage lives in `cli/test/generate-contract.test.js` and checks:
+
+- document lifecycle, payment, create-from, and utility classification;
+- required record-scoped action metadata;
+- explicit POST endpoint metadata;
+- `docAction` payload metadata for document actions;
+- at least three edge cases per generated action;
+- curated overrides from `window.actions`;
+- action test-manifest entries using the action name.

--- a/docs/plans/2026-05-12-etp-3957-form-state-metadata.md
+++ b/docs/plans/2026-05-12-etp-3957-form-state-metadata.md
@@ -1,0 +1,72 @@
+# ETP-3957 Form State Metadata
+
+## Purpose
+
+ETP-3957 adds a `formState` section to generated contracts so MCP and NEO
+agents can inspect field-level form fidelity before creating or updating
+records. The metadata describes whether each exposed field is visible,
+read-only, required, controlled by display or read-only logic, affected by
+callouts, or dependent on session context.
+
+## Jira Scope Mapping
+
+The Jira task asks agents to understand the same form constraints used by the
+SPA: visible fields, required fields, writable fields, callout dependencies, and
+session context. This Schema Forge phase covers the contract declaration layer:
+
+- expose per-entity field state under `formState.entities`;
+- preserve extracted `displayLogic` and `readOnlyLogic` expressions;
+- list callout trigger classes found in business rules;
+- expose default values when the schema contains them;
+- extract `@#VAR@` references into `requiredSessionVariables`.
+
+Runtime evaluation remains owned by NEO Headless in `com.etendoerp.go`.
+Schema Forge declares the expressions and dependencies; it does not decide the
+current runtime result for a specific user, role, organization, or record.
+
+## Generated Shape
+
+Each generated contract now includes:
+
+```json
+{
+  "formState": {
+    "entities": {
+      "header": {
+        "fields": {
+          "businessPartner": {
+            "visible": true,
+            "readOnly": false,
+            "required": true,
+            "displayLogic": null,
+            "readOnlyLogic": null,
+            "calloutTriggers": ["BPartnerCallout"],
+            "defaultValue": null,
+            "provenance": "extracted"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": ["#AD_Client_ID", "#AD_Org_ID"],
+    "evaluationMode": "runtime"
+  }
+}
+```
+
+System and discarded fields are excluded. Hidden but relevant fields may still
+be represented with `visible: false` when they are not classified as system or
+discarded.
+
+## Validation
+
+Generator coverage lives in `cli/test/generate-contract.test.js` and checks:
+
+- the `formState` section is always emitted;
+- editable and read-only fields are classified correctly;
+- system and discarded fields are excluded;
+- callout triggers are collected from rules;
+- display and read-only expressions are preserved;
+- default values are exposed when present;
+- session variables are extracted from both field metadata and rule
+  expressions;
+- empty schemas produce an empty but stable `formState`.


### PR DESCRIPTION
## Summary
- Add a `formState` section to generated contracts with per-entity field metadata for MCP agents.
- Expose field visibility, read-only, required/default metadata, display/read-only logic, callout triggers, and provenance.
- Extract `requiredSessionVariables` from field expressions and rule expressions so agents can plan the needed runtime context.
- Keep system and discarded fields out of generated form-state metadata.

## Stack
- Previous PR: https://github.com/etendosoftware/etendo_schema_forge/pull/524 (`feature/ETP-3956`)
- This branch: `feature/ETP-3957`
- Base branch: `feature/ETP-3956`
- Next planned branch: `feature/ETP-3958`

## Schema Forge Changes
- `cli/src/generate-contract.js`: add form-state contract generation and session-variable extraction.
- `cli/test/generate-contract.test.js`: add focused form-state generation coverage.
- `docs/plans/2026-05-12-etp-3957-form-state-metadata.md`: document the ETP-3957 metadata contract and validation scope.

## com.etendoerp.go Changes
- None. Runtime evaluation and callout execution remain a NEO Headless responsibility.

## Tests
- [x] `node --test --test-reporter=spec cli/test/generate-contract.test.js` (117 tests)
- [x] `make test` (414 CLI tests, 611 app-shell tests)
- [x] Local Sonar PR scan uploaded for PR #525

## Known Limitations
- Form-state metadata is structural; runtime evaluation of display/read-only expressions requires NEO Headless.
- Callout execution is not implemented in Schema Forge; trigger metadata is exposed for runtime consumers.
