### PR TITLE
Feature ETP-4067: Document Email Observability

### DIFF
--- a/docs/architecture/10-observability.md
+++ b/docs/architecture/10-observability.md
@@ -237,6 +237,13 @@ Email contract logs must be structured and redacted. Include `requestId`, `audit
 
 Do not log provider API keys, reset tokens, raw custom HTML, full message bodies, or secrets derived from provider configuration. See [../ops/transactional-email-security.md](../ops/transactional-email-security.md).
 
+The Etendo Go email executor emits one terminal observability event for each
+contract attempt. The default implementation writes redacted structured logs;
+future sinks can forward the same event to Prometheus, OpenTelemetry, or another
+metrics backend. Events include `recipientDomain` and `recipientHash` instead of
+the raw destination address, plus optional `providerDurationMs`,
+`throttleScope`, `killSwitchScope`, and `errorClass`.
+
 ---
 
 ## 5. Layer 3: Metrics
@@ -263,6 +270,22 @@ Do not log provider API keys, reset tokens, raw custom HTML, full message bodies
 | `sf_email_suppression_total` | Counter | contract, tenant, reason | Bounce, complaint, and manual suppression impact |
 | `sf_email_kill_switch_total` | Counter | scope, contract, tenant | Kill switch activations |
 | `sf_email_provider_error_total` | Counter | provider, contract, error_class | Provider failure analysis |
+
+Implementation notes:
+
+- `sf_email_send_total` is emitted for every terminal executor outcome,
+  including validation failures before provider submission.
+- `sf_email_provider_duration_seconds` is emitted only when a provider call is
+  attempted.
+- `sf_email_provider_error_total` distinguishes provider rejection,
+  unconfigured provider, and transport/serialization failures through
+  `error_class`.
+- `sf_email_throttle_total`, `sf_email_duplicate_total`,
+  `sf_email_suppression_total`, and `sf_email_kill_switch_total` are derived
+  from the same terminal event, so dashboards can correlate controls without
+  joining separate logs.
+- Keep recipient-level analysis in logs with `recipientHash`; do not create
+  high-cardinality metrics labels for raw recipients.
 
 ### 5.3 Infrastructure Metrics
 

--- a/docs/email-contracts.md
+++ b/docs/email-contracts.md
@@ -279,3 +279,4 @@ Before merging a contract change:
 - UI maps all executor statuses used by the contract.
 - Provider secret values are not present in code, docs, tests, fixtures, screenshots, or frontend bundles.
 - Operations runbook and metrics are updated when behavior changes.
+- Observability tests or verification scripts prove the contract emits redacted events for success, validation failure, throttle, duplicate, suppression/kill switch, and provider failure outcomes.

--- a/docs/ops/transactional-email-security.md
+++ b/docs/ops/transactional-email-security.md
@@ -147,6 +147,27 @@ Do not log:
 - raw HTML from custom sends
 - complete recipient lists for bulk-like support operations
 
+The runtime emits one redacted terminal event per executor outcome through the
+email observability sink. The default sink writes structured logs with these
+fields:
+
+| Field | Purpose | Redaction rule |
+|-------|---------|----------------|
+| `metrics` | Comma-separated metric names that can be derived from the event | No secret values |
+| `status` | Executor outcome such as `SENT`, `THROTTLED`, `DUPLICATE`, `SUPPRESSED`, `PROVIDER_FAILED`, or `VALIDATION_FAILED` | Safe enum |
+| `contract`, `version` | Contract identity and command version | Safe metadata |
+| `tenantId`, `userId`, `recordId` | Abuse and support correlation | Do not add business payload fields |
+| `template` | Provider template resolved by the contract | Safe identifier |
+| `recipientDomain` | Destination domain | Domain only |
+| `recipientHash` | Stable SHA-256 hash of the destination address | Never log the raw address in metric labels |
+| `providerStatus`, `providerDurationMs` | Provider outcome and latency | No provider body |
+| `throttleScope`, `killSwitchScope` | Anti-abuse control that stopped the send | Scope only |
+| `errorClass` | Generic provider/configuration failure class | No stack trace in metric labels |
+| `durationMs` | End-to-end executor duration | Numeric |
+
+Provider response bodies, reset tokens, custom HTML, API keys, and sender
+credentials must not be placed in observability fields.
+
 ## Metrics and Alerts
 
 Required metrics:
@@ -161,6 +182,23 @@ Required metrics:
 | `sf_email_kill_switch_total` | Counter | scope, contract, tenant |
 | `sf_email_provider_error_total` | Counter | provider, contract, error_class |
 
+Runtime events map to metrics as follows:
+
+| Outcome | Required metric signals |
+|---------|-------------------------|
+| Any terminal outcome | `sf_email_send_total` |
+| Provider call attempted | `sf_email_provider_duration_seconds` |
+| `PROVIDER_FAILED` | `sf_email_provider_error_total` |
+| `THROTTLED` | `sf_email_throttle_total` |
+| `DUPLICATE` | `sf_email_duplicate_total` |
+| `SUPPRESSED` | `sf_email_suppression_total` |
+| Kill switch suppression | `sf_email_kill_switch_total` and `sf_email_suppression_total` |
+
+Use low-cardinality labels for metrics: `contract`, `version`, `tenant`,
+`template`, `status`, `throttle_scope`, `kill_switch_scope`, and
+`error_class`. Use `recipientHash` only in logs or investigation queries, not
+as a high-cardinality Prometheus label.
+
 Recommended alerts:
 
 - provider failure rate above threshold for 5 minutes
@@ -169,6 +207,26 @@ Recommended alerts:
 - suppression or complaint rate spikes
 - kill switch activated
 - custom support contract used outside expected support hours or volume
+
+## Operational Queries
+
+Adapt these examples to Loki, Elasticsearch, CloudWatch Logs, or the active log
+backend. They assume the default email observability log shape.
+
+| Question | Query shape |
+|----------|-------------|
+| Provider failures by contract | `event=email_contract status=PROVIDER_FAILED | stats count by contract,errorClass,providerStatus` |
+| Throttle spike by tenant | `event=email_contract status=THROTTLED | stats count by tenantId,contract,throttleScope` |
+| Duplicate/idempotent sends | `event=email_contract status=DUPLICATE | stats count by tenantId,contract,recordId` |
+| Suppressed recipients by domain | `event=email_contract status=SUPPRESSED | stats count by tenantId,contract,recipientDomain,killSwitchScope` |
+| Abuse toward one recipient | `event=email_contract recipientHash=<hash> | stats count by contract,status,tenantId` |
+| Provider latency | `event=email_contract providerDurationMs=* | percentile(providerDurationMs, 95) by contract,status` |
+| Kill switch activation | `event=email_contract killSwitchScope=* | stats count by killSwitchScope,tenantId,contract` |
+
+During an incident, start with `status`, `contract`, `tenantId`, `template`,
+`recipientDomain`, and `recipientHash`. Do not request provider bodies or raw
+email addresses unless support policy explicitly requires it and the storage
+location is approved for PII.
 
 ## Production Smoke Test
 


### PR DESCRIPTION
## Summary
- Document redacted transactional email observability fields and metric mapping.
- Add operational query shapes for provider failures, throttles, duplicates, suppressions, recipient-hash investigations, latency, and kill switches.
- Extend the email contract review checklist with observability verification expectations.

## Stack
- Base branch: feature/ETP-4066
- Previous schema-forge layer: #612 / feature/ETP-4066
- Current schema-forge layer: feature/ETP-4067
- Runtime dependency: com.etendoerp.go #352

## Verification
- git diff --check

## Notes
- Documentation matches the runtime event fields introduced in com.etendoerp.go #352.
- Recipient-level investigation uses recipientHash and recipientDomain; raw recipient addresses are not metric labels.