### PR TITLE
Feature ETP-4061: Document Email Contract Framework

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,18 @@ Data flow:
    - Prefer Schema Forge + NEO contracts/specs and handlers (`push-to-neo`, `ETGO_SF_*`, NEO endpoints).
    - Avoid classic AD/Jasper/classic-process patterns as the default implementation path.
 
+## Transactional Email Rules
+
+Transactional email must follow `docs/transactional-email-framework.md` and `docs/email-contracts.md`.
+
+1. Never call an external email provider directly from frontend code.
+2. Never commit provider endpoints, API keys, signing secrets, sender credentials, or other email provider secrets.
+3. Never expose a browser endpoint that accepts an arbitrary provider payload such as `to`, `template`, and `data`.
+4. Every email send must go through an explicit versioned email contract with authorization, recipient resolution, throttle, idempotency, audit, suppression, and kill switch behavior.
+5. Resolve recipients server-side from trusted records by default. Caller-provided recipients are allowed only for explicit admin/support contracts.
+6. `custom` email is allowed only as a controlled contract with role checks, sanitizer, strict throttle, reason capture, and audit.
+7. Each email contract must document at least 3 edge cases and include behavioral/security test coverage before it is considered complete.
+
 ## Pipeline Expectations
 
 Canonical phase order:

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -87,6 +87,21 @@ Schema Forge decides **what** to expose. Etendo Go decides **how** to serve it.
 | Contract tests | Node.js (JSON assertions) | Schema Forge |
 | Integration tests | JUnit (extends OBBaseTest) | Etendo Go |
 
+## Transactional Email Boundary
+
+Transactional email is a NEO Headless runtime capability, not a frontend/provider integration. Schema Forge documents contract methodology and app-shell integration rules; Etendo Go executes sends through server-side email contracts.
+
+Required boundary:
+
+```
+React SPA -> /sws/neo/email-contracts/{contractName}/send
+  -> EmailContractExecutor
+  -> Provider adapter
+  -> External email provider
+```
+
+The SPA sends a contract command. It must not receive provider secrets or send arbitrary `to/template/data` provider payloads. See [transactional-email-framework.md](transactional-email-framework.md), [email-contracts.md](email-contracts.md), and [ops/transactional-email-security.md](ops/transactional-email-security.md).
+
 ## Repository Structure
 
 ```

--- a/docs/architecture/04-api-layer.md
+++ b/docs/architecture/04-api-layer.md
@@ -49,6 +49,29 @@ The response is a simplified list:
 
 The selector query uses the `AD_Reference_Value` configuration to determine which table and identifier column to search.
 
+### 1.4 Transactional Email Contract Endpoint
+
+Transactional email uses a contract command endpoint, not a provider passthrough endpoint:
+
+```
+POST /sws/neo/email-contracts/{contractName}/send
+```
+
+The request body must contain only the versioned command data required by the contract, such as `recordId`, `intent`, and `idempotencyKey`. The browser must not send provider API keys, sender identity, template names selected outside the contract, or arbitrary `to/template/data` payloads.
+
+Server-side flow:
+
+1. Validate JWT and initialize Etendo context.
+2. Resolve the named contract and version.
+3. Enforce role, tenant, organization, and record authorization.
+4. Resolve recipient and variables from trusted server records.
+5. Apply throttle, idempotency, suppression, and kill switches.
+6. Write audit state.
+7. Call the provider adapter with server-side configuration only.
+8. Return a structured status such as `SENT`, `DUPLICATE`, `THROTTLED`, `UNAUTHORIZED`, `NO_RECIPIENT`, `SUPPRESSED`, `KILL_SWITCHED`, or `PROVIDER_FAILED`.
+
+See [../transactional-email-framework.md](../transactional-email-framework.md) and [../email-contracts.md](../email-contracts.md).
+
 ---
 
 ## 2. Request/Response Flow

--- a/docs/architecture/07-auth-and-security.md
+++ b/docs/architecture/07-auth-and-security.md
@@ -251,6 +251,19 @@ The API may return all fields visible to the role, even if the current UI view d
 **Audit Logging**
 Etendo has `AD_Audit_Trail` for tracking data changes. Ensure it is enabled for sensitive entities (user management, financial transactions, role changes).
 
+**Transactional Email**
+Transactional email must be protected as a server-side contract system:
+- The frontend must never call the provider endpoint directly.
+- Provider endpoint URLs, API keys, sender identities, and signing secrets must stay in server configuration only.
+- No browser-visible endpoint may accept an arbitrary email payload such as `to`, `template`, and `data`.
+- Each send must execute a versioned contract that defines authorization, recipient resolution, variables, throttle, idempotency, audit, suppression, and kill switch behavior.
+- Recipients must be derived from trusted server records by default.
+- Caller-provided recipients are allowed only for explicit admin/support contracts.
+- Reply-To must be disabled by default or constrained to a documented allowlist policy.
+- Controlled custom HTML email requires role checks, reason capture, sanitizer, strict throttle, and audit.
+
+See [../transactional-email-framework.md](../transactional-email-framework.md), [../email-contracts.md](../email-contracts.md), and [../ops/transactional-email-security.md](../ops/transactional-email-security.md).
+
 ## HTTPS / TLS
 
 ### TLS Termination

--- a/docs/architecture/09-reliability.md
+++ b/docs/architecture/09-reliability.md
@@ -58,6 +58,16 @@ Analysis of failure modes, resilience patterns, and recovery objectives for Sche
 | **Dynamic import failure** | Specific window will not load | Browser console: `Failed to fetch dynamically imported module` | Usually caused by cache serving old chunk references after deployment. Force refresh or clear PWA cache. Mitigate with proper cache-busting hashes in filenames |
 | **Auth token expired** | Silent 401 errors, confusing UX | API calls return 401, no user-visible indication | Frontend should intercept 401 responses globally and redirect to login. Currently no centralized auth error handling |
 
+### 2.5 Transactional Email Failures
+
+| Failure | Impact | Detection | Recovery |
+|---------|--------|-----------|----------|
+| **Provider unavailable** | Email sends fail after local validation | `PROVIDER_FAILED` metrics/logs spike | Keep audit records, show retry/support state, and retry only through explicit contract policy |
+| **Duplicate UI submission** | Multiple emails could be sent for one action | Idempotency duplicate count | Return `DUPLICATE` without a provider call |
+| **Throttle misconfiguration** | Spam risk or legitimate sends blocked | Throttle metrics by contract/tenant | Adjust contract limits and keep audit trail of blocked sends |
+| **Recipient suppression** | User expects an email that is not delivered | `SUPPRESSED` audit/metric | Explain safe UI state, resolve suppression only through support workflow |
+| **Kill switch activation** | All or scoped email sends disabled | Kill switch metric/alert | Confirm scope, fix incident, smoke test, then re-enable |
+
 ---
 
 ## 3. Resilience Patterns
@@ -75,6 +85,8 @@ Analysis of failure modes, resilience patterns, and recovery objectives for Sche
 | **Graceful degradation** | None | WARNING | Show last-known cached data when API is unreachable (read-only mode) |
 | **Connection pool monitoring** | Default HikariCP settings | WARNING | Expose pool metrics (active, idle, waiting). Alert when utilization exceeds 80% |
 | **Rate limiting** | None | WARNING | Nginx `limit_req` zone or Tomcat valve. Prevent accidental DoS from misbehaving clients |
+| **Email contract idempotency** | Required for new transactional email work | CRITICAL | Derive or require an idempotency key per contract so repeated sends do not call the provider twice |
+| **Email kill switches** | Required for new transactional email work | CRITICAL | Support global, tenant, contract, provider, recipient, and domain disablement |
 | **Backup automation** | Likely manual `pg_dump` | WARNING | Automated daily `pg_dump` with retention policy. Periodic restore test |
 
 ### 3.2 Implementation Priority

--- a/docs/architecture/10-observability.md
+++ b/docs/architecture/10-observability.md
@@ -231,6 +231,12 @@ Etendo uses log4j2 (configured via `log4j2-web.xml` or `log4j2.properties`). The
 </RollingFile>
 ```
 
