### PR TITLE
Feature ETP-4076: Add Mixpanel Adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2657,6 +2657,62 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mixpanel/rrdom": {
+      "version": "2.0.0-alpha.18.4",
+      "resolved": "https://registry.npmjs.org/@mixpanel/rrdom/-/rrdom-2.0.0-alpha.18.4.tgz",
+      "integrity": "sha512-58sWLQDPRU0VQn8VzB1tx4ujih9X327Vr6xAzbJ4zge9GENm2L696T4TbWvrRGWPW6w99tHIHbv6SvcLhjjmcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixpanel/rrweb-snapshot": "^2.0.0-alpha.18"
+      }
+    },
+    "node_modules/@mixpanel/rrweb": {
+      "version": "2.0.0-alpha.18.4",
+      "resolved": "https://registry.npmjs.org/@mixpanel/rrweb/-/rrweb-2.0.0-alpha.18.4.tgz",
+      "integrity": "sha512-ICpEYDFEEiCoUuQg+de3VvQCsolF4lNHfEM9DBp5Pwuc7EgXqwWV4wUpiRF/NbhoKk+82X1Qe+oqqlKJb/CGFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixpanel/rrdom": "^2.0.0-alpha.18",
+        "@mixpanel/rrweb-snapshot": "^2.0.0-alpha.18",
+        "@mixpanel/rrweb-types": "^2.0.0-alpha.18",
+        "@mixpanel/rrweb-utils": "^2.0.0-alpha.18",
+        "@types/css-font-loading-module": "0.0.7",
+        "@xstate/fsm": "^1.4.0",
+        "base64-arraybuffer": "^1.0.1",
+        "mitt": "^3.0.0"
+      }
+    },
+    "node_modules/@mixpanel/rrweb-plugin-console-record": {
+      "version": "2.0.0-alpha.18.4",
+      "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-plugin-console-record/-/rrweb-plugin-console-record-2.0.0-alpha.18.4.tgz",
+      "integrity": "sha512-gGxEnNpfWurQht+fpSJbwPV60ug0LAENlk4Ux3XRmYooNJGPBO1TiQHcM7g0yhrKf4tfbTiKKZ4EXzFlOZs/pw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@mixpanel/rrweb": "^2.0.0-alpha.18",
+        "@mixpanel/rrweb-utils": "^2.0.0-alpha.18"
+      }
+    },
+    "node_modules/@mixpanel/rrweb-snapshot": {
+      "version": "2.0.0-alpha.18.4",
+      "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.4.tgz",
+      "integrity": "sha512-ubLGwgPiMMi0rl7zJRh1uMScQ480lT95tkHkIAHkiZOemMY4JSkYZh2v9fpMNwJhaGwB5n/76KI7Cwy8F5qixQ==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.38"
+      }
+    },
+    "node_modules/@mixpanel/rrweb-types": {
+      "version": "2.0.0-alpha.18.4",
+      "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-types/-/rrweb-types-2.0.0-alpha.18.4.tgz",
+      "integrity": "sha512-7kRuk7pK6Firrb26Mm235Po7s/z+9k0gUKZU/DZkzg5U1yQRcsu4byIrnWTiTQr+LFLUrIiyRKnpGK/QneAhTw==",
+      "license": "MIT"
+    },
+    "node_modules/@mixpanel/rrweb-utils": {
+      "version": "2.0.0-alpha.18.4",
+      "resolved": "https://registry.npmjs.org/@mixpanel/rrweb-utils/-/rrweb-utils-2.0.0-alpha.18.4.tgz",
+      "integrity": "sha512-c3nUbQl19kxHjf8nowFMeXlJw0ZqLesIVBb9t4g1nC4WtaNEPkFotWRdGt5V2cJNQ+aY38/v2uYb8Ren4IcdSQ==",
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.27.1",
       "dev": true,
@@ -4763,6 +4819,12 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4782,6 +4844,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/json-logic-js": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/json-logic-js/-/json-logic-js-2.0.5.tgz",
+      "integrity": "sha512-hu/FTi0zwCjQEFfbPur275cNoZj6NsuOBhhYNzqoSdfmMhuxFr58OZ957lyIOWc9+kO+2tFlBthRjcxuytD4HA==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.6.0",
@@ -5003,6 +5071,12 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@xstate/fsm": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
+      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -5376,6 +5450,15 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -8320,6 +8403,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/json-logic-js": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/json-logic-js/-/json-logic-js-2.0.5.tgz",
+      "integrity": "sha512-rTT2+lqcuUmj4DgWfmzupZqQDA64AdmYqizzMPWj3DxGdfFNsxPpcNVSaTj4l8W2tG/+hg7/mQhxjU3aPacO6g==",
+      "license": "MIT"
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "dev": true,
@@ -8739,6 +8828,28 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
+    },
+    "node_modules/mixpanel-browser": {
+      "version": "2.79.0",
+      "resolved": "https://registry.npmjs.org/mixpanel-browser/-/mixpanel-browser-2.79.0.tgz",
+      "integrity": "sha512-+XRUJfplXy6bwW85ZOEIABlxZyfAVgyBPfMO0QiWr6wkRbvpWbS4xCPTR6iEl5ATPN8+ae+Nv4vusANjrk0DEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mixpanel/rrweb": "2.0.0-alpha.18.4",
+        "@mixpanel/rrweb-plugin-console-record": "2.0.0-alpha.18.4",
+        "@mixpanel/rrweb-utils": "2.0.0-alpha.18.4",
+        "@types/json-logic-js": "2.0.5",
+        "json-logic-js": "2.0.5"
+      },
+      "engines": {
+        "node": ">=20 <26"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "license": "MIT"
@@ -8806,7 +8917,6 @@
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9330,7 +9440,6 @@
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -9418,7 +9527,6 @@
     },
     "node_modules/postcss": {
       "version": "8.5.8",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10727,7 +10835,6 @@
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -13417,6 +13524,7 @@
         "date-fns": "^4.1.0",
         "handlebars": "^4.7.9",
         "lucide-react": "^0.400.0",
+        "mixpanel-browser": "^2.79.0",
         "next-themes": "^0.4.6",
         "react": "^18.3.0",
         "react-day-picker": "^9.14.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -35,6 +35,7 @@
     "date-fns": "^4.1.0",
     "handlebars": "^4.7.9",
     "lucide-react": "^0.400.0",
+    "mixpanel-browser": "^2.79.0",
     "next-themes": "^0.4.6",
     "react": "^18.3.0",
     "react-day-picker": "^9.14.0",

--- a/tools/app-shell/src/lib/__tests__/observability-adapters.test.js
+++ b/tools/app-shell/src/lib/__tests__/observability-adapters.test.js
@@ -169,7 +169,7 @@ describe('browser observability config', () => {
       hostname: 'go.staging.etendo.cloud',
       mockMode: false,
     });
-    assert.deepEqual(config.providers.map(provider => provider.name), ['sentry', 'aws-rum']);
-    assert.deepEqual(config.providers.map(provider => provider.enabled), [true, true]);
+    assert.deepEqual(config.providers.map(provider => provider.name), ['sentry', 'aws-rum', 'mixpanel']);
+    assert.deepEqual(config.providers.map(provider => provider.enabled), [true, true, false]);
   });
 });

