### PR TITLE
Feature ETP-4075: Normalize Observability Payloads

### DIFF
--- a/tools/app-shell/src/lib/__tests__/observability-adapters.test.js
+++ b/tools/app-shell/src/lib/__tests__/observability-adapters.test.js
@@ -166,6 +166,8 @@ describe('browser observability config', () => {
     assert.deepEqual(config.context, {
       app: 'app-shell',
       environment: 'go.staging.etendo.cloud',
+      hostname: 'go.staging.etendo.cloud',
+      mockMode: false,
     });
     assert.deepEqual(config.providers.map(provider => provider.name), ['sentry', 'aws-rum']);
     assert.deepEqual(config.providers.map(provider => provider.enabled), [true, true]);

--- a/tools/app-shell/src/lib/__tests__/observability-payload.test.js
+++ b/tools/app-shell/src/lib/__tests__/observability-payload.test.js
@@ -1,0 +1,92 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildEventPayload,
+  extractWindowName,
+  normalizeRoute,
+  sanitizeEventProperties,
+} from '../observability/payload.js';
+
+describe('observability payload normalization', () => {
+  it('strips query strings, hashes, and raw URLs from routes', () => {
+    assert.equal(
+      normalizeRoute('/authorize?code=abc&state=oauth-state#token'),
+      '/authorize'
+    );
+    assert.equal(
+      normalizeRoute('https://go.etendo.cloud/sales-order/ABC123?token=secret#frag'),
+      '/sales-order/:recordId'
+    );
+  });
+
+  it('normalizes record-detail routes without leaking record ids', () => {
+    assert.equal(normalizeRoute('/sales-order/ABC123'), '/sales-order/:recordId');
+    assert.equal(
+      normalizeRoute('/purchase-invoice/12345678901234567890'),
+      '/purchase-invoice/:recordId'
+    );
+  });
+
+  it('normalizes dynamic nested segments and keeps safe route names', () => {
+    assert.equal(
+      normalizeRoute('/reports/run/550e8400-e29b-41d4-a716-446655440000'),
+      '/reports/run/:id'
+    );
+    assert.equal(normalizeRoute('/artifacts/sales-order'), '/artifacts/sales-order');
+  });
+
+  it('extracts only the safe top-level route as windowName', () => {
+    assert.equal(extractWindowName('/sales-order/:recordId'), 'sales-order');
+    assert.equal(extractWindowName('/'), undefined);
+  });
+
+  it('allowlists event properties and removes sensitive fields', () => {
+    assert.deepEqual(
+      sanitizeEventProperties({
+        action: 'open',
+        component: 'menu',
+        documentId: 'secret-doc-id',
+        label: 'Customer Name',
+        rawUrl: '/sales-order/ABC123?token=secret',
+        token: 'secret',
+        url: 'https://example.test',
+      }),
+      {
+        action: 'open',
+        component: 'menu',
+      }
+    );
+  });
+
+  it('builds a safe event envelope with common metadata', () => {
+    const payload = buildEventPayload({
+      route: '/sales-order/ABC123?code=secret&state=secret#hash',
+      metadata: {
+        app: 'app-shell',
+        environment: 'staging',
+        hostname: 'go.staging.etendo.cloud',
+        mockMode: false,
+      },
+      properties: {
+        action: 'view',
+        documentNo: 'SO-001',
+        status: 'opened',
+      },
+      timestamp: '2026-05-19T00:00:00.000Z',
+    });
+
+    assert.deepEqual(payload, {
+      app: 'app-shell',
+      environment: 'staging',
+      hostname: 'go.staging.etendo.cloud',
+      mockMode: false,
+      action: 'view',
+      status: 'opened',
+      timestamp: '2026-05-19T00:00:00.000Z',
+      route: '/sales-order/:recordId',
+      routePattern: '/sales-order/:recordId',
+      windowName: 'sales-order',
+    });
+  });
+});

--- a/tools/app-shell/src/lib/__tests__/observability.test.js
+++ b/tools/app-shell/src/lib/__tests__/observability.test.js
@@ -79,7 +79,11 @@ describe('observability core', () => {
         'second:flush',
       ]
     );
-    assert.deepEqual(calls[2][4].context, { app: 'app-shell' });
+    assert.equal(calls[2][2], 'app_started');
+    assert.equal(typeof calls[2][3].timestamp, 'string');
+    assert.equal(calls[2][3].app, 'app-shell');
+    assert.equal(calls[4][2], '/dashboard');
+    assert.equal(calls[4][3].routePattern, '/dashboard');
   });
 
   it('merges context and notifies providers when context changes', async () => {
@@ -103,6 +107,8 @@ describe('observability core', () => {
       environment: 'staging',
       locale: 'en_US',
     });
+    assert.equal(calls[2][3].environment, 'staging');
+    assert.equal(calls[2][3].locale, 'en_US');
   });
 
   it('continues dispatching when one provider throws', async () => {

--- a/tools/app-shell/src/lib/observability/browser.js
+++ b/tools/app-shell/src/lib/observability/browser.js
@@ -14,6 +14,14 @@ export function buildBrowserObservabilityConfig({
     context: {
       app: 'app-shell',
       environment: hostname,
+      hostname,
+      mockMode: env.VITE_MOCK === 'true',
+    },
+    metadata: {
+      app: 'app-shell',
+      environment: hostname,
+      hostname,
+      mockMode: env.VITE_MOCK === 'true',
     },
     providers: [
       createSentryProvider({

--- a/tools/app-shell/src/lib/observability/core.js
+++ b/tools/app-shell/src/lib/observability/core.js
@@ -1,3 +1,5 @@
+import { buildEventPayload } from './payload.js';
+
 function isProviderEnabled(provider) {
   return provider && provider.enabled !== false;
 }
@@ -16,6 +18,7 @@ export function createObservability(options = {}) {
   let logger = options.logger ?? console;
   let providers = [];
   let context = {};
+  let metadata = {};
   let initialized = false;
 
   async function callProvider(provider, methodName, args) {
@@ -43,6 +46,7 @@ export function createObservability(options = {}) {
       logger = config.logger ?? logger;
       providers = (config.providers ?? []).filter(isProviderEnabled);
       context = { ...(config.context ?? {}) };
+      metadata = { ...(config.metadata ?? {}) };
       initialized = true;
 
       await Promise.all(
@@ -52,20 +56,22 @@ export function createObservability(options = {}) {
 
     async track(eventName, properties = {}) {
       if (!initialized || !eventName) return;
+      const payload = buildEventPayload({ properties, context, metadata });
 
       await Promise.all(
         providers.map(provider =>
-          callProvider(provider, 'track', [eventName, { ...properties }, { context: getContext() }])
+          callProvider(provider, 'track', [eventName, payload, { context: getContext() }])
         )
       );
     },
 
     async page(path, properties = {}) {
       if (!initialized || !path) return;
+      const payload = buildEventPayload({ properties, context, metadata, route: path });
 
       await Promise.all(
         providers.map(provider =>
-          callProvider(provider, 'page', [path, { ...properties }, { context: getContext() }])
+          callProvider(provider, 'page', [payload.route, payload, { context: getContext() }])
         )
       );
     },

--- a/tools/app-shell/src/lib/observability/payload.js
+++ b/tools/app-shell/src/lib/observability/payload.js
@@ -1,0 +1,161 @@
+const DENYLISTED_PROPERTY_KEYS = new Set([
+  'authCode',
+  'authorization',
+  'businessPartner',
+  'businessPartnerName',
+  'code',
+  'documentId',
+  'documentNo',
+  'hash',
+  'id',
+  'label',
+  'name',
+  'oauthState',
+  'query',
+  'rawUrl',
+  'recordId',
+  'search',
+  'state',
+  'token',
+  'url',
+]);
+
+const SAFE_EVENT_PROPERTY_KEYS = new Set([
+  'action',
+  'app',
+  'component',
+  'enabled',
+  'environment',
+  'event',
+  'hostname',
+  'locale',
+  'mockMode',
+  'provider',
+  'route',
+  'routePattern',
+  'source',
+  'status',
+  'timestamp',
+  'type',
+  'windowName',
+]);
+
+function toPathname(value = '/') {
+  const raw = String(value || '/');
+
+  try {
+    return new URL(raw, 'https://observability.local').pathname || '/';
+  } catch {
+    return raw.split(/[?#]/, 1)[0] || '/';
+  }
+}
+
+function sanitizeSegment(segment) {
+  return Array.from(segment)
+    .filter(char => isAllowedRouteChar(char))
+    .join('');
+}
+
+function isAllowedRouteChar(char) {
+  return isAlphaNumeric(char) || ['.', '_', '~', '-'].includes(char);
+}
+
+function isAlphaNumeric(char) {
+  const code = char.charCodeAt(0);
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122)
+  );
+}
+
+function isHexChar(char) {
+  const code = char.charCodeAt(0);
+  return (code >= 48 && code <= 57) || (code >= 97 && code <= 102);
+}
+
+function isNumericId(segment) {
+  return segment.length > 0 && Array.from(segment).every(char => {
+    const code = char.charCodeAt(0);
+    return code >= 48 && code <= 57;
+  });
+}
+
+function isHexId(segment) {
+  const compact = segment.replaceAll('-', '').toLowerCase();
+  return compact.length >= 16 && Array.from(compact).every(isHexChar);
+}
+
+function isOpaqueId(segment) {
+  return segment.length >= 12 && Array.from(segment).every(char => (
+    isAlphaNumeric(char) || char === '_' || char === '-'
+  ));
+}
+
+function isRecordDetailRoute(segments) {
+  return segments.length === 2 && segments[0] !== 'artifacts';
+}
+
+function isDynamicSegment(segment) {
+  return isNumericId(segment) || isHexId(segment) || isOpaqueId(segment);
+}
+
+export function normalizeRoute(value = '/') {
+  const pathname = toPathname(value);
+  const segments = pathname
+    .split('/')
+    .map(sanitizeSegment)
+    .filter(Boolean);
+
+  if (segments.length === 0) return '/';
+
+  const normalized = segments.map((segment, index) => {
+    if (isRecordDetailRoute(segments) && index === 1) return ':recordId';
+    if (index > 0 && isDynamicSegment(segment)) return ':id';
+    return segment;
+  });
+
+  return `/${normalized.join('/')}`;
+}
+
+export function extractWindowName(route = '/') {
+  const [firstSegment] = normalizeRoute(route).split('/').filter(Boolean);
+  return firstSegment && !firstSegment.startsWith(':') ? firstSegment : undefined;
+}
+
+export function sanitizeEventProperties(properties = {}) {
+  const sanitized = {};
+
+  for (const [key, value] of Object.entries(properties ?? {})) {
+    if (DENYLISTED_PROPERTY_KEYS.has(key) || !SAFE_EVENT_PROPERTY_KEYS.has(key)) continue;
+    if (value == null) continue;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      sanitized[key] = value;
+    }
+  }
+
+  return sanitized;
+}
+
+export function buildEventPayload({
+  properties = {},
+  context = {},
+  metadata = {},
+  route,
+  timestamp = new Date().toISOString(),
+} = {}) {
+  const normalizedRoute = route ? normalizeRoute(route) : undefined;
+  const safeProperties = sanitizeEventProperties(properties);
+  const safeContext = sanitizeEventProperties(context);
+  const safeMetadata = sanitizeEventProperties(metadata);
+  const windowName = normalizedRoute ? extractWindowName(normalizedRoute) : undefined;
+
+  return {
+    ...safeMetadata,
+    ...safeContext,
+    ...safeProperties,
+    timestamp,
+    ...(normalizedRoute ? { route: normalizedRoute, routePattern: normalizedRoute } : {}),
+    ...(windowName ? { windowName } : {}),
+  };
+}


### PR DESCRIPTION
## Summary
- Adds privacy-safe observability payload normalization.
- Strips query strings, hashes, raw URLs, OAuth params, record IDs, and other sensitive fields.
- Enriches events with safe common metadata and route patterns before provider dispatch.

## Validation
- npm --workspace @schema-forge/app-shell exec -- node --test src/lib/__tests__/observability-payload.test.js src/lib/__tests__/observability.test.js src/lib/__tests__/observability-adapters.test.js
- npm --workspace @schema-forge/app-shell run test
- npm --workspace @schema-forge/app-shell run build

## Jira
- ETP-4075

## Stack
- Base PR: #601 / feature/ETP-4074
- This PR targets feature/ETP-4074.
- Next: feature/ETP-4076 will stack on this PR.