### PR TITLE
Feature ETP-3958: Add Agent Profile Metadata

### DIFF
--- a/artifacts/assets/contract.json
+++ b/artifacts/assets/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.2.0",
   "generatedAt": "2026-04-29T19:06:30.936Z",
-  "updatedAt": "2026-05-15T16:33:40.192Z",
-  "checksum": "0861dc952c5f0eef",
+  "updatedAt": "2026-05-15T16:36:35.035Z",
+  "checksum": "0337b1a57f8a8cae",
   "frontendContract": {
     "window": {
       "id": "800027",
@@ -2244,6 +2244,69 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage assets financial records.",
+    "whenToUse": [
+      "Use for assets management."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "searchKey",
+        "name",
+        "assetCategory",
+        "depreciate",
+        "depreciationType",
+        "calculateType",
+        "amortize",
+        "everyMonthIs30Days",
+        "processed",
+        "processAsset",
+        "accumulatedDepreciation",
+        "depreciation"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [],
+    "actions": [],
+    "workflow": [
+      "Add at least one valid line"
+    ],
+    "edgeCases": [
+      "Required context is missing",
+      "User lacks permission",
+      "Record is in an incompatible state",
+      "Required field without default value must be provided",
+      "Validate the current form state before running lifecycle actions",
+      "Do not run destructive lifecycle actions without explicit user confirmation"
+    ],
+    "examples": [
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "searchKey",
+          "name",
+          "assetCategory",
+          "depreciate",
+          "depreciationType",
+          "calculateType",
+          "amortize",
+          "everyMonthIs30Days",
+          "processed",
+          "processAsset",
+          "accumulatedDepreciation",
+          "depreciation"
+        ]
+      }
+    ],
+    "warnings": [
+      "Transactional spec has no generated lifecycle action metadata"
+    ],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/contacts/contract.json
+++ b/artifacts/contacts/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.8.1",
   "generatedAt": "2026-05-06T15:52:09.982Z",
-  "updatedAt": "2026-05-15T16:33:38.056Z",
-  "checksum": "9f44204a9101aa79",
+  "updatedAt": "2026-05-15T16:36:32.902Z",
+  "checksum": "b55eb716a4550e61",
   "frontendContract": {
     "window": {
       "id": "123",
@@ -11893,6 +11893,107 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage contacts records.",
+    "whenToUse": [
+      "Use for contacts management."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "searchKey",
+        "name",
+        "etgoFirstname",
+        "etgoLastname",
+        "oBTIKTaxIDKey",
+        "businessPartnerCategory",
+        "customer",
+        "vendor",
+        "employee",
+        "setNewCurrency",
+        "creditLimit",
+        "etgoIsperson",
+        "customerBlocking",
+        "isSalesRepresentative",
+        "vendorBlocking",
+        "customer",
+        "customerBlocking",
+        "salesOrder",
+        "goodsShipment",
+        "salesInvoice",
+        "paymentIn",
+        "aeatsiiDefaultsiikey",
+        "customerReceivablesNo",
+        "privateCustomer",
+        "vendor",
+        "cashVAT",
+        "vendorBlocking",
+        "purchaseOrder",
+        "goodsReceipt",
+        "purchaseInvoice",
+        "paymentOut",
+        "vendorLiability",
+        "employee",
+        "isSalesRepresentative",
+        "startingDate",
+        "salaryCategory",
+        "bankFormat",
+        "documentcategory",
+        "issotrx",
+        "cDoctypeID",
+        "active",
+        "locationAddress",
+        "name",
+        "shipToAddress",
+        "invoiceToAddress",
+        "taxLocation",
+        "isdefaultfordocs",
+        "grantPortalAccess",
+        "commercialauth",
+        "viasms",
+        "viaemail",
+        "lineNo",
+        "discount",
+        "customer",
+        "vendor",
+        "applyInOrder",
+        "cascade"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "bankAccount",
+        "field": "userContact",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "processNow"
+    ],
+    "workflow": [],
+    "edgeCases": [
+      "Required context is missing",
+      "User lacks permission",
+      "Record is in an incompatible state",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action"
+    ],
+    "examples": [],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/goods-movements/contract.json
+++ b/artifacts/goods-movements/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T19:05:48.778Z",
-  "updatedAt": "2026-05-15T16:33:39.675Z",
-  "checksum": "1e2c7281b4a8708d",
+  "updatedAt": "2026-05-15T16:36:34.520Z",
+  "checksum": "809e54c0f07d4e62",
   "frontendContract": {
     "window": {
       "id": "170",
@@ -1178,6 +1178,68 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage goods movements inventory operations.",
+    "whenToUse": [
+      "Use for stock and warehouse operations."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "name",
+        "movementDate",
+        "lineNo",
+        "product",
+        "movementQuantity",
+        "storageBin",
+        "newStorageBin"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [],
+    "actions": [
+      "processNow",
+      "posted"
+    ],
+    "workflow": [
+      "Add at least one valid line"
+    ],
+    "edgeCases": [
+      "Required context is missing",
+      "User lacks permission",
+      "Record is in an incompatible state",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Required field without default value must be provided",
+      "Validate the current form state before running lifecycle actions",
+      "Do not run destructive lifecycle actions without explicit user confirmation"
+    ],
+    "examples": [
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "name",
+          "movementDate",
+          "lineNo",
+          "product",
+          "movementQuantity",
+          "storageBin",
+          "newStorageBin"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "processNow"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/goods-receipt/contract.json
+++ b/artifacts/goods-receipt/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.4.0",
   "generatedAt": "2026-04-29T19:05:20.719Z",
-  "updatedAt": "2026-05-15T16:33:38.923Z",
-  "checksum": "6574f880394951b7",
+  "updatedAt": "2026-05-15T16:36:33.763Z",
+  "checksum": "d0ac9980cc5c2cef",
   "frontendContract": {
     "window": {
       "id": "184",
@@ -2704,6 +2704,118 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Create and manage goods receipt documents.",
+    "whenToUse": [
+      "Use for supplier goods receipt before receipt or invoice."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "warehouse",
+        "businessPartner",
+        "partnerAddress",
+        "movementDate",
+        "accountingDate",
+        "lineNo",
+        "movementQuantity"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "goodsReceipt",
+        "field": "partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "goodsReceipt",
+        "field": "project",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "goodsReceiptLine",
+        "field": "operativeUOM",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "createLinesFrom",
+      "generateTo",
+      "documentAction",
+      "posted",
+      "receiveMaterials",
+      "sendMaterials"
+    ],
+    "workflow": [
+      "Add at least one valid line",
+      "Validate form state",
+      "Complete the document"
+    ],
+    "edgeCases": [
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Required context is missing",
+      "User lacks permission",
+      "Record is in an incompatible state",
+      "Required field without default value must be provided"
+    ],
+    "examples": [
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "warehouse",
+          "businessPartner",
+          "partnerAddress",
+          "movementDate",
+          "accountingDate",
+          "lineNo",
+          "movementQuantity"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "createLinesFrom"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/goods-receipt/contract.prev.json
+++ b/artifacts/goods-receipt/contract.prev.json
@@ -1,8 +1,8 @@
 {
   "version": "0.4.0",
   "generatedAt": "2026-04-29T19:05:20.719Z",
-  "updatedAt": "2026-05-15T16:33:38.923Z",
-  "checksum": "6574f880394951b7",
+  "updatedAt": "2026-05-15T16:36:33.763Z",
+  "checksum": "d0ac9980cc5c2cef",
   "frontendContract": {
     "window": {
       "id": "184",
@@ -2704,6 +2704,118 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Create and manage goods receipt documents.",
+    "whenToUse": [
+      "Use for supplier goods receipt before receipt or invoice."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "warehouse",
+        "businessPartner",
+        "partnerAddress",
+        "movementDate",
+        "accountingDate",
+        "lineNo",
+        "movementQuantity"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "goodsReceipt",
+        "field": "partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "goodsReceipt",
+        "field": "project",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "goodsReceiptLine",
+        "field": "operativeUOM",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "createLinesFrom",
+      "generateTo",
+      "documentAction",
+      "posted",
+      "receiveMaterials",
+      "sendMaterials"
+    ],
+    "workflow": [
+      "Add at least one valid line",
+      "Validate form state",
+      "Complete the document"
+    ],
+    "edgeCases": [
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Required context is missing",
+      "User lacks permission",
+      "Record is in an incompatible state",
+      "Required field without default value must be provided"
+    ],
+    "examples": [
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "warehouse",
+          "businessPartner",
+          "partnerAddress",
+          "movementDate",
+          "accountingDate",
+          "lineNo",
+          "movementQuantity"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "createLinesFrom"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/goods-shipment/contract.json
+++ b/artifacts/goods-shipment/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.6.0",
   "generatedAt": "2026-04-29T19:04:55.657Z",
-  "updatedAt": "2026-05-15T16:33:38.382Z",
-  "checksum": "999ccdc835bf9152",
+  "updatedAt": "2026-05-15T16:36:33.230Z",
+  "checksum": "add8b45251789578",
   "frontendContract": {
     "window": {
       "id": "169",
@@ -1949,6 +1949,85 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Create and manage goods shipment documents.",
+    "whenToUse": [
+      "Use for customer goods shipment before receipt or invoice."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "warehouse",
+        "businessPartner",
+        "partnerAddress",
+        "movementDate",
+        "movementQuantity"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "goodsShipment",
+        "field": "partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "createLinesFrom",
+      "documentAction",
+      "posted",
+      "generateTo",
+      "receiveMaterials",
+      "sendMaterials"
+    ],
+    "workflow": [
+      "Add at least one valid line",
+      "Validate form state",
+      "Complete the document"
+    ],
+    "edgeCases": [
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Required context is missing",
+      "User lacks permission",
+      "Record is in an incompatible state",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Required field without default value must be provided"
+    ],
+    "examples": [
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "warehouse",
+          "businessPartner",
+          "partnerAddress",
+          "movementDate",
+          "movementQuantity"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "createLinesFrom"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/internal-consumption/contract.json
+++ b/artifacts/internal-consumption/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.4.0",
   "generatedAt": "2026-04-29T19:05:49.589Z",
-  "updatedAt": "2026-05-15T16:33:39.775Z",
-  "checksum": "a5a39867d19d927b",
+  "updatedAt": "2026-05-15T16:36:34.621Z",
+  "checksum": "a8eb6884b1fb5828",
   "frontendContract": {
     "window": {
       "id": "800076",
@@ -935,6 +935,63 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage internal consumption inventory operations.",
+    "whenToUse": [
+      "Use for stock and warehouse operations."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "movementDate",
+        "name",
+        "status",
+        "product",
+        "movementQuantity",
+        "storageBin"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [],
+    "actions": [
+      "processNow",
+      "posted"
+    ],
+    "workflow": [
+      "Add at least one valid line"
+    ],
+    "edgeCases": [
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Required field without default value must be provided",
+      "Validate the current form state before running lifecycle actions",
+      "Do not run destructive lifecycle actions without explicit user confirmation"
+    ],
+    "examples": [
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "movementDate",
+          "name",
+          "status",
+          "product",
+          "movementQuantity",
+          "storageBin"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "processNow"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/payment-in/contract.json
+++ b/artifacts/payment-in/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T19:05:52.312Z",
-  "updatedAt": "2026-05-15T16:33:39.981Z",
-  "checksum": "6b7311c247a257c1",
+  "updatedAt": "2026-05-15T16:36:34.824Z",
+  "checksum": "49afd001444c6b75",
   "frontendContract": {
     "window": {
       "id": "E547CE89D4C04429B6340FFA44E70716",
@@ -1694,6 +1694,87 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage payment in financial records.",
+    "whenToUse": [
+      "Use for payment in management."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "amount"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "finPayment",
+        "field": "account",
+        "context": {
+          "required": [
+            {
+              "param": "Fin_Paymentmethod_ID",
+              "source": "field",
+              "field": "paymentMethod"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "finPayment",
+        "field": "currency",
+        "context": {
+          "required": [
+            {
+              "param": "FIN_Financial_Account_ID",
+              "source": "field",
+              "field": "account"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "posted",
+      "aPRMReversePayment",
+      "aeatsiiSend"
+    ],
+    "workflow": [
+      "Add at least one valid line"
+    ],
+    "edgeCases": [
+      "Payment amount exceeds remaining balance",
+      "Payment method is not configured for the business partner",
+      "Invoice is already fully paid",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Required field without default value must be provided"
+    ],
+    "examples": [
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "amount"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "posted"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": [
+      "aPRMReversePayment"
+    ]
   },
   "testManifest": {
     "tests": [

--- a/artifacts/payment-method/contract.json
+++ b/artifacts/payment-method/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.4.0",
   "generatedAt": "2026-04-29T18:12:23.942Z",
-  "updatedAt": "2026-05-15T16:33:40.490Z",
-  "checksum": "16dbff15b5a9da1c",
+  "updatedAt": "2026-05-15T16:36:35.332Z",
+  "checksum": "dc49d9522ab22d0f",
   "frontendContract": {
     "window": {
       "id": "3CAAC7D54593489384452416ACF356DD",
@@ -715,6 +715,34 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage payment method records.",
+    "whenToUse": [
+      "Use for payment method management."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "name",
+        "payinAllow",
+        "automaticReceipt",
+        "automaticDeposit",
+        "payoutAllow",
+        "automaticPayment",
+        "automaticWithdrawn"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [],
+    "actions": [],
+    "workflow": [],
+    "edgeCases": [],
+    "examples": [],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/payment-out/contract.json
+++ b/artifacts/payment-out/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T18:11:46.137Z",
-  "updatedAt": "2026-05-15T16:33:40.086Z",
-  "checksum": "0d75aefbbf853e78",
+  "updatedAt": "2026-05-15T16:36:34.932Z",
+  "checksum": "94464a11a1d43ea1",
   "frontendContract": {
     "window": {
       "id": "6F8F913FA60F4CBD93DC1D3AA696E76E",
@@ -4740,6 +4740,94 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage payment out financial records.",
+    "whenToUse": [
+      "Use for payment out management."
+    ],
+    "minimumCreate": {
+      "headerFields": [
+        "documentType",
+        "paymentMethod",
+        "account",
+        "currency",
+        "financialTransactionAmount",
+        "financialTransactionConvertRate"
+      ],
+      "lineFields": [
+        "amount",
+        "active",
+        "toCurrency",
+        "foreignAmount",
+        "creditPaymentUsed",
+        "amount",
+        "currency"
+      ],
+      "recommendedOrder": [
+        "createHeader",
+        "createLines"
+      ]
+    },
+    "selectorContexts": [],
+    "actions": [
+      "posted",
+      "aPRMReversePayment",
+      "aeatsiiSend"
+    ],
+    "workflow": [
+      "Create draft header with required fields",
+      "Add at least one valid line"
+    ],
+    "edgeCases": [
+      "Payment amount exceeds remaining balance",
+      "Payment method is not configured for the business partner",
+      "Invoice is already fully paid",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Required field without default value must be provided"
+    ],
+    "examples": [
+      {
+        "operation": "createHeader",
+        "description": "Create a draft header with the minimum required editable fields.",
+        "fields": [
+          "documentType",
+          "paymentMethod",
+          "account",
+          "currency",
+          "financialTransactionAmount",
+          "financialTransactionConvertRate"
+        ]
+      },
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "amount",
+          "active",
+          "toCurrency",
+          "foreignAmount",
+          "creditPaymentUsed",
+          "amount",
+          "currency"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "posted"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": [
+      "aPRMReversePayment"
+    ]
   },
   "testManifest": {
     "tests": [

--- a/artifacts/payment-term/contract.json
+++ b/artifacts/payment-term/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T19:06:55.269Z",
-  "updatedAt": "2026-05-15T16:33:40.394Z",
-  "checksum": "d4c158ee909f6dc2",
+  "updatedAt": "2026-05-15T16:36:35.233Z",
+  "checksum": "720d4173030decc2",
   "frontendContract": {
     "window": {
       "id": "141",
@@ -481,6 +481,42 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage payment term records.",
+    "whenToUse": [
+      "Use for payment term management."
+    ],
+    "minimumCreate": {
+      "headerFields": [
+        "searchKey",
+        "name",
+        "offsetMonthDue",
+        "overduePaymentDaysRule"
+      ],
+      "recommendedOrder": [
+        "createHeader"
+      ]
+    },
+    "selectorContexts": [],
+    "actions": [],
+    "workflow": [],
+    "edgeCases": [],
+    "examples": [
+      {
+        "operation": "createHeader",
+        "description": "Create a draft header with the minimum required editable fields.",
+        "fields": [
+          "searchKey",
+          "name",
+          "offsetMonthDue",
+          "overduePaymentDaysRule"
+        ]
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/physical-inventory/contract.json
+++ b/artifacts/physical-inventory/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.17.0",
   "generatedAt": "2026-04-29T19:05:48.442Z",
-  "updatedAt": "2026-05-15T16:33:39.571Z",
-  "checksum": "3e7936d659733fc1",
+  "updatedAt": "2026-05-15T16:36:34.418Z",
+  "checksum": "d84c1afc62493cdc",
   "frontendContract": {
     "window": {
       "id": "168",
@@ -1363,6 +1363,68 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage physical inventory inventory operations.",
+    "whenToUse": [
+      "Use for stock and warehouse operations."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "movementDate",
+        "name",
+        "warehouse",
+        "product",
+        "storageBin",
+        "quantityCount"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [],
+    "actions": [
+      "generateList",
+      "processNow",
+      "posted"
+    ],
+    "workflow": [
+      "Add at least one valid line"
+    ],
+    "edgeCases": [
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Required context is missing",
+      "User lacks permission",
+      "Record is in an incompatible state",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Required field without default value must be provided"
+    ],
+    "examples": [
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "movementDate",
+          "name",
+          "warehouse",
+          "product",
+          "storageBin",
+          "quantityCount"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "generateList"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/price-list/contract.json
+++ b/artifacts/price-list/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.2.0",
   "generatedAt": "2026-04-29T18:12:11.134Z",
-  "updatedAt": "2026-05-15T16:33:40.294Z",
-  "checksum": "a32f5e13b735ef1d",
+  "updatedAt": "2026-05-15T16:36:35.133Z",
+  "checksum": "aba22578b670d36d",
   "frontendContract": {
     "window": {
       "id": "146",
@@ -1300,6 +1300,48 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage price list records.",
+    "whenToUse": [
+      "Use for price list management."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "name",
+        "currency",
+        "salesPriceList",
+        "costBasedPriceList",
+        "priceIncludesTax",
+        "default",
+        "name",
+        "validFromDate",
+        "priceListSchema",
+        "product",
+        "standardPrice",
+        "listPrice",
+        "cost",
+        "algorithm"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [],
+    "actions": [
+      "create",
+      "generatePriceListVersion"
+    ],
+    "workflow": [],
+    "edgeCases": [
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)"
+    ],
+    "examples": [],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/product-category/contract.json
+++ b/artifacts/product-category/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T18:11:26.703Z",
-  "updatedAt": "2026-05-15T16:33:39.468Z",
-  "checksum": "aefa9396313175e8",
+  "updatedAt": "2026-05-15T16:36:34.315Z",
+  "checksum": "33aaedab0a85e219",
   "frontendContract": {
     "window": {
       "id": "144",
@@ -1791,6 +1791,63 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage product category inventory operations.",
+    "whenToUse": [
+      "Use for stock and warehouse operations."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "searchKey",
+        "name",
+        "default",
+        "summaryLevel"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [],
+    "actions": [
+      "processNow",
+      "createVariants"
+    ],
+    "workflow": [
+      "Add at least one valid line"
+    ],
+    "edgeCases": [
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Required context is missing",
+      "User lacks permission",
+      "Record is in an incompatible state",
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Required field without default value must be provided"
+    ],
+    "examples": [
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "searchKey",
+          "name",
+          "default",
+          "summaryLevel"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "processNow"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/product/contract.json
+++ b/artifacts/product/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.2.0",
   "generatedAt": "2026-04-29T18:11:24.842Z",
-  "updatedAt": "2026-05-15T16:33:39.363Z",
-  "checksum": "6b1df83415e79717",
+  "updatedAt": "2026-05-15T16:36:34.209Z",
+  "checksum": "6d8766b7bf1934d5",
   "frontendContract": {
     "window": {
       "id": "140",
@@ -5975,6 +5975,133 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage product inventory operations.",
+    "whenToUse": [
+      "Use for stock and warehouse operations."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "searchKey",
+        "name",
+        "uOM",
+        "productCategory",
+        "taxCategory",
+        "purchase",
+        "sale",
+        "productType",
+        "stocked",
+        "returnable",
+        "priceListVersion",
+        "standardPrice",
+        "listPrice",
+        "cost",
+        "active",
+        "validFromDate",
+        "lineNo",
+        "bOMProduct",
+        "bOMQuantity",
+        "costDate",
+        "cost",
+        "cCurrencyID",
+        "unitCost",
+        "accountingDate",
+        "sequenceNumber",
+        "characteristic",
+        "variant",
+        "explodeConfigurationTab",
+        "definesPrice",
+        "priceListType",
+        "definesImage",
+        "active",
+        "active",
+        "validFromDate",
+        "uOM",
+        "conversionRate",
+        "sales",
+        "purchase",
+        "logistics"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [],
+    "actions": [
+      "processNow",
+      "createVariants"
+    ],
+    "workflow": [
+      "Add at least one valid line"
+    ],
+    "edgeCases": [
+      "Required context is missing",
+      "User lacks permission",
+      "Record is in an incompatible state",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Required field without default value must be provided"
+    ],
+    "examples": [
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "searchKey",
+          "name",
+          "uOM",
+          "productCategory",
+          "taxCategory",
+          "purchase",
+          "sale",
+          "productType",
+          "stocked",
+          "returnable",
+          "priceListVersion",
+          "standardPrice",
+          "listPrice",
+          "cost",
+          "active",
+          "validFromDate",
+          "lineNo",
+          "bOMProduct",
+          "bOMQuantity",
+          "costDate",
+          "cost",
+          "cCurrencyID",
+          "unitCost",
+          "accountingDate",
+          "sequenceNumber",
+          "characteristic",
+          "variant",
+          "explodeConfigurationTab",
+          "definesPrice",
+          "priceListType",
+          "definesImage",
+          "active",
+          "active",
+          "validFromDate",
+          "uOM",
+          "conversionRate",
+          "sales",
+          "purchase",
+          "logistics"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "processNow"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/purchase-invoice/contract.json
+++ b/artifacts/purchase-invoice/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.27.0",
   "generatedAt": "2026-04-30T15:42:46.722Z",
-  "updatedAt": "2026-05-15T16:33:39.037Z",
-  "checksum": "f566b73d953107c3",
+  "updatedAt": "2026-05-15T16:36:33.880Z",
+  "checksum": "afd5e9176c796bed",
   "frontendContract": {
     "window": {
       "id": "183",
@@ -10673,6 +10673,219 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Create and manage purchase invoice documents.",
+    "whenToUse": [
+      "Use for supplier purchase invoice before receipt or invoice."
+    ],
+    "minimumCreate": {
+      "headerFields": [
+        "transactionDocument",
+        "invoiceDate",
+        "businessPartner",
+        "partnerAddress",
+        "priceList",
+        "accountingDate",
+        "paymentTerms",
+        "paymentMethod",
+        "currency",
+        "aeatsiiIsauthorization"
+      ],
+      "lineFields": [
+        "invoicedQuantity",
+        "listPrice",
+        "unitPrice",
+        "hasSuplementaryUnit",
+        "lineNo",
+        "discount",
+        "cascade",
+        "expectedDate",
+        "amount2",
+        "estadoRegistro",
+        "active"
+      ],
+      "recommendedOrder": [
+        "createHeader",
+        "createLines"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "header",
+        "field": "transactionDocument",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "priceList",
+        "context": {
+          "required": [
+            {
+              "param": "isSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "paymentMethod",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "userContact",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "project",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "lines",
+        "field": "tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "generateTo",
+      "posted",
+      "documentAction",
+      "createLinesFromOrder",
+      "createLinesFromShipment",
+      "copyFrom",
+      "aeatsiiSend",
+      "processNow",
+      "createLinesFrom",
+      "etvfacRectCreate",
+      "tbaiVoidxmlgenerator"
+    ],
+    "workflow": [
+      "Create draft header with required fields",
+      "Add at least one valid line",
+      "Validate form state",
+      "Complete the document"
+    ],
+    "edgeCases": [
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Payment amount exceeds remaining balance",
+      "Payment method is not configured for the business partner",
+      "Invoice is already fully paid",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Required context is missing"
+    ],
+    "examples": [
+      {
+        "operation": "createHeader",
+        "description": "Create a draft header with the minimum required editable fields.",
+        "fields": [
+          "transactionDocument",
+          "invoiceDate",
+          "businessPartner",
+          "partnerAddress",
+          "priceList",
+          "accountingDate",
+          "paymentTerms",
+          "paymentMethod",
+          "currency",
+          "aeatsiiIsauthorization"
+        ]
+      },
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "invoicedQuantity",
+          "listPrice",
+          "unitPrice",
+          "hasSuplementaryUnit",
+          "lineNo",
+          "discount",
+          "cascade",
+          "expectedDate",
+          "amount2",
+          "estadoRegistro",
+          "active"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "generateTo"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": [
+      "tbaiVoidxmlgenerator"
+    ]
   },
   "testManifest": {
     "tests": [

--- a/artifacts/purchase-invoice/contract.prev.json
+++ b/artifacts/purchase-invoice/contract.prev.json
@@ -1,8 +1,8 @@
 {
   "version": "0.27.0",
   "generatedAt": "2026-04-30T15:42:46.722Z",
-  "updatedAt": "2026-05-15T16:33:39.037Z",
-  "checksum": "f566b73d953107c3",
+  "updatedAt": "2026-05-15T16:36:33.880Z",
+  "checksum": "afd5e9176c796bed",
   "frontendContract": {
     "window": {
       "id": "183",
@@ -10673,6 +10673,219 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Create and manage purchase invoice documents.",
+    "whenToUse": [
+      "Use for supplier purchase invoice before receipt or invoice."
+    ],
+    "minimumCreate": {
+      "headerFields": [
+        "transactionDocument",
+        "invoiceDate",
+        "businessPartner",
+        "partnerAddress",
+        "priceList",
+        "accountingDate",
+        "paymentTerms",
+        "paymentMethod",
+        "currency",
+        "aeatsiiIsauthorization"
+      ],
+      "lineFields": [
+        "invoicedQuantity",
+        "listPrice",
+        "unitPrice",
+        "hasSuplementaryUnit",
+        "lineNo",
+        "discount",
+        "cascade",
+        "expectedDate",
+        "amount2",
+        "estadoRegistro",
+        "active"
+      ],
+      "recommendedOrder": [
+        "createHeader",
+        "createLines"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "header",
+        "field": "transactionDocument",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "priceList",
+        "context": {
+          "required": [
+            {
+              "param": "isSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "paymentMethod",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "userContact",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "project",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "lines",
+        "field": "tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "generateTo",
+      "posted",
+      "documentAction",
+      "createLinesFromOrder",
+      "createLinesFromShipment",
+      "copyFrom",
+      "aeatsiiSend",
+      "processNow",
+      "createLinesFrom",
+      "etvfacRectCreate",
+      "tbaiVoidxmlgenerator"
+    ],
+    "workflow": [
+      "Create draft header with required fields",
+      "Add at least one valid line",
+      "Validate form state",
+      "Complete the document"
+    ],
+    "edgeCases": [
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Payment amount exceeds remaining balance",
+      "Payment method is not configured for the business partner",
+      "Invoice is already fully paid",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Required context is missing"
+    ],
+    "examples": [
+      {
+        "operation": "createHeader",
+        "description": "Create a draft header with the minimum required editable fields.",
+        "fields": [
+          "transactionDocument",
+          "invoiceDate",
+          "businessPartner",
+          "partnerAddress",
+          "priceList",
+          "accountingDate",
+          "paymentTerms",
+          "paymentMethod",
+          "currency",
+          "aeatsiiIsauthorization"
+        ]
+      },
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "invoicedQuantity",
+          "listPrice",
+          "unitPrice",
+          "hasSuplementaryUnit",
+          "lineNo",
+          "discount",
+          "cascade",
+          "expectedDate",
+          "amount2",
+          "estadoRegistro",
+          "active"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "generateTo"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": [
+      "tbaiVoidxmlgenerator"
+    ]
   },
   "testManifest": {
     "tests": [

--- a/artifacts/purchase-order/contract.json
+++ b/artifacts/purchase-order/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.19.0",
   "generatedAt": "2026-04-30T15:42:46.497Z",
-  "updatedAt": "2026-05-15T16:33:38.817Z",
-  "checksum": "db2af24b1a59c801",
+  "updatedAt": "2026-05-15T16:36:33.657Z",
+  "checksum": "33886fd2bccac66a",
   "frontendContract": {
     "window": {
       "id": "181",
@@ -6507,6 +6507,242 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Create and manage purchase order documents.",
+    "whenToUse": [
+      "Use for supplier purchase order before receipt or invoice."
+    ],
+    "minimumCreate": {
+      "headerFields": [
+        "businessPartner",
+        "orderDate",
+        "partnerAddress",
+        "scheduledDeliveryDate",
+        "transactionDocument",
+        "warehouse",
+        "paymentTerms",
+        "priceList",
+        "cashVAT",
+        "invoiceFrom",
+        "deliveryMethod",
+        "priority",
+        "deliveryTerms"
+      ],
+      "lineFields": [
+        "product",
+        "orderedQuantity",
+        "listPrice",
+        "tax",
+        "unitPrice",
+        "lineNetAmount"
+      ],
+      "recommendedOrder": [
+        "createHeader",
+        "createLines"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "header",
+        "field": "partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "transactionDocument",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "paymentMethod",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "priceList",
+        "context": {
+          "required": [
+            {
+              "param": "isSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "invoiceFrom",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "project",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "lines",
+        "field": "tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "lines",
+        "field": "operativeUOM",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "lines",
+        "field": "partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "generateTemplate",
+      "rMPickFromShipment",
+      "rMReceiveMaterials",
+      "rMCreateInvoice",
+      "documentAction",
+      "copyFrom",
+      "copyFromPO",
+      "createOrder",
+      "createPOLines",
+      "processNow",
+      "posted",
+      "rMPickfromreceipt"
+    ],
+    "workflow": [
+      "Create draft header with required fields",
+      "Add at least one valid line",
+      "Validate form state",
+      "Complete the document"
+    ],
+    "edgeCases": [
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Payment amount exceeds remaining balance",
+      "Payment method is not configured for the business partner",
+      "Invoice is already fully paid",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Required context is missing"
+    ],
+    "examples": [
+      {
+        "operation": "createHeader",
+        "description": "Create a draft header with the minimum required editable fields.",
+        "fields": [
+          "businessPartner",
+          "orderDate",
+          "partnerAddress",
+          "scheduledDeliveryDate",
+          "transactionDocument",
+          "warehouse",
+          "paymentTerms",
+          "priceList",
+          "cashVAT",
+          "invoiceFrom",
+          "deliveryMethod",
+          "priority",
+          "deliveryTerms"
+        ]
+      },
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "product",
+          "orderedQuantity",
+          "listPrice",
+          "tax",
+          "unitPrice",
+          "lineNetAmount"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "generateTemplate"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": [
+      "cancelandreplace",
+      "confirmcancelandreplace"
+    ]
   },
   "testManifest": {
     "tests": [

--- a/artifacts/purchase-order/contract.prev.json
+++ b/artifacts/purchase-order/contract.prev.json
@@ -1,8 +1,8 @@
 {
   "version": "0.19.0",
   "generatedAt": "2026-04-30T15:42:46.497Z",
-  "updatedAt": "2026-05-15T16:33:38.817Z",
-  "checksum": "db2af24b1a59c801",
+  "updatedAt": "2026-05-15T16:36:33.657Z",
+  "checksum": "33886fd2bccac66a",
   "frontendContract": {
     "window": {
       "id": "181",
@@ -6507,6 +6507,242 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Create and manage purchase order documents.",
+    "whenToUse": [
+      "Use for supplier purchase order before receipt or invoice."
+    ],
+    "minimumCreate": {
+      "headerFields": [
+        "businessPartner",
+        "orderDate",
+        "partnerAddress",
+        "scheduledDeliveryDate",
+        "transactionDocument",
+        "warehouse",
+        "paymentTerms",
+        "priceList",
+        "cashVAT",
+        "invoiceFrom",
+        "deliveryMethod",
+        "priority",
+        "deliveryTerms"
+      ],
+      "lineFields": [
+        "product",
+        "orderedQuantity",
+        "listPrice",
+        "tax",
+        "unitPrice",
+        "lineNetAmount"
+      ],
+      "recommendedOrder": [
+        "createHeader",
+        "createLines"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "header",
+        "field": "partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "transactionDocument",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "paymentMethod",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "priceList",
+        "context": {
+          "required": [
+            {
+              "param": "isSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "invoiceFrom",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "project",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "lines",
+        "field": "tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "lines",
+        "field": "operativeUOM",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "lines",
+        "field": "partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "generateTemplate",
+      "rMPickFromShipment",
+      "rMReceiveMaterials",
+      "rMCreateInvoice",
+      "documentAction",
+      "copyFrom",
+      "copyFromPO",
+      "createOrder",
+      "createPOLines",
+      "processNow",
+      "posted",
+      "rMPickfromreceipt"
+    ],
+    "workflow": [
+      "Create draft header with required fields",
+      "Add at least one valid line",
+      "Validate form state",
+      "Complete the document"
+    ],
+    "edgeCases": [
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Payment amount exceeds remaining balance",
+      "Payment method is not configured for the business partner",
+      "Invoice is already fully paid",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Required context is missing"
+    ],
+    "examples": [
+      {
+        "operation": "createHeader",
+        "description": "Create a draft header with the minimum required editable fields.",
+        "fields": [
+          "businessPartner",
+          "orderDate",
+          "partnerAddress",
+          "scheduledDeliveryDate",
+          "transactionDocument",
+          "warehouse",
+          "paymentTerms",
+          "priceList",
+          "cashVAT",
+          "invoiceFrom",
+          "deliveryMethod",
+          "priority",
+          "deliveryTerms"
+        ]
+      },
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "product",
+          "orderedQuantity",
+          "listPrice",
+          "tax",
+          "unitPrice",
+          "lineNetAmount"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "generateTemplate"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": [
+      "cancelandreplace",
+      "confirmcancelandreplace"
+    ]
   },
   "testManifest": {
     "tests": [

--- a/artifacts/return-from-customer/contract.json
+++ b/artifacts/return-from-customer/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T19:46:12.773Z",
-  "updatedAt": "2026-05-15T16:33:38.596Z",
-  "checksum": "ceb2e80134be71ca",
+  "updatedAt": "2026-05-15T16:36:33.444Z",
+  "checksum": "54924ba1530477d3",
   "frontendContract": {
     "window": {
       "id": "FF808081330213E60133021822E40007",
@@ -3214,6 +3214,115 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Create and manage returns documents.",
+    "whenToUse": [
+      "Use for customer returns before receipt or invoice."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "orderDate",
+        "businessPartner",
+        "partnerAddress",
+        "warehouse",
+        "lineNo",
+        "orderedQuantity"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "customerReturn",
+        "field": "partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "customerReturnLine",
+        "field": "tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "documentAction",
+      "rMReceiveMaterials",
+      "rMPickFromShipment",
+      "rMCreateInvoice",
+      "processNow",
+      "copyFrom",
+      "generateTemplate",
+      "copyFromPO",
+      "posted",
+      "createOrder",
+      "createPOLines",
+      "rMPickfromreceipt"
+    ],
+    "workflow": [
+      "Add at least one valid line",
+      "Validate form state",
+      "Complete the document"
+    ],
+    "edgeCases": [
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Required context is missing",
+      "User lacks permission",
+      "Record is in an incompatible state",
+      "Payment amount exceeds remaining balance"
+    ],
+    "examples": [
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "orderDate",
+          "businessPartner",
+          "partnerAddress",
+          "warehouse",
+          "lineNo",
+          "orderedQuantity"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "documentAction"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": [
+      "cancelandreplace",
+      "confirmcancelandreplace"
+    ]
   },
   "testManifest": {
     "tests": [

--- a/artifacts/return-material-receipt/contract.json
+++ b/artifacts/return-material-receipt/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.2.0",
   "generatedAt": "2026-04-29T18:11:05.114Z",
-  "updatedAt": "2026-05-15T16:33:38.706Z",
-  "checksum": "c30ce521fb63c8e3",
+  "updatedAt": "2026-05-15T16:36:33.549Z",
+  "checksum": "e7bf6e2352daab35",
   "frontendContract": {
     "window": {
       "id": "123271B9AD60469BAE8A924841456B63",
@@ -2031,6 +2031,83 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Create and manage return material receipt documents.",
+    "whenToUse": [
+      "Use for customer return material receipt before receipt or invoice."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "movementDate",
+        "businessPartner",
+        "warehouse",
+        "partnerAddress"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "returnMaterialReceipt",
+        "field": "partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "receiveMaterials",
+      "createLinesFrom",
+      "documentAction",
+      "posted",
+      "sendMaterials",
+      "generateTo"
+    ],
+    "workflow": [
+      "Add at least one valid line",
+      "Validate form state",
+      "Complete the document"
+    ],
+    "edgeCases": [
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Required context is missing",
+      "User lacks permission",
+      "Record is in an incompatible state",
+      "Required field without default value must be provided"
+    ],
+    "examples": [
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "movementDate",
+          "businessPartner",
+          "warehouse",
+          "partnerAddress"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "receiveMaterials"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/return-to-vendor-shipment/contract.json
+++ b/artifacts/return-to-vendor-shipment/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.4.0",
   "generatedAt": "2026-04-29T18:11:17.025Z",
-  "updatedAt": "2026-05-15T16:33:39.256Z",
-  "checksum": "db9da5faf9c4e661",
+  "updatedAt": "2026-05-15T16:36:34.100Z",
+  "checksum": "fd8d7f6b6866c827",
   "frontendContract": {
     "window": {
       "id": "273673D2ED914C399A6C51DB758BE0F9",
@@ -2535,6 +2535,116 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Create and manage return to vendor shipment documents.",
+    "whenToUse": [
+      "Use for supplier return to vendor shipment before receipt or invoice."
+    ],
+    "minimumCreate": {
+      "headerFields": [
+        "businessPartner",
+        "partnerAddress",
+        "movementDate",
+        "accountingDate",
+        "warehouse",
+        "documentAction"
+      ],
+      "recommendedOrder": [
+        "createHeader"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "header",
+        "field": "partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "project",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "lines",
+        "field": "operativeUOM",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "sendMaterials",
+      "createLinesFrom",
+      "generateTo",
+      "documentAction",
+      "posted",
+      "receiveMaterials"
+    ],
+    "workflow": [
+      "Create draft header with required fields",
+      "Validate form state",
+      "Complete the document"
+    ],
+    "edgeCases": [
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Required context is missing",
+      "User lacks permission",
+      "Record is in an incompatible state",
+      "Required field without default value must be provided"
+    ],
+    "examples": [
+      {
+        "operation": "createHeader",
+        "description": "Create a draft header with the minimum required editable fields.",
+        "fields": [
+          "businessPartner",
+          "partnerAddress",
+          "movementDate",
+          "accountingDate",
+          "warehouse",
+          "documentAction"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "sendMaterials"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/return-to-vendor/contract.json
+++ b/artifacts/return-to-vendor/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.5.0",
   "generatedAt": "2026-04-29T19:46:13.628Z",
-  "updatedAt": "2026-05-15T16:33:39.149Z",
-  "checksum": "9a5e40e7f48a00d9",
+  "updatedAt": "2026-05-15T16:36:33.994Z",
+  "checksum": "2d3aade59387eacb",
   "frontendContract": {
     "window": {
       "id": "C50A8AEE6F044825B5EF54FAAE76826F",
@@ -6051,6 +6051,208 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Create and manage return to vendor documents.",
+    "whenToUse": [
+      "Use for supplier return to vendor before receipt or invoice."
+    ],
+    "minimumCreate": {
+      "headerFields": [
+        "documentAction",
+        "orderDate",
+        "businessPartner",
+        "partnerAddress",
+        "warehouse",
+        "paymentTerms",
+        "priceList"
+      ],
+      "lineFields": [
+        "tax",
+        "taxableAmount",
+        "taxAmount",
+        "lineNo",
+        "discount",
+        "cascade",
+        "active",
+        "paymentMethod",
+        "expected",
+        "received",
+        "outstanding",
+        "currency",
+        "payment",
+        "paidAmount"
+      ],
+      "recommendedOrder": [
+        "createHeader",
+        "createLines"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "header",
+        "field": "partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "paymentMethod",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "priceList",
+        "context": {
+          "required": [
+            {
+              "param": "isSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "project",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "C_BPartner_ID",
+              "source": "parentField",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "lines",
+        "field": "operativeUOM",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "lines",
+        "field": "tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "documentAction",
+      "rMPickfromreceipt",
+      "generateTemplate",
+      "rMReceiveMaterials",
+      "rMCreateInvoice",
+      "copyFrom",
+      "copyFromPO",
+      "processNow",
+      "posted",
+      "createOrder",
+      "createPOLines",
+      "rMPickFromShipment"
+    ],
+    "workflow": [
+      "Create draft header with required fields",
+      "Add at least one valid line",
+      "Validate form state",
+      "Complete the document"
+    ],
+    "edgeCases": [
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Required context is missing",
+      "User lacks permission",
+      "Record is in an incompatible state",
+      "Payment amount exceeds remaining balance"
+    ],
+    "examples": [
+      {
+        "operation": "createHeader",
+        "description": "Create a draft header with the minimum required editable fields.",
+        "fields": [
+          "documentAction",
+          "orderDate",
+          "businessPartner",
+          "partnerAddress",
+          "warehouse",
+          "paymentTerms",
+          "priceList"
+        ]
+      },
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "tax",
+          "taxableAmount",
+          "taxAmount",
+          "lineNo",
+          "discount",
+          "cascade",
+          "active",
+          "paymentMethod",
+          "expected",
+          "received",
+          "outstanding",
+          "currency",
+          "payment",
+          "paidAmount"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "documentAction"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": [
+      "cancelandreplace",
+      "confirmcancelandreplace"
+    ]
   },
   "testManifest": {
     "tests": [

--- a/artifacts/sales-invoice/contract.json
+++ b/artifacts/sales-invoice/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.24.0",
   "generatedAt": "2026-04-30T15:42:46.582Z",
-  "updatedAt": "2026-05-15T16:33:38.488Z",
-  "checksum": "8b4a080ff9f10555",
+  "updatedAt": "2026-05-15T16:36:33.337Z",
+  "checksum": "af5a1342ebe82e45",
   "frontendContract": {
     "window": {
       "id": "167",
@@ -5144,6 +5144,157 @@
       "#ShowAcct"
     ],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Create and manage sales invoice documents.",
+    "whenToUse": [
+      "Use for customer sales invoice before receipt or invoice."
+    ],
+    "minimumCreate": {
+      "headerFields": [
+        "invoiceDate",
+        "businessPartner",
+        "partnerAddress",
+        "paymentTerms",
+        "paymentMethod",
+        "priceList",
+        "aeatsiiIsauthorization"
+      ],
+      "lineFields": [
+        "invoicedQuantity",
+        "listPrice",
+        "unitPrice",
+        "expectedDate"
+      ],
+      "recommendedOrder": [
+        "createHeader",
+        "createLines"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "header",
+        "field": "partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "paymentMethod",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "priceList",
+        "context": {
+          "required": [
+            {
+              "param": "isSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "lines",
+        "field": "tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "posted",
+      "documentAction",
+      "createLinesFromOrder",
+      "createLinesFromShipment",
+      "copyFrom",
+      "etvfacRectCreate",
+      "tbaiVoidxmlgenerator",
+      "aeatsiiSend",
+      "processNow",
+      "generateTo",
+      "createLinesFrom"
+    ],
+    "workflow": [
+      "Create draft header with required fields",
+      "Add at least one valid line",
+      "Validate form state",
+      "Complete the document"
+    ],
+    "edgeCases": [
+      "Payment amount exceeds remaining balance",
+      "Payment method is not configured for the business partner",
+      "Invoice is already fully paid",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Required context is missing"
+    ],
+    "examples": [
+      {
+        "operation": "createHeader",
+        "description": "Create a draft header with the minimum required editable fields.",
+        "fields": [
+          "invoiceDate",
+          "businessPartner",
+          "partnerAddress",
+          "paymentTerms",
+          "paymentMethod",
+          "priceList",
+          "aeatsiiIsauthorization"
+        ]
+      },
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "invoicedQuantity",
+          "listPrice",
+          "unitPrice",
+          "expectedDate"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "posted"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": [
+      "tbaiVoidxmlgenerator"
+    ]
   },
   "testManifest": {
     "tests": [

--- a/artifacts/sales-order/contract.json
+++ b/artifacts/sales-order/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.1.0",
   "generatedAt": "2026-05-12T16:47:39.614Z",
-  "updatedAt": "2026-05-15T16:33:38.278Z",
-  "checksum": "31fb4d3412c22037",
+  "updatedAt": "2026-05-15T16:36:33.124Z",
+  "checksum": "4ae4f7ca2b7a7535",
   "frontendContract": {
     "window": {
       "id": "143",
@@ -3405,6 +3405,159 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Create and manage sales order documents.",
+    "whenToUse": [
+      "Use for customer sales order before receipt or invoice."
+    ],
+    "minimumCreate": {
+      "headerFields": [
+        "orderDate",
+        "businessPartner",
+        "partnerAddress",
+        "priceList",
+        "paymentTerms",
+        "warehouse"
+      ],
+      "lineFields": [
+        "product",
+        "orderedQuantity",
+        "listPrice",
+        "tax",
+        "unitPrice"
+      ],
+      "recommendedOrder": [
+        "createHeader",
+        "createLines"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "header",
+        "field": "partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "priceList",
+        "context": {
+          "required": [
+            {
+              "param": "isSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "header",
+        "field": "paymentMethod",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "lines",
+        "field": "tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "rMPickFromShipment",
+      "rMReceiveMaterials",
+      "rMCreateInvoice",
+      "documentAction",
+      "copyFrom",
+      "copyFromPO",
+      "createOrder",
+      "processNow",
+      "posted",
+      "generateTemplate",
+      "createPOLines",
+      "rMPickfromreceipt"
+    ],
+    "workflow": [
+      "Create draft header with required fields",
+      "Add at least one valid line",
+      "Validate form state",
+      "Complete the document"
+    ],
+    "edgeCases": [
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Payment amount exceeds remaining balance",
+      "Payment method is not configured for the business partner",
+      "Invoice is already fully paid",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Required context is missing"
+    ],
+    "examples": [
+      {
+        "operation": "createHeader",
+        "description": "Create a draft header with the minimum required editable fields.",
+        "fields": [
+          "orderDate",
+          "businessPartner",
+          "partnerAddress",
+          "priceList",
+          "paymentTerms",
+          "warehouse"
+        ]
+      },
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "product",
+          "orderedQuantity",
+          "listPrice",
+          "tax",
+          "unitPrice"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "rMPickFromShipment"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": [
+      "cancelAndReplace",
+      "confirmCancelAndReplace"
+    ]
   },
   "testManifest": {
     "tests": [

--- a/artifacts/sales-quotation/contract.json
+++ b/artifacts/sales-quotation/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.6.0",
   "generatedAt": "2026-04-30T15:42:46.907Z",
-  "updatedAt": "2026-05-15T16:33:38.169Z",
-  "checksum": "5a05d01d48852d04",
+  "updatedAt": "2026-05-15T16:36:33.016Z",
+  "checksum": "3e5ad03753058254",
   "frontendContract": {
     "window": {
       "id": "6CB5B67ED33F47DFA334079D3EA2340E",
@@ -3422,6 +3422,149 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Create and manage sales quotation documents.",
+    "whenToUse": [
+      "Use for customer sales quotation before receipt or invoice."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "orderDate",
+        "businessPartner",
+        "partnerAddress",
+        "priceList",
+        "paymentTerms",
+        "product",
+        "orderedQuantity",
+        "listPrice",
+        "tax",
+        "unitPrice",
+        "lineNetAmount"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "quotation",
+        "field": "partnerAddress",
+        "context": {
+          "required": [
+            {
+              "param": "C_BPartner_ID",
+              "source": "field",
+              "field": "businessPartner"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "quotation",
+        "field": "priceList",
+        "context": {
+          "required": [
+            {
+              "param": "isSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "quotation",
+        "field": "paymentMethod",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "quotationLine",
+        "field": "tax",
+        "context": {
+          "required": [
+            {
+              "param": "IsSOTrx",
+              "source": "windowCategory"
+            },
+            {
+              "param": "DateInvoiced",
+              "source": "parentField",
+              "field": "invoiceDate",
+              "fallbackField": "orderDate",
+              "format": "DD-MM-YYYY"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "rMPickFromShipment",
+      "rMReceiveMaterials",
+      "rMCreateInvoice",
+      "copyFrom",
+      "copyFromPO",
+      "documentAction",
+      "createOrder",
+      "generateTemplate",
+      "processNow",
+      "posted",
+      "createPOLines",
+      "rMPickfromreceipt"
+    ],
+    "workflow": [
+      "Add at least one valid line",
+      "Validate form state",
+      "Complete the document"
+    ],
+    "edgeCases": [
+      "Source document has no valid lines to copy",
+      "Target entity already has linked records",
+      "Required reference data is missing (price list, warehouse, etc.)",
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Required context is missing",
+      "User lacks permission",
+      "Record is in an incompatible state",
+      "Payment amount exceeds remaining balance"
+    ],
+    "examples": [
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "orderDate",
+          "businessPartner",
+          "partnerAddress",
+          "priceList",
+          "paymentTerms",
+          "product",
+          "orderedQuantity",
+          "listPrice",
+          "tax",
+          "unitPrice",
+          "lineNetAmount"
+        ]
+      },
+      {
+        "operation": "completeDocument",
+        "description": "Validate form state and run the document lifecycle action when the draft is complete.",
+        "action": "rMPickFromShipment"
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": [
+      "cancelandreplace",
+      "confirmcancelandreplace"
+    ]
   },
   "testManifest": {
     "tests": [

--- a/artifacts/tax/contract.json
+++ b/artifacts/tax/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.4.0",
   "generatedAt": "2026-04-27T19:18:32.198Z",
-  "updatedAt": "2026-05-15T16:33:40.590Z",
-  "checksum": "a6db6ad31a9201b5",
+  "updatedAt": "2026-05-15T16:36:35.434Z",
+  "checksum": "62ebdc3ce9f5c61c",
   "frontendContract": {
     "window": {
       "id": "137",
@@ -912,6 +912,33 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage tax rate records.",
+    "whenToUse": [
+      "Use for tax rate management."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "name",
+        "validFromDate",
+        "rate",
+        "salesPurchaseType",
+        "docTaxAmount",
+        "baseAmount"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [],
+    "actions": [],
+    "workflow": [],
+    "edgeCases": [],
+    "examples": [],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/unit-of-measure/contract.json
+++ b/artifacts/unit-of-measure/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.2.0",
   "generatedAt": "2026-04-29T18:12:30.399Z",
-  "updatedAt": "2026-05-15T16:33:40.687Z",
-  "checksum": "ab05297826abf1f0",
+  "updatedAt": "2026-05-15T16:36:35.533Z",
+  "checksum": "2f124e9e38acede6",
   "frontendContract": {
     "window": {
       "id": "120",
@@ -825,6 +825,36 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage unit of measure records.",
+    "whenToUse": [
+      "Use for unit of measure management."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "eDICode",
+        "name",
+        "standardPrecision",
+        "costingPrecision",
+        "default",
+        "useinproduction",
+        "toUOM",
+        "multipleRateBy",
+        "divideRateBy"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [],
+    "actions": [],
+    "workflow": [],
+    "edgeCases": [],
+    "examples": [],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/user/contract.json
+++ b/artifacts/user/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.3.0",
   "generatedAt": "2026-04-29T18:12:34.035Z",
-  "updatedAt": "2026-05-15T16:33:40.789Z",
-  "checksum": "c8027686276fce34",
+  "updatedAt": "2026-05-15T16:36:35.633Z",
+  "checksum": "857747391889a00b",
   "frontendContract": {
     "window": {
       "id": "108",
@@ -2141,6 +2141,87 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage user records.",
+    "whenToUse": [
+      "Use for user management."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "name",
+        "username",
+        "role",
+        "roleAdmin",
+        "active",
+        "smtpServer",
+        "sMTPAuthentification",
+        "smtpConnectionSecurity",
+        "smtpPort",
+        "smtpconnectiontest",
+        "defaultConfiguration"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [
+      {
+        "entity": "user",
+        "field": "defaultClient",
+        "context": {
+          "required": [
+            {
+              "param": "Default_AD_Role_ID",
+              "source": "field",
+              "field": "defaultRole"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "user",
+        "field": "defaultOrganization",
+        "context": {
+          "required": [
+            {
+              "param": "Default_AD_Role_ID",
+              "source": "field",
+              "field": "defaultRole"
+            }
+          ]
+        }
+      },
+      {
+        "entity": "user",
+        "field": "defaultWarehouse",
+        "context": {
+          "required": [
+            {
+              "param": "Default_AD_Client_ID",
+              "source": "field",
+              "field": "defaultClient"
+            }
+          ]
+        }
+      }
+    ],
+    "actions": [
+      "processNow"
+    ],
+    "workflow": [],
+    "edgeCases": [
+      "Document is already completed or closed",
+      "Document has pending lines or missing required fields",
+      "User lacks permission to execute the action",
+      "Required context is missing",
+      "User lacks permission",
+      "Record is in an incompatible state"
+    ],
+    "examples": [],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/artifacts/warehouse/contract.json
+++ b/artifacts/warehouse/contract.json
@@ -1,8 +1,8 @@
 {
   "version": "0.5.0",
   "generatedAt": "2026-04-29T18:11:37.816Z",
-  "updatedAt": "2026-05-15T16:33:39.878Z",
-  "checksum": "a18f761a13edd8d1",
+  "updatedAt": "2026-05-15T16:36:34.723Z",
+  "checksum": "6362e650345a7071",
   "frontendContract": {
     "window": {
       "id": "139",
@@ -2185,6 +2185,72 @@
     },
     "requiredSessionVariables": [],
     "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage warehouse inventory operations.",
+    "whenToUse": [
+      "Use for stock and warehouse operations."
+    ],
+    "minimumCreate": {
+      "lineFields": [
+        "searchKey",
+        "name",
+        "locationAddress",
+        "allocated",
+        "searchKey",
+        "rowX",
+        "stackY",
+        "levelZ",
+        "relativePriority",
+        "default",
+        "changeStatus",
+        "product",
+        "uOM"
+      ],
+      "recommendedOrder": [
+        "createLines"
+      ]
+    },
+    "selectorContexts": [],
+    "actions": [],
+    "workflow": [
+      "Add at least one valid line"
+    ],
+    "edgeCases": [
+      "Required context is missing",
+      "User lacks permission",
+      "Record is in an incompatible state",
+      "Required field without default value must be provided",
+      "Validate the current form state before running lifecycle actions",
+      "Do not run destructive lifecycle actions without explicit user confirmation"
+    ],
+    "examples": [
+      {
+        "operation": "createLine",
+        "description": "Add a line after the header exists and parent context is available.",
+        "fields": [
+          "searchKey",
+          "name",
+          "locationAddress",
+          "allocated",
+          "searchKey",
+          "rowX",
+          "stackY",
+          "levelZ",
+          "relativePriority",
+          "default",
+          "changeStatus",
+          "product",
+          "uOM"
+        ]
+      }
+    ],
+    "warnings": [
+      "System lifecycle actions are present but are not exposed as editable agent actions",
+      "Transactional spec has no generated lifecycle action metadata"
+    ],
+    "knownLimitations": [],
+    "dangerousOperations": []
   },
   "testManifest": {
     "tests": [

--- a/cli/src/generate-contract.js
+++ b/cli/src/generate-contract.js
@@ -1136,6 +1136,236 @@ function generateFormState(schema, rules) {
 
 // ─── End form-state generation ───────────────────────────────────────────────
 
+// ─── Agent Profile generation for ETP-3958 ───────────────────────────────────
+
+/**
+ * Generate an agentProfile for a spec.
+ *
+ * The profile provides a concise, agent-friendly summary of what the spec does,
+ * how to use it, and what to watch out for.
+ *
+ * @param {object} schema - Full schema
+ * @param {object} apiPrediction - Generated apiPrediction section
+ * @param {object} formState - Generated formState section
+ * @param {object} windowConfig - Window config from decisions.json
+ * @returns {object} agentProfile
+ */
+function generateAgentProfile(schema, apiPrediction, formState, windowConfig) {
+  const specName = apiPrediction.specName;
+  const category = schema.window.category ?? 'unknown';
+  const isTransactional = ['sales', 'purchases', 'inventory', 'finance'].includes(category);
+
+  // Derive purpose from category and window name
+  const windowName = schema.window.name ?? specName;
+  const purpose = derivePurpose(windowName, category);
+  const whenToUse = deriveWhenToUse(windowName, category);
+
+  // Derive minimum create fields from required editable fields
+  const minimumCreate = deriveMinimumCreate(schema, formState);
+
+  // Collect context-sensitive selectors from apiPrediction
+  const selectorContexts = deriveSelectorContexts(apiPrediction);
+
+  // Collect action names
+  const actions = (apiPrediction.actions ?? [])
+    .filter(a => a.actionType === 'documentAction' || a.actionType === 'createFrom')
+    .map(a => a.name);
+
+  // Derive workflow
+  const workflow = deriveWorkflow(isTransactional, actions, minimumCreate);
+
+  // Edge cases from actions and form-state metadata
+  const edgeCases = deriveProfileEdgeCases(apiPrediction, formState, isTransactional);
+
+  // Examples and warnings
+  const examples = deriveProfileExamples(isTransactional, minimumCreate, actions);
+  const warnings = deriveProfileWarnings(schema, formState, isTransactional, actions);
+
+  // Dangerous operations
+  const dangerousOperations = (apiPrediction.actions ?? [])
+    .filter(a => ['void', 'reverse', 'reactivate', 'cancel'].some(p => (a.name ?? '').toLowerCase().includes(p)))
+    .map(a => a.name);
+
+  return {
+    purpose,
+    whenToUse,
+    minimumCreate,
+    selectorContexts,
+    actions,
+    workflow,
+    edgeCases,
+    examples,
+    warnings,
+    knownLimitations: [],
+    dangerousOperations,
+  };
+}
+
+function derivePurpose(windowName, category) {
+  const name = windowName.toLowerCase();
+  if (category === 'sales') return `Create and manage ${name} documents.`;
+  if (category === 'purchases') return `Create and manage ${name} documents.`;
+  if (category === 'inventory') return `Manage ${name} inventory operations.`;
+  if (category === 'finance') return `Manage ${name} financial records.`;
+  return `Manage ${name} records.`;
+}
+
+function deriveWhenToUse(windowName, category) {
+  const when = [];
+  if (category === 'sales') when.push(`Use for customer ${windowName.toLowerCase()} before receipt or invoice.`);
+  if (category === 'purchases') when.push(`Use for supplier ${windowName.toLowerCase()} before receipt or invoice.`);
+  if (category === 'inventory') when.push(`Use for stock and warehouse operations.`);
+  if (when.length === 0) when.push(`Use for ${windowName.toLowerCase()} management.`);
+  return when;
+}
+
+function deriveMinimumCreate(schema, formState) {
+  const headerFields = [];
+  const lineFields = [];
+
+  for (const entity of schema.entities ?? []) {
+    const entityState = formState?.entities?.[entity.name]?.fields ?? {};
+    const requiredFields = Object.entries(entityState)
+      .filter(([, f]) => f.required && f.visible && !f.readOnly)
+      .map(([name]) => name);
+
+    if (entity.level === 'header' || entity.name === 'header') {
+      headerFields.push(...requiredFields);
+    } else {
+      lineFields.push(...requiredFields);
+    }
+  }
+
+  const recommendedOrder = [];
+  if (headerFields.length > 0) recommendedOrder.push('createHeader');
+  if (lineFields.length > 0) recommendedOrder.push('createLines');
+
+  return {
+    headerFields: headerFields.length > 0 ? headerFields : undefined,
+    lineFields: lineFields.length > 0 ? lineFields : undefined,
+    recommendedOrder: recommendedOrder.length > 0 ? recommendedOrder : undefined,
+  };
+}
+
+function deriveSelectorContexts(apiPrediction) {
+  return (apiPrediction.selectors ?? [])
+    .filter(s => s.context)
+    .map(s => ({
+      entity: s.entity,
+      field: s.field,
+      context: s.context,
+    }));
+}
+
+function deriveWorkflow(isTransactional, actions, minimumCreate) {
+  if (!isTransactional) return [];
+
+  const steps = [];
+  if (minimumCreate.headerFields) steps.push('Create draft header with required fields');
+  if (minimumCreate.lineFields) steps.push('Add at least one valid line');
+  if (actions.includes('documentAction') || actions.some(a => a.includes('complete'))) {
+    steps.push('Validate form state');
+    steps.push('Complete the document');
+  }
+  return steps.length > 0 ? steps : ['Create a new record', 'Update as needed'];
+}
+
+function deriveProfileEdgeCases(apiPrediction, formState, isTransactional) {
+  const edges = new Set();
+
+  for (const edge of collectActionEdgeCases(apiPrediction.actions)) {
+    edges.add(edge);
+  }
+
+  if (isTransactional) {
+    if (hasRequiredFieldWithoutDefault(formState)) {
+      edges.add('Required field without default value must be provided');
+    }
+
+    if ((apiPrediction.actions ?? []).length > 0) {
+      edges.add('Validate the current form state before running lifecycle actions');
+      edges.add('Do not run destructive lifecycle actions without explicit user confirmation');
+    }
+  }
+
+  return Array.from(edges).slice(0, 10);
+}
+
+function collectActionEdgeCases(actions = []) {
+  return actions.flatMap(action => action.edgeCases ?? []);
+}
+
+function hasRequiredFieldWithoutDefault(formState) {
+  return Object.values(formState?.entities ?? {}).some(entity =>
+    Object.values(entity.fields ?? {}).some(field => field.required && !field.defaultValue)
+  );
+}
+
+function deriveProfileExamples(isTransactional, minimumCreate, actions) {
+  const examples = [];
+
+  if (minimumCreate.headerFields?.length) {
+    examples.push({
+      operation: 'createHeader',
+      description: 'Create a draft header with the minimum required editable fields.',
+      fields: minimumCreate.headerFields,
+    });
+  }
+
+  if (isTransactional && minimumCreate.lineFields?.length) {
+    examples.push({
+      operation: 'createLine',
+      description: 'Add a line after the header exists and parent context is available.',
+      fields: minimumCreate.lineFields,
+    });
+  }
+
+  if (isTransactional && actions.length > 0) {
+    examples.push({
+      operation: 'completeDocument',
+      description: 'Validate form state and run the document lifecycle action when the draft is complete.',
+      action: actions[0],
+    });
+  }
+
+  return examples;
+}
+
+function deriveProfileWarnings(schema, formState, isTransactional, actions) {
+  const warnings = new Set();
+  const entities = schema.entities ?? [];
+  const visibleFieldCount = Object.values(formState?.entities ?? {})
+    .reduce((count, entity) => count + Object.keys(entity.fields ?? {}).length, 0);
+
+  if (visibleFieldCount === 0) {
+    warnings.add('No editable or read-only form fields are exposed for this spec');
+  }
+
+  const editableFieldCount = Object.values(formState?.entities ?? {})
+    .reduce((count, entity) => {
+      return count + Object.values(entity.fields ?? {}).filter(field => field.visible && !field.readOnly).length;
+    }, 0);
+
+  if (editableFieldCount === 0 && visibleFieldCount > 0) {
+    warnings.add('This spec appears read-only from generated form metadata');
+  }
+
+  const hasSystemButtons = entities.some(entity =>
+    (entity.fields ?? []).some(field => field.type === 'button' && field.visibility === 'system')
+  );
+  if (hasSystemButtons && actions.length === 0) {
+    warnings.add('System lifecycle actions are present but are not exposed as editable agent actions');
+  }
+
+  if (isTransactional && actions.length === 0) {
+    warnings.add('Transactional spec has no generated lifecycle action metadata');
+  }
+
+  return Array.from(warnings);
+}
+
+// ─── End agent profile generation ────────────────────────────────────────────
+
 /**
  * Main orchestrator: generates the full contract object.
  */
@@ -1147,6 +1377,7 @@ export function generateContract(schema, rules = [], processes = [], previousVer
   const testManifest = generateTestManifest(frontendContract, backendContract, rules, processes);
   const apiPrediction = generateApiPrediction(schema, frontendContract, backendContract);
   const formState = generateFormState(schema, rules);
+  const agentProfile = generateAgentProfile(schema, apiPrediction, formState, schema.window);
 
   // Append apiPrediction-based tests to testManifest using stable IDs
   const makeId = testManifest._makeId;
@@ -1199,7 +1430,7 @@ export function generateContract(schema, rules = [], processes = [], previousVer
     byRunner: updatedByRunner,
   };
 
-  const contractData = { frontendContract, backendContract, apiPrediction, formState, testManifest };
+  const contractData = { frontendContract, backendContract, apiPrediction, formState, agentProfile, testManifest };
   const checksum = createHash('sha256')
     .update(JSON.stringify(contractData))
     .digest('hex')

--- a/cli/test/generate-contract.test.js
+++ b/cli/test/generate-contract.test.js
@@ -1580,3 +1580,160 @@ describe('generateContract — formState (ETP-3957)', () => {
     assert.deepStrictEqual(contract.formState.requiredSessionVariables, []);
   });
 });
+
+// ─── Agent Profile Metadata (ETP-3958) ───────────────────────────────────────
+
+describe('generateContract — agentProfile (ETP-3958)', () => {
+  const profileSchema = {
+    version: '0.1.0',
+    window: { id: '1000', name: 'Purchase Order', primaryEntity: 'header', category: 'purchases' },
+    entities: [{
+      name: 'header',
+      table: 'C_Order',
+      level: 'header',
+      fields: [
+        { name: 'businessPartner', column: 'C_BPartner_ID', type: 'foreignKey', visibility: 'editable', required: true, searchable: true, grid: true, form: true, reference: 'BusinessPartner', dependsOn: { field: 'organization', filterKey: 'AD_Org_ID' } },
+        { name: 'orderDate', column: 'DateOrdered', type: 'date', visibility: 'editable', required: false, searchable: true, grid: true, form: true },
+        { name: 'documentAction', column: 'DocAction', type: 'button', visibility: 'system', required: false, searchable: false, grid: false, form: false, processId: '104', processType: 'classic' },
+      ],
+    }, {
+      name: 'lines',
+      table: 'C_OrderLine',
+      level: 'line',
+      fields: [
+        { name: 'product', column: 'M_Product_ID', type: 'foreignKey', visibility: 'editable', required: true, searchable: true, grid: true, form: true, reference: 'Product', validationRule: { cascadeParams: ['C_BPartner_ID'] } },
+        { name: 'quantity', column: 'QtyOrdered', type: 'number', visibility: 'editable', required: true, searchable: false, grid: true, form: true },
+      ],
+    }],
+  };
+
+  it('contract includes agentProfile section', () => {
+    const contract = generateContract(profileSchema, []);
+    assert.ok(contract.agentProfile, 'contract should have agentProfile');
+  });
+
+  it('agentProfile has purpose field', () => {
+    const contract = generateContract(profileSchema, []);
+    assert.ok(typeof contract.agentProfile.purpose === 'string');
+    assert.ok(contract.agentProfile.purpose.length > 0);
+  });
+
+  it('agentProfile has whenToUse array', () => {
+    const contract = generateContract(profileSchema, []);
+    assert.ok(Array.isArray(contract.agentProfile.whenToUse));
+    assert.ok(contract.agentProfile.whenToUse.length > 0);
+  });
+
+  it('agentProfile minimumCreate identifies required header fields', () => {
+    const contract = generateContract(profileSchema, []);
+    assert.ok(contract.agentProfile.minimumCreate);
+    assert.ok(contract.agentProfile.minimumCreate.headerFields.includes('businessPartner'));
+  });
+
+  it('agentProfile minimumCreate identifies required line fields', () => {
+    const contract = generateContract(profileSchema, []);
+    assert.ok(contract.agentProfile.minimumCreate.lineFields.includes('product'));
+    assert.ok(contract.agentProfile.minimumCreate.lineFields.includes('quantity'));
+  });
+
+  it('agentProfile includes selectorContexts', () => {
+    const contract = generateContract(profileSchema, []);
+    assert.ok(Array.isArray(contract.agentProfile.selectorContexts));
+    assert.deepStrictEqual(contract.agentProfile.selectorContexts.map(s => s.field), [
+      'businessPartner',
+      'product',
+    ]);
+    assert.equal(contract.agentProfile.selectorContexts[0].context.required[0].param, 'AD_Org_ID');
+    assert.equal(contract.agentProfile.selectorContexts[1].context.required[0].param, 'C_BPartner_ID');
+  });
+
+  it('agentProfile includes document actions', () => {
+    const contract = generateContract(profileSchema, []);
+    assert.ok(Array.isArray(contract.agentProfile.actions));
+    assert.ok(contract.agentProfile.actions.includes('documentAction'));
+  });
+
+  it('agentProfile includes workflow for transactional specs', () => {
+    const contract = generateContract(profileSchema, []);
+    assert.ok(Array.isArray(contract.agentProfile.workflow));
+    assert.ok(contract.agentProfile.workflow.length > 0);
+  });
+
+  it('agentProfile includes edgeCases', () => {
+    const contract = generateContract(profileSchema, []);
+    assert.ok(Array.isArray(contract.agentProfile.edgeCases));
+    assert.ok(contract.agentProfile.edgeCases.length >= 3);
+  });
+
+  it('agentProfile includes examples for transactional specs', () => {
+    const contract = generateContract(profileSchema, []);
+    assert.ok(Array.isArray(contract.agentProfile.examples));
+    assert.deepStrictEqual(contract.agentProfile.examples.map(e => e.operation), [
+      'createHeader',
+      'createLine',
+      'completeDocument',
+    ]);
+  });
+
+  it('agentProfile exposes warnings for read-only specs without boilerplate workflow', () => {
+    const readOnlySchema = {
+      version: '0.1.0',
+      window: { id: '1001', name: 'Audit Setup', primaryEntity: 'header', category: 'configuration' },
+      entities: [{
+        name: 'header',
+        table: 'AD_Audit_Setup',
+        level: 'header',
+        fields: [
+          { name: 'name', column: 'Name', type: 'string', visibility: 'readOnly', required: false, searchable: true, grid: true, form: true },
+        ],
+      }],
+    };
+    const contract = generateContract(readOnlySchema, []);
+    assert.deepStrictEqual(contract.agentProfile.workflow, []);
+    assert.deepStrictEqual(contract.agentProfile.edgeCases, []);
+    assert.ok(contract.agentProfile.warnings.includes('This spec appears read-only from generated form metadata'));
+  });
+
+  it('agentProfile includes dangerousOperations for void/reactive actions', () => {
+    const schemaWithDanger = {
+      ...profileSchema,
+      entities: [{
+        ...profileSchema.entities[0],
+        fields: [
+          ...profileSchema.entities[0].fields,
+          { name: 'voidDocument', column: 'Void', type: 'button', visibility: 'editable', required: false, searchable: false, grid: false, form: true },
+          { name: 'reactivateDocument', column: 'Reactivate', type: 'button', visibility: 'editable', required: false, searchable: false, grid: false, form: true },
+        ],
+      }],
+    };
+    const contract = generateContract(schemaWithDanger, []);
+    assert.ok(Array.isArray(contract.agentProfile.dangerousOperations));
+    assert.ok(contract.agentProfile.dangerousOperations.includes('voidDocument'));
+    assert.ok(contract.agentProfile.dangerousOperations.includes('reactivateDocument'));
+  });
+
+  it('agentProfile references only existing fields/selectors/actions', () => {
+    const contract = generateContract(profileSchema, []);
+    const profile = contract.agentProfile;
+
+    // Verify minimumCreate fields exist in formState
+    for (const field of profile.minimumCreate.headerFields ?? []) {
+      assert.ok(contract.formState.entities.header.fields[field], `minimumCreate header field ${field} should exist in formState`);
+    }
+    for (const field of profile.minimumCreate.lineFields ?? []) {
+      assert.ok(contract.formState.entities.lines.fields[field], `minimumCreate line field ${field} should exist in formState`);
+    }
+
+    // Verify selectorContexts exist in apiPrediction
+    const selectorNames = new Set(contract.apiPrediction.selectors.filter(s => s.context).map(s => s.field));
+    for (const sel of profile.selectorContexts) {
+      assert.ok(selectorNames.has(sel.field), `selectorContext ${sel.field} should exist in apiPrediction`);
+    }
+
+    // Verify actions exist in apiPrediction
+    const actionNames = new Set(contract.apiPrediction.actions.map(a => a.name));
+    for (const action of profile.actions) {
+      assert.ok(actionNames.has(action), `action ${action} should exist in apiPrediction`);
+    }
+  });
+});

--- a/docs/plans/2026-05-12-etp-3958-agent-profile-metadata.md
+++ b/docs/plans/2026-05-12-etp-3958-agent-profile-metadata.md
@@ -1,0 +1,54 @@
+# ETP-3958 Agent Profile Metadata
+
+ETP-3958 adds an `agentProfile` section to generated contracts. The profile is
+intended for MCP agents and other runtime consumers that need concise guidance
+about how a generated spec should be used.
+
+## Contract Shape
+
+The generated profile contains:
+
+- `purpose`: short human-readable summary derived from window name and category.
+- `whenToUse`: short usage hints for the spec.
+- `minimumCreate`: required editable fields grouped by header and line entities.
+- `selectorContexts`: selectors that require runtime context, including the
+  required and optional context parameters exposed by `apiPrediction`.
+- `actions`: generated document or create-from action names.
+- `workflow`: transactional workflow hints. Master-data and configuration specs
+  stay empty unless generated metadata proves a workflow exists.
+- `edgeCases`: generated action and form-state caveats. Transactional specs with
+  lifecycle actions must expose at least three useful edge cases.
+- `examples`: minimal generated operation examples for create header, create
+  line, and lifecycle completion when those operations are supported.
+- `warnings`: read-only, system-action, or missing-lifecycle warnings derived
+  from generated form and action metadata.
+- `knownLimitations`: reserved for curated overrides.
+- `dangerousOperations`: destructive lifecycle actions inferred from generated
+  action names.
+
+## Source Of Truth
+
+The profile is generated from `schema`, `apiPrediction`, and `formState` in
+`cli/src/generate-contract.js`. Do not edit generated contracts manually. To
+change profile output, update extractor inputs, decisions, or the profile
+generator.
+
+## Jira Mapping
+
+The profile satisfies the ETP-3958 acceptance criteria as follows:
+
+- Stable metadata schema: `agentProfile` is always present in generated
+  contracts.
+- Priority document specs: transactional categories generate workflow, examples,
+  lifecycle actions, and at least three edge cases when actions exist.
+- No generated-output edits: profile generation happens in
+  `generate-contract.js`.
+- Simple master data: non-transactional specs do not receive workflow or generic
+  edge-case boilerplate.
+- Documentation: this file explains the shape and update path.
+
+## Validation
+
+Focused tests live in `cli/test/generate-contract.test.js` under
+`generateContract - agentProfile (ETP-3958)`.
+


### PR DESCRIPTION
## Summary
- Add an `agentProfile` section to generated contracts with agent-facing usage metadata.
- Expose purpose, when-to-use guidance, minimum create fields, context-sensitive selectors, supported actions, workflow, edge cases, examples, warnings, known limitations, and dangerous operations.
- Keep master-data/configuration specs simple by avoiding generic workflow and edge-case boilerplate.
- Generate all metadata from schema, `apiPrediction`, and `formState`; no generated outputs are edited manually.

## Stack
- Previous PR: https://github.com/etendosoftware/etendo_schema_forge/pull/525 (`feature/ETP-3957`)
- This branch: `feature/ETP-3958`
- Base branch: `feature/ETP-3957`
- Next planned branch: `feature/ETP-3959`

## Schema Forge Changes
- `cli/src/generate-contract.js`: add `agentProfile` generation, contextual selector profile entries, examples, warnings, and process-heavy edge-case handling.
- `cli/test/generate-contract.test.js`: add focused agent-profile coverage, including transactional examples, contextual selectors, read-only warnings, and reference validation.
- `docs/plans/2026-05-12-etp-3958-agent-profile-metadata.md`: document the metadata shape and update path.

## com.etendoerp.go Changes
- None. Runtime profile exposure through schema discovery remains a NEO Headless responsibility.

## Tests
- [x] `node --test --test-reporter=spec cli/test/generate-contract.test.js` (130 tests)
- [x] `make test` (414 CLI tests, 611 app-shell tests)
- [x] Local Sonar PR scan uploaded for PR #526; Quality Gate OK, 0 new issues

## Sonar
- Fixed local Sonar blocking issue: reduced cognitive complexity in agent-profile edge-case derivation.

## Known Limitations
- `knownLimitations` is reserved for curated overrides.
- Profile metadata is static; runtime action availability warnings are deferred to NEO Headless.
