### PR TITLE
Feature ETP-4073: Define Observability API

### DIFF
--- a/tools/app-shell/src/lib/__tests__/observability.test.js
+++ b/tools/app-shell/src/lib/__tests__/observability.test.js
@@ -1,0 +1,157 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createObservability } from '../observability.js';
+
+function createProvider(name, calls) {
+  return {
+    name,
+    async init(payload) {
+      calls.push([name, 'init', payload]);
+    },
+    async track(eventName, properties, meta) {
+      calls.push([name, 'track', eventName, properties, meta]);
+    },
+    async page(path, properties, meta) {
+      calls.push([name, 'page', path, properties, meta]);
+    },
+    async identify(userId, traits, meta) {
+      calls.push([name, 'identify', userId, traits, meta]);
+    },
+    async captureException(error, details, meta) {
+      calls.push([name, 'captureException', error.message, details, meta]);
+    },
+    async setContext(context) {
+      calls.push([name, 'setContext', context]);
+    },
+    async flush(meta) {
+      calls.push([name, 'flush', meta]);
+    },
+  };
+}
+
+describe('observability core', () => {
+  it('works as a no-op when no providers are enabled', async () => {
+    const client = createObservability({ logger: { warn() {} } });
+
+    await client.initObservability();
+    await client.track('event');
+    await client.page('/dashboard');
+    await client.identify('user-1');
+    await client.captureException(new Error('boom'));
+    await client.flush();
+
+    assert.deepEqual(client.getProviders(), []);
+  });
+
+  it('dispatches supported calls to each enabled provider', async () => {
+    const calls = [];
+    const client = createObservability({ logger: { warn() {} } });
+
+    await client.initObservability({
+      context: { app: 'app-shell' },
+      providers: [
+        createProvider('first', calls),
+        { ...createProvider('disabled', calls), enabled: false },
+        createProvider('second', calls),
+      ],
+    });
+    await client.track('app_started', { mockMode: false });
+    await client.page('/dashboard', { route: '/dashboard' });
+    await client.identify('user-1', { role: 'admin' });
+    await client.captureException(new Error('boom'), { handled: true });
+    await client.flush();
+
+    assert.deepEqual(
+      calls.map(call => `${call[0]}:${call[1]}`),
+      [
+        'first:init',
+        'second:init',
+        'first:track',
+        'second:track',
+        'first:page',
+        'second:page',
+        'first:identify',
+        'second:identify',
+        'first:captureException',
+        'second:captureException',
+        'first:flush',
+        'second:flush',
+      ]
+    );
+    assert.deepEqual(calls[2][4].context, { app: 'app-shell' });
+  });
+
+  it('merges context and notifies providers when context changes', async () => {
+    const calls = [];
+    const client = createObservability({ logger: { warn() {} } });
+
+    await client.initObservability({
+      context: { app: 'app-shell', environment: 'development' },
+      providers: [createProvider('provider', calls)],
+    });
+    await client.setContext({ environment: 'staging', locale: 'en_US' });
+    await client.track('event');
+
+    assert.deepEqual(calls[1], [
+      'provider',
+      'setContext',
+      { app: 'app-shell', environment: 'staging', locale: 'en_US' },
+    ]);
+    assert.deepEqual(calls[2][4].context, {
+      app: 'app-shell',
+      environment: 'staging',
+      locale: 'en_US',
+    });
+  });
+
+  it('continues dispatching when one provider throws', async () => {
+    const calls = [];
+    const warnings = [];
+    const client = createObservability({
+      logger: {
+        warn(message, error) {
+          warnings.push([message, error.message]);
+        },
+      },
+    });
+
+    await client.initObservability({
+      providers: [
+        {
+          name: 'broken',
+          track() {
+            throw new Error('provider down');
+          },
+        },
+        createProvider('healthy', calls),
+      ],
+    });
+    await client.track('event');
+
+    assert.deepEqual(calls.map(call => `${call[0]}:${call[1]}`), ['healthy:init', 'healthy:track']);
+    assert.deepEqual(warnings, [
+      ['[observability] broken.track failed', 'provider down'],
+    ]);
+  });
+
+  it('awaits async flush handlers', async () => {
+    const calls = [];
+    const client = createObservability({ logger: { warn() {} } });
+
+    await client.initObservability({
+      providers: [
+        {
+          name: 'async-provider',
+          async flush() {
+            await new Promise(resolve => setTimeout(resolve, 5));
+            calls.push('flushed');
+          },
+        },
+      ],
+    });
+    await client.flush();
+
+    assert.deepEqual(calls, ['flushed']);
+  });
+});

