### PR TITLE
Feature ETP-4074: Wrap Sentry And RUM Adapters

### DIFF
--- a/tools/app-shell/src/lib/__tests__/observability-adapters.test.js
+++ b/tools/app-shell/src/lib/__tests__/observability-adapters.test.js
@@ -1,0 +1,173 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildBrowserObservabilityConfig } from '../observability/browser.js';
+import { createRumProvider, resolveRumConfig } from '../rum.js';
+import { createSentryProvider, resolveSentryEnvironment } from '../sentry.js';
+
+describe('sentry observability adapter', () => {
+  it('preserves hostname to environment mapping', () => {
+    assert.equal(resolveSentryEnvironment('go.staging.etendo.cloud'), 'staging');
+    assert.equal(resolveSentryEnvironment('go.experimental.etendo.cloud'), 'experimental');
+    assert.equal(resolveSentryEnvironment('go.etendo.cloud'), 'production');
+    assert.equal(resolveSentryEnvironment('localhost'), 'development');
+  });
+
+  it('initializes Sentry with the existing tracing and PII config', () => {
+    const calls = [];
+    const fakeSentry = {
+      browserTracingIntegration() {
+        return 'browser-tracing';
+      },
+      init(options) {
+        calls.push(options);
+      },
+    };
+
+    const provider = createSentryProvider({
+      dsn: 'dsn-123',
+      hostname: 'go.staging.etendo.cloud',
+      sentry: fakeSentry,
+    });
+    provider.init();
+
+    assert.equal(provider.name, 'sentry');
+    assert.equal(provider.enabled, true);
+    assert.equal(calls[0].dsn, 'dsn-123');
+    assert.equal(calls[0].environment, 'staging');
+    assert.deepEqual(calls[0].integrations, ['browser-tracing']);
+    assert.equal(calls[0].tracesSampleRate, 0.1);
+    assert.equal(calls[0].sendDefaultPii, true);
+    assert.deepEqual(calls[0].tracePropagationTargets, [/core\..+\.etendo\.cloud/, 'core.etendo.cloud']);
+  });
+
+  it('can be disabled when no DSN is configured', () => {
+    const provider = createSentryProvider({ dsn: '' });
+
+    assert.equal(provider.enabled, false);
+  });
+});
+
+describe('AWS RUM observability adapter', () => {
+  it('preserves hostname-gated RUM config mapping', () => {
+    const env = {
+      VITE_RUM_APP_MONITOR_ID_STAGING: 'staging-monitor',
+      VITE_RUM_IDENTITY_POOL_ID_STAGING: 'staging-pool',
+      VITE_RUM_APP_MONITOR_ID_EXPERIMENTAL: 'experimental-monitor',
+      VITE_RUM_IDENTITY_POOL_ID_EXPERIMENTAL: 'experimental-pool',
+    };
+
+    assert.deepEqual(resolveRumConfig('go.staging.etendo.cloud', env), {
+      appMonitorId: 'staging-monitor',
+      identityPoolId: 'staging-pool',
+    });
+    assert.deepEqual(resolveRumConfig('go.experimental.etendo.cloud', env), {
+      appMonitorId: 'experimental-monitor',
+      identityPoolId: 'experimental-pool',
+    });
+    assert.equal(resolveRumConfig('go.etendo.cloud', env), undefined);
+  });
+
+  it('initializes AWS RUM with the existing region, endpoint, and telemetries', () => {
+    const calls = [];
+    class FakeAwsRum {
+      constructor(...args) {
+        calls.push(args);
+      }
+    }
+
+    const provider = createRumProvider({
+      hostname: 'go.experimental.etendo.cloud',
+      env: {
+        VITE_RUM_APP_MONITOR_ID_EXPERIMENTAL: 'monitor-id',
+        VITE_RUM_IDENTITY_POOL_ID_EXPERIMENTAL: 'pool-id',
+      },
+      AwsRumCtor: FakeAwsRum,
+      logger: { warn() {} },
+    });
+    provider.init();
+
+    assert.equal(provider.name, 'aws-rum');
+    assert.equal(provider.enabled, true);
+    assert.deepEqual(calls[0], [
+      'monitor-id',
+      '1.0.0',
+      'eu-west-3',
+      {
+        sessionSampleRate: 1,
+        identityPoolId: 'pool-id',
+        endpoint: 'https://dataplane.rum.eu-west-3.amazonaws.com',
+        telemetries: ['performance', 'errors', 'http'],
+        allowCookies: true,
+        enableXRay: false,
+      },
+    ]);
+  });
+
+  it('logs and contains AWS RUM init failures', () => {
+    const warnings = [];
+    class BrokenAwsRum {
+      constructor() {
+        throw new Error('rum unavailable');
+      }
+    }
+
+    const provider = createRumProvider({
+      hostname: 'go.staging.etendo.cloud',
+      env: {
+        VITE_RUM_APP_MONITOR_ID_STAGING: 'monitor-id',
+        VITE_RUM_IDENTITY_POOL_ID_STAGING: 'pool-id',
+      },
+      AwsRumCtor: BrokenAwsRum,
+      logger: {
+        warn(message, error) {
+          warnings.push([message, error.message]);
+        },
+      },
+    });
+
+    assert.doesNotThrow(() => provider.init());
+    assert.deepEqual(warnings, [['CloudWatch RUM init failed', 'rum unavailable']]);
+  });
+
+  it('keeps legacy no-op behavior when no hostname config matches', () => {
+    const calls = [];
+    class FakeAwsRum {
+      constructor(...args) {
+        calls.push(args);
+      }
+    }
+
+    const provider = createRumProvider({
+      hostname: 'localhost',
+      env: {},
+      AwsRumCtor: FakeAwsRum,
+      logger: { warn() {} },
+    });
+
+    assert.equal(provider.enabled, false);
+    assert.doesNotThrow(() => provider.init());
+    assert.deepEqual(calls, []);
+  });
+});
+
+describe('browser observability config', () => {
+  it('registers Sentry and AWS RUM providers behind the shared config', () => {
+    const config = buildBrowserObservabilityConfig({
+      env: {
+        VITE_SENTRY_DSN: 'dsn-123',
+        VITE_RUM_APP_MONITOR_ID_STAGING: 'monitor-id',
+        VITE_RUM_IDENTITY_POOL_ID_STAGING: 'pool-id',
+      },
+      location: { hostname: 'go.staging.etendo.cloud' },
+      logger: { warn() {} },
+    });
+
+    assert.deepEqual(config.context, {
+      app: 'app-shell',
+      environment: 'go.staging.etendo.cloud',
+    });
+    assert.deepEqual(config.providers.map(provider => provider.name), ['sentry', 'aws-rum']);
+    assert.deepEqual(config.providers.map(provider => provider.enabled), [true, true]);
+  });
+});