--- a/tools/app-shell/src/lib/__tests__/observability-mixpanel.test.js
+++ b/tools/app-shell/src/lib/__tests__/observability-mixpanel.test.js
@@ -1,0 +1,113 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { buildBrowserObservabilityConfig } from '../observability/browser.js';
+import { createMixpanelProvider } from '../observability/providers/mixpanel.js';
+
+function createFakeMixpanel(calls) {
+  return {
+    init(token, options) {
+      calls.push(['init', token, options]);
+    },
+    track(eventName, properties) {
+      calls.push(['track', eventName, properties]);
+    },
+    identify(userId) {
+      calls.push(['identify', userId]);
+    },
+    people: {
+      set(traits) {
+        calls.push(['people.set', traits]);
+      },
+    },
+    async flush() {
+      calls.push(['flush']);
+    },
+  };
+}
+
+describe('Mixpanel observability adapter', () => {
+  it('stays disabled and does not load the SDK unless explicitly enabled', async () => {
+    let loadCount = 0;
+    const provider = createMixpanelProvider({
+      enabled: false,
+      token: 'token-123',
+      loader: async () => {
+        loadCount += 1;
+        return createFakeMixpanel([]);
+      },
+    });
+
+    await provider.init();
+    await provider.track('event');
+
+    assert.equal(provider.enabled, false);
+    assert.equal(loadCount, 0);
+  });
+
+  it('warns and remains disabled when enabled without token', async () => {
+    const warnings = [];
+    const provider = createMixpanelProvider({
+      enabled: 'true',
+      token: '',
+      logger: {
+        warn(message) {
+          warnings.push(message);
+        },
+      },
+      loader: async () => createFakeMixpanel([]),
+    });
+
+    await provider.init();
+
+    assert.equal(provider.enabled, false);
+    assert.deepEqual(warnings, [
+      '[observability] Mixpanel is enabled but VITE_MIXPANEL_TOKEN is missing',
+    ]);
+  });
+
+  it('initializes and tracks through the lazy-loaded SDK when configured', async () => {
+    const calls = [];
+    const provider = createMixpanelProvider({
+      enabled: 'true',
+      token: 'token-123',
+      debug: 'true',
+      apiHost: 'https://mixpanel.example',
+      loader: async () => ({ default: createFakeMixpanel(calls) }),
+    });
+
+    await provider.init();
+    await provider.track('app_started', { app: 'app-shell' });
+    await provider.page('/dashboard', { route: '/dashboard' });
+    await provider.identify('user-1', { role: 'admin' });
+    await provider.flush();
+
+    assert.deepEqual(calls, [
+      ['init', 'token-123', { debug: true, api_host: 'https://mixpanel.example' }],
+      ['track', 'app_started', { app: 'app-shell' }],
+      ['track', 'page_view', { route: '/dashboard', routePattern: '/dashboard' }],
+      ['identify', 'user-1'],
+      ['people.set', { role: 'admin' }],
+      ['flush'],
+    ]);
+  });
+
+  it('registers Mixpanel from browser config only when env enables it', () => {
+    const disabledConfig = buildBrowserObservabilityConfig({
+      env: {},
+      location: { hostname: 'localhost' },
+      logger: { warn() {} },
+    });
+    const enabledConfig = buildBrowserObservabilityConfig({
+      env: {
+        VITE_MIXPANEL_ENABLED: 'true',
+        VITE_MIXPANEL_TOKEN: 'token-123',
+      },
+      location: { hostname: 'localhost' },
+      logger: { warn() {} },
+    });
+
+    assert.equal(disabledConfig.providers.find(provider => provider.name === 'mixpanel').enabled, false);
+    assert.equal(enabledConfig.providers.find(provider => provider.name === 'mixpanel').enabled, true);
+  });
+});

