### PR TITLE
Feature ETP-3960: Add Etendo GO Risk Gates

### DIFF
--- a/cli/test/etendogo-agentic-risk-integration.test.js
+++ b/cli/test/etendogo-agentic-risk-integration.test.js
@@ -1,0 +1,168 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  buildSelectorContext,
+} from '../../tools/app-shell/src/lib/selectorContext.js';
+
+const repoRoot = resolve(import.meta.dirname, '..', '..');
+
+const DOCUMENT_SCENARIOS = [
+  { spec: 'sales-order', category: 'sales', expectedIsSOTrx: 'Y', dateField: 'orderDate' },
+  { spec: 'purchase-order', category: 'purchases', expectedIsSOTrx: 'N', dateField: 'orderDate', hasTransactionDocument: true },
+  { spec: 'sales-invoice', category: 'sales', expectedIsSOTrx: 'Y', dateField: 'invoiceDate' },
+  { spec: 'purchase-invoice', category: 'purchases', expectedIsSOTrx: 'N', dateField: 'invoiceDate', hasTransactionDocument: true },
+];
+
+const SHIPMENT_SCENARIOS = [
+  { spec: 'goods-receipt', entity: 'goodsReceipt', category: 'purchases' },
+  { spec: 'goods-shipment', entity: 'goodsShipment', category: 'sales' },
+];
+
+function readContract(spec) {
+  return JSON.parse(readFileSync(resolve(repoRoot, 'artifacts', spec, 'contract.json'), 'utf8'));
+}
+
+function selectors(contract) {
+  return contract.apiPrediction?.selectors ?? [];
+}
+
+function selectorFor(contract, entity, field) {
+  return selectors(contract).find((selector) => selector.entity === entity && selector.field === field);
+}
+
+function frontendField(contract, entity, field) {
+  return contract.frontendContract?.entities?.[entity]?.fields?.find((candidate) => candidate.name === field);
+}
+
+function assertRequiredContext(selector, expectedEntries, label) {
+  const required = selector?.context?.required ?? [];
+  for (const expected of expectedEntries) {
+    assert.ok(
+      required.some((entry) => Object.entries(expected).every(([key, value]) => entry[key] === value)),
+      `${label} must include required context ${JSON.stringify(expected)}; got ${JSON.stringify(required)}`,
+    );
+  }
+}
+
+function attachSelectorContext(field, selector) {
+  return { ...field, context: selector?.context ?? field?.context };
+}
+
+describe('Etendo GO integration risk gates for contextual selectors', () => {
+  for (const scenario of DOCUMENT_SCENARIOS) {
+    it(`${scenario.spec} keeps BP address, price list, tax, and document defaults context-safe`, () => {
+      const contract = readContract(scenario.spec);
+      assert.equal(contract.frontendContract.window.category, scenario.category);
+
+      const partnerAddressSelector = selectorFor(contract, 'header', 'partnerAddress');
+      assert.ok(partnerAddressSelector, `${scenario.spec} must expose partnerAddress selector metadata`);
+      assertRequiredContext(
+        partnerAddressSelector,
+        [{ param: 'C_BPartner_ID', source: 'field', field: 'businessPartner' }],
+        `${scenario.spec}:partnerAddress`,
+      );
+
+      const partnerAddressField = frontendField(contract, 'header', 'partnerAddress');
+      assert.deepEqual(
+        buildSelectorContext({
+          windowCategory: scenario.category,
+          entityName: 'header',
+          field: attachSelectorContext(partnerAddressField, partnerAddressSelector),
+          record: { businessPartner: 'BP-001' },
+        }),
+        { C_BPartner_ID: 'BP-001' },
+        `${scenario.spec}:partnerAddress must resolve the selected BP into selector params`,
+      );
+
+      const priceListSelector = selectorFor(contract, 'header', 'priceList');
+      assert.ok(priceListSelector, `${scenario.spec} must expose priceList selector metadata`);
+      assertRequiredContext(
+        priceListSelector,
+        [{ param: 'isSOTrx', source: 'windowCategory' }],
+        `${scenario.spec}:priceList`,
+      );
+
+      const priceListField = frontendField(contract, 'header', 'priceList');
+      assert.deepEqual(
+        buildSelectorContext({
+          windowCategory: scenario.category,
+          entityName: 'header',
+          field: attachSelectorContext(priceListField, priceListSelector),
+        }),
+        { isSOTrx: scenario.expectedIsSOTrx, IsSOTrx: scenario.expectedIsSOTrx },
+        `${scenario.spec}:priceList must derive the sales/purchase side from the window category`,
+      );
+
+      const taxSelector = selectorFor(contract, 'lines', 'tax');
+      assert.ok(taxSelector, `${scenario.spec} must expose line tax selector metadata`);
+      assertRequiredContext(
+        taxSelector,
+        [
+          { param: 'IsSOTrx', source: 'windowCategory' },
+          { param: 'DateInvoiced', source: 'parentField' },
+        ],
+        `${scenario.spec}:lines.tax`,
+      );
+
+      const taxField = frontendField(contract, 'lines', 'tax');
+      const headerRecord = {
+        [scenario.dateField]: '2026-05-12',
+        priceList: 'PL-001',
+        partnerAddress: 'LOC-001',
+      };
+      assert.deepEqual(
+        buildSelectorContext({
+          windowCategory: scenario.category,
+          entityName: 'lines',
+          field: attachSelectorContext(taxField, taxSelector),
+          parentRecord: headerRecord,
+          parentId: 'HDR-001',
+        }),
+        {
+          IsSOTrx: scenario.expectedIsSOTrx,
+          isSOTrx: scenario.expectedIsSOTrx,
+          DateInvoiced: '12-05-2026',
+          parentId: 'HDR-001',
+        },
+        `${scenario.spec}:lines.tax must carry the transaction side and accounting date`,
+      );
+
+      if (scenario.hasTransactionDocument) {
+        const transactionDocumentSelector = selectorFor(contract, 'header', 'transactionDocument');
+        assert.ok(transactionDocumentSelector, `${scenario.spec} must expose transactionDocument context`);
+        assertRequiredContext(
+          transactionDocumentSelector,
+          [{ param: 'IsSOTrx', source: 'windowCategory' }],
+          `${scenario.spec}:transactionDocument`,
+        );
+      }
+    });
+  }
+
+  for (const scenario of SHIPMENT_SCENARIOS) {
+    it(`${scenario.spec} keeps BP address context-safe in movement forms`, () => {
+      const contract = readContract(scenario.spec);
+      const partnerAddressSelector = selectorFor(contract, scenario.entity, 'partnerAddress');
+      assert.ok(partnerAddressSelector, `${scenario.spec} must expose partnerAddress selector metadata`);
+      assertRequiredContext(
+        partnerAddressSelector,
+        [{ param: 'C_BPartner_ID', source: 'field', field: 'businessPartner' }],
+        `${scenario.spec}:partnerAddress`,
+      );
+
+      const partnerAddressField = frontendField(contract, scenario.entity, 'partnerAddress');
+      assert.deepEqual(
+        buildSelectorContext({
+          windowCategory: scenario.category,
+          entityName: scenario.entity,
+          field: attachSelectorContext(partnerAddressField, partnerAddressSelector),
+          record: { businessPartner: 'BP-002' },
+        }),
+        { C_BPartner_ID: 'BP-002' },
+      );
+    });
+  }
+});
+