--- a/tools/app-shell/src/lib/observability/browser.js
+++ b/tools/app-shell/src/lib/observability/browser.js
@@ -1,0 +1,34 @@
+import { initObservability } from '../observability.js';
+import { createRumProvider } from '../rum.js';
+import { createSentryProvider } from '../sentry.js';
+
+export function buildBrowserObservabilityConfig({
+  env = import.meta.env,
+  location = globalThis.window?.location,
+  logger = console,
+} = {}) {
+  const hostname = location?.hostname;
+
+  return {
+    logger,
+    context: {
+      app: 'app-shell',
+      environment: hostname,
+    },
+    providers: [
+      createSentryProvider({
+        dsn: env.VITE_SENTRY_DSN,
+        hostname,
+      }),
+      createRumProvider({
+        env,
+        hostname,
+        logger,
+      }),
+    ],
+  };
+}
+
+export function initBrowserObservability(options = {}) {
+  return initObservability(buildBrowserObservabilityConfig(options));
+}

--- a/tools/app-shell/src/lib/rum.js
+++ b/tools/app-shell/src/lib/rum.js
@@ -1,30 +1,54 @@
 import { AwsRum } from 'aws-rum-web';
 
-const CONFIGS = {
+export function getRumConfigs(env = import.meta.env) {
+  return {
   'go.staging.etendo.cloud': {
-    appMonitorId: import.meta.env.VITE_RUM_APP_MONITOR_ID_STAGING,
-    identityPoolId: import.meta.env.VITE_RUM_IDENTITY_POOL_ID_STAGING,
+    appMonitorId: env.VITE_RUM_APP_MONITOR_ID_STAGING,
+    identityPoolId: env.VITE_RUM_IDENTITY_POOL_ID_STAGING,
   },
   'go.experimental.etendo.cloud': {
-    appMonitorId: import.meta.env.VITE_RUM_APP_MONITOR_ID_EXPERIMENTAL,
-    identityPoolId: import.meta.env.VITE_RUM_IDENTITY_POOL_ID_EXPERIMENTAL,
+    appMonitorId: env.VITE_RUM_APP_MONITOR_ID_EXPERIMENTAL,
+    identityPoolId: env.VITE_RUM_IDENTITY_POOL_ID_EXPERIMENTAL,
   },
 };
+}
 
-export function initRum() {
-  const config = CONFIGS[window.location.hostname];
-  if (!config?.appMonitorId || !config?.identityPoolId) return;
+export function resolveRumConfig(hostname, env = import.meta.env) {
+  return getRumConfigs(env)[hostname];
+}
 
-  try {
-    new AwsRum(config.appMonitorId, '1.0.0', 'eu-west-3', {
-      sessionSampleRate: 1,
-      identityPoolId: config.identityPoolId,
-      endpoint: 'https://dataplane.rum.eu-west-3.amazonaws.com',
-      telemetries: ['performance', 'errors', 'http'],
-      allowCookies: true,
-      enableXRay: false,
-    });
-  } catch (e) {
-    console.warn('CloudWatch RUM init failed', e);
-  }
+export function createRumProvider({
+  hostname = globalThis.window?.location?.hostname,
+  env = import.meta.env,
+  AwsRumCtor = AwsRum,
+  logger = console,
+  enabled = true,
+} = {}) {
+  const config = resolveRumConfig(hostname, env);
+
+  return {
+    name: 'aws-rum',
+    enabled: enabled && Boolean(config?.appMonitorId && config?.identityPoolId),
+
+    init() {
+      if (!config?.appMonitorId || !config?.identityPoolId) return;
+
+      try {
+        new AwsRumCtor(config.appMonitorId, '1.0.0', 'eu-west-3', {
+          sessionSampleRate: 1,
+          identityPoolId: config.identityPoolId,
+          endpoint: 'https://dataplane.rum.eu-west-3.amazonaws.com',
+          telemetries: ['performance', 'errors', 'http'],
+          allowCookies: true,
+          enableXRay: false,
+        });
+      } catch (e) {
+        logger.warn('CloudWatch RUM init failed', e);
+      }
+    },
+  };
+}
+
+export function initRum(options = {}) {
+  return createRumProvider(options).init();
 }

--- a/tools/app-shell/src/lib/sentry.js
+++ b/tools/app-shell/src/lib/sentry.js
@@ -1,21 +1,53 @@
 import * as Sentry from '@sentry/react';
 
-const ENV_MAP = {
+export const SENTRY_ENV_MAP = {
   'go.staging.etendo.cloud': 'staging',
   'go.experimental.etendo.cloud': 'experimental',
   'go.etendo.cloud': 'production',
 };
 
-export function initSentry() {
-  const dsn = import.meta.env.VITE_SENTRY_DSN;
-  if (!dsn) return;
+export function resolveSentryEnvironment(hostname) {
+  return SENTRY_ENV_MAP[hostname] ?? 'development';
+}
 
-  Sentry.init({
-    dsn,
-    environment: ENV_MAP[window.location.hostname] ?? 'development',
-    integrations: [Sentry.browserTracingIntegration()],
-    tracesSampleRate: 0.1,
-    tracePropagationTargets: [/core\..+\.etendo\.cloud/, 'core.etendo.cloud'],
-    sendDefaultPii: true,
-  });
+export function createSentryProvider({
+  dsn,
+  hostname = globalThis.window?.location?.hostname,
+  enabled = Boolean(dsn),
+  sentry = Sentry,
+} = {}) {
+  return {
+    name: 'sentry',
+    enabled,
+
+    init() {
+      if (!dsn) return;
+
+      sentry.init({
+        dsn,
+        environment: resolveSentryEnvironment(hostname),
+        integrations: [sentry.browserTracingIntegration()],
+        tracesSampleRate: 0.1,
+        tracePropagationTargets: [/core\..+\.etendo\.cloud/, 'core.etendo.cloud'],
+        sendDefaultPii: true,
+      });
+    },
+
+    captureException(error, details = {}) {
+      if (typeof sentry.captureException === 'function') {
+        sentry.captureException(error, { extra: details });
+      }
+    },
+
+    setContext(context = {}) {
+      if (typeof sentry.setContext === 'function') {
+        sentry.setContext('app', context);
+      }
+    },
+  };
+}
+
+export function initSentry(options = {}) {
+  const dsn = options.dsn ?? import.meta.env.VITE_SENTRY_DSN;
+  return createSentryProvider({ ...options, dsn }).init();
 }

--- a/tools/app-shell/src/main.jsx
+++ b/tools/app-shell/src/main.jsx
@@ -1,9 +1,7 @@
 import { createRoot } from 'react-dom/client';
-import { initSentry } from './lib/sentry.js';
-import { initRum } from './lib/rum.js';
+import { initBrowserObservability } from './lib/observability/browser.js';
 
-initSentry();
-initRum();
+initBrowserObservability();
 import { ThemeProvider } from 'next-themes';
 import { Toaster } from 'sonner';
 import App from './App.jsx';


### PR DESCRIPTION
## Summary
- Moves Sentry and AWS RUM startup behind observability providers.
- Keeps the previous Sentry and AWS RUM config behavior available through legacy init helpers.
- Updates app-shell startup to initialize browser observability through one abstraction.

## Validation
- npm --workspace @schema-forge/app-shell exec -- node --test src/lib/__tests__/observability-adapters.test.js src/lib/__tests__/observability.test.js
- npm --workspace @schema-forge/app-shell run test
- npm --workspace @schema-forge/app-shell run build

## Jira
- ETP-4074

## Stack
- Base PR: #600 / feature/ETP-4073
- This PR targets feature/ETP-4073.
- Next: feature/ETP-4075 will stack on this PR.