### PR TITLE
Feature ETP-3660: Fix multi-EntityForm validation overwrite regression

### DIFF
--- a/e2e/tests/flows/required-field-validation.mocked.spec.js
+++ b/e2e/tests/flows/required-field-validation.mocked.spec.js
@@ -1,0 +1,131 @@
+import { test, expect } from '@playwright/test';
+import { login } from '../helpers/auth.js';
+
+/**
+ * Required-field validation on new record form — mocked.
+ *
+ * Verifies the ETP-3894 fix: when a window renders more than one EntityForm
+ * instance (e.g. main section + collapsed "more details" section), all forms
+ * must contribute to the validation set. Previously, the second EntityForm
+ * overwrote the first (Array ref), so form-1's required fields were silently
+ * dropped.
+ *
+ * The spec targets /sales-quotation/new because:
+ *  - The window uses EntityForm for the header section.
+ *  - Required fields: businessPartner, partnerAddress, priceList, paymentTerms.
+ *  - The form is accessible without a real backend (mock mode).
+ *
+ * Mocked routes (registered AFTER login() so they win over the generic stub):
+ *  - GET /sws/neo/sales-quotation/quotation        → empty list
+ *  - GET /sws/neo/sales-quotation/quotation/defaults → synthetic defaults
+ *  - POST /sws/neo/sales-quotation/quotation       → synthetic saved record
+ *
+ * data-testid conventions (from EntityForm.jsx / e2e-testing-guide.md):
+ *  - `field-{fieldKey}`      → input/control wrapper
+ *  - `error-{fieldKey}`      → inline error paragraph appended by renderFieldWithError
+ *  - `action-save-draft`     → "Guardar" (save draft) button — calls handleSave()
+ *  - `action-save`           → "Confirmar" button — calls handleSaveAndProcess()
+ *
+ * NOTE: sales-quotation uses draftMode, so the toolbar shows:
+ *   [Guardar] (action-save-draft) + [Confirmar] (action-save)
+ * The required-field validation runs in handleSave(), so the "Guardar"
+ * (action-save-draft) button is the correct trigger for this test.
+ */
+
+async function installQuotationNewMocks(page, { postResponse } = {}) {
+  // List endpoint — return empty so the page doesn't try to show a table.
+  await page.route('**/sws/neo/sales-quotation/quotation', async (route) => {
+    const method = route.request().method();
+    if (method === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ response: { data: [], totalRows: 0 } }),
+      });
+      return;
+    }
+    if (method === 'POST') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(postResponse ?? { response: { data: [{ id: 'new-quot-001' }] } }),
+      });
+      return;
+    }
+    route.fallback();
+  });
+
+  // Defaults endpoint — return minimal values to pre-populate non-required fields.
+  await page.route('**/sws/neo/sales-quotation/quotation/defaults', async (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        defaults: {
+          orderDate: '14-05-2026',
+        },
+      }),
+    });
+  });
+}
+
+test.describe('Required-field validation — /sales-quotation/new (ETP-3894)', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await installQuotationNewMocks(page);
+    await page.goto('/sales-quotation/new');
+    await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 1: inline error appears under the first required field that is
+  // empty when "Guardar" (save draft) is clicked.
+  // -------------------------------------------------------------------------
+  test('shows inline error on required field when saving empty form', async ({ page }) => {
+    // Wait for the form to be fully rendered before clicking.
+    const bpWrapper = page.getByTestId('field-businessPartner');
+    await expect(bpWrapper).toBeVisible({ timeout: 8_000 });
+
+    // "Guardar" (save draft) is action-save-draft in draftMode windows.
+    // Clicking it calls handleSave() which runs the formFieldsRef validation.
+    const saveDraftBtn = page.getByTestId('action-save-draft');
+    await expect(saveDraftBtn).toBeVisible({ timeout: 5_000 });
+    await saveDraftBtn.click();
+
+    // businessPartner is the canonical first required field on this form.
+    // EntityForm appends <p data-testid="error-{key}"> via renderFieldWithError.
+    const bpError = page.getByTestId('error-businessPartner');
+    await expect(bpError).toBeVisible({ timeout: 5_000 });
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 2: toast fires when required fields are missing.
+  // -------------------------------------------------------------------------
+  test('toast appears when required fields are missing on save', async ({ page }) => {
+    const bpWrapper = page.getByTestId('field-businessPartner');
+    await expect(bpWrapper).toBeVisible({ timeout: 8_000 });
+
+    const saveDraftBtn = page.getByTestId('action-save-draft');
+    await expect(saveDraftBtn).toBeVisible({ timeout: 5_000 });
+    await saveDraftBtn.click();
+
+    // Sonner renders toasts with [data-sonner-toast] — locale-independent assertion.
+    const toastLocator = page.locator('[data-sonner-toast]').first();
+    await expect(toastLocator).toBeVisible({ timeout: 5_000 });
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 3: no inline error under businessPartner before any save attempt.
+  // The field must not show an error on the initial load (happy path: pristine).
+  // -------------------------------------------------------------------------
+  test('no inline error on pristine form before save is attempted', async ({ page }) => {
+    // Wait for the form to render completely.
+    const bpWrapper = page.getByTestId('field-businessPartner');
+    await expect(bpWrapper).toBeVisible({ timeout: 8_000 });
+
+    // No save attempt yet — the error element must not exist in the DOM.
+    const bpError = page.getByTestId('error-businessPartner');
+    await expect(bpError).toHaveCount(0);
+  });
+});

--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -1825,6 +1825,7 @@ export function DetailView({
                       apiBaseUrl={apiBaseUrl}
                       selectorContext={selectorContextByEntity[entity]}
                       labelOverrides={labelOverrides}
+                      registerFields={hook.registerFields}
                       fieldErrors={hook.fieldErrors}
                       onFieldBlur={autoSaveOnBlur ? handleFieldBlur : undefined}
                     />

--- a/tools/app-shell/src/components/contract-ui/EntityForm.jsx
+++ b/tools/app-shell/src/components/contract-ui/EntityForm.jsx
@@ -475,16 +475,22 @@ export function EntityForm({ entity, fields = [], data, onChange, catalogs, layo
   // tabs where visibility depends on a sibling checkbox value (no server round-trip needed).
   displayFields = displayFields.filter(f => evalDisplayLogic(f, data));
 
+  // Stable ID unique to this EntityForm instance. Used as the Map key in useEntity's
+  // formFieldsRef so multiple EntityForms on the same screen accumulate rather than
+  // overwrite each other.
+  const formId = React.useId();
+
   // Register only the currently visible fields with useEntity so handleSave validates
   // what the user can actually see and fill — not hidden fields controlled by displayLogic.
+  // Cleanup removes this form's entry when the component unmounts (e.g. conditional blocks).
   React.useEffect(() => {
-    if (typeof registerFields === 'function') {
-      registerFields(displayFields);
-    }
+    if (typeof registerFields !== 'function') return;
+    registerFields(displayFields, formId);
+    return () => registerFields(null, formId);
   // displayFields is recomputed on every render; the effect intentionally re-runs
   // whenever visibility changes so the validation set stays in sync with the form.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [registerFields, data, displayLogic, fields, excludeFields, section, layout]);
+  }, [registerFields, formId, data, displayLogic, fields, excludeFields, section, layout]);
 
   if (displayFields.length === 0) return null;
 

--- a/tools/app-shell/src/hooks/__tests__/useEntity.registerFields.test.js
+++ b/tools/app-shell/src/hooks/__tests__/useEntity.registerFields.test.js
@@ -1,0 +1,159 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+/**
+ * ETP-3894: tests for the multi-form registerFields / handleSave fix.
+ *
+ * The Map-based formFieldsRef is reproduced in isolation so the logic can be
+ * exercised without a React renderer or any fetch infrastructure.
+ *
+ * Each test mirrors the exact logic in useEntity.js:
+ *
+ *   registerFields(fields, formId = '__default__')
+ *     → if fields === null  → Map.delete(formId)
+ *     → else               → Map.set(formId, Array.isArray(fields) ? fields : [])
+ *
+ *   handleSave validation (isNew branch)
+ *     → fields = [...formFieldsRef.values()].flat()
+ *     → find required + editable + visible + non-checkbox + non-summary fields
+ *       whose value in editing is null / '' / whitespace-only
+ */
+
+// ---------------------------------------------------------------------------
+// Inline reproduction of the register/flatten logic
+// ---------------------------------------------------------------------------
+
+function makeFormFieldsMap() {
+  return new Map();
+}
+
+function registerFields(map, fields, formId = '__default__') {
+  if (fields === null) {
+    map.delete(formId);
+  } else {
+    map.set(formId, Array.isArray(fields) ? fields : []);
+  }
+}
+
+function getValidationFields(map) {
+  return [...map.values()].flat();
+}
+
+// Mirrors the isNew validation block inside useEntity.handleSave.
+function findMissingRequired(editing, map) {
+  const fields = getValidationFields(map);
+
+  const isReadOnly = (f) => {
+    if (f.readOnly === true) return true;
+    try {
+      return typeof f.readOnlyLogic === 'function'
+        ? Boolean(f.readOnlyLogic(editing))
+        : false;
+    } catch {
+      return false;
+    }
+  };
+
+  const isVisible = (f) => {
+    if (typeof f.displayLogic !== 'function') return true;
+    try { return !!f.displayLogic(editing ?? {}); } catch { return true; }
+  };
+
+  return fields
+    .filter(f =>
+      f.required &&
+      !isReadOnly(f) &&
+      isVisible(f) &&
+      f.type !== 'checkbox' &&
+      f.section !== 'summary'
+    )
+    .filter(f => {
+      const v = editing?.[f.key];
+      return v == null || v === '' || (typeof v === 'string' && v.trim() === '');
+    })
+    .map(f => f.key);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const requiredField = (key) => ({ key, required: true, type: 'text' });
+const optionalField = (key) => ({ key, required: false, type: 'text' });
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('registerFields — Map accumulation (ETP-3894)', () => {
+
+  it('accumulates fields from multiple formIds', () => {
+    const map = makeFormFieldsMap();
+    registerFields(map, [requiredField('businessPartner')], 'form-1');
+    registerFields(map, [requiredField('orderDate')], 'form-2');
+
+    assert.equal(map.size, 2, 'Map must contain exactly 2 entries after two registrations');
+    assert.ok(map.has('form-1'), 'form-1 must be present');
+    assert.ok(map.has('form-2'), 'form-2 must be present');
+  });
+
+  it('cleanup removes only the matching formId', () => {
+    const map = makeFormFieldsMap();
+    registerFields(map, [requiredField('businessPartner')], 'form-1');
+    registerFields(map, [requiredField('orderDate')], 'form-2');
+
+    // Simulate EntityForm unmount cleanup: registerFields(null, formId)
+    registerFields(map, null, 'form-1');
+
+    assert.equal(map.size, 1, 'Map must contain 1 entry after cleanup of form-1');
+    assert.ok(!map.has('form-1'), 'form-1 must be gone');
+    assert.ok(map.has('form-2'), 'form-2 must still be present');
+  });
+
+  it('handleSave validates all forms combined', () => {
+    const map = makeFormFieldsMap();
+    // Two separate EntityForm instances, each with a required field.
+    registerFields(map, [requiredField('businessPartner')], 'form-1');
+    registerFields(map, [requiredField('orderDate')], 'form-2');
+
+    // editing is empty — both fields are missing.
+    const missing = findMissingRequired({}, map);
+    assert.ok(missing.includes('businessPartner'), 'businessPartner must be flagged');
+    assert.ok(missing.includes('orderDate'), 'orderDate must be flagged');
+    assert.equal(missing.length, 2, 'Exactly 2 fields must be flagged');
+  });
+
+  it('last-write-wins regression is gone: second form does not overwrite first', () => {
+    // Regression introduced before the fix: the old Array ref was overwritten on
+    // every registerFields call, so the last EntityForm to mount "won" and the
+    // first form's required fields were silently dropped from validation.
+    //
+    // With the Map fix, both sets of fields must coexist.
+    const map = makeFormFieldsMap();
+    registerFields(map, [requiredField('businessPartner')], 'form-1');
+    // form-2 registers only a non-required field — it must NOT silence form-1's validation.
+    registerFields(map, [optionalField('notes')], 'form-2');
+
+    const missing = findMissingRequired({}, map);
+    assert.ok(
+      missing.includes('businessPartner'),
+      'businessPartner (from form-1) must still be flagged even after form-2 registers'
+    );
+  });
+
+  it('stale fields from unmounted form are excluded from validation', () => {
+    const map = makeFormFieldsMap();
+    registerFields(map, [requiredField('businessPartner')], 'form-1');
+
+    // Simulate the cleanup effect from EntityForm unmount.
+    registerFields(map, null, 'form-1');
+
+    const missing = findMissingRequired({}, map);
+    assert.deepEqual(
+      missing,
+      [],
+      'No errors expected after the only form has been unmounted (cleanup path)'
+    );
+  });
+
+});

--- a/tools/app-shell/src/hooks/useEntity.js
+++ b/tools/app-shell/src/hooks/useEntity.js
@@ -333,9 +333,10 @@ export function useEntity(entity, childEntity, {
   const backendDefaultKeysRef = useRef(new Set());
   // Fields explicitly changed by the user (via handleChange) in the current new-record session.
   const userChangedKeysRef = useRef(new Set());
-  // ETP-3894: snapshot of the form-level fields contract registered by EntityForm.
-  // Used in handleSave to validate required+editable fields before posting to the backend.
-  const formFieldsRef = useRef([]);
+  // ETP-3894: per-form snapshot of visible fields registered by each EntityForm instance.
+  // Keyed by a stable formId (React.useId) so multiple EntityForms accumulate rather than
+  // overwrite each other. handleSave flattens all entries to validate the complete form.
+  const formFieldsRef = useRef(new Map());
 
   // True when editing has diverged from the last-saved selected state.
   // For new records (selected === null): dirty as soon as any non-id field has a value.
@@ -565,10 +566,15 @@ export function useEntity(entity, childEntity, {
     });
   }, []);
 
-  // ETP-3894: EntityForm calls this on mount with its `fields` array so handleSave
-  // can validate required+editable fields client-side before hitting the backend.
-  const registerFields = useCallback((fields) => {
-    formFieldsRef.current = Array.isArray(fields) ? fields : [];
+  // ETP-3894: EntityForm calls this on mount/update with its visible fields and a stable
+  // formId. Passing fields=null on unmount removes that form's entry so stale fields
+  // (e.g. conditionally hidden blocks) don't pollute the validation set.
+  const registerFields = useCallback((fields, formId = '__default__') => {
+    if (fields === null) {
+      formFieldsRef.current.delete(formId);
+    } else {
+      formFieldsRef.current.set(formId, Array.isArray(fields) ? fields : []);
+    }
   }, []);
 
   const handleSave = useCallback(async () => {
@@ -580,7 +586,7 @@ export function useEntity(entity, childEntity, {
     // round-trip and shows per-field errors immediately. Only runs on create — for
     // existing records, `editing` already includes server-resolved values.
     if (isNew) {
-      const fields = formFieldsRef.current || [];
+      const fields = [...formFieldsRef.current.values()].flat();
       const isReadOnly = (f) => {
         if (f.readOnly === true) return true;
         try {


### PR DESCRIPTION
formFieldsRef was a plain array overwritten on each registerFields call, so only the last mounted EntityForm's fields were validated on save. Switch to a Map keyed by React.useId() so every EntityForm accumulates its entry independently. Cleanup on unmount removes stale entries. DetailView collapsed section now receives registerFields so its required fields are also validated.

Adds 5 unit tests (Node test runner) and 3 Playwright mocked E2E tests.