+### 4.6 Transactional Email Logging
+
+Email contract logs must be structured and redacted. Include `requestId`, `auditId`, `contract`, `version`, `tenantId`, `userId`, `recordId` when applicable, `status`, `throttleBucket`, `providerStatus`, and `durationMs`.
+
+Do not log provider API keys, reset tokens, raw custom HTML, full message bodies, or secrets derived from provider configuration. See [../ops/transactional-email-security.md](../ops/transactional-email-security.md).
+
 ---
 
 ## 5. Layer 3: Metrics
@@ -246,7 +252,19 @@ Etendo uses log4j2 (configured via `log4j2-web.xml` or `log4j2.properties`). The
 | `sf_process_duration_seconds` | Histogram | process_name, status | DalProcess execution time |
 | `sf_active_sessions` | Gauge | -- | Number of active AD_Session records |
 
-### 5.2 Infrastructure Metrics
+### 5.2 Transactional Email Metrics
+
+| Metric | Type | Labels | Purpose |
+|--------|------|--------|---------|
+| `sf_email_send_total` | Counter | contract, version, tenant, status | Send outcomes and error rate |
+| `sf_email_provider_duration_seconds` | Histogram | provider, contract, status | Provider latency and timeout behavior |
+| `sf_email_throttle_total` | Counter | contract, tenant, throttle_bucket | Abuse control visibility |
+| `sf_email_duplicate_total` | Counter | contract, tenant | Idempotency effectiveness |
+| `sf_email_suppression_total` | Counter | contract, tenant, reason | Bounce, complaint, and manual suppression impact |
+| `sf_email_kill_switch_total` | Counter | scope, contract, tenant | Kill switch activations |
+| `sf_email_provider_error_total` | Counter | provider, contract, error_class | Provider failure analysis |
+
+### 5.3 Infrastructure Metrics
 
 | Metric | Source | Purpose |
 |--------|--------|---------|
@@ -256,7 +274,7 @@ Etendo uses log4j2 (configured via `log4j2-web.xml` or `log4j2.properties`). The
 | PostgreSQL connections, query time, lock waits | `pg_stat_activity`, `pg_stat_statements` | Database health |
 | Disk usage, CPU, memory | Node exporter (Prometheus) | System resource monitoring |
 
-### 5.3 Business Metrics
+### 5.4 Business Metrics
 
 | Metric | Purpose |
 |--------|---------|
@@ -266,7 +284,7 @@ Etendo uses log4j2 (configured via `log4j2-web.xml` or `log4j2.properties`). The
 | User session duration | Engagement, session timeout tuning |
 | Error rate per window | Identify problematic windows |
 
-### 5.4 Metric Exposition
+### 5.5 Metric Exposition
 
 **Recommended approach:** Prometheus JMX exporter (sidecar or javaagent) for JVM/Tomcat/HikariCP metrics. Custom Prometheus servlet endpoint (`/metrics`) for application metrics using the Prometheus Java client library.
 
