### PR TITLE
Feature ETP-4000: Fix sales-quotation list-to-record navigation

### DIFF
--- a/e2e/tests/flows/sales-quotation-navigation.mocked.spec.js
+++ b/e2e/tests/flows/sales-quotation-navigation.mocked.spec.js
@@ -1,0 +1,219 @@
+import { test, expect } from '@playwright/test';
+import { login } from '../helpers/auth.js';
+
+/**
+ * Sales Quotation — navigation regression (ETP-4000, mocked).
+ *
+ * Bug: clicking a list row or "+ Nuevo presupuesto" updated the URL but did
+ * NOT render the detail page — only a manual browser refresh recovered.
+ *
+ * Root cause (already fixed on this branch): the i18n hooks `useUI`,
+ * `useMenuLabel` and `useLabel` returned a new function reference each render,
+ * which invalidated a `useMemo(() => buildQuotationColumns(ui), [ui])` in
+ * `SalesQuotationWindow`. Fresh column identity propagated through
+ * `DataTable.onColumnsReady` → `ListView.setTableColumns`, forming an
+ * infinite update loop and a "Maximum update depth exceeded" error that
+ * blocked further URL transitions.
+ *
+ * These tests prove:
+ *   1. List → existing record renders WITHOUT a refresh.
+ *   2. List → +New renders WITHOUT a refresh.
+ *   3. Detail → back to list → another record renders.
+ *
+ * Each test installs a console-error listener that fails the test if React
+ * reports "Maximum update depth exceeded" — the canonical signal for this
+ * regression class.
+ */
+
+const ROWS = [
+  {
+    id: 'quot-001',
+    documentNo: 'QUOT-001',
+    documentStatus: 'DR',
+    'documentStatus$_identifier': 'Draft',
+    orderDate: '2026-05-01',
+    validUntil: null,
+    businessPartner: 'bp-1',
+    'businessPartner$_identifier': 'Laura Morat',
+    partnerAddress: 'addr-1',
+    'partnerAddress$_identifier': 'Rio Cuarto, Santa Fe 488',
+    priceList: 'pl-1',
+    'priceList$_identifier': 'Lista de venta',
+    paymentMethod: 'pm-1',
+    'paymentMethod$_identifier': 'Efectivo',
+    paymentTerms: 'pt-1',
+    'paymentTerms$_identifier': '30 Días',
+    grandTotalAmount: 100,
+    summedLineAmount: 100,
+    description: '',
+    processed: false,
+  },
+  {
+    id: 'quot-002',
+    documentNo: 'QUOT-002',
+    documentStatus: 'DR',
+    'documentStatus$_identifier': 'Draft',
+    orderDate: '2026-05-02',
+    validUntil: null,
+    businessPartner: 'bp-2',
+    'businessPartner$_identifier': 'Pedro Salinas',
+    partnerAddress: 'addr-2',
+    'partnerAddress$_identifier': 'Av. Rivadavia 1234',
+    priceList: 'pl-1',
+    'priceList$_identifier': 'Lista de venta',
+    paymentMethod: 'pm-1',
+    'paymentMethod$_identifier': 'Efectivo',
+    paymentTerms: 'pt-1',
+    'paymentTerms$_identifier': '30 Días',
+    grandTotalAmount: 250,
+    summedLineAmount: 250,
+    description: '',
+    processed: false,
+  },
+];
+
+/**
+ * Install handlers for the sales-quotation backend after login() — Playwright
+ * matches routes in reverse registration order so this wins over the generic
+ * /sws/** stub.
+ */
+async function installQuotationMock(page) {
+  await page.route('**/sws/neo/sales-quotation/**', (route) => {
+    const req = route.request();
+    const url = new URL(req.url());
+    const segments = url.pathname.split('/').filter(Boolean);
+    const idx = segments.indexOf('sales-quotation');
+    const entity = segments[idx + 1];
+    const idOrSubpath = segments[idx + 2];
+
+    // Empty child lists — header navigation is the focus of this spec.
+    if (entity === 'quotationLine') {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ response: { data: [] } }),
+      });
+      return;
+    }
+
+    if (entity === 'quotation' && req.method() === 'GET') {
+      // Detail GET → /quotation/{id}
+      if (idOrSubpath) {
+        const found = ROWS.find((r) => r.id === idOrSubpath);
+        if (found) {
+          route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({ response: { data: [found] } }),
+          });
+          return;
+        }
+      }
+      // List GET → /quotation
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ response: { data: ROWS, totalRows: ROWS.length } }),
+      });
+      return;
+    }
+
+    // Anything else (defaults, callouts, selectors, ...) falls through to the
+    // auth.js catch-all so its synthetic responses keep the UI happy.
+    route.fallback();
+  });
+}
+
+/**
+ * Installs a console-error listener that fails the test if React reports
+ * "Maximum update depth exceeded" — the canonical signal for the regression
+ * fixed in ETP-4000.
+ */
+function watchForInfiniteLoop(page) {
+  const errors = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error' && msg.text().includes('Maximum update depth exceeded')) {
+      errors.push(msg.text());
+    }
+  });
+  page.on('pageerror', (err) => {
+    if ((err.message || '').includes('Maximum update depth exceeded')) {
+      errors.push(err.message);
+    }
+  });
+  return errors;
+}
+
+test.describe('Sales Quotation — navigation without refresh (ETP-4000)', () => {
+  let consoleErrors;
+
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await installQuotationMock(page);
+    consoleErrors = watchForInfiniteLoop(page);
+  });
+
+  test.afterEach(() => {
+    expect(consoleErrors, 'No infinite update loop should occur during navigation').toEqual([]);
+  });
+
+  test('list → existing record renders detail without a manual refresh', async ({ page }) => {
+    await page.goto('/sales-quotation');
+    const firstRow = page.locator('tbody tr').filter({ hasText: 'QUOT-001' }).first();
+    await expect(firstRow).toBeVisible({ timeout: 10_000 });
+
+    await firstRow.click();
+
+    // URL must transition AND detail must render — no reload allowed.
+    await page.waitForURL(/\/sales-quotation\/quot-001/, { timeout: 10_000 });
+    await expect(page).toHaveURL(/\/sales-quotation\/quot-001/);
+
+    // Detail-only element — must be visible without page.reload().
+    const documentNoField = page.getByTestId('field-documentNo');
+    await expect(documentNoField).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('list → +New navigates to /new and renders the form without a refresh', async ({ page }) => {
+    await page.goto('/sales-quotation');
+    await expect(page.locator('tbody tr').filter({ hasText: 'QUOT-001' }).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.getByTestId('action-new').click();
+
+    await page.waitForURL(/\/sales-quotation\/new/, { timeout: 10_000 });
+    await expect(page).toHaveURL(/\/sales-quotation\/new/);
+
+    // BusinessPartner is one of the principal form fields on the new record
+    // form — its presence confirms the detail branch rendered without reload.
+    await expect(page.getByTestId('field-businessPartner')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('list → record → back → another record renders', async ({ page }) => {
+    // 1. Start at the list — establishes the SPA history so goBack() has a
+    //    valid in-app entry to return to (avoids about:blank).
+    await page.goto('/sales-quotation');
+    const firstRow = page.locator('tbody tr').filter({ hasText: 'QUOT-001' }).first();
+    await expect(firstRow).toBeVisible({ timeout: 10_000 });
+
+    // 2. Click into the first detail.
+    await firstRow.click();
+    await page.waitForURL(/\/sales-quotation\/quot-001/, { timeout: 10_000 });
+    await expect(page.getByTestId('field-documentNo')).toBeVisible({ timeout: 10_000 });
+
+    // 3. Go back to the list view.
+    await page.goBack();
+    await page.waitForURL(/\/sales-quotation(?:\/)?$/, { timeout: 10_000 });
+    const secondRow = page.locator('tbody tr').filter({ hasText: 'QUOT-002' }).first();
+    await expect(secondRow).toBeVisible({ timeout: 10_000 });
+
+    // 4. Click a DIFFERENT row — this is the exact case that broke before the
+    //    fix (list → detail transition after another navigation, without a
+    //    hard reload).
+    await secondRow.click();
+
+    await page.waitForURL(/\/sales-quotation\/quot-002/, { timeout: 10_000 });
+    await expect(page).toHaveURL(/\/sales-quotation\/quot-002/);
+    await expect(page.getByTestId('field-documentNo')).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/tools/app-shell/src/i18n/__tests__/useUI-stability.vitest.jsx
+++ b/tools/app-shell/src/i18n/__tests__/useUI-stability.vitest.jsx
@@ -1,0 +1,200 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { LocaleProvider } from '../LocaleProvider.jsx';
+import { useUI } from '../useUI.js';
+import { useMenuLabel } from '../useMenuLabel.js';
+import { useLabel } from '../useLabel.js';
+
+/**
+ * Regression tests for ETP-4000 — i18n hook stability.
+ *
+ * Bug: `useUI`, `useMenuLabel` and `useLabel` returned a NEW function reference
+ * on every render. In `SalesQuotationWindow`:
+ *
+ *   const ui = useUI();
+ *   const quotationColumns = useMemo(() => buildQuotationColumns(ui), [ui]);
+ *
+ * Because `ui` changed identity every render, the `useMemo` invalidated each
+ * render → `quotationColumns` was a fresh array each render → passed to
+ * `<DataTable>` whose `useEffect(() => onColumnsReady(columns), [columns, ...])`
+ * called `setTableColumns` on the parent `ListView` → infinite update loop →
+ * React threw "Maximum update depth exceeded" → URL transitions stopped
+ * propagating.
+ *
+ * The fix wraps the returned function in `useCallback(..., [dictionary])`
+ * (or `[dictionary, langOverrides]` for `useLabel`). These tests guarantee
+ * the returned function reference is stable across renders when the locale
+ * does not change, and changes when the locale (or overrides) do change.
+ */
+
+function makeWrapper(locale) {
+  return function Wrapper({ children }) {
+    return <LocaleProvider locale={locale}>{children}</LocaleProvider>;
+  };
+}
+
+/**
+ * Mounts a probe component under a LocaleProvider and captures the hook value
+ * on every render. Returns { captured, rerender } where rerender accepts a new
+ * `locale` (and optional `overrides`) to drive re-renders.
+ */
+function mountProbe(useHook, initialLocale, initialOverrides = undefined) {
+  const captured = [];
+  function Probe({ overrides }) {
+    const value = useHook(overrides);
+    captured.push(value);
+    return null;
+  }
+  function Harness({ locale, overrides }) {
+    return (
+      <LocaleProvider locale={locale}>
+        <Probe overrides={overrides} />
+      </LocaleProvider>
+    );
+  }
+  const { rerender } = render(<Harness locale={initialLocale} overrides={initialOverrides} />);
+  return {
+    captured,
+    rerender: (locale, overrides) => rerender(<Harness locale={locale} overrides={overrides} />),
+  };
+}
+
+describe('i18n hook stability — function identity across renders', () => {
+  describe('useUI', () => {
+    it('returns the SAME function reference across re-renders when locale does not change', () => {
+      const { result, rerender } = renderHook(() => useUI(), {
+        wrapper: makeWrapper('en_US'),
+      });
+
+      const first = result.current;
+      rerender();
+      const second = result.current;
+      rerender();
+      const third = result.current;
+
+      expect(typeof first).toBe('function');
+      expect(second).toBe(first);
+      expect(third).toBe(first);
+    });
+
+    it('returns a NEW function reference when the locale changes', () => {
+      const { captured, rerender } = mountProbe(() => useUI(), 'en_US');
+
+      rerender('en_US');             // same locale → reference must stay stable
+      rerender('es_ES');             // locale change → new reference expected
+      rerender('es_ES');             // back to stable
+
+      // captured: [enRender1, enRender2, esRender1, esRender2]
+      expect(captured.length).toBe(4);
+      expect(captured[1]).toBe(captured[0]);     // same locale, same reference
+      expect(captured[2]).not.toBe(captured[1]); // locale change → new reference
+      expect(captured[3]).toBe(captured[2]);     // stable after switch
+    });
+  });
+
+  describe('useMenuLabel', () => {
+    it('returns the SAME function reference across re-renders when locale does not change', () => {
+      const { result, rerender } = renderHook(() => useMenuLabel(), {
+        wrapper: makeWrapper('en_US'),
+      });
+
+      const first = result.current;
+      rerender();
+      const second = result.current;
+      rerender();
+      const third = result.current;
+
+      expect(typeof first).toBe('function');
+      expect(second).toBe(first);
+      expect(third).toBe(first);
+    });
+
+    it('returns a NEW function reference when the locale changes', () => {
+      const { captured, rerender } = mountProbe(() => useMenuLabel(), 'en_US');
+
+      rerender('en_US');
+      rerender('es_ES');
+      rerender('es_ES');
+
+      expect(captured.length).toBe(4);
+      expect(captured[1]).toBe(captured[0]);
+      expect(captured[2]).not.toBe(captured[1]);
+      expect(captured[3]).toBe(captured[2]);
+    });
+  });
+
+  describe('useLabel (no overrides)', () => {
+    it('returns the SAME function reference across re-renders when locale does not change', () => {
+      const { result, rerender } = renderHook(() => useLabel(), {
+        wrapper: makeWrapper('en_US'),
+      });
+
+      const first = result.current;
+      rerender();
+      const second = result.current;
+      rerender();
+      const third = result.current;
+
+      expect(typeof first).toBe('function');
+      expect(second).toBe(first);
+      expect(third).toBe(first);
+    });
+
+    it('returns a NEW function reference when the locale changes', () => {
+      const { captured, rerender } = mountProbe(() => useLabel(), 'en_US');
+
+      rerender('en_US');
+      rerender('es_ES');
+      rerender('es_ES');
+
+      expect(captured.length).toBe(4);
+      expect(captured[1]).toBe(captured[0]);
+      expect(captured[2]).not.toBe(captured[1]);
+      expect(captured[3]).toBe(captured[2]);
+    });
+  });
+
+  describe('useLabel (with overrides)', () => {
+    it('returns the SAME function reference when the same overrides object is passed across renders', () => {
+      const overrides = {
+        es_ES: { C_BPartner_ID: 'Contacto' },
+        en_US: { C_BPartner_ID: 'Contact' },
+      };
+      const { result, rerender } = renderHook(() => useLabel(overrides), {
+        wrapper: makeWrapper('en_US'),
+      });
+
+      const first = result.current;
+      rerender();
+      const second = result.current;
+      rerender();
+      const third = result.current;
+
+      expect(typeof first).toBe('function');
+      expect(second).toBe(first);
+      expect(third).toBe(first);
+    });
+
+    it('returns a NEW function reference when the overrides[locale] slice identity changes', () => {
+      // useLabel depends on dictionary + langOverrides (the locale-specific slice).
+      // Changing the slice's identity (even with equivalent content) must invalidate
+      // the memo — this is the contract guaranteed by `[dictionary, langOverrides]`.
+      const initialOverrides = { en_US: { C_BPartner_ID: 'Contact' } };
+      const changedSlice    = { en_US: { C_BPartner_ID: 'Customer' } };
+
+      const { captured, rerender } = mountProbe(
+        (overrides) => useLabel(overrides),
+        'en_US',
+        initialOverrides,
+      );
+
+      rerender('en_US', initialOverrides);   // same overrides object → stable
+      rerender('en_US', changedSlice);       // new slice identity → new reference
+
+      expect(captured.length).toBe(3);
+      expect(captured[1]).toBe(captured[0]);     // same overrides ref → stable
+      expect(captured[2]).not.toBe(captured[1]); // overrides ref changed → new fn
+    });
+  });
+});

--- a/tools/app-shell/src/i18n/useLabel.js
+++ b/tools/app-shell/src/i18n/useLabel.js
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useLocale, useLocaleSwitch } from './LocaleProvider.jsx';
 import { resolveLabel } from './resolveLabel.js';
 
@@ -10,6 +11,9 @@ import { resolveLabel } from './resolveLabel.js';
  *
  * Resolution chain: labelOverrides[locale][column] → dictionary.fields[column] → null
  *
+ * The returned function is memoized so it stays stable across renders as long
+ * as the dictionary and overrides do not change. See useUI for the rationale.
+ *
  * Usage:
  *   const t = useLabel();
  *   t('C_BPartner_ID')   // "Business Partner"
@@ -21,5 +25,8 @@ export function useLabel(labelOverrides) {
   const dictionary = useLocale();
   const { locale } = useLocaleSwitch();
   const langOverrides = labelOverrides?.[locale] ?? null;
-  return (columnName) => resolveLabel(dictionary, columnName, langOverrides);
+  return useCallback(
+    (columnName) => resolveLabel(dictionary, columnName, langOverrides),
+    [dictionary, langOverrides],
+  );
 }

--- a/tools/app-shell/src/i18n/useMenuLabel.js
+++ b/tools/app-shell/src/i18n/useMenuLabel.js
@@ -1,9 +1,13 @@
+import { useCallback } from 'react';
 import { useLocale } from './LocaleProvider.jsx';
 
 /**
  * Hook that returns a translator function for menu group names, tab labels,
  * and other UI strings.
  * Looks up keys in: ui → menus → windows → tabs → genericLabels → raw key.
+ *
+ * The returned function is memoized on the dictionary so it is safe to use as
+ * a dependency of `useMemo`/`useEffect`. See useUI for the rationale.
  *
  * Usage:
  *   const tMenu = useMenuLabel();
@@ -12,9 +16,7 @@ import { useLocale } from './LocaleProvider.jsx';
  */
 export function useMenuLabel() {
   const dictionary = useLocale();
-  return (key, { field } = {}) => {
-    // When `field` is provided, reads that field directly from windows[key].
-    // Returns null (not the raw key) if the entry or field is missing.
+  return useCallback((key, { field } = {}) => {
     if (field) {
       return dictionary?.windows?.[key]?.[field] ?? null;
     }
@@ -26,5 +28,5 @@ export function useMenuLabel() {
       dictionary?.genericLabels?.[key] ??
       key
     );
-  };
+  }, [dictionary]);
 }

--- a/tools/app-shell/src/i18n/useUI.js
+++ b/tools/app-shell/src/i18n/useUI.js
@@ -1,8 +1,16 @@
+import { useCallback } from 'react';
 import { useLocale } from './LocaleProvider.jsx';
 
 /**
  * Hook that returns a translator function for generic UI labels.
  * Resolves keys from the `genericLabels` section of the locale dictionary.
+ *
+ * The returned function is memoized on the dictionary so consumers can safely
+ * use it as a dependency of `useMemo`/`useEffect` without re-triggering on
+ * every render. Without this guarantee a `useMemo(() => buildX(ui), [ui])`
+ * would invalidate on every render and propagate fresh array identities to
+ * children — see DataTable.onColumnsReady → ListView.setTableColumns, which
+ * forms an infinite update loop when columns identity changes each render.
  *
  * Usage:
  *   const ui = useUI();
@@ -11,7 +19,7 @@ import { useLocale } from './LocaleProvider.jsx';
  */
 export function useUI() {
   const dictionary = useLocale();
-  return (key, params = {}) => {
+  return useCallback((key, params = {}) => {
     let text = dictionary?.genericLabels?.[key] ?? key;
     if (params && typeof params === 'object') {
       Object.keys(params).forEach((p) => {
@@ -19,5 +27,5 @@ export function useUI() {
       });
     }
     return text;
-  };
+  }, [dictionary]);
 }


### PR DESCRIPTION
useUI, useLabel and useMenuLabel returned a fresh function on every render, invalidating callers that used the result in useMemo deps. CustomQuotationTable rebuilt its columns each render, propagating a new reference into DataTable.onColumnsReady -> setTableColumns -> re-render, looping until React aborted with "Maximum update depth exceeded". The aborted update tree blocked URL transitions on click, so detail and +Nuevo only rendered after a hard refresh.

Memoize the three hooks with useCallback keyed on the dictionary (plus the language override slice in useLabel) so the returned translator is identity-stable per locale. Add a vitest suite that asserts identity stability across re-renders, and a mocked Playwright spec for sales-quotation that fails on the canonical "Maximum update depth exceeded" console signal.