### PR TITLE
Feature ETP-3965: Fix package-lock.json conflict markers on develop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3891,10 +3891,6 @@
         "node": ">=16.0.0"
       }
     },
-<<<<<<< Updated upstream
-    "node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
-=======
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
@@ -4581,7 +4577,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
       "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
->>>>>>> Stashed changes
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -7094,25 +7089,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-<<<<<<< Updated upstream
-    "node_modules/follow-redirects": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-=======
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -7128,7 +7104,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
->>>>>>> Stashed changes
       }
     },
     "node_modules/for-each": {
@@ -14601,12 +14576,6 @@
         "node": ">= 0.6"
       }
     },
-<<<<<<< Updated upstream
-    "tools/spike-hello-app/node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-=======
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -14629,7 +14598,6 @@
       "engines": {
         "node": ">=18"
       },
->>>>>>> Stashed changes
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -14699,24 +14667,6 @@
       "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
       "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
       "dependencies": {
-<<<<<<< Updated upstream
-        "debug": "2.6.9",
-        "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "encodeurl": "~2.0.0",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "~0.5.2",
-        "http-errors": "~2.0.1",
-        "mime": "1.6.0",
-        "ms": "2.1.3",
-        "on-finished": "~2.4.1",
-        "range-parser": "~1.2.1",
-        "statuses": "~2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-=======
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -14750,7 +14700,6 @@
         "tailwindcss": "^3.4.0",
         "vite": "^6.0.0",
         "vite-plugin-pwa": "^1.2.0"
->>>>>>> Stashed changes
       }
     },
     "tools/spike-hello-app/node_modules/serve-static": {


### PR DESCRIPTION
## Summary
- Resolves 4 merge conflict markers (`<<<<<<<` / `=======` / `>>>>>>>`) left in `package-lock.json` on `develop`
- These were blocking the Deploy SPA workflow: `npm ci` fails when the lockfile has conflict syntax
- Change is **51 lines deleted** — only the conflict markers and the discarded upstream sections are removed
- Keeps the `feature/ETP-3965` (stashed) side of each conflict, which includes the 32 Sentry packages

## Root cause
PR #520 was merged with a `package-lock.json` that already had conflict markers from a `git stash pop` operation.

## Test plan
- [ ] Diff shows only 51 deletions (conflict markers + upstream sections)
- [ ] JSON is valid (no conflict syntax)
- [ ] `npm ci` passes in Deploy SPA workflow after merge
- [ ] Sentry packages present: `@sentry/react`, `@sentry/vite-plugin` and 30 related packages