@@ -297,6 +315,9 @@ scrape_configs:
 | **WARNING** | JVM heap usage > 85% for 10 minutes | Notify ops channel |
 | **WARNING** | Disk usage > 80% | Notify ops channel |
 | **WARNING** | GC pause > 500ms | Notify ops channel |
+| **WARNING** | Email provider failure rate above threshold for 5 minutes | Notify ops channel and check email runbook |
+| **WARNING** | Email throttle or suppression spike for one tenant/contract | Notify ops channel and investigate abuse or misconfiguration |
+| **INFO** | Email kill switch activated | Notify ops channel with scope and actor |
 | **INFO** | Deployment completed (health check transitions DOWN -> UP) | Notify ops channel |
 | **INFO** | Unusual session spike (>2x normal for time of day) | Log for review |
 

--- a/docs/architecture/12-end-user-experience.md
+++ b/docs/architecture/12-end-user-experience.md
@@ -91,7 +91,22 @@ From the user's perspective, responsiveness determines whether the system feels 
 | **Window load failure** | White screen | No ErrorBoundary | Show error boundary with "This window could not be loaded. Try again." button |
 | **Unhandled JS exception** | White screen (entire SPA crashes) | No top-level ErrorBoundary | Show app-level error boundary with "Something went wrong" and option to return to dashboard |
 
-### 3.2 Error Message Guidelines
+### 3.2 Transactional Email States
+
+Email sending UI must call Etendo Go email contracts and map executor outcomes directly. The UI must never call the provider endpoint or send arbitrary provider payloads.
+
+| Contract Result | What the User Sees | Required Behavior |
+|-----------------|--------------------|-------------------|
+| `SENT` | Success confirmation | Close or update the send modal and preserve request reference if shown |
+| `DUPLICATE` | Already sent or recently sent | Treat as non-fatal and do not ask the user to retry immediately |
+| `THROTTLED` | Too many attempts | Show wait/retry guidance without provider details |
+| `UNAUTHORIZED` | Permission denied | Hide the action when possible and show a permission message if reached |
+| `NO_RECIPIENT` | Missing recipient | Ask the user to fix the business contact data |
+| `SUPPRESSED` | Delivery disabled | Explain that the recipient/domain cannot receive email and direct to support |
+| `KILL_SWITCHED` | Email temporarily unavailable | Keep the document/action state unchanged and show a support-safe message |
+| `PROVIDER_FAILED` | Send failed | Offer retry or support escalation with request reference |
+
+### 3.3 Error Message Guidelines
 
 - Use plain language, not technical jargon
 - Tell the user what happened and what they can do about it