--- a/tools/app-shell/src/lib/observability.js
+++ b/tools/app-shell/src/lib/observability.js
@@ -1,0 +1,13 @@
+import { createObservability } from './observability/core.js';
+
+export { createObservability } from './observability/core.js';
+
+const observability = createObservability();
+
+export const initObservability = observability.initObservability;
+export const track = observability.track;
+export const page = observability.page;
+export const identify = observability.identify;
+export const captureException = observability.captureException;
+export const flush = observability.flush;
+export const setContext = observability.setContext;

--- a/tools/app-shell/src/lib/observability/core.js
+++ b/tools/app-shell/src/lib/observability/core.js
@@ -1,0 +1,116 @@
+function isProviderEnabled(provider) {
+  return provider && provider.enabled !== false;
+}
+
+function getProviderName(provider) {
+  return provider?.name || 'unknown-provider';
+}
+
+function warn(logger, message, error) {
+  if (typeof logger?.warn === 'function') {
+    logger.warn(message, error);
+  }
+}
+
+export function createObservability(options = {}) {
+  let logger = options.logger ?? console;
+  let providers = [];
+  let context = {};
+  let initialized = false;
+
+  async function callProvider(provider, methodName, args) {
+    const method = provider?.[methodName];
+    if (typeof method !== 'function') return undefined;
+
+    try {
+      return await method.apply(provider, args);
+    } catch (error) {
+      warn(
+        logger,
+        `[observability] ${getProviderName(provider)}.${methodName} failed`,
+        error
+      );
+      return undefined;
+    }
+  }
+
+  function getContext() {
+    return { ...context };
+  }
+
+  return {
+    async initObservability(config = {}) {
+      logger = config.logger ?? logger;
+      providers = (config.providers ?? []).filter(isProviderEnabled);
+      context = { ...(config.context ?? {}) };
+      initialized = true;
+
+      await Promise.all(
+        providers.map(provider => callProvider(provider, 'init', [{ context: getContext() }]))
+      );
+    },
+
+    async track(eventName, properties = {}) {
+      if (!initialized || !eventName) return;
+
+      await Promise.all(
+        providers.map(provider =>
+          callProvider(provider, 'track', [eventName, { ...properties }, { context: getContext() }])
+        )
+      );
+    },
+
+    async page(path, properties = {}) {
+      if (!initialized || !path) return;
+
+      await Promise.all(
+        providers.map(provider =>
+          callProvider(provider, 'page', [path, { ...properties }, { context: getContext() }])
+        )
+      );
+    },
+
+    async identify(userId, traits = {}) {
+      if (!initialized || !userId) return;
+
+      await Promise.all(
+        providers.map(provider =>
+          callProvider(provider, 'identify', [userId, { ...traits }, { context: getContext() }])
+        )
+      );
+    },
+
+    async captureException(error, details = {}) {
+      if (!initialized || !error) return;
+
+      await Promise.all(
+        providers.map(provider =>
+          callProvider(provider, 'captureException', [error, { ...details }, { context: getContext() }])
+        )
+      );
+    },
+
+    async flush() {
+      if (!initialized) return;
+
+      await Promise.all(
+        providers.map(provider => callProvider(provider, 'flush', [{ context: getContext() }]))
+      );
+    },
+
+    async setContext(nextContext = {}) {
+      context = { ...context, ...nextContext };
+
+      if (!initialized) return;
+
+      await Promise.all(
+        providers.map(provider => callProvider(provider, 'setContext', [getContext()]))
+      );
+    },
+
+    getContext,
+    getProviders() {
+      return [...providers];
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds a vendor-neutral observability core for app-shell.
- Exposes initObservability, track, page, identify, captureException, flush, and setContext through a singleton API.
- Adds provider registry tests for no-op behavior, dispatch, context propagation, exception isolation, and async flush.

## Validation
- npm --workspace @schema-forge/app-shell run test
- npm --workspace @schema-forge/app-shell run build

## Jira
- ETP-4073

## Stack
- Base: epic/ETP-3504
- Next: feature/ETP-4074 will stack on this PR.