### PR TITLE
Feature ETP-3994: Move core approval gate to code-owner branch rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,12 @@
-# Default reviewers for all files
+# Core review ownership.
+#
+# Branch protection/rulesets should enable "Require review from Code Owners".
+# With that setting, changes outside artifacts/ block merge until the required
+# branch-rule approvals are present, without failing a CI check.
 * @sebastianbarrozo @valenvivaldi
+
+# Generated/window artifacts do not need the core owner gate by themselves.
+/artifacts/
+
+# Keep ownership on this policy file explicit.
+/.github/CODEOWNERS @sebastianbarrozo @valenvivaldi

--- a/.github/workflows/core-approval.yml
+++ b/.github/workflows/core-approval.yml
@@ -1,14 +1,11 @@
-name: Core Files Approval Gate
+name: Core Files Review Notice
 
 on:
-  pull_request_review:
-    types: [submitted]
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   core-approval:
@@ -18,53 +15,38 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Check for non-artifact changes
+      - name: Check for core changes
         id: check
+        shell: bash
         run: |
+          set -euo pipefail
+
           BASE="${{ github.event.pull_request.base.sha }}"
           HEAD="${{ github.event.pull_request.head.sha }}"
-          NON_ARTIFACT=$(git diff --name-only "$BASE" "$HEAD" | grep -v '^artifacts/' || true)
-          if [ -n "$NON_ARTIFACT" ]; then
+          CORE_CHANGES=$(git diff --name-only "$BASE...$HEAD" | grep -v '^artifacts/' || true)
+
+          if [ -n "$CORE_CHANGES" ]; then
             echo "has_core_changes=true" >> "$GITHUB_OUTPUT"
-            echo "Core files changed:"
-            echo "$NON_ARTIFACT"
+            echo "::notice::Core files changed. Merge gating is handled by CODEOWNERS plus branch protection/rulesets."
+            {
+              echo "### Core file review required"
+              echo
+              echo "This PR modifies files outside \`artifacts/\`."
+              echo
+              echo "Merge blocking is handled by GitHub code-owner review rules, not by this workflow failing."
+              echo
+              echo "Changed core files:"
+              echo
+              echo '```'
+              echo "$CORE_CHANGES"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "has_core_changes=false" >> "$GITHUB_OUTPUT"
-            echo "Only artifact changes — no approval gate needed."
-          fi
-
-      - name: Verify required approval
-        if: steps.check.outputs.has_core_changes == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          REQUIRED_REVIEWERS="valenvivaldi sebastianbarrozo"
-          PR_AUTHOR="${{ github.event.pull_request.user.login }}"
-          PR_NUMBER="${{ github.event.pull_request.number }}"
-
-          # Skip check if PR author is a required reviewer
-          for reviewer in $REQUIRED_REVIEWERS; do
-            if [ "$PR_AUTHOR" = "$reviewer" ]; then
-              echo "PR author ($PR_AUTHOR) is a required reviewer — skipping approval gate."
-              exit 0
-            fi
-          done
-
-          APPROVALS=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews" \
-            --jq '[.[] | select(.state == "APPROVED") | .user.login] | unique | .[]')
-
-          echo "Current approvals: $APPROVALS"
-
-          APPROVED=false
-          for reviewer in $REQUIRED_REVIEWERS; do
-            if echo "$APPROVALS" | grep -qx "$reviewer"; then
-              echo "Approved by required reviewer: $reviewer"
-              APPROVED=true
-              break
-            fi
-          done
-
-          if [ "$APPROVED" = "false" ]; then
-            echo "::error::This PR modifies core files (outside artifacts/) and requires approval from one of: $REQUIRED_REVIEWERS"
-            exit 1
+            echo "Only artifact changes - no core owner gate needed."
+            {
+              echo "### No core file review required"
+              echo
+              echo "This PR only modifies files under \`artifacts/\`."
+            } >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/docs/branch-workflow.md
+++ b/docs/branch-workflow.md
@@ -83,3 +83,14 @@ When working on a feature, always check if there's a corresponding branch/PR in 
 ## Branch Safety (MANDATORY)
 
 Both repos **MUST** be on the same branch. This prevents accidental commits to `main` or `develop` in the module. Always verify both repos are on matching branches before generating or committing code.
+
+## Core File Approval Rule
+
+Core-file merge blocking is handled by GitHub code-owner review rules, not by a failing CI check.
+
+- `.github/CODEOWNERS` assigns `@sebastianbarrozo` and `@valenvivaldi` as owners for repository files outside `artifacts/`.
+- `.github/CODEOWNERS` leaves `/artifacts/` ownerless so artifact-only PRs do not trigger the core owner gate by themselves.
+- Protected branches or rulesets that accept Schema Forge PRs must enable **Require review from Code Owners**.
+- Keep `.github/workflows/core-approval.yml` informational only. It may summarize core changes, but it must not fail just because required approvals are still pending.
+
+With this setup, a PR that changes core files stays unmergeable until the branch rule has the required approval state. The PR should show a pending review requirement instead of a red `core-approval` check.

--- a/docs/ops/copilot-pr-review.md
+++ b/docs/ops/copilot-pr-review.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-This repository already had deterministic PR checks (`core-approval.yml`, `test.yml`, `pr-architecture-alert.yml`), but the architecture review was limited to a PR comment with a few regex-based findings.
+This repository already had deterministic PR automation (`core-approval.yml`, `test.yml`, `pr-architecture-alert.yml`), but the architecture review was limited to a PR comment with a few regex-based findings.
 
 The goal of this change is to make pull request review stricter and more useful for the cases that repeatedly hurt this codebase:
 

--- a/docs/plans/2026-04-16-auto-sync-develop-to-epic.md
+++ b/docs/plans/2026-04-16-auto-sync-develop-to-epic.md
@@ -128,7 +128,7 @@ jobs:
 ```
 
 **Pros**
-- All required checks (`test.yml`, `core-approval.yml`, `pr-architecture-alert.yml`, etc.) run against the merge before it lands → much safer.
+- All required checks (`test.yml`, `pr-architecture-alert.yml`, etc.) run against the merge before it lands, while core-file approval is enforced by the code-owner branch rule.
 - No need for elevated tokens or branch-protection exceptions.
 - Conflicts are visible in the PR UI, where reviewers can fix them.
 - Plays nicely with the project rule "agents NEVER merge to develop/main" — this PR goes the other direction (develop → epic), still respects branch protection.
@@ -179,7 +179,7 @@ Same as Option A but trigger on `schedule: '0 6 * * *'` instead of `push`.
 - Auto-create the PR on every push to `develop`.
 - Add `--label epic-sync` so we can filter/track these PRs separately.
 - Enable GH "auto-merge" with method = merge (never squash) so it lands as soon as
-  the existing required checks (`test`, `core-approval`, etc.) pass.
+  the existing required checks (`test`, etc.) pass and any required code-owner approval is present.
 - On conflict, the PR stays open and waits for a human — which is the right behavior
   for a long-lived epic with multiple parallel features.
 


### PR DESCRIPTION
## Summary

- Moves the core-file merge gate from a failing workflow check to CODEOWNERS plus branch protection/ruleset review requirements.
- Keeps `core-approval.yml` as an informational workflow that summarizes core changes without failing while approvals are pending.
- Documents the required GitHub setting: `Require review from Code Owners` for protected Schema Forge PR target branches.

## Jira

- https://etendoproject.atlassian.net/browse/ETP-3994

## Validation

- `git diff --check`
- YAML parse check for `.github/workflows/core-approval.yml`