--- a/docs/email-contracts.md
+++ b/docs/email-contracts.md
@@ -1,0 +1,279 @@
+# Email Contracts Guide
+
+Email contracts are the only supported way to send transactional email from Etendo Go. A contract is a server-side agreement between a product workflow and the email executor. It describes authorization, recipient resolution, variable resolution, throttling, idempotency, audit, and provider behavior.
+
+Use this guide when adding or changing a contract.
+
+## Contract Descriptor
+
+Every contract must define these fields.
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Stable kebab-case contract name, for example `reset-password` |
+| `version` | Yes | Contract schema version, starting at `v1` |
+| `template` | Yes | Provider template identifier or internal renderer key |
+| `enabled` | Yes | Default enabled state; kill switches can override it |
+| `description` | Yes | Short business purpose |
+| `caller` | Yes | Allowed source, such as `frontend`, `system`, `support`, or `admin` |
+| `authorization` | Yes | Role, process, window, record, tenant, and organization checks |
+| `recipient` | Yes | Server-side recipient source and validation rules |
+| `variables` | Yes | Allowed variable names, types, sources, and required flags |
+| `replyTo` | Yes | Disabled by default or explicit allowlist policy |
+| `links` | If links exist | Link generator, expiry, host policy, and token policy |
+| `throttle` | Yes | Per-contract abuse limits |
+| `idempotency` | Yes | Key strategy and duplicate window |
+| `audit` | Yes | Events and redaction rules |
+| `suppression` | Yes | Recipient/domain suppression behavior |
+| `killSwitch` | Yes | Global, tenant, and contract disable behavior |
+| `edgeCases` | Yes | At least three edge cases with expected outcomes |
+
+## Request Contract
+
+The browser sends a command to Etendo Go:
+
+```http
+POST /sws/neo/email-contracts/{contractName}/send
+Authorization: Bearer <jwt>
+Content-Type: application/json
+```
+
+```json
+{
+  "version": "v1",
+  "recordId": "E2F7A13B...",
+  "intent": "send-document",
+  "idempotencyKey": "sales-invoice:E2F7A13B:send:v1"
+}
+```
+
+The browser must not send provider API keys, sender addresses, raw templates, or arbitrary provider payloads.
+
+## Response Contract
+
+Recommended executor response:
+
+```json
+{
+  "status": "SENT",
+  "contract": "sales-invoice-send",
+  "version": "v1",
+  "requestId": "req-8d7f0a",
+  "auditId": "audit-7bc0",
+  "duplicate": false,
+  "retryAfterSeconds": null
+}
+```
+
+Allowed statuses:
+
+| Status | Meaning |
+|--------|---------|
+| `SENT` | Provider accepted the send |
+| `DUPLICATE` | Idempotency found an equivalent send in the duplicate window |
+| `THROTTLED` | A contract throttle limit blocked the send |
+| `UNAUTHORIZED` | Authenticated user cannot execute the contract or access the record |
+| `VALIDATION_FAILED` | Command, record state, or variables failed validation |
+| `NO_RECIPIENT` | The contract could not resolve a valid recipient |
+| `SUPPRESSED` | Recipient or domain is suppressed |
+| `KILL_SWITCHED` | Global, tenant, provider, or contract switch disabled sending |
+| `PROVIDER_FAILED` | Provider call failed after validation and audit |
+
+## Recipient Policies
+
+Default policy: resolve the recipient from trusted server data.
+
+Allowed recipient sources:
+
+| Source | Allowed For | Notes |
+|--------|-------------|-------|
+| `account-owner` | Auth/account flows | Uses account user email from server records |
+| `business-partner-contact` | Document flows | Uses the selected contact on the document or business partner |
+| `responsible-user` | Internal alerts | Uses the server-side assigned user |
+| `caller-provided` | Admin/support only | Requires explicit contract, role check, reason, validation, and audit |
+
+Reject any command that tries to override recipient, sender, Reply-To, template, or provider metadata outside the contract schema.
+
+## Reply-To Policy
+
+Reply-To is disabled unless the contract explicitly enables it.
+
+When enabled:
+
+- it must be derived from a trusted server record or allowlisted support mailbox
+- it must be syntactically valid
+- it must not change the sender identity
+- it must be recorded in audit
+- it must not permit tenant domain spoofing
+
+## Template and Variable Policy
+
+Variables must be allowlisted and typed. HTML variables require sanitizer policy.
+
+| Type | Rule |
+|------|------|
+| `string` | Escape by default before rendering |
+| `date` | Format server-side or pass a typed value plus locale |
+| `currency` | Include amount and ISO currency code; avoid preformatted ambiguous strings when possible |
+| `url` | Generate server-side; allowlisted hosts only |
+| `html` | Only for controlled contracts; sanitize and audit sanitizer outcome |
+
+## Initial Contracts
+
+### `reset-password`
+
+Purpose: send a password reset link without revealing account existence.
+
+Descriptor sketch:
+
+```json
+{
+  "name": "reset-password",
+  "version": "v1",
+  "template": "reset-password",
+  "caller": ["public-auth-flow", "system"],
+  "recipient": { "source": "account-owner" },
+  "variables": {
+    "name": { "type": "string", "source": "user.displayName", "required": true },
+    "link": { "type": "url", "source": "resetToken.url", "required": true }
+  },
+  "replyTo": { "enabled": false },
+  "idempotency": { "key": "reset-password:{tenantId}:{userId}:active-token:v1", "windowSeconds": 900 }
+}
+```
+
+Required edge cases:
+
+- Unknown email returns neutral success and writes a security audit event without provider send.
+- Disabled user suppresses the send unless an explicit account recovery policy allows it.
+- Repeated requests within the duplicate window reuse idempotency and do not create multiple active reset tokens.
+
+### `new-account`
+
+Purpose: notify users that their account or environment is ready.
+
+Required edge cases:
+
+- Environment readiness is incomplete: block send with `VALIDATION_FAILED`.
+- User email is not verified when verification is required: block or route to verification contract.
+- Duplicate onboarding completion event: return `DUPLICATE`.
+
+### `login-alert`
+
+Purpose: notify a user about a security-relevant login event.
+
+Descriptor sketch:
+
+```json
+{
+  "name": "login-alert",
+  "version": "v1",
+  "template": "login-alert",
+  "caller": ["system"],
+  "recipient": { "source": "account-owner" },
+  "variables": {
+    "name": { "type": "string", "source": "user.displayName", "required": true },
+    "ip": { "type": "string", "source": "loginEvent.ip", "required": false },
+    "date": { "type": "date", "source": "loginEvent.occurredAt", "required": true }
+  },
+  "replyTo": { "enabled": false },
+  "idempotency": { "key": "login-alert:{tenantId}:{userId}:{loginEventId}:v1", "windowSeconds": 86400 }
+}
+```
+
+Required edge cases:
+
+- Missing IP or device metadata uses safe fallback text and logs missing metadata.
+- High-volume attempts throttle per account and source IP.
+- User has disabled security emails only if policy allows opt-out; mandatory alerts ignore preference.
+
+### `sales-invoice-send`
+
+Purpose: send an invoice/document notification to the recipient resolved from the document.
+
+Descriptor sketch:
+
+```json
+{
+  "name": "sales-invoice-send",
+  "version": "v1",
+  "template": "invoice",
+  "caller": ["frontend"],
+  "authorization": {
+    "windowAccess": "sales-invoice",
+    "recordAccess": "recordId",
+    "requiresReadableDocument": true
+  },
+  "recipient": { "source": "business-partner-contact", "recordId": "request.recordId" },
+  "variables": {
+    "name": { "type": "string", "source": "businessPartner.name", "required": true },
+    "invoice_number": { "type": "string", "source": "invoice.documentNo", "required": true },
+    "amount": { "type": "currency", "source": "invoice.grandTotal", "required": true },
+    "download_link": { "type": "url", "source": "documentDownload.url", "required": true }
+  },
+  "replyTo": { "enabled": false },
+  "idempotency": { "key": "sales-invoice-send:{tenantId}:{recordId}:v1", "windowSeconds": 3600 }
+}
+```
+
+Required edge cases:
+
+- Caller lacks record access: return `UNAUTHORIZED` and do not reveal record details.
+- Document has no contact email: return `NO_RECIPIENT`.
+- Document status is not allowed for sending: return `VALIDATION_FAILED`.
+
+### `support-custom-email`
+
+Purpose: controlled support/admin email for exceptional workflows.
+
+This is the only permitted custom email shape. It must not be exposed to general users.
+
+Descriptor sketch:
+
+```json
+{
+  "name": "support-custom-email",
+  "version": "v1",
+  "template": "custom",
+  "caller": ["support", "admin"],
+  "authorization": {
+    "roles": ["Support Admin", "System Administrator"],
+    "requiresReason": true
+  },
+  "recipient": {
+    "source": "caller-provided",
+    "validateEmail": true,
+    "domainPolicy": "allow-or-review"
+  },
+  "variables": {
+    "subject": { "type": "string", "source": "request.subject", "required": true },
+    "body": { "type": "html", "source": "request.body", "required": true, "sanitizer": "strict-email-html" }
+  },
+  "replyTo": { "enabled": true, "source": "allowlisted-support-mailbox" },
+  "idempotency": { "key": "support-custom-email:{tenantId}:{recipientHash}:{subjectHash}:v1", "windowSeconds": 600 }
+}
+```
+
+Required edge cases:
+
+- Non-support user executes the command: return `UNAUTHORIZED`.
+- Body contains unsafe HTML: return `VALIDATION_FAILED` or send sanitized output according to policy, and audit the sanitizer result.
+- Missing reason: return `VALIDATION_FAILED`.
+
+## Versioning Rules
+
+- Add a new version when request shape, authorization, recipient source, variable semantics, or throttle behavior changes.
+- Keep old versions only while clients still need them.
+- Deprecate a version by documenting the replacement and adding observability for remaining usage.
+- Do not change a contract in place when it can cause a client to send a different recipient, template, or set of variables.
+
+## Review Checklist
+
+Before merging a contract change:
+
+- Contract entry exists in this guide.
+- At least three edge cases are listed.
+- Backend tests cover authorization, recipient resolution, invalid recipient, idempotency, throttling, provider failure, audit, and Reply-To policy.
+- UI maps all executor statuses used by the contract.
+- Provider secret values are not present in code, docs, tests, fixtures, screenshots, or frontend bundles.
+- Operations runbook and metrics are updated when behavior changes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,8 @@
 | File | Description |
 |------|-------------|
 | [architecture-overview.md](architecture-overview.md) | System architecture: Schema Forge (tooling) + Etendo Go (runtime), data flow, component inventory |
