### PR TITLE
Feature ETP-4077: Track App And Page Events

### DIFF
--- a/tools/app-shell/src/App.jsx
+++ b/tools/app-shell/src/App.jsx
@@ -25,6 +25,7 @@ import { useInstalledApps } from './hooks/useInstalledApps.js';
 import { useAppStoreUnlock, attachKeySequenceWatcher } from './hooks/useAppStoreUnlock.js';
 import { CurrencyProvider } from './hooks/useCurrency.jsx';
 import { buildOnboardingReturnTo } from './lib/oauthReturnTo.js';
+import { ObservabilityRouteTracker } from './lib/observability/RouteTracker.jsx';
 
 import ArtifactViewerPage from './pages/ArtifactViewerPage.jsx';
 
@@ -253,6 +254,7 @@ export default function App() {
 
   return (
     <BrowserRouter basename={routerBase}>
+      <ObservabilityRouteTracker />
       <ServiceWorkerManager />
       <AppStoreKeyWatcher />
       <LocaleProvider locale={locale} setLocale={setLocale}>

--- a/tools/app-shell/src/lib/__tests__/ObservabilityRouteTracker.vitest.jsx
+++ b/tools/app-shell/src/lib/__tests__/ObservabilityRouteTracker.vitest.jsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Link, MemoryRouter, Route, Routes } from 'react-router-dom';
+
+import { ObservabilityRouteTracker } from '../observability/RouteTracker.jsx';
+
+function TestPage({ target }) {
+  return <Link to={target}>go</Link>;
+}
+
+function renderTracker(initialEntries, events) {
+  return render(
+    <MemoryRouter initialEntries={initialEntries}>
+      <ObservabilityRouteTracker trackPage={(path) => events.push(path)} />
+      <Routes>
+        <Route path="/sales-order/:recordId" element={<TestPage target="/dashboard?token=secret#hash" />} />
+        <Route path="/dashboard" element={<TestPage target="/dashboard?token=changed#other" />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ObservabilityRouteTracker', () => {
+  it('tracks initial route and subsequent pathname changes once', async () => {
+    const events = [];
+    renderTracker(['/sales-order/ABC123?token=secret#hash'], events);
+
+    expect(events).toEqual(['/sales-order/ABC123']);
+
+    await userEvent.click(screen.getByText('go'));
+    expect(events).toEqual(['/sales-order/ABC123', '/dashboard']);
+  });
+
+  it('does not duplicate events for query or hash changes on the same pathname', async () => {
+    const events = [];
+    renderTracker(['/dashboard?token=secret#hash'], events);
+
+    expect(events).toEqual(['/dashboard']);
+
+    await userEvent.click(screen.getByText('go'));
+    expect(events).toEqual(['/dashboard']);
+  });
+});

--- a/tools/app-shell/src/lib/__tests__/observability-browser.test.js
+++ b/tools/app-shell/src/lib/__tests__/observability-browser.test.js
@@ -1,0 +1,32 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { initBrowserObservability } from '../observability/browser.js';
+
+describe('browser observability startup', () => {
+  it('emits app_started once after initializing providers', async () => {
+    const calls = [];
+    const client = {
+      async initObservability(config) {
+        calls.push(['initObservability', config.context.app]);
+      },
+      async track(eventName) {
+        calls.push(['track', eventName]);
+      },
+    };
+
+    await initBrowserObservability(
+      {
+        env: {},
+        location: { hostname: 'localhost' },
+        logger: { warn() {} },
+      },
+      client
+    );
+
+    assert.deepEqual(calls, [
+      ['initObservability', 'app-shell'],
+      ['track', 'app_started'],
+    ]);
+  });
+});

--- a/tools/app-shell/src/lib/observability/RouteTracker.jsx
+++ b/tools/app-shell/src/lib/observability/RouteTracker.jsx
@@ -1,0 +1,17 @@
+import { useEffect, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
+import { page } from '../observability.js';
+
+export function ObservabilityRouteTracker({ trackPage = page }) {
+  const location = useLocation();
+  const lastPathRef = useRef(null);
+
+  useEffect(() => {
+    const currentPath = location.pathname || '/';
+    if (lastPathRef.current === currentPath) return;
+    lastPathRef.current = currentPath;
+    trackPage(currentPath);
+  }, [location.pathname, trackPage]);
+
+  return null;
+}

--- a/tools/app-shell/src/lib/observability/browser.js
+++ b/tools/app-shell/src/lib/observability/browser.js
@@ -1,4 +1,4 @@
-import { initObservability } from '../observability.js';
+import { initObservability, track } from '../observability.js';
 import { createMixpanelProvider } from './providers/mixpanel.js';
 import { createRumProvider } from '../rum.js';
 import { createSentryProvider } from '../sentry.js';
@@ -45,6 +45,10 @@ export function buildBrowserObservabilityConfig({
   };
 }
 
-export function initBrowserObservability(options = {}) {
-  return initObservability(buildBrowserObservabilityConfig(options));
+export async function initBrowserObservability(
+  options = {},
+  client = { initObservability, track }
+) {
+  await client.initObservability(buildBrowserObservabilityConfig(options));
+  await client.track('app_started');
 }


### PR DESCRIPTION
## Summary
- Emits app_started after browser observability initialization.
- Adds a router-aware ObservabilityRouteTracker for page_view events.
- Tracks path changes once and ignores query/hash-only changes.

## Validation
- npm --workspace @schema-forge/app-shell exec -- node --test src/lib/__tests__/observability-browser.test.js src/lib/__tests__/observability-mixpanel.test.js src/lib/__tests__/observability-payload.test.js src/lib/__tests__/observability.test.js
- npm --workspace @schema-forge/app-shell exec -- vitest run src/lib/__tests__/ObservabilityRouteTracker.vitest.jsx
- npm --workspace @schema-forge/app-shell run test
- npm --workspace @schema-forge/app-shell run build

## Jira
- ETP-4077

## Stack
- Base PR: #603 / feature/ETP-4076
- This PR targets feature/ETP-4076.
- Next: feature/ETP-4078 will stack on this PR.