--- a/docs/bug-reports/2026-05-19-selector-url-mismatch.md
+++ b/docs/bug-reports/2026-05-19-selector-url-mismatch.md
@@ -1,0 +1,63 @@
+# Selector URL mismatch between generated contracts and Etendo GO runtime
+
+Date: 2026-05-19
+
+Jira: [ETP-4058](https://etendoproject.atlassian.net/browse/ETP-4058)
+
+## Summary
+
+Generated Schema Forge contracts and generated UI expose selector URLs using logical field names, such as:
+
+- `/sws/neo/sales-order/header/selectors/partnerAddress`
+- `/sws/neo/sales-order/header/selectors/priceList`
+- `/sws/neo/sales-order/lines/selectors/tax`
+
+The local Etendo GO runtime rejects those URLs with `404 Field not found or not included`. Manual probing showed that at least some column-name selector URLs are accepted, for example `/selectors/M_PriceList_ID`.
+
+This is a transversal Etendo GO risk because generated UI, NEO consumers, and agentic integrations can receive valid generated URLs that do not execute against runtime.
+
+## Reproduction
+
+Start local Etendo GO, then run:
+
+```bash
+cd e2e
+ETENDO_URL=http://localhost:8080/etendo npm run test:etendogo-contextual-selectors
+```
+
+The smoke is intentionally opt-in and should be skipped by default in normal Playwright runs.
+
+## Observed Failures
+
+- `sales-order/header/partnerAddress` -> 404 `Field not found or not included: partnerAddress`
+- `purchase-order/header/partnerAddress` -> 404 `Field not found or not included: partnerAddress`
+- `sales-invoice/header/partnerAddress` -> 404 `Field not found or not included: partnerAddress`
+- `purchase-invoice/header/partnerAddress` -> 404 `Field not found or not included: partnerAddress`
+- `goods-receipt/goodsReceipt/partnerAddress` -> 404 `Field not found or not included: partnerAddress`
+- `goods-shipment/goodsShipment/partnerAddress` -> 404 `Field not found or not included: partnerAddress`
+
+Manual probe:
+
+```bash
+TOKEN=$(./scripts/neo-token-groupadmin.sh)
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8080/etendo/sws/neo/sales-order/header/selectors/priceList?isSOTrx=Y"
+
+curl -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8080/etendo/sws/neo/sales-order/header/selectors/M_PriceList_ID?isSOTrx=Y"
+```
+
+Observed result:
+
+- `priceList` returns 404.
+- `M_PriceList_ID` returns 200 with selector items.
+
+## Expected Resolution
+
+Either Etendo GO should accept the logical field identifiers emitted by Schema Forge, or Schema Forge should emit the runtime-supported selector identifier consistently. The final selector URL contract must preserve backward compatibility for any existing column-name clients.
+
+## Related Integration Gates
+
+- `cli/test/etendogo-agentic-risk-integration.test.js`: always-on contract/app-shell gate.
+- `e2e/tests/flows/etendogo-contextual-selectors.integration.spec.js`: opt-in live Etendo GO smoke that exposes this bug.
+

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -27,6 +27,28 @@ npm install -g agent-browser && agent-browser install   # Optional: install agen
 
 ---
 
+## Etendo GO Contextual Selector Smoke
+
+`e2e/tests/flows/etendogo-contextual-selectors.integration.spec.js` validates the non-MCP Etendo GO integration risk for contextual FK selectors. It is skipped by default because it requires a live Etendo backend, a loaded F&B dataset, and a JWT-capable test user.
+
+Run it explicitly against local Etendo:
+
+```bash
+cd e2e
+ETENDO_URL=http://localhost:8080/etendo npm run test:etendogo-contextual-selectors
+```
+
+The smoke gets a read JWT through `scripts/neo-token-groupadmin.sh` unless `E2E_ETENDOGO_JWT` is already set. It verifies that generated selector identifiers work at runtime for the highest-risk document contexts:
+
+- sales/purchase partner address from selected business partner;
+- sales/purchase price list from `isSOTrx`;
+- sales/purchase tax from transaction side plus date;
+- goods receipt/shipment partner address from selected business partner.
+
+If this smoke fails because generated field-name selector URLs return `404 Field not found or not included`, track it under [ETP-4058](https://etendoproject.atlassian.net/browse/ETP-4058). That bug is intentionally separate from the integration-test scope: the test detects the runtime/generator contract mismatch, but the fix belongs to the Etendo GO / Schema Forge selector URL compatibility task.
+
+---
+
 ## Deployed MCP OAuth2 Smoke
 
 `e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js` validates the public MCP/OAuth integration after deploy. It models the browser flow started by `opencode mcp auth etendo`: clean session, OAuth authorize URL, login, requested permissions, explicit authorization, local callback, and PKCE token exchange. The UI preserves the original `/authorize?...` URL through onboarding with a local-only `returnTo` parameter, then resumes the authorization screen after environment login. It is skipped by default because it targets a deployed environment, uses real smoke credentials, can create an OAuth client through DCR, and binds a local callback server.

--- a/docs/plans/2026-05-12-etp-3955-contextual-fk-selectors-design.md
+++ b/docs/plans/2026-05-12-etp-3955-contextual-fk-selectors-design.md
@@ -726,6 +726,17 @@ Target scripts:
 - `tests/test-contextual-selectors-purchase-order.sh`
 - optional shared Node script if bash becomes too brittle.
 
+### Integration Gates Added 2026-05-19
+
+The non-MCP cut risk is covered by two integration gates:
+
+- `cli/test/etendogo-agentic-risk-integration.test.js` runs in the normal Node test suite. It checks the real generated contracts against the app-shell selector-context builder for sales/purchase orders, sales/purchase invoices, goods receipt, and goods shipment. This keeps BP address, price list, tax, and transaction document context metadata aligned without requiring a live backend.
+- `e2e/tests/flows/etendogo-contextual-selectors.integration.spec.js` is an opt-in live Etendo GO smoke. Run it with `cd e2e && ETENDO_URL=http://localhost:8080/etendo npm run test:etendogo-contextual-selectors`.
+
+Known bug detected by the live smoke:
+
+- [ETP-4058](https://etendoproject.atlassian.net/browse/ETP-4058): generated selector URLs use logical field names such as `partnerAddress` and `priceList`, while the local runtime rejects them with `404 Field not found or not included`; some column-name variants, such as `M_PriceList_ID`, are accepted.
+
 ### E2E Tests
 
 Existing:

--- a/docs/plans/evaluations/etp-3938-qa-matrix.md
+++ b/docs/plans/evaluations/etp-3938-qa-matrix.md
@@ -1,0 +1,68 @@
+# ETP-3938 QA Matrix: Agentic Corrections
+
+Maps each original finding from the JuanCarlos.mbox validation reports to its current status.
+
+## QA Matrix
+
+| # | Original Finding | Jira Task | Affected Spec | Status | Generated Metadata | Runtime Expectation | Test Coverage |
+|---|-----------------|-----------|---------------|--------|-------------------|---------------------|---------------|
+| 1 | `partnerAddress` returns empty without BP context | ETP-3955 | sales-order, purchase-order, sales-invoice, purchase-invoice | **Fixed** | `dependsOn` + `context.required` with `C_BPartner_ID` | Selector accepts `C_BPartner_ID` param | `selectorContext.js` unit tests |
+| 2 | `priceList` returns wrong mode (sales vs purchase) | ETP-3955 | All transactional specs | **Fixed** | `context.required` with `isSOTrx` from window category | Selector filters by `isSOTrx=Y/N` | `selectorContext.js` + contract tests |
+| 3 | `transactionDocument` hidden but required | ETP-3955 | purchase-order, purchase-invoice | **Fixed** | Classified as `system` with default expectation | `neo_defaults` returns valid doc type | Contract generation tests |
+| 4 | Line `tax` returns empty without date/SO context | ETP-3955 | All transactional specs | **Fixed** | `context.required` with `IsSOTrx`, `DateInvoiced` | Selector maps date to `DD-MM-YYYY` | `selectorContext.js` date format tests |
+| 5 | Document actions not discoverable | ETP-3956 | All transactional specs | **Fixed** | `apiPrediction.actions[]` with type, params, preconditions | `neo_actions_discover` endpoint | `generate-contract.test.js` action tests |
+| 6 | No edge cases documented for processes | ETP-3956 | All specs with actions | **Fixed** | Every action has `edgeCases` array (>= 3) | Runtime returns structured diagnostics | F13 quality gate + 10 contract tests |
+| 7 | Agents cannot evaluate form state before write | ETP-3957 | All specs | **Fixed** | `formState` with visible, readOnly, required, calloutTriggers | `neo_form_state` endpoint | 11 formState contract tests |
+| 8 | No session context exposed for agents | ETP-3957 | All specs | **Fixed** | `formState.requiredSessionVariables` from `@#VAR@` patterns | `neo_whoami` or session endpoint | `requiredSessionVariables` test |
+| 9 | Raw contracts too large for agent planning | ETP-3958 | All specs | **Fixed** | `agentProfile` with purpose, minimumCreate, workflow | Schema discovery includes profile | 11 agentProfile contract tests |
+| 10 | No quality gates for generated artifacts | ETP-3959 | All specs | **Fixed** | F13-F16 rules in validate-pipeline.js | N/A (design-time gate) | 5 validator tests |
+| 11 | `bp-location` access denied | ETP-3955 | bp-location | **Deferred** | N/A | RBAC/configuration gap | Out of scope |
+| 12 | `verifactu-config` entity not found | ETP-3955 | verifactu-config | **Deferred** | N/A | Module not installed | Out of scope |
+| 13 | `tbai-facturas-enviadas` entity not found | ETP-3955 | tbai-facturas-enviadas | **Deferred** | N/A | Module not installed | Out of scope |
+| 14 | Dashboard widgets not agent-accessible | ETP-3958 | dashboard | **Deferred** | N/A | Widget API not exposed | Follow-up ETP |
+| 15 | Report specs not agent-accessible | ETP-3958 | reports | **Deferred** | N/A | Report API not exposed | Follow-up ETP |
+
+## Summary
+
+- **Fixed**: 10 findings (ETP-3955 through ETP-3959)
+- **Deferred**: 5 findings (RBAC gaps, missing modules, widget/report APIs)
+- **Out of scope**: 0
+- **Total test coverage**: 42 new tests across generate-contract, validate-pipeline, and selectorContext
+
+## Edge Cases per Process-Heavy Flow
+
+### Sales Order
+1. Business partner has no active address
+2. Document type not valid for selected organization
+3. Product inactive in selected price list
+
+### Purchase Order
+1. Vendor has no vendor role in current client
+2. Price list missing for purchase mode
+3. Document already completed (action blocked)
+
+### Sales Invoice
+1. Invoice created without lines (blocked)
+2. Payment method not configured for BP
+3. Tax date outside valid range
+
+### Goods Receipt
+1. Shipment has no pending lines
+2. Warehouse not accessible for current org
+3. Partner address missing for vendor
+
+## Behavioral Test Commands
+
+```bash
+# Full CLI test suite
+make test
+
+# Contract generation tests (actions, formState, agentProfile)
+cd cli && node --test test/generate-contract.test.js
+
+# Pipeline validation tests (quality gates F13-F16)
+cd cli && node --test test/validate-pipeline.test.js
+
+# Selector context builder tests
+node --test tools/app-shell/src/lib/__tests__/selectorContext.vitest.js
+```

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -7,6 +7,7 @@
     "test:headed": "npx playwright test --headed",
     "test:ui": "npx playwright test --ui",
     "test:debug": "npx playwright test --debug",
+    "test:etendogo-contextual-selectors": "E2E_ETENDOGO_CONTEXT_SELECTORS=1 npx playwright test tests/flows/etendogo-contextual-selectors.integration.spec.js",
     "test:mcp-oauth-smoke": "npx playwright test tests/flows/mcp-oauth-pkce.smoke.spec.js",
     "report": "npx playwright show-report"
   },

--- a/e2e/tests/flows/etendogo-contextual-selectors.integration.spec.js
+++ b/e2e/tests/flows/etendogo-contextual-selectors.integration.spec.js
@@ -1,0 +1,145 @@
+import { expect, test } from '@playwright/test';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+
+const RUN_LIVE_CONTEXT_SMOKE = process.env.E2E_ETENDOGO_CONTEXT_SELECTORS === '1';
+const ETENDO_BASE_URL = trimTrailingSlash(process.env.ETENDO_URL || 'http://localhost:8080/etendo');
+const TOKEN = process.env.E2E_ETENDOGO_JWT || resolveJwt();
+
+const DOCUMENT_SCENARIOS = [
+  {
+    spec: 'sales-order',
+    entity: 'header',
+    lineEntity: 'lines',
+    roleParam: { isCustomer: 'Y' },
+    isSOTrx: 'Y',
+  },
+  {
+    spec: 'purchase-order',
+    entity: 'header',
+    lineEntity: 'lines',
+    roleParam: { isVendor: 'Y' },
+    isSOTrx: 'N',
+  },
+  {
+    spec: 'sales-invoice',
+    entity: 'header',
+    lineEntity: 'lines',
+    roleParam: { isCustomer: 'Y' },
+    isSOTrx: 'Y',
+  },
+  {
+    spec: 'purchase-invoice',
+    entity: 'header',
+    lineEntity: 'lines',
+    roleParam: { isVendor: 'Y' },
+    isSOTrx: 'N',
+  },
+];
+
+const MOVEMENT_SCENARIOS = [
+  { spec: 'goods-receipt', entity: 'goodsReceipt', roleParam: { isVendor: 'Y' } },
+  { spec: 'goods-shipment', entity: 'goodsShipment', roleParam: { isCustomer: 'Y' } },
+];
+
+test.describe('Etendo GO contextual selector live integration', () => {
+  test.skip(
+    !RUN_LIVE_CONTEXT_SMOKE,
+    'Set E2E_ETENDOGO_CONTEXT_SELECTORS=1 to run this live Etendo GO selector smoke.',
+  );
+
+  test.describe.configure({ timeout: 120_000 });
+
+  for (const scenario of DOCUMENT_SCENARIOS) {
+    test(`${scenario.spec} selectors return data with Etendo GO context params`, async ({ request }) => {
+      const fixtureRecord = await firstRecordWith(request, scenario.spec, scenario.entity, 'businessPartner');
+      test.skip(!fixtureRecord, `${scenario.spec} has no existing ${scenario.entity} record with businessPartner`);
+
+      const partnerAddress = await firstSelectorItem(request, scenario.spec, scenario.entity, 'partnerAddress', {
+        C_BPartner_ID: fixtureRecord.businessPartner,
+      });
+      expect(partnerAddress?.id, `${scenario.spec} partnerAddress should resolve from selected BP`).toBeTruthy();
+
+      const priceList = await firstSelectorItem(request, scenario.spec, scenario.entity, 'priceList', {
+        isSOTrx: scenario.isSOTrx,
+      });
+      expect(priceList?.id, `${scenario.spec} priceList should resolve for isSOTrx=${scenario.isSOTrx}`).toBeTruthy();
+
+      const tax = await firstSelectorItem(request, scenario.spec, scenario.lineEntity, 'tax', {
+        IsSOTrx: scenario.isSOTrx,
+        isSOTrx: scenario.isSOTrx,
+        DateInvoiced: '12-05-2026',
+      });
+      expect(tax?.id, `${scenario.spec} line tax should resolve from side/date context`).toBeTruthy();
+    });
+  }
+
+  for (const scenario of MOVEMENT_SCENARIOS) {
+    test(`${scenario.spec} movement partner address selector returns data with selected BP`, async ({ request }) => {
+      const fixtureRecord = await firstRecordWith(request, scenario.spec, scenario.entity, 'businessPartner');
+      test.skip(!fixtureRecord, `${scenario.spec} has no existing ${scenario.entity} record with businessPartner`);
+
+      const partnerAddress = await firstSelectorItem(request, scenario.spec, scenario.entity, 'partnerAddress', {
+        C_BPartner_ID: fixtureRecord.businessPartner,
+      });
+      expect(partnerAddress?.id, `${scenario.spec} partnerAddress should resolve from selected BP`).toBeTruthy();
+    });
+  }
+});
+
+async function firstRecordWith(request, spec, entity, field) {
+  const url = new URL(`${ETENDO_BASE_URL}/sws/neo/${spec}/${entity}`);
+  url.searchParams.set('limit', '50');
+  url.searchParams.set('offset', '0');
+
+  const response = await request.get(url.toString(), {
+    headers: { authorization: `Bearer ${TOKEN}` },
+  });
+  expect(
+    response.ok(),
+    `${spec}/${entity} list should return HTTP 2xx: ${await response.text()}`,
+  ).toBe(true);
+
+  const body = await response.json();
+  const rows = body.response?.data ?? body.data ?? [];
+  return Array.isArray(rows) ? rows.find((row) => row?.[field]) ?? null : null;
+}
+
+async function firstSelectorItem(request, spec, entity, field, params = {}) {
+  const url = new URL(`${ETENDO_BASE_URL}/sws/neo/${spec}/${entity}/selectors/${field}`);
+  for (const [key, value] of Object.entries({ ...params, limit: 50, offset: 0 })) {
+    if (value != null && value !== '') url.searchParams.set(key, value);
+  }
+
+  const response = await request.get(url.toString(), {
+    headers: { authorization: `Bearer ${TOKEN}` },
+  });
+  expect(
+    response.ok(),
+    `${spec}/${entity}/${field} selector should return HTTP 2xx: ${await response.text()}`,
+  ).toBe(true);
+
+  const body = await response.json();
+  const items = body.items ?? body.response?.data ?? body.data ?? [];
+  return Array.isArray(items) ? items[0] : null;
+}
+
+function resolveJwt() {
+  if (!RUN_LIVE_CONTEXT_SMOKE) return '';
+  try {
+    return execFileSync(
+      resolve(import.meta.dirname, '..', '..', '..', 'scripts', 'neo-token-groupadmin.sh'),
+      {
+        encoding: 'utf8',
+        env: { ...process.env, ETENDO_URL: ETENDO_BASE_URL },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    ).trim();
+  } catch (error) {
+    throw new Error(`Could not get Etendo GO JWT for live context smoke: ${error.stderr || error.message}`);
+  }
+}
+
+function trimTrailingSlash(value) {
+  return String(value || '').replace(/\/+$/, '');
+}


### PR DESCRIPTION
## Summary
- Add a QA matrix mapping all 15 original JuanCarlos.mbox findings to fixed/deferred status.
- Add TDD-style Etendo GO integration risk gates for contextual FK selectors using generated contracts plus the real app-shell selector context builder.
- Add an optional live Playwright smoke for Etendo GO contextual selectors, skipped by default unless explicitly enabled.
- Document runtime findings and QA commands for future MCP/agentic validation.

## Stack
- Previous PR: https://github.com/etendosoftware/etendo_schema_forge/pull/528 (feature/ETP-3959)
- This branch: feature/ETP-3960
- Base branch: feature/ETP-3959
- Next planned branch: feature/ETP-3961

## Schema Forge Changes
- `docs/plans/evaluations/etp-3938-qa-matrix.md`: QA matrix with fixed/deferred status, metadata coverage, runtime expectations, and behavioral test commands.
- `cli/test/etendogo-agentic-risk-integration.test.js`: always-on integration risk gate for sales/purchase order, sales/purchase invoice, goods receipt, and goods shipment selector contexts.
- `e2e/tests/flows/etendogo-contextual-selectors.integration.spec.js`: optional live Etendo GO contextual selector smoke.
- `docs/e2e-testing-guide.md`: command and expectations for the live selector smoke.
- `docs/bug-reports/2026-05-19-selector-url-mismatch.md`: local reproduction notes for the runtime selector URL mismatch.

## Tests
- [x] node --test --test-reporter=spec cli/test/validate-pipeline.test.js
- [x] node cli/src/validate-pipeline.js --changed-since=origin/feature/ETP-3959 --format=text
- [x] node --test --test-reporter=spec cli/test/etendogo-agentic-risk-integration.test.js
- [x] CI=true npx playwright test tests/flows/etendogo-contextual-selectors.integration.spec.js (default skip gate)
- [x] npx vitest run src/lib/__tests__/selectorContext.vitest.js
- [ ] make test: reaches app-shell Vitest and currently fails on localStorage setup; tracked as ETP-4059.
- [ ] ETENDO_URL=http://localhost:8080/etendo npm run test:etendogo-contextual-selectors: currently reproduces ETP-4058.

## CI Status
- [x] GitHub `test` check passed.
- [x] Sonar Build passed.
- [x] SonarQube Code Analysis passed.
- [x] Core Files Approval Gate passed.
- [x] Window Doc Freshness passed.
- [ ] Etendo GO Regeneration check failed at `Install Etendo (DB)`; tracked as ETP-4069 because Jenkins logs are not accessible from the agent environment.

## Bugs Found During Integration
- ETP-4058: [Agentic] Fix selector endpoint mismatch between generated field-name URLs and Etendo GO runtime.
- ETP-4059: [Agentic] Stabilize Vitest localStorage setup for app-shell tests.
- ETP-4069: [Agentic] Investigate Etendo GO regeneration Jenkins DB install failure for Schema Forge PR #529.

## Known Limitations
- 5 findings remain deferred (RBAC gaps, missing modules, widget/report APIs) and are documented in the QA matrix.
- The live Etendo GO selector smoke is intentionally opt-in until ETP-4058 is fixed.