+| [transactional-email-framework.md](transactional-email-framework.md) | Transactional email framework: contract-driven execution, security boundary, lifecycle, edge cases, and agent checklist |
+| [email-contracts.md](email-contracts.md) | Email contracts guide: descriptor schema, request/response contract, recipient policies, versioning, and initial contract sketches |
 | [NEO Headless API Reference](../modules/com.etendoerp.go/docs/neo-headless.md) | Full API reference for the runtime module (NeoServlet, selectors, processes, webhooks) |
 | [NEO Headless Extensibility Guide](neo-headless-extensibility.md) | How to extend/customize NEO Headless: NeoHandler hooks, configuration, patterns |
 | [NEO Entity Naming Investigation](neo-entity-naming-investigation.md) | Investigation report on `push-to-neo` naming, duplicate entities/fields, runtime endpoint resolution, and unification rule |
@@ -87,6 +89,7 @@ General findings about how the Etendo Application Dictionary works. Not window-s
 | File | Description |
 |------|-------------|
 | [ops/cloudfront-alb-routing.md](ops/cloudfront-alb-routing.md) | CloudFront + ALB routing for the SPA, same-origin `/etendo/*` forwarding, and deployment runbook |
+| [ops/transactional-email-security.md](ops/transactional-email-security.md) | Transactional email security runbook: secrets, throttle, suppression, kill switches, incident response, and metrics |
 | [ops/copilot-pr-review.md](ops/copilot-pr-review.md) | Copilot-aligned PR review gate: review instructions, deterministic findings, PR comments, and request-changes behavior |
 | [ops/window-doc-freshness.md](ops/window-doc-freshness.md) | Window-specific doc freshness warning: diff-based CI review for `docs/generated-custom-windows/<window>.md` |
 | [ops/epic-rollup-report.md](ops/epic-rollup-report.md) | Develop-targeted epic rollout report: included feature PRs, prior review findings, and aggregated release-risk summary |

--- a/docs/ops/transactional-email-security.md
+++ b/docs/ops/transactional-email-security.md
@@ -1,0 +1,201 @@
+# Transactional Email Security Runbook
+
+This runbook covers operational controls for transactional email in Etendo Go. Use it during implementation reviews, incidents, provider rotation, and production support.
+
+## Security Boundary
+
+The email provider is a backend-only dependency.
+
+Never place these values in frontend code, generated artifacts, browser-visible JSON, screenshots, or committed fixtures:
+
+- provider endpoint API key
+- provider signing secret
+- sender mailbox credentials
+- internal provider URLs that are not public product endpoints
+- raw message body from support custom sends
+
+Frontend code may call only Etendo Go contract endpoints such as:
+
+```http
+POST /sws/neo/email-contracts/{contractName}/send
+```
+
+## Provider Configuration
+
+Store provider configuration in server-side configuration only.
+
+Recommended variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `ETGO_EMAIL_PROVIDER_BASE_URL` | Provider/API Gateway base URL |
+| `ETGO_EMAIL_PROVIDER_API_KEY` | Secret API key |
+| `ETGO_EMAIL_PROVIDER_TIMEOUT_MS` | Provider call timeout |
+| `ETGO_EMAIL_PROVIDER_ENABLED` | Adapter-level kill switch |
+| `ETGO_EMAIL_SENDER_ADDRESS` | Owned sender identity |
+| `ETGO_EMAIL_SENDER_NAME` | Display sender name |
+
+Configuration must be loaded at runtime by the backend. It must not be exported into Vite variables or any `public/` asset.
+
+## Secret Rotation
+
+Rotate provider credentials when onboarding the service, after suspected exposure, and on the regular security schedule.
+
+Procedure:
+
+1. Create a new provider key in the provider console.
+2. Add the new key to the server secret store.
+3. Deploy/restart the backend so the adapter uses the new key.
+4. Send a test through a low-risk contract in staging.
+5. Send a production smoke test to an internal mailbox.
+6. Revoke the old provider key.
+7. Check logs and metrics for `PROVIDER_FAILED` spikes.
+8. Record the rotation in the operational change log.
+
+If the key was exposed, also enable the provider kill switch until rotation is complete.
+
+## Throttle Policy
+
+Each contract defines its own limits, but operations must support these dimensions:
+
+| Dimension | Example Use |
+|-----------|-------------|
+| User/account | Password reset and login alert bursts |
+| Tenant/client | Tenant-level runaway workflows |
+| Contract/template | Misconfigured contract or frontend loop |
+| Recipient | Mailbox flooding |
+| Domain | Abuse toward one customer domain |
+| Source IP | Public auth endpoints |
+| Record | Duplicate document sends |
+| Global | Provider or reputation safety cap |
+
+Throttle outcomes must be audited and counted as metrics. Do not call the provider after a throttle block.
+
+## Suppression Policy
+
+Suppression blocks delivery before provider submission.
+
+Suppression sources:
+
+- provider bounce or complaint events
+- manual support suppression
+- tenant-level disablement
+- domain-level block
+- legal or compliance block
+
+Suppression records should include recipient or domain, reason, source, actor, timestamp, and optional expiry. Avoid storing full message content.
+
+## Kill Switches
+
+Kill switches are required at multiple levels.
+
+| Switch | Scope | Expected Result |
+|--------|-------|-----------------|
+| Global email | All contracts | Return `KILL_SWITCHED`, audit, no provider call |
+| Provider adapter | All provider calls | Return `KILL_SWITCHED` or `PROVIDER_FAILED` depending on state |
+| Tenant/client | One tenant | Return `KILL_SWITCHED` for that tenant |
+| Contract/template | One contract | Return `KILL_SWITCHED` for that contract |
+| Recipient/domain | One target | Return `SUPPRESSED` |
+
+Emergency response should prefer kill switches over code rollback when the risk is email abuse.
+
+## Abuse Incident Response
+
+Use this procedure when suspicious send volume, recipient complaints, or provider warnings appear.
+
+1. Enable the narrowest effective kill switch.
+2. Check metrics by contract, tenant, recipient, domain, and source IP.
+3. Identify whether traffic came from UI, system job, public auth flow, or support/admin contract.
+4. Review audit events for unauthorized attempts, throttle misses, duplicate keys, and custom HTML usage.
+5. Suppress affected recipients or domains if required.
+6. Rotate provider secrets if exposure is possible.
+7. Patch the contract, throttle, or authorization gap.
+8. Re-enable only after a staging smoke test and production canary.
+9. Document the incident, root cause, affected contracts, and follow-up tickets.
+
+## Bounce and Complaint Handling
+
+When provider events are available:
+
+- map hard bounces to recipient suppression
+- map complaints to recipient or domain suppression depending on policy
+- keep soft bounces as metrics first, then suppress after repeated failures
+- audit provider event IDs and timestamps
+- never expose bounce/complaint internals to general users
+
+## Logging Rules
+
+Structured logs should include:
+
+- `requestId`
+- `auditId`
+- `contract`
+- `version`
+- `tenantId`
+- `userId`
+- `recordId` when applicable
+- `status`
+- `throttleBucket` when blocked
+- `providerStatus` without provider secret values
+- `durationMs`
+
+Do not log:
+
+- provider API keys
+- reset tokens
+- full message body
+- raw HTML from custom sends
+- complete recipient lists for bulk-like support operations
+
+## Metrics and Alerts
+
+Required metrics:
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `sf_email_send_total` | Counter | contract, version, tenant, status |
+| `sf_email_provider_duration_seconds` | Histogram | provider, contract, status |
+| `sf_email_throttle_total` | Counter | contract, tenant, throttle_bucket |
+| `sf_email_duplicate_total` | Counter | contract, tenant |
+| `sf_email_suppression_total` | Counter | contract, tenant, reason |
+| `sf_email_kill_switch_total` | Counter | scope, contract, tenant |
+| `sf_email_provider_error_total` | Counter | provider, contract, error_class |
+
+Recommended alerts:
+
+- provider failure rate above threshold for 5 minutes
+- throttled sends spike for one contract or tenant
+- global send volume exceeds expected baseline
+- suppression or complaint rate spikes
+- kill switch activated
+- custom support contract used outside expected support hours or volume
+
+## Production Smoke Test
+
+Use a controlled internal mailbox and a low-risk contract.
+
+Checklist:
+
+1. Confirm provider key is configured only server-side.
+2. Confirm the contract is enabled for the test tenant.
+3. Send one email with a unique idempotency key.
+4. Repeat the same command and verify `DUPLICATE`.
+5. Trigger a throttle scenario in staging, not production.
+6. Confirm audit, metrics, and logs contain request IDs and no secrets.
+7. Confirm the frontend maps success and duplicate states correctly.
+
+## Custom Contract Review
+
+Before enabling any controlled custom contract:
+
+- role access is limited to support/admin roles
+- every send requires a reason
+- HTML sanitizer rejects scripts, event handlers, unsafe links, and tracking pixels unless explicitly allowed by policy
+- throttle is stricter than fixed transactional contracts
+- body storage is redacted or avoided in audit
+- Reply-To uses allowlisted support mailboxes only
+- metrics distinguish custom sends from fixed-template sends
+
+## Local and CI Expectations
+
+Documentation-only changes should at minimum pass whitespace checks and repository tests that are reasonable for the scope. Behavior changes must also pass the relevant backend/frontend tests and must account for the conditional Jenkins Etendo Go regeneration gate. If Jenkins is flaky, record the failing run and rerun once before treating it as a product failure.

--- a/docs/transactional-email-framework.md
+++ b/docs/transactional-email-framework.md
@@ -1,0 +1,235 @@
+# Transactional Email Framework
+
+This guide defines the working model for transactional email in Etendo Go. Transactional email is a server-side capability for account recovery, account creation, security alerts, document notifications, and controlled support/admin communication.
+
+The system must not become a generic email relay. Every send must be driven by an explicit, versioned email contract with authorization, recipient resolution, throttling, idempotency, audit, and operational controls.
+
+## Non-Negotiable Rules
+
+1. The frontend never calls the email provider endpoint directly.
+2. Provider URLs, API keys, sender identity, and signing secrets stay in server configuration only.
+3. The browser never sends a generic provider payload such as `{ "to": "...", "template": "...", "data": ... }`.
+4. Every email send uses a named email contract and a versioned command schema.
+5. Recipients are resolved server-side from the authenticated context or business record by default.
+6. Caller-provided recipients are allowed only for explicit admin/support contracts with role checks, throttle, reason capture, and audit.
+7. `custom` email is not a public capability. It can exist only as a controlled contract with sanitizer, allowlisted roles, tight throttle, and complete audit.
+8. Reply-To is disabled by default and must never allow tenant-owned sender spoofing. If enabled, it must be validated and recorded.
+9. Each contract must define throttle, idempotency, audit fields, kill switch behavior, and at least three edge cases.
+10. Documentation and tests must move with behavior changes in the same PR.
+
+## Architecture
+
+Transactional email is executed inside Etendo Go, behind the NEO Headless boundary.
+
+```
+React SPA
+  -> POST /sws/neo/email-contracts/{contractName}/send
+  -> JWT auth and role/org context
+  -> EmailContractExecutor
+  -> Contract registry
+  -> Authorization check
+  -> Recipient resolver
+  -> Variable resolver and validation
+  -> Throttle, idempotency, suppression, kill switches
+  -> Audit record
+  -> Provider adapter
+  -> External email provider
+```
+
+Schema Forge documents the contract methodology and generated UI integration points. Etendo Go owns runtime execution, provider configuration, persistence, and enforcement.
+
+## Command Shape
+
+The frontend sends a contract command, not an email provider payload.
+
+```json
+{
+  "recordId": "E2F7A13B...",
+  "version": "v1",
+  "intent": "send-document",
+  "idempotencyKey": "sales-invoice:E2F7A13B:email:v1",
+  "clientReference": "ui-send-modal-2026-05-19T12:30:00Z"
+}
+```
+
+The contract decides:
+
+- which template is used
+- who can execute it
+- how recipients are resolved
+- which variables are allowed
+- how links are generated
+- whether Reply-To is allowed
+- how throttling and idempotency work
+- which audit fields are stored
+- what happens if a kill switch is active
+
+## Contract Lifecycle
+
+| Phase | Owner | Required Output |
+|-------|-------|-----------------|
+| Design | Product/engineering | Contract name, user story, allowed roles, recipient source, variables, edge cases |
+| Implementation | Backend | Contract class/descriptor, executor wiring, provider adapter usage |
+| UI integration | Frontend | Contract command call and mapped user-facing states |
+| QA | QA/security | Authorization, throttling, idempotency, failure, sanitizer, and audit tests |
+| Operations | Support/DevOps | Metrics, logs, runbook entry, kill switch path, alert thresholds |
+| Documentation | Engineering | Contract entry in [email-contracts.md](email-contracts.md) and runbook updates |
+
+## Initial Contract Families
+
+### Password Reset
+
+Purpose: send a recovery link to the account owner.
+
+Expected contract: `reset-password`.
+
+Edge cases:
+
+- The requested user does not exist: return a neutral success response and do not reveal account existence.
+- The user has no active email address: suppress the send, audit the reason, and return a neutral response.
+- Multiple requests arrive in a short window: reuse idempotency and throttle by account, IP, recipient, and tenant.
+- The reset token is expired or already used: the link target handles invalid token state without resending automatically.
+
+### New Account
+
+Purpose: notify a user that an account or environment is ready.
+
+Expected contract: `new-account`.
+
+Edge cases:
+
+- The account exists but is inactive: block the send unless a dedicated activation flow permits it.
+- The environment is not fully provisioned: do not send the email until readiness checks pass.
+- The recipient email belongs to an existing user in another tenant: keep tenant context isolated and avoid cross-tenant data in variables.
+- The invite link is regenerated: invalidate or supersede prior links according to the contract idempotency rule.
+
+### Login Alert
+
+Purpose: notify a user about security-relevant login events.
+
+Expected contract: `login-alert`.
+
+Edge cases:
+
+- Login comes from a known device but a new IP: send only when the contract's risk threshold requires it.
+- Login metadata is incomplete: send with a safe fallback for missing location/device fields.
+- A burst of failed logins happens: throttle per account and IP while preserving audit records for security review.
+- The account is locked after the event: send the lock-related alert contract instead of duplicating generic login alerts.
+
+### Invoice and Document Notification
+
+Purpose: send a business document notification derived from an Etendo record.
+
+Expected contracts: `sales-invoice-send`, `sales-order-send`, or a document-specific contract name.
+
+Edge cases:
+
+- The user cannot access the document: return unauthorized and do not disclose whether the record exists.
+- The document has no valid recipient contact: block the send with a clear UI state and audit `NO_RECIPIENT`.
+- The document is draft or voided: block unless the contract explicitly allows that document status.
+- The same document is sent twice from the UI: idempotency returns a duplicate/sent state without a second provider call.
+
+### Controlled Custom Support Email
+
+Purpose: allow support/admin teams to send controlled HTML or rich text when no fixed template exists.
+
+Expected contract: `support-custom-email`.
+
+Edge cases:
+
+- A general user attempts to execute the contract: return forbidden and audit the attempt.
+- HTML contains scripts, event handlers, external tracking pixels, or unsafe links: sanitize or reject according to the contract.
+- The operator omits a reason: reject the command because support custom sends must be justified.
+- The recipient is outside the allowed domain policy: block or require elevated approval according to the contract.
+
+## Required Runtime Controls
+
+### Authorization
+
+Each contract must verify the authenticated user, role, tenant, organization, and target record before resolving recipients or variables. Frontend button visibility is a UX hint only.
+
+### Recipient Resolution
+
+Contracts should resolve recipients from trusted server-side data:
+
+- account owner email for authentication flows
+- business partner contact email for documents
+- responsible user email for internal alerts
+- allowlisted caller-provided email only for admin/support contracts
+
+### Throttling
+
+Contracts must declare limits at the levels that apply to their abuse profile:
+
+- per user
+- per tenant/client
+- per contract/template
+- per recipient
+- per domain
+- per source IP when available
+- per target record
+- global provider safety limit
+
+### Idempotency
+
+All send commands must require or derive an idempotency key. Duplicate commands must not trigger duplicate provider calls within the configured window.
+
+Recommended key shape:
+
+```
+{contractName}:{tenantId}:{recordOrSubjectId}:{semanticAction}:{version}
+```
+
+### Audit
+
+Audit records must be written for success, blocked, duplicate, throttled, unauthorized, suppressed, sanitizer rejection, provider failure, and kill-switch outcomes. Audit must not store provider secrets or full HTML bodies.
+
+### Kill Switches
+
+The executor must support:
+
+- global email kill switch
+- tenant/client kill switch
+- contract/template kill switch
+- provider adapter disable switch
+- emergency suppressions by recipient or domain
+
+## UI State Contract
+
+Frontend integrations must map executor responses to explicit user states:
+
+| Executor Result | UI Behavior |
+|-----------------|-------------|
+| `SENT` | Show success and persist send status if the flow needs it |
+| `DUPLICATE` | Show already sent or recently sent, not an error |
+| `THROTTLED` | Show wait/retry guidance without provider details |
+| `UNAUTHORIZED` | Hide/disallow action and show a permission message |
+| `NO_RECIPIENT` | Ask the user to fix the business contact data |
+| `SUPPRESSED` | Show that delivery is disabled for the recipient/domain |
+| `KILL_SWITCHED` | Show service unavailable for email sends |
+| `PROVIDER_FAILED` | Show retry/support message with request reference |
+
+## Agent Checklist
+
+When creating or maintaining email sending behavior:
+
+1. Update or create the contract entry in [email-contracts.md](email-contracts.md).
+2. Keep provider endpoint/API key in server config only.
+3. Do not add frontend code that accepts arbitrary `to`, `template`, or raw provider data.
+4. Implement backend authorization before recipient or variable resolution.
+5. Add throttling, idempotency, audit, suppression, and kill switch handling.
+6. Add at least three edge cases for the contract family.
+7. Add tests for unauthorized access, invalid recipient, forbidden sender/reply-to fields, duplicate send, throttle, and provider failure.
+8. Update [ops/transactional-email-security.md](ops/transactional-email-security.md) when operations behavior changes.
+
+## Definition of Done
+
+An email contract is done only when:
+
+- the contract is documented
+- the executor path is covered by automated tests
+- the UI never exposes provider secrets or arbitrary provider payloads
+- audit and metrics are emitted for all terminal outcomes
+- throttle and idempotency behavior are deterministic
+- kill switch behavior is verified
+- security review covers custom HTML if the contract accepts rich text


### PR DESCRIPTION

## Summary
- Add the transactional email framework guide and email contract guide.
- Add the transactional email security/operations runbook.
- Wire the methodology into AGENTS.md, docs index, and architecture/security/reliability/observability/UX docs.

## Validation
- git diff --cached --check
- make test

## Notes
- Docs only. No provider endpoint or API key is committed.
- Native GitHub stacked PRs are disabled for this repository, so this is the first manual stack PR targeting epic/ETP-4060.

Jira: ETP-4061