--- a/tools/app-shell/src/lib/observability/browser.js
+++ b/tools/app-shell/src/lib/observability/browser.js
@@ -1,4 +1,5 @@
 import { initObservability } from '../observability.js';
+import { createMixpanelProvider } from './providers/mixpanel.js';
 import { createRumProvider } from '../rum.js';
 import { createSentryProvider } from '../sentry.js';
 
@@ -31,6 +32,13 @@ export function buildBrowserObservabilityConfig({
       createRumProvider({
         env,
         hostname,
+        logger,
+      }),
+      createMixpanelProvider({
+        enabled: env.VITE_MIXPANEL_ENABLED,
+        token: env.VITE_MIXPANEL_TOKEN,
+        debug: env.VITE_MIXPANEL_DEBUG,
+        apiHost: env.VITE_MIXPANEL_API_HOST,
         logger,
       }),
     ],

--- a/tools/app-shell/src/lib/observability/providers/mixpanel.js
+++ b/tools/app-shell/src/lib/observability/providers/mixpanel.js
@@ -1,0 +1,77 @@
+function isEnabled(value) {
+  return value === true || value === 'true';
+}
+
+function normalizeOptions({ apiHost, debug } = {}) {
+  const options = { debug: isEnabled(debug) };
+  if (apiHost) {
+    options.api_host = apiHost;
+  }
+  return options;
+}
+
+export function createMixpanelProvider({
+  enabled = false,
+  token,
+  debug = false,
+  apiHost,
+  logger = console,
+  loader = () => import('mixpanel-browser'),
+} = {}) {
+  const explicitlyEnabled = isEnabled(enabled);
+  const providerEnabled = explicitlyEnabled && Boolean(token);
+  let clientPromise;
+
+  if (explicitlyEnabled && !token) {
+    logger.warn('[observability] Mixpanel is enabled but VITE_MIXPANEL_TOKEN is missing');
+  }
+
+  async function getClient() {
+    if (!providerEnabled) return undefined;
+    if (!clientPromise) {
+      clientPromise = loader().then(module => module.default ?? module);
+    }
+    return clientPromise;
+  }
+
+  return {
+    name: 'mixpanel',
+    enabled: providerEnabled,
+
+    async init() {
+      const client = await getClient();
+      if (!client) return;
+      client.init(token, normalizeOptions({ apiHost, debug }));
+    },
+
+    async track(eventName, properties = {}) {
+      const client = await getClient();
+      if (!client || typeof client.track !== 'function') return;
+      client.track(eventName, properties);
+    },
+
+    async page(path, properties = {}) {
+      const client = await getClient();
+      if (!client || typeof client.track !== 'function') return;
+      client.track('page_view', { ...properties, route: path, routePattern: path });
+    },
+
+    async identify(userId, traits = {}) {
+      const client = await getClient();
+      if (!client) return;
+      if (typeof client.identify === 'function') {
+        client.identify(userId);
+      }
+      if (typeof client.people?.set === 'function') {
+        client.people.set(traits);
+      }
+    },
+
+    async flush() {
+      const client = await getClient();
+      if (typeof client?.flush === 'function') {
+        await client.flush();
+      }
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds optional Mixpanel observability provider behind the shared API.
- Gates initialization on VITE_MIXPANEL_ENABLED plus VITE_MIXPANEL_TOKEN.
- Lazy-loads mixpanel-browser only when the provider is enabled and used.

## Validation
- npm --workspace @schema-forge/app-shell exec -- node --test src/lib/__tests__/observability-mixpanel.test.js src/lib/__tests__/observability-adapters.test.js src/lib/__tests__/observability-payload.test.js src/lib/__tests__/observability.test.js
- npm --workspace @schema-forge/app-shell run test
- npm --workspace @schema-forge/app-shell run build

## Jira
- ETP-4076

## Stack
- Base PR: #602 / feature/ETP-4075
- This PR targets feature/ETP-4075.
- Next: feature/ETP-4077 will stack on this PR.