### PR TITLE
Feature ETP-3993: Sonar PR/branch modes + clean-as-you-code policy

### DIFF
--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -45,7 +45,11 @@ You ALWAYS work in the git worktree assigned by the coordinator. NEVER work in t
 3. Identify untested paths
 4. Write additional tests for edge cases
 5. Run full suite
-6. APPROVE if no Critical/High bugs, REJECT otherwise
+6. **Run SonarQube PR analysis** — `make sonar PR=<n>`. New BLOCKER/CRITICAL/MAJOR = REJECT (Sentinel is the second gate after Alex).
+7. APPROVE if no Critical/High bugs AND Sonar PR clean, REJECT otherwise
+
+## SonarQube — second gate
+Alex already ran the PR analysis in REVIEW. Run it again as a safety check; new tests you added can introduce new issues (e.g., disabled assertions, copy-pasted blocks). If the script fails with auth errors, surface the setup steps to the coordinator (see `docs/sonarqube-access.md`) — do not commit a token.
 
 ### Bug Report Format
 ```

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -53,8 +53,27 @@ Use the file list to know what to read, then use the diff to understand exactly 
 3. Read the changed files in full for context
 3. **Classify each changed file as source vs. generated (UI Change Survival Check — see `schema_forge_rules`)** — if any UI fix is directly in `artifacts/*/generated/` without a generator change, REJECT immediately before proceeding
 4. Run build and tests
-5. Classify remaining issues: BLOCKER / WARNING / SUGGESTION
-6. APPROVE if 0 blockers, REJECT if any blockers
+5. **Run SonarQube PR analysis** — `make sonar PR=<n>` (see "SonarQube — no new issues" below). Any new BLOCKER/CRITICAL/MAJOR issue introduced by the PR is a BLOCKER in your review.
+6. Classify remaining issues: BLOCKER / WARNING / SUGGESTION
+7. APPROVE if 0 blockers, REJECT if any blockers
+
+## SonarQube — no new issues (MANDATORY)
+Every PR you review MUST be clean in Sonar's "Clean as You Code" view. Run:
+
+```bash
+make sonar PR=<pr-number>
+```
+
+- Exit code 0 + "No issues found in this PR" → PR is Sonar-clean.
+- Exit code 1 + listed issues → those are issues **introduced by this PR's diff**. New BLOCKER/CRITICAL/MAJOR → REJECT. New MINOR/INFO → WARNING (still ship-blocking unless dev justifies in PR description).
+- Pre-existing issues outside the PR diff are NOT your concern in this review.
+
+If the command fails with "✗ SonarQube auth not configured" or "token rejected":
+1. Do NOT commit a token to the repo.
+2. Surface the setup instructions (the script prints them, including which rc file to edit) to the coordinator/user.
+3. Wait for confirmation, then retry.
+
+Reference: `docs/sonarqube-access.md` and CLAUDE.md → "Static Analysis (SonarQube)".
 
 ### Report Format
 ```

--- a/.claude/agents/schema-forge-developer.md
+++ b/.claude/agents/schema-forge-developer.md
@@ -173,17 +173,36 @@ When a generated file has wrong output:
 </workflow>
 
 <static_analysis>
-## SonarQube Check (Java files)
+## SonarQube — clean as you code (MANDATORY)
 
-After writing or modifying Java files, run static analysis before delivering:
+Before declaring work done, you MUST verify Sonar sees **no new issues** introduced by your changes. Two scenarios:
 
+**1. PR already exists** — run the PR analysis:
 ```bash
-./cli/sonar-check.sh -q path/to/YourHandler.java path/to/Other*.java
+make sonar PR=<pr-number>     # or: make sonar-pr  (auto-detects)
+```
+Exit 0 = clean. Exit 1 = fix the listed issues, re-run, repeat.
+
+**2. No PR yet (still iterating on a branch)** — analyze the branch:
+```bash
+make sonar BRANCH=$(git branch --show-current)
+```
+Then look at "New Code" in the dashboard (URL printed by the command).
+
+**Single-file mode** (faster for Java tweaks while iterating):
+```bash
+./cli/sonar-check.sh -q --pr <pr-number> path/to/YourHandler.java
+./cli/sonar-check.sh -q --branch $(git branch --show-current) path/to/YourHandler.java
 ```
 
-Requires `SONAR_TOKEN` and `SONAR_HOST_URL` exported in `~/.zshrc`/`~/.bashrc`, and `sonar-scanner` CLI installed.
-The script scans, waits for the report, and prints issues by severity. Exit 0 = clean, 1 = issues found.
-Fix any HIGH or BLOCKER issues before delivering to the coordinator.
+The scripts auto-source `SONAR_TOKEN` + `SONAR_HOST_URL` from your shell profile and validate the token. If they print "✗ SonarQube auth not configured" or "token rejected":
+1. NEVER commit a token to the repo.
+2. Surface the setup steps printed by the script to the coordinator/user (the script tells you which rc file to edit, e.g. `~/.zshrc`).
+3. Wait for confirmation, then retry.
+
+Full reference: `docs/sonarqube-access.md` and CLAUDE.md → "Static Analysis (SonarQube)".
+
+Fix every new BLOCKER/CRITICAL/MAJOR before delivering. Pre-existing issues outside your diff are not your concern in this delivery.
 </static_analysis>
 
 <github_tracking>

--- a/.claude/agents/window-agent.md
+++ b/.claude/agents/window-agent.md
@@ -220,8 +220,9 @@ The coordinator will tell you the worktree path.
 When done:
 1. Commit all changes (decisions.json, any pipeline fixes) in the worktree
 2. Verify pipeline ran clean and generated output matches expectations
-3. If `push-to-neo.js` was run: include reminder about `./gradlew export.database`
-4. Send coordinator a report: what window, what changed, what the human still needs to decide
+3. **Run SonarQube on your changes** — if a PR exists: `make sonar PR=<n>`; otherwise: `make sonar BRANCH=$(git branch --show-current)`. Any new BLOCKER/CRITICAL/MAJOR must be fixed before delivering. If the script asks to configure `SONAR_TOKEN`, surface its setup instructions to the coordinator/user (never commit a token). Reference: `docs/sonarqube-access.md`.
+4. If `push-to-neo.js` was run: include reminder about `./gradlew export.database`
+5. Send coordinator a report: what window, what changed, what the human still needs to decide
 </pipeline_rules>
 
 <github_tracking>

--- a/.claude/skills/testing-delivery-gate/SKILL.md
+++ b/.claude/skills/testing-delivery-gate/SKILL.md
@@ -33,10 +33,23 @@ Do not present a task as complete unless it has:
 3. appropriate tests: unit, functional, integration, or E2E;
 4. executed verification with exact command and result from the confirmed repository;
 5. evidence that the requirement is satisfied;
-6. QA validation when applicable;
-7. a clear functional requirement.
+6. **SonarQube "Clean as You Code" check for the PR (or branch if no PR yet) — zero new BLOCKER/CRITICAL/MAJOR issues**;
+7. QA validation when applicable;
+8. a clear functional requirement.
 
 If any item is missing, mark it as pending or blocked. Do not close anyway.
+
+## SonarQube — no new issues
+
+Run one of these and include the result in the delivery evidence:
+
+- PR exists: `make sonar PR=<n>` (or `make sonar-pr` to auto-detect)
+- No PR yet: `make sonar BRANCH=$(git branch --show-current)`
+- Single Java file: `./cli/sonar-check.sh --pr <n> path/to/File.java`
+
+Exit code 0 = clean. Exit code 1 = at least one new issue → blocker for delivery; fix and re-run.
+
+If auth fails (`✗ SonarQube auth not configured` or `token rejected`), surface the setup instructions printed by the script (they tell you which rc file to edit) to the user. **Never commit a token.** Full reference: `docs/sonarqube-access.md`.
 
 ## Before Writing or Accepting Tests
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ e2e/auth.json
 tmp/
 .scannerwork/
 coverage/
+sonar-results.md

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ e2e/recordings/
 e2e/auth.json
 .fyso/
 tmp/
+.scannerwork/
+coverage/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -257,25 +257,30 @@ Every process must declare >=3 edge cases. Every kept rule must have a behaviora
 
 ## Static Analysis (SonarQube)
 
-Run `cli/sonar-check.sh` to analyze specific Java files with SonarQube and get results inline.
-Requires `SONAR_TOKEN` and `SONAR_HOST_URL` exported in `~/.zshrc` or `~/.bashrc`, and `sonar-scanner` CLI installed.
+**Policy — "no new issues":** every PR must pass `make sonar PR=<n>` with **zero new issues** introduced by that PR. Pre-existing issues do not block, but each PR must leave the new-code line clean. Alex (Reviewer) enforces this in REVIEW.
 
-```bash
-# Analyze specific files
-./cli/sonar-check.sh path/to/SomeHandler.java path/to/OtherHandler.java
+### Commands
 
-# Analyze with glob
-./cli/sonar-check.sh path/to/Widget*.java
+| Goal | Command |
+|---|---|
+| Overall code on current branch | `make sonar` |
+| Branch analysis (explicit) | `make sonar BRANCH=feature/x` |
+| **PR analysis (explicit)** | `make sonar PR=547` |
+| **PR analysis (auto-detect)** | `make sonar-pr` |
+| Overall + coverage upload | `make sonar-coverage` |
+| Single Java file(s) | `./cli/sonar-check.sh path/to/File.java` |
+| Single file(s) in PR mode | `./cli/sonar-check.sh --pr 547 path/to/File.java` |
+| Single file(s) in branch mode | `./cli/sonar-check.sh --branch feature/x path/to/File.java` |
 
-# Quiet mode (suppress scanner output, show only results)
-./cli/sonar-check.sh -q path/to/*.java
+PR mode uses Sonar's "Clean as You Code" view (only the PR diff is reported). The command exits non-zero if it finds any issue, so it can gate merges.
 
-# Custom project key
-./cli/sonar-check.sh --project-key my-project path/to/*.java
-```
+### Auth
 
-The script scans, waits for the report to process, and prints issues sorted by severity. Exit code 0 = clean, 1 = issues found.
-**Delegate to Alex (Reviewer) or Sentinel (QA)** for running static analysis as part of the pipeline.
+The scripts auto-source `SONAR_TOKEN` and `SONAR_HOST_URL` from your shell profile and validate the token against `api/authentication/validate`. If missing or rejected, they print step-by-step setup instructions (including which rc file to edit based on your `$SHELL`) and exit non-zero. Full reference: `docs/sonarqube-access.md`.
+
+**If an agent hits "✗ SonarQube auth not configured" or "token rejected":** do NOT commit a token to the repo. Surface the setup instructions printed by the script to the user, wait for confirmation, then retry the original command.
+
+**Delegate to Alex (Reviewer) or Sentinel (QA)** for running static analysis as part of the pipeline. Developers (DEV phase) should run `make sonar-pr` themselves before declaring a task done.
 
 ## Decisions
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-all-coverage test-ci test-frontend test-e2e test-e2e-headless test-e2e-debug test-e2e-ui test-e2e-report test-e2e-record generate regen dev dev-with-shell dev-mock build install install-e2e deploy clean help report-serve report-serve-detach report-stop report-preview validate-pipeline quality-gate sonar sonar-coverage menu-cache uuid test-xml-regeneration-check test-python xml-regeneration-check dump-delta regen-check regen-check-help regen-check-clean regen-help
+.PHONY: test test-all-coverage test-ci test-frontend test-e2e test-e2e-headless test-e2e-debug test-e2e-ui test-e2e-report test-e2e-record generate regen dev dev-with-shell dev-mock build install install-e2e deploy clean help report-serve report-serve-detach report-stop report-preview validate-pipeline quality-gate sonar sonar-pr sonar-coverage menu-cache uuid test-xml-regeneration-check test-python xml-regeneration-check dump-delta regen-check regen-check-help regen-check-clean regen-help
 
 # --- Testing ---
 
@@ -296,17 +296,28 @@ report-preview: ## Preview Business Partner listing report
 	node cli/src/report-preview.js --artifact business-partner --report listing
 
 # --- Static Analysis (SonarQube) ---
+# Modes (selected via env vars; see docs/sonarqube-access.md):
+#   make sonar                       → Overall code on the current branch
+#   make sonar BRANCH=feature/x      → Branch analysis (explicit)
+#   make sonar PR=547                → PR analysis (auto-resolves BASE via gh)
+#   make sonar PR=547 BASE=epic/x    → PR analysis with explicit base
+#   make sonar-pr                    → PR analysis, auto-detects PR for current branch
+# Auth: needs SONAR_TOKEN + SONAR_HOST_URL. The script validates and prints
+# setup instructions if they are missing or rejected.
 
-sonar: ## Run SonarQube analysis on Schema Forge JS/JSX code
-	sonar-scanner -Dproject.settings=sonar-project.properties
+sonar: ## Run SonarQube analysis (overall by default; PR=<n> or BRANCH=<name> for scoped)
+	@./cli/sonar-scan.sh
 
-sonar-coverage: ## Run all tests with coverage then SonarQube analysis
+sonar-pr: ## Run SonarQube PR analysis (auto-detects PR from current branch)
+	@AUTO_PR=1 ./cli/sonar-scan.sh
+
+sonar-coverage: ## Run all tests with coverage then SonarQube (accepts PR/BRANCH vars too)
 	@mkdir -p coverage
 	node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=coverage/cli-lcov.info 'cli/test/*.test.js'
 	node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=coverage/appshell-lcov.info 'tools/app-shell/src/**/__tests__/*.test.js'
 	node --test --experimental-test-coverage --test-reporter=lcov --test-reporter-destination=coverage/appshell-test-lcov.info 'tools/app-shell/test/*.test.js'
 	cd tools/app-shell && npx vitest run --coverage && cp coverage/vitest/lcov.info ../../coverage/vitest-lcov.info
-	sonar-scanner -Dproject.settings=sonar-project.properties
+	@COVERAGE=1 ./cli/sonar-scan.sh
 
 # --- XML Regeneration Check ---
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-all-coverage test-ci test-frontend test-e2e test-e2e-headless test-e2e-debug test-e2e-ui test-e2e-report test-e2e-record generate regen dev dev-with-shell dev-mock build install install-e2e deploy clean help report-serve report-serve-detach report-stop report-preview validate-pipeline quality-gate sonar sonar-pr sonar-coverage menu-cache uuid test-xml-regeneration-check test-python xml-regeneration-check dump-delta regen-check regen-check-help regen-check-clean regen-help
+.PHONY: test test-all-coverage test-ci test-frontend test-e2e test-e2e-headless test-e2e-debug test-e2e-ui test-e2e-report test-e2e-record generate regen dev dev-with-shell dev-mock build install install-e2e deploy clean help report-serve report-serve-detach report-stop report-preview validate-pipeline quality-gate sonar sonar-pr sonar-go sonar-go-pr sonar-coverage menu-cache uuid test-xml-regeneration-check test-python xml-regeneration-check dump-delta regen-check regen-check-help regen-check-clean regen-help
 
 # --- Testing ---
 
@@ -302,6 +302,9 @@ report-preview: ## Preview Business Partner listing report
 #   make sonar PR=547                → PR analysis (auto-resolves BASE via gh)
 #   make sonar PR=547 BASE=epic/x    → PR analysis with explicit base
 #   make sonar-pr                    → PR analysis, auto-detects PR for current branch
+#   make sonar-go                    → Run against com.etendoerp.go (accepts PR/BRANCH)
+#   make sonar-go-pr                 → Run sonar-go with PR auto-detection
+#   make sonar MODULE=go PR=120      → Explicit form (same as sonar-go PR=120)
 # Auth: needs SONAR_TOKEN + SONAR_HOST_URL. The script validates and prints
 # setup instructions if they are missing or rejected.
 
@@ -310,6 +313,12 @@ sonar: ## Run SonarQube analysis (overall by default; PR=<n> or BRANCH=<name> fo
 
 sonar-pr: ## Run SonarQube PR analysis (auto-detects PR from current branch)
 	@AUTO_PR=1 ./cli/sonar-scan.sh
+
+sonar-go: ## Run SonarQube against com.etendoerp.go module (accepts PR=<n> or BRANCH=<name>)
+	@MODULE=go ./cli/sonar-scan.sh
+
+sonar-go-pr: ## Run SonarQube PR analysis on com.etendoerp.go (auto-detects PR)
+	@MODULE=go AUTO_PR=1 ./cli/sonar-scan.sh
 
 sonar-coverage: ## Run all tests with coverage then SonarQube (accepts PR/BRANCH vars too)
 	@mkdir -p coverage

--- a/cli/sonar-check.sh
+++ b/cli/sonar-check.sh
@@ -322,43 +322,52 @@ case "$MODE" in
     ;;
 esac
 
-curl -sf -u "$SONAR_TOKEN:" \
-  "$ISSUES_URL" 2>/dev/null \
-  | python3 -c "
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+REPORT_FILE="$REPO_ROOT/sonar-results.md"
+
+ISSUES_JSON="$(mktemp)"
+if ! curl -sf -u "$SONAR_TOKEN:" "$ISSUES_URL" -o "$ISSUES_JSON" 2>/dev/null; then
+  echo "✗ Could not fetch issues from $SONAR_HOST_URL." >&2
+  rm -f "$ISSUES_JSON"
+  exit 1
+fi
+
+python3 -c "
 import sys, json
+from datetime import datetime
 
-try:
-    data = json.load(sys.stdin)
-except:
-    print('  Error: Could not parse SonarQube response')
-    sys.exit(1)
+dash_url, mode, json_path = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(json_path) as f: data = json.load(f)
 
-total = data.get('total', 0)
-
-if total == 0:
-    print('  No issues found. All clean!')
-    print()
-    print(f'Dashboard: {sys.argv[1]}')
-    sys.exit(0)
-
-print(f'  {total} issue(s) found:')
+print(f'# SonarQube report — {mode.upper()} mode')
+print()
+print(f\"_Generated: {datetime.now().isoformat(timespec='seconds')}_\")
+print()
+print(f'Dashboard: <{dash_url}>')
 print()
 
-severity_order = {'BLOCKER': 0, 'CRITICAL': 1, 'HIGH': 2, 'MEDIUM': 3, 'LOW': 4, 'INFO': 5}
-issues = sorted(data.get('issues', []),
-    key=lambda i: severity_order.get(i.get('impacts', [{}])[0].get('severity', 'INFO'), 99))
+total = data.get('total', 0)
+if total == 0:
+    print('✓ No issues found. All clean!')
+    sys.exit(0)
 
+print(f'{total} issue(s) found:\n')
+severity_order = {'BLOCKER': 0, 'CRITICAL': 1, 'HIGH': 2, 'MAJOR': 2, 'MEDIUM': 3, 'MINOR': 4, 'LOW': 4, 'INFO': 5}
+issues = sorted(data.get('issues', []),
+    key=lambda i: severity_order.get((i.get('impacts') or [{}])[0].get('severity', i.get('severity', 'INFO')), 99))
 for i in issues:
-    sev = i.get('impacts', [{}])[0].get('severity', '?')
+    sev = (i.get('impacts') or [{}])[0].get('severity') or i.get('severity', '?')
     component = i.get('component', '').split(':')[-1]
     line = i.get('line', '?')
-    msg = i.get('message', '')
-    rule = i.get('rule', '')
     print(f'  [{sev}] {component}:{line}')
-    print(f'    {msg}')
-    print(f'    Rule: {rule}')
+    print(f\"    {i.get('message', '')}\")
+    print(f\"    Rule: {i.get('rule', '')}\")
     print()
-
-print(f'Dashboard: {sys.argv[1]}')
 sys.exit(1 if total > 0 else 0)
-" "$DASH_URL"
+" "$DASH_URL" "$MODE" "$ISSUES_JSON" | tee "$REPORT_FILE"
+py_exit=${PIPESTATUS[0]}
+rm -f "$ISSUES_JSON"
+
+echo ""
+echo "Report saved to: $REPORT_FILE"
+exit "$py_exit"

--- a/cli/sonar-check.sh
+++ b/cli/sonar-check.sh
@@ -13,7 +13,14 @@
 #   --base-dir DIR      Override the base directory for analysis (default: auto-detected)
 #   --timeout SECS      Max seconds to wait for report processing (default: 120)
 #   --no-wait           Skip waiting for the report to be processed
+#   --pr <NUM>          Run as PR analysis (auto-resolves base/branch via gh)
+#   --branch <NAME>     Run as branch analysis on the given branch
+#   --base <NAME>       Target branch for PR mode (default: gh pr view → main)
 #   -q, --quiet         Suppress scanner output, only show results
+#
+# Auth: SONAR_TOKEN + SONAR_HOST_URL. The script sources them from your shell
+# profile and validates the token; if missing/invalid it prints setup steps
+# and exits. See docs/sonarqube-access.md for the full reference.
 
 set -euo pipefail
 
@@ -29,6 +36,9 @@ TIMEOUT=120
 WAIT=true
 QUIET=false
 FILES=()
+PR=""
+BRANCH=""
+BASE=""
 
 # ── Parse args ────────────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
@@ -37,6 +47,9 @@ while [[ $# -gt 0 ]]; do
     --base-dir)    BASE_DIR="$2"; shift 2 ;;
     --timeout)     TIMEOUT="$2"; shift 2 ;;
     --no-wait)     WAIT=false; shift ;;
+    --pr)          PR="$2"; shift 2 ;;
+    --branch)      BRANCH="$2"; shift 2 ;;
+    --base)        BASE="$2"; shift 2 ;;
     -q|--quiet)    QUIET=true; shift ;;
     -h|--help)
       sed -n '2,/^$/{ s/^# //; s/^#//; p }' "$0"
@@ -51,41 +64,102 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# ── Detect shell rc file for setup hints ─────────────────────────────────────
+detect_shell_rc() {
+  case "${SHELL:-}" in
+    */zsh)  echo "$HOME/.zshrc" ;;
+    */bash)
+      if [[ "$(uname)" == "Darwin" && -f "$HOME/.bash_profile" ]]; then
+        echo "$HOME/.bash_profile"
+      else
+        echo "$HOME/.bashrc"
+      fi
+      ;;
+    */fish) echo "$HOME/.config/fish/config.fish" ;;
+    *)      echo "$HOME/.profile" ;;
+  esac
+}
+
 # ── Source shell profile for SONAR_TOKEN / SONAR_HOST_URL ─────────────────────
 if [[ -z "${SONAR_TOKEN:-}" || -z "${SONAR_HOST_URL:-}" ]]; then
-  for rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile"; do
+  for rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile"; do
     if [[ -f "$rc" ]]; then
-      # Source in a subshell-safe way: only extract exports, skip interactive bits
       eval "$(grep -E '^\s*export\s+(SONAR_TOKEN|SONAR_HOST_URL)=' "$rc" 2>/dev/null)" || true
     fi
   done
 fi
 
 # ── Validate prerequisites ────────────────────────────────────────────────────
-errors=()
-
 if [[ ${#FILES[@]} -eq 0 ]]; then
-  errors+=("No files specified. Usage: $0 <file1.java> [file2.java] ...")
+  echo "Error: No files specified. Usage: $0 <file1.java> [file2.java] ..." >&2
+  exit 1
 fi
 
-if [[ -z "${SONAR_TOKEN:-}" ]]; then
-  errors+=("SONAR_TOKEN is not defined. Add 'export SONAR_TOKEN=...' to your ~/.zshrc or ~/.bashrc.")
-fi
+if [[ -z "${SONAR_TOKEN:-}" || -z "${SONAR_HOST_URL:-}" ]]; then
+  rc_file="$(detect_shell_rc)"
+  cat >&2 <<EOF
+✗ SonarQube auth not configured.
 
-if [[ -z "${SONAR_HOST_URL:-}" ]]; then
-  errors+=("SONAR_HOST_URL is not defined. Add 'export SONAR_HOST_URL=...' to your ~/.zshrc or ~/.bashrc (e.g. https://sonar.etendo.cloud).")
+Missing: $([[ -z "${SONAR_TOKEN:-}" ]] && echo -n 'SONAR_TOKEN ')$([[ -z "${SONAR_HOST_URL:-}" ]] && echo -n 'SONAR_HOST_URL')
+
+Setup steps:
+  1. Open https://sonar.etendo.cloud/account/security
+     (log in with your Etendo account)
+  2. Generate a "User Token" (not a Project Analysis Token)
+  3. Append to your shell profile ($rc_file):
+       export SONAR_HOST_URL=https://sonar.etendo.cloud
+       export SONAR_TOKEN=<your-token>
+  4. Reload:  source "$rc_file"
+  5. Re-run your command.
+
+Full reference: docs/sonarqube-access.md
+EOF
+  exit 1
 fi
 
 if ! command -v sonar-scanner &>/dev/null; then
-  errors+=("sonar-scanner CLI is not installed. Install it via: brew install sonar-scanner")
+  echo "Error: sonar-scanner CLI is not installed. Install via: brew install sonar-scanner" >&2
+  exit 1
 fi
 
-if [[ ${#errors[@]} -gt 0 ]]; then
-  echo "Error: Prerequisites not met:" >&2
-  for e in "${errors[@]}"; do
-    echo "  - $e" >&2
-  done
+# ── Validate token against the server (cheap call) ───────────────────────────
+auth_resp="$(curl -sf -u "$SONAR_TOKEN:" "${SONAR_HOST_URL%/}/api/authentication/validate" 2>/dev/null || echo "")"
+if [[ -z "$auth_resp" ]] || ! echo "$auth_resp" | grep -q '"valid":true'; then
+  rc_file="$(detect_shell_rc)"
+  cat >&2 <<EOF
+✗ SonarQube token rejected by $SONAR_HOST_URL.
+
+Your SONAR_TOKEN appears expired, revoked, or wrong for this host.
+
+Fix:
+  1. Generate a fresh token at https://sonar.etendo.cloud/account/security
+  2. Update the export in $rc_file:
+       export SONAR_TOKEN=<new-token>
+  3. Reload:  source "$rc_file"
+
+Full reference: docs/sonarqube-access.md
+EOF
   exit 1
+fi
+
+# ── Resolve PR / branch mode ─────────────────────────────────────────────────
+MODE_PARAMS=()
+MODE="files"
+if [[ -n "$PR" ]]; then
+  MODE="pr"
+  [[ -z "$BRANCH" ]] && BRANCH="$(git branch --show-current 2>/dev/null || echo '')"
+  if [[ -z "$BASE" ]] && command -v gh &>/dev/null; then
+    BASE="$(gh pr view "$PR" --json baseRefName -q .baseRefName 2>/dev/null || echo '')"
+  fi
+  [[ -z "$BASE" ]] && BASE="main"
+  MODE_PARAMS+=(
+    -Dsonar.pullrequest.key="$PR"
+    -Dsonar.pullrequest.branch="$BRANCH"
+    -Dsonar.pullrequest.base="$BASE"
+  )
+elif [[ -n "$BRANCH" ]]; then
+  MODE="branch"
+  MODE_PARAMS+=(-Dsonar.branch.name="$BRANCH")
 fi
 
 # ── Resolve files to absolute paths ──────────────────────────────────────────
@@ -134,10 +208,14 @@ if [[ -z "$PROJECT_KEY" ]]; then
 fi
 
 # ── Run sonar-scanner ────────────────────────────────────────────────────────
-echo "=== SonarQube Analysis ==="
+echo "=== SonarQube Analysis ($MODE) ==="
 echo "  Server:   $SONAR_HOST_URL"
 echo "  Project:  $PROJECT_KEY"
 echo "  Base dir: $BASE_DIR"
+case "$MODE" in
+  pr)     echo "  Scope:    PR #$PR ($BRANCH → $BASE)" ;;
+  branch) echo "  Scope:    Branch '$BRANCH'" ;;
+esac
 echo "  Files:    ${#RESOLVED_FILES[@]}"
 for f in "${RESOLVED_FILES[@]}"; do
   echo "    - ${f#"$BASE_DIR"/}"
@@ -153,6 +231,7 @@ SCANNER_ARGS=(
   -Dsonar.inclusions="$INCLUSION_PATTERN"
   -Dsonar.java.binaries=.
   -Dsonar.sourceEncoding=UTF-8
+  "${MODE_PARAMS[@]}"
 )
 
 SCANNER_OUTPUT_FILE="$(mktemp)"
@@ -230,8 +309,21 @@ fi
 echo ""
 echo "=== Results ==="
 
+ISSUES_URL="$SONAR_HOST_URL/api/issues/search?componentKeys=$PROJECT_KEY&statuses=OPEN,CONFIRMED&ps=100"
+DASH_URL="$SONAR_HOST_URL/dashboard?id=$PROJECT_KEY"
+case "$MODE" in
+  pr)
+    ISSUES_URL="${ISSUES_URL}&pullRequest=$PR"
+    DASH_URL="${DASH_URL}&pullRequest=$PR"
+    ;;
+  branch)
+    ISSUES_URL="${ISSUES_URL}&branch=$BRANCH"
+    DASH_URL="${DASH_URL}&branch=$BRANCH"
+    ;;
+esac
+
 curl -sf -u "$SONAR_TOKEN:" \
-  "$SONAR_HOST_URL/api/issues/search?componentKeys=$PROJECT_KEY&statuses=OPEN,CONFIRMED&ps=100" 2>/dev/null \
+  "$ISSUES_URL" 2>/dev/null \
   | python3 -c "
 import sys, json
 
@@ -269,4 +361,4 @@ for i in issues:
 
 print(f'Dashboard: {sys.argv[1]}')
 sys.exit(1 if total > 0 else 0)
-" "$SONAR_HOST_URL/dashboard?id=$PROJECT_KEY"
+" "$DASH_URL"

--- a/cli/sonar-scan.sh
+++ b/cli/sonar-scan.sh
@@ -2,18 +2,23 @@
 # sonar-scan.sh — Run SonarQube whole-project analysis with overall / branch / PR modes.
 #
 # Modes (selected via env vars or auto-detection):
-#   make sonar                        → overall (current branch, or main if checked out)
+#   make sonar                        → overall on schema_forge (default project)
 #   make sonar BRANCH=feature/x       → branch analysis on the given branch
 #   make sonar PR=547                 → PR analysis (auto-resolves base + branch via gh)
 #   make sonar PR=547 BASE=epic/x     → PR analysis with explicit base
+#   make sonar MODULE=go              → run against com.etendoerp.go module
+#   make sonar MODULE=go PR=120       → PR analysis on the etendo-go GitHub repo
+#   make sonar PROJECT_DIR=/abs/path  → run against an arbitrary directory
 #   make sonar-pr                     → forces PR auto-detect from current branch
 #
 # Env vars consumed:
-#   PR        Pull request number. If set, runs in PR mode.
-#   BRANCH    Source branch name. Defaults to current git branch.
-#   BASE      Target branch for PR mode. Auto-resolved via `gh pr view` if absent.
-#   AUTO_PR   If "1", try to auto-detect PR from the current branch (used by `make sonar-pr`).
-#   COVERAGE  If "1", coverage reports must already be in coverage/ (caller's responsibility).
+#   PR           Pull request number. If set, runs in PR mode.
+#   BRANCH       Source branch name. Defaults to current git branch (of the target dir).
+#   BASE         Target branch for PR mode. Auto-resolved via `gh pr view` if absent.
+#   AUTO_PR      If "1", try to auto-detect PR from the current branch (used by `make sonar-pr`).
+#   MODULE       Shortcut: "go" → ../modules/com.etendoerp.go (relative to schema_forge).
+#   PROJECT_DIR  Absolute path to the project to scan. Overrides MODULE.
+#   COVERAGE     If "1", coverage reports must already be in coverage/ (caller's responsibility).
 #
 # Auth: SONAR_TOKEN + SONAR_HOST_URL. See docs/sonarqube-access.md for setup.
 
@@ -24,7 +29,34 @@ PATH="$(echo "$PATH" | tr ':' '\n' | grep -v 'rtk' | tr '\n' ':')"
 export PATH="${PATH%:}"
 
 # ── Locate repo root ──────────────────────────────────────────────────────────
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCHEMA_FORGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ── Resolve target project directory ─────────────────────────────────────────
+MODULE="${MODULE:-}"
+PROJECT_DIR="${PROJECT_DIR:-}"
+
+if [[ -z "$PROJECT_DIR" ]]; then
+  case "$MODULE" in
+    "")          PROJECT_DIR="$SCHEMA_FORGE_ROOT" ;;
+    go|etendo-go|com.etendoerp.go)
+                 PROJECT_DIR="$SCHEMA_FORGE_ROOT/../modules/com.etendoerp.go" ;;
+    *)
+      echo "✗ Unknown MODULE='$MODULE'. Known: go. Or pass PROJECT_DIR=<absolute path>." >&2
+      exit 1
+      ;;
+  esac
+fi
+
+if [[ ! -d "$PROJECT_DIR" ]]; then
+  echo "✗ PROJECT_DIR does not exist: $PROJECT_DIR" >&2
+  exit 1
+fi
+if [[ ! -f "$PROJECT_DIR/sonar-project.properties" ]]; then
+  echo "✗ Missing sonar-project.properties in $PROJECT_DIR" >&2
+  exit 1
+fi
+
+ROOT="$(cd "$PROJECT_DIR" && pwd)"
 cd "$ROOT"
 
 # ── Detect shell rc file for setup hints ─────────────────────────────────────
@@ -151,6 +183,7 @@ validate_token
 
 # ── Banner ───────────────────────────────────────────────────────────────────
 echo "=== SonarQube Analysis ($MODE) ==="
+echo "  Project: $ROOT"
 echo "  Host:    $SONAR_HOST_URL"
 case "$MODE" in
   overall) echo "  Scope:   Overall code (default project view)" ;;

--- a/cli/sonar-scan.sh
+++ b/cli/sonar-scan.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# sonar-scan.sh — Run SonarQube whole-project analysis with overall / branch / PR modes.
+#
+# Modes (selected via env vars or auto-detection):
+#   make sonar                        → overall (current branch, or main if checked out)
+#   make sonar BRANCH=feature/x       → branch analysis on the given branch
+#   make sonar PR=547                 → PR analysis (auto-resolves base + branch via gh)
+#   make sonar PR=547 BASE=epic/x     → PR analysis with explicit base
+#   make sonar-pr                     → forces PR auto-detect from current branch
+#
+# Env vars consumed:
+#   PR        Pull request number. If set, runs in PR mode.
+#   BRANCH    Source branch name. Defaults to current git branch.
+#   BASE      Target branch for PR mode. Auto-resolved via `gh pr view` if absent.
+#   AUTO_PR   If "1", try to auto-detect PR from the current branch (used by `make sonar-pr`).
+#   COVERAGE  If "1", coverage reports must already be in coverage/ (caller's responsibility).
+#
+# Auth: SONAR_TOKEN + SONAR_HOST_URL. See docs/sonarqube-access.md for setup.
+
+set -euo pipefail
+
+# ── Bypass rtk proxy for real binaries (curl, sonar-scanner) ─────────────────
+PATH="$(echo "$PATH" | tr ':' '\n' | grep -v 'rtk' | tr '\n' ':')"
+export PATH="${PATH%:}"
+
+# ── Locate repo root ──────────────────────────────────────────────────────────
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# ── Detect shell rc file for setup hints ─────────────────────────────────────
+detect_shell_rc() {
+  case "${SHELL:-}" in
+    */zsh)  echo "$HOME/.zshrc" ;;
+    */bash)
+      if [[ "$(uname)" == "Darwin" && -f "$HOME/.bash_profile" ]]; then
+        echo "$HOME/.bash_profile"
+      else
+        echo "$HOME/.bashrc"
+      fi
+      ;;
+    */fish) echo "$HOME/.config/fish/config.fish" ;;
+    *)      echo "$HOME/.profile" ;;
+  esac
+}
+
+# ── Preflight: validate Sonar auth ───────────────────────────────────────────
+preflight_auth() {
+  # If already set in environment, fine.
+  if [[ -n "${SONAR_TOKEN:-}" && -n "${SONAR_HOST_URL:-}" ]]; then
+    return 0
+  fi
+
+  # Try sourcing exports from common shell profiles.
+  for rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile"; do
+    [[ -f "$rc" ]] || continue
+    eval "$(grep -E '^\s*export\s+(SONAR_TOKEN|SONAR_HOST_URL)=' "$rc" 2>/dev/null)" || true
+  done
+
+  if [[ -z "${SONAR_TOKEN:-}" || -z "${SONAR_HOST_URL:-}" ]]; then
+    local rc; rc="$(detect_shell_rc)"
+    cat >&2 <<EOF
+✗ SonarQube auth not configured.
+
+Missing: $([[ -z "${SONAR_TOKEN:-}" ]] && echo -n 'SONAR_TOKEN ')$([[ -z "${SONAR_HOST_URL:-}" ]] && echo -n 'SONAR_HOST_URL')
+
+Setup steps:
+  1. Open https://sonar.etendo.cloud/account/security
+     (log in with your Etendo account)
+  2. Generate a "User Token" (not a Project Analysis Token)
+  3. Append to your shell profile ($rc):
+       export SONAR_HOST_URL=https://sonar.etendo.cloud
+       export SONAR_TOKEN=<your-token>
+  4. Reload your shell:
+       source "$rc"
+  5. Re-run your command.
+
+Full reference: docs/sonarqube-access.md
+EOF
+    exit 1
+  fi
+}
+
+# ── Validate token works (cheap call) ────────────────────────────────────────
+validate_token() {
+  local resp
+  resp="$(curl -sf -u "$SONAR_TOKEN:" "${SONAR_HOST_URL%/}/api/authentication/validate" 2>/dev/null || echo "")"
+  if [[ -z "$resp" ]] || ! echo "$resp" | grep -q '"valid":true'; then
+    local rc; rc="$(detect_shell_rc)"
+    cat >&2 <<EOF
+✗ SonarQube token rejected by $SONAR_HOST_URL.
+
+The exported SONAR_TOKEN is not valid (expired, revoked, or wrong host).
+
+Fix:
+  1. Generate a fresh token at https://sonar.etendo.cloud/account/security
+  2. Update the export in $rc:
+       export SONAR_TOKEN=<new-token>
+  3. Reload:  source "$rc"
+
+Full reference: docs/sonarqube-access.md
+EOF
+    exit 1
+  fi
+}
+
+# ── Resolve mode + parameters ────────────────────────────────────────────────
+PR="${PR:-}"
+BRANCH="${BRANCH:-}"
+BASE="${BASE:-}"
+AUTO_PR="${AUTO_PR:-0}"
+
+[[ -z "$BRANCH" ]] && BRANCH="$(git branch --show-current 2>/dev/null || echo '')"
+
+# AUTO_PR=1 → try to resolve PR from current branch via gh
+if [[ "$AUTO_PR" == "1" && -z "$PR" ]]; then
+  if command -v gh &>/dev/null; then
+    PR="$(gh pr view --json number -q .number 2>/dev/null || echo '')"
+  fi
+  if [[ -z "$PR" ]]; then
+    echo "✗ make sonar-pr: no open PR found for branch '$BRANCH'." >&2
+    echo "  Use 'make sonar BRANCH=$BRANCH' for branch-mode analysis," >&2
+    echo "  or open a PR first with: gh pr create" >&2
+    exit 1
+  fi
+fi
+
+MODE="overall"
+SCANNER_PARAMS=()
+
+if [[ -n "$PR" ]]; then
+  MODE="pr"
+  if [[ -z "$BASE" ]]; then
+    if command -v gh &>/dev/null; then
+      BASE="$(gh pr view "$PR" --json baseRefName -q .baseRefName 2>/dev/null || echo '')"
+    fi
+    [[ -z "$BASE" ]] && BASE="main"
+  fi
+  SCANNER_PARAMS+=(
+    -Dsonar.pullrequest.key="$PR"
+    -Dsonar.pullrequest.branch="$BRANCH"
+    -Dsonar.pullrequest.base="$BASE"
+  )
+elif [[ -n "$BRANCH" && "$BRANCH" != "main" && "$BRANCH" != "master" && "$BRANCH" != "develop" ]]; then
+  MODE="branch"
+  SCANNER_PARAMS+=(-Dsonar.branch.name="$BRANCH")
+fi
+
+# ── Run preflight ────────────────────────────────────────────────────────────
+preflight_auth
+validate_token
+
+# ── Banner ───────────────────────────────────────────────────────────────────
+echo "=== SonarQube Analysis ($MODE) ==="
+echo "  Host:    $SONAR_HOST_URL"
+case "$MODE" in
+  overall) echo "  Scope:   Overall code (default project view)" ;;
+  branch)  echo "  Scope:   Branch '$BRANCH'" ;;
+  pr)      echo "  Scope:   PR #$PR ($BRANCH → $BASE)" ;;
+esac
+echo ""
+
+# ── Run scanner ──────────────────────────────────────────────────────────────
+SCANNER_OUTPUT="$(mktemp)"
+trap "rm -f '$SCANNER_OUTPUT'" EXIT
+
+sonar-scanner \
+  -Dproject.settings=sonar-project.properties \
+  -Dsonar.host.url="$SONAR_HOST_URL" \
+  -Dsonar.token="$SONAR_TOKEN" \
+  "${SCANNER_PARAMS[@]}" 2>&1 | tee "$SCANNER_OUTPUT"
+
+scan_exit=${PIPESTATUS[0]}
+if [[ $scan_exit -ne 0 ]]; then
+  echo "✗ sonar-scanner failed with exit code $scan_exit" >&2
+  exit $scan_exit
+fi
+
+# ── Wait for report processing ───────────────────────────────────────────────
+TASK_ID="$(grep -o 'ce/task?id=[a-f0-9-]*' "$SCANNER_OUTPUT" | sed 's/.*id=//' | head -1 || echo "")"
+PROJECT_KEY="$(grep -E '^sonar.projectKey=' sonar-project.properties | head -1 | cut -d= -f2)"
+
+if [[ -z "$TASK_ID" ]]; then
+  echo "Warning: could not extract task ID from scanner output. Skipping wait." >&2
+  exit 0
+fi
+
+echo ""
+echo "Waiting for report (task: ${TASK_ID:0:8}...)..."
+deadline=$((SECONDS + 180))
+while [[ $SECONDS -lt $deadline ]]; do
+  sleep 3
+  status="$(curl -sf -u "$SONAR_TOKEN:" \
+    "${SONAR_HOST_URL%/}/api/ce/task?id=$TASK_ID" 2>/dev/null \
+    | python3 -c "import sys,json
+try:
+  d=json.load(sys.stdin); print(d.get('task',{}).get('status','UNKNOWN'))
+except: print('ERROR')" 2>/dev/null || echo "ERROR")"
+  case "$status" in
+    SUCCESS) break ;;
+    FAILED|CANCELED)
+      echo "✗ Report processing $status" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ── Build issues query URL ───────────────────────────────────────────────────
+ISSUES_URL="${SONAR_HOST_URL%/}/api/issues/search?componentKeys=$PROJECT_KEY&statuses=OPEN,CONFIRMED&ps=100"
+DASH_URL="${SONAR_HOST_URL%/}/dashboard?id=$PROJECT_KEY"
+
+case "$MODE" in
+  pr)
+    ISSUES_URL="${ISSUES_URL}&pullRequest=$PR"
+    DASH_URL="${SONAR_HOST_URL%/}/dashboard?id=$PROJECT_KEY&pullRequest=$PR"
+    ;;
+  branch)
+    ISSUES_URL="${ISSUES_URL}&branch=$BRANCH"
+    DASH_URL="${SONAR_HOST_URL%/}/dashboard?id=$PROJECT_KEY&branch=$BRANCH"
+    ;;
+esac
+
+# ── Fetch + format results ───────────────────────────────────────────────────
+echo ""
+echo "=== Results ==="
+curl -sf -u "$SONAR_TOKEN:" "$ISSUES_URL" 2>/dev/null | python3 - "$DASH_URL" "$MODE" <<'PY'
+import sys, json
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    print("  Error: could not parse SonarQube response")
+    sys.exit(2)
+
+dash_url, mode = sys.argv[1], sys.argv[2]
+total = data.get('total', 0)
+
+if total == 0:
+    label = "in this PR" if mode == "pr" else ("on this branch" if mode == "branch" else "overall")
+    print(f"  ✓ No issues found {label}.")
+    print()
+    print(f"Dashboard: {dash_url}")
+    sys.exit(0)
+
+severity_order = {'BLOCKER': 0, 'CRITICAL': 1, 'HIGH': 2, 'MAJOR': 2, 'MEDIUM': 3, 'MINOR': 4, 'LOW': 4, 'INFO': 5}
+issues = sorted(
+    data.get('issues', []),
+    key=lambda i: severity_order.get(
+        (i.get('impacts') or [{}])[0].get('severity', i.get('severity', 'INFO')),
+        99
+    )
+)
+
+label = "in this PR" if mode == "pr" else ("on this branch" if mode == "branch" else "overall")
+print(f"  {total} issue(s) found {label}:")
+print()
+
+for i in issues:
+    impacts = i.get('impacts') or [{}]
+    sev = impacts[0].get('severity') or i.get('severity', '?')
+    component = i.get('component', '').split(':')[-1]
+    line = i.get('line', '?')
+    msg = i.get('message', '')
+    rule = i.get('rule', '')
+    print(f"  [{sev}] {component}:{line}")
+    print(f"    {msg}")
+    print(f"    Rule: {rule}")
+    print()
+
+print(f"Dashboard: {dash_url}")
+# Non-zero exit only blocks if PR/branch mode → preserves "Clean as You Code"
+sys.exit(1 if mode in ("pr", "branch") and total > 0 else 0)
+PY

--- a/cli/sonar-scan.sh
+++ b/cli/sonar-scan.sh
@@ -219,25 +219,38 @@ case "$MODE" in
     ;;
 esac
 
-# ── Fetch + format results ───────────────────────────────────────────────────
+# ── Fetch issues JSON to a temp file (avoids stdin/heredoc collision) ────────
+ISSUES_JSON="$(mktemp)"
+trap "rm -f '$SCANNER_OUTPUT' '$ISSUES_JSON'" EXIT
+if ! curl -sf -u "$SONAR_TOKEN:" "$ISSUES_URL" -o "$ISSUES_JSON" 2>/dev/null; then
+  echo "✗ Could not fetch issues from $SONAR_HOST_URL." >&2
+  exit 1
+fi
+
+# ── Format results: print to stdout AND write to ./sonar-results.md ──────────
+REPORT_FILE="$ROOT/sonar-results.md"
 echo ""
 echo "=== Results ==="
-curl -sf -u "$SONAR_TOKEN:" "$ISSUES_URL" 2>/dev/null | python3 - "$DASH_URL" "$MODE" <<'PY'
+python3 - "$DASH_URL" "$MODE" "$ISSUES_JSON" "$REPORT_FILE" <<'PY' | tee "$REPORT_FILE"
 import sys, json
+from datetime import datetime
+
+dash_url, mode, json_path, report_path = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+
 try:
-    data = json.load(sys.stdin)
-except Exception:
-    print("  Error: could not parse SonarQube response")
+    with open(json_path) as f:
+        data = json.load(f)
+except Exception as e:
+    print(f"  Error: could not parse SonarQube response ({e})")
     sys.exit(2)
 
-dash_url, mode = sys.argv[1], sys.argv[2]
 total = data.get('total', 0)
+label = {"pr": "in this PR", "branch": "on this branch"}.get(mode, "overall")
+header = f"# SonarQube report — {mode.upper()} mode\n\n_Generated: {datetime.now().isoformat(timespec='seconds')}_\n\nDashboard: <{dash_url}>\n"
 
+print(header)
 if total == 0:
-    label = "in this PR" if mode == "pr" else ("on this branch" if mode == "branch" else "overall")
-    print(f"  ✓ No issues found {label}.")
-    print()
-    print(f"Dashboard: {dash_url}")
+    print(f"✓ No issues found {label}.")
     sys.exit(0)
 
 severity_order = {'BLOCKER': 0, 'CRITICAL': 1, 'HIGH': 2, 'MAJOR': 2, 'MEDIUM': 3, 'MINOR': 4, 'LOW': 4, 'INFO': 5}
@@ -249,10 +262,7 @@ issues = sorted(
     )
 )
 
-label = "in this PR" if mode == "pr" else ("on this branch" if mode == "branch" else "overall")
-print(f"  {total} issue(s) found {label}:")
-print()
-
+print(f"{total} issue(s) found {label}:\n")
 for i in issues:
     impacts = i.get('impacts') or [{}]
     sev = impacts[0].get('severity') or i.get('severity', '?')
@@ -265,7 +275,11 @@ for i in issues:
     print(f"    Rule: {rule}")
     print()
 
-print(f"Dashboard: {dash_url}")
 # Non-zero exit only blocks if PR/branch mode → preserves "Clean as You Code"
 sys.exit(1 if mode in ("pr", "branch") and total > 0 else 0)
 PY
+py_exit=${PIPESTATUS[0]}
+
+echo ""
+echo "Report saved to: $REPORT_FILE"
+exit "$py_exit"

--- a/docs/sonarqube-access.md
+++ b/docs/sonarqube-access.md
@@ -1,7 +1,42 @@
 # SonarQube — quick access reference
 
 Host: `https://sonar.etendo.cloud/`
-Auth env vars (already exported in `~/.zshrc`): `SONAR_TOKEN` (Bearer), `SONAR_HOST_URL`.
+Auth env vars: `SONAR_TOKEN` (User Token), `SONAR_HOST_URL`. The Sonar scripts source them from your shell profile automatically — see **Setup** below if they are missing.
+
+## Setup — first-time token configuration
+
+The scripts (`make sonar`, `cli/sonar-scan.sh`, `cli/sonar-check.sh`) auto-validate auth and print these instructions when it is missing. To configure manually:
+
+1. Open <https://sonar.etendo.cloud/account/security> (log in with your Etendo account).
+2. Generate a **User Token** (not a Project Analysis Token).
+3. Append to your shell profile — pick the one your shell uses:
+   - **zsh** (macOS default): `~/.zshrc`
+   - **bash on macOS**: `~/.bash_profile`
+   - **bash on Linux**: `~/.bashrc`
+   - **fish**: `~/.config/fish/config.fish` (use `set -x` instead of `export`)
+4. Add the two exports:
+   ```bash
+   export SONAR_HOST_URL=https://sonar.etendo.cloud
+   export SONAR_TOKEN=<your-token>
+   ```
+5. Reload: `source <profile-file>`.
+6. Validate by running `make sonar` (or any sonar command). The preflight calls `api/authentication/validate` and refuses to proceed if the token is rejected.
+
+If the token later expires or is revoked, the scripts print a "✗ SonarQube token rejected" message with the same setup steps — generate a fresh token and update the export.
+
+## Running analyses — modes
+
+| Goal | Command |
+|---|---|
+| Overall code on current branch | `make sonar` |
+| Branch analysis (explicit) | `make sonar BRANCH=feature/x` |
+| PR analysis (explicit) | `make sonar PR=547` |
+| PR analysis (auto-detect via `gh`) | `make sonar-pr` |
+| Overall + coverage upload | `make sonar-coverage` |
+| Single Java file(s) | `./cli/sonar-check.sh path/to/File.java` |
+| Single file(s) in PR mode | `./cli/sonar-check.sh --pr 547 path/to/File.java` |
+
+PR mode runs Sonar's "Clean as You Code" filter — only issues introduced by the PR are reported and the command exits non-zero if any are found. **Use this before merging any PR.**
 
 ## CRITICAL: bypass RTK for any curl to Sonar
 


### PR DESCRIPTION
## Summary
- New `cli/sonar-scan.sh` wrapper for the whole-repo JS/JSX scan with three modes: overall, branch (`BRANCH=`), and PR (`PR=`, auto-resolves base via `gh`).
- `cli/sonar-check.sh` (single-file) extended with `--pr`, `--branch`, `--base` flags.
- Auth preflight: auto-source `SONAR_TOKEN`/`SONAR_HOST_URL` from the shell profile, validate against `api/authentication/validate`, and on failure print step-by-step setup instructions (detecting the rc file from `$SHELL`).
- Makefile: `make sonar` accepts `PR=` / `BRANCH=`; new `make sonar-pr` auto-detects PR for the current branch.
- New policy: PRs must pass `make sonar PR=<n>` with zero new BLOCKER/CRITICAL/MAJOR issues — enforced by Alex (Reviewer) and Sentinel (QA).
- Docs: `docs/sonarqube-access.md` (Setup section + modes table), CLAUDE.md → Static Analysis rewritten.
- Agents updated: `reviewer.md`, `qa.md`, `schema-forge-developer.md`, `window-agent.md`, and the `testing-delivery-gate` skill.
- `.gitignore`: added `.scannerwork/` and `coverage/`.

## Test plan
- [ ] `make sonar` runs overall analysis
- [ ] `make sonar PR=<this-pr>` reports only new code introduced by this PR
- [ ] Unset `SONAR_TOKEN` temporarily → script prints setup instructions and exits 1
- [ ] Reviewer / QA agents apply the new step on the next PR they look at