### PR TITLE
Feature ETP-4083: Refactor migrations and invariants to reduce 

### DIFF
--- a/cli/src/generate-aggregate.js
+++ b/cli/src/generate-aggregate.js
@@ -78,18 +78,7 @@ function generateMockData(contract) {
 
   // Group kpi-single sections into a combined 'kpis' object keyed by their `key` field
   const kpiSingleSections = sectionsList.filter(s => s.type === 'kpi-single');
-  if (kpiSingleSections.length > 0) {
-    const kpisObj = {};
-    for (const s of kpiSingleSections) {
-      if (s.key && mockData[s.id] !== undefined) {
-        kpisObj[s.key] = mockData[s.id];
-      }
-    }
-    if (Object.keys(kpisObj).length > 0) {
-      lines.push(`export const kpis = ${JSON.stringify(kpisObj, null, 2)};`);
-      lines.push('');
-    }
-  }
+  aggregateKpiSingleSections(kpiSingleSections, mockData, lines);
 
   for (const section of sectionsList) {
     if (section.type === 'quick-actions') continue;
@@ -142,6 +131,21 @@ if (isDirectRun) {
     console.error('Usage: node cli/src/generate-aggregate.js <aggregate-contract.json>');
     console.error('       node cli/src/generate-aggregate.js --all');
     process.exit(1);
+  }
+}
+
+function aggregateKpiSingleSections(kpiSingleSections, mockData, lines) {
+  if (kpiSingleSections.length > 0) {
+    const kpisObj = {};
+    for (const s of kpiSingleSections) {
+      if (s.key && mockData[s.id] !== undefined) {
+        kpisObj[s.key] = mockData[s.id];
+      }
+    }
+    if (Object.keys(kpisObj).length > 0) {
+      lines.push(`export const kpis = ${JSON.stringify(kpisObj, null, 2)};`);
+      lines.push('');
+    }
   }
 }
 

--- a/cli/src/generate-mock-data.js
+++ b/cli/src/generate-mock-data.js
@@ -108,44 +108,24 @@ export function generateMockValue(field, index, entityName) {
   }
 
   // documentNo or fields ending in No (but not lineNo which is handled above)
-  if (name === 'documentNo' || (name.endsWith('No') && name !== 'lineNo')) {
+  if (isDocumentOrNumberField(name)) {
     const prefix = entityPrefix(entityName);
     return `${prefix}-${padNumber(index + 1)}`;
   }
 
-  // Business partner / customer
-  if (nameLower.includes('partner') || nameLower.includes('customer')) {
-    return cyclePool(COMPANY_NAMES, index);
-  }
-
   // Doc status
-  if (name === 'docStatus' || nameLower.includes('status')) {
+  if (isDocumentStatus(name, nameLower)) {
     return cyclePool(DOC_STATUSES, index);
   }
 
-  // Currency
-  if (nameLower.includes('currency')) {
-    return cyclePool(CURRENCIES, index);
-  }
-
-  // Warehouse
-  if (nameLower.includes('warehouse')) {
-    return cyclePool(WAREHOUSE_NAMES, index);
-  }
-
-  // Product
-  if (nameLower.includes('product')) {
-    return cyclePool(PRODUCT_NAMES, index);
+  const dependentValue = resolveFieldDependentValue(nameLower, index);
+  if (dependentValue !== null) {
+    return dependentValue;
   }
 
   // Description
   if (name === 'description') {
     return cyclePool(DESCRIPTION_PHRASES, index);
-  }
-
-  // Tax
-  if (nameLower.includes('tax')) {
-    return cyclePool(TAX_NAMES, index);
   }
 
   // Discount
@@ -190,6 +170,33 @@ export function generateMockValue(field, index, entityName) {
 
   // Default string
   return `Sample ${name}`;
+}
+
+function resolveFieldDependentValue(nameLower, index) {
+  if (nameLower.includes('partner') || nameLower.includes('customer')) {
+    return cyclePool(COMPANY_NAMES, index);
+  }
+  if (nameLower.includes('currency')) {
+    return cyclePool(CURRENCIES, index);
+  }
+  if (nameLower.includes('warehouse')) {
+    return cyclePool(WAREHOUSE_NAMES, index);
+  }
+  if (nameLower.includes('product')) {
+    return cyclePool(PRODUCT_NAMES, index);
+  }
+  if (nameLower.includes('tax')) {
+    return cyclePool(TAX_NAMES, index);
+  }
+  return null;
+}
+
+function isDocumentStatus(name, nameLower) {
+  return name === 'docStatus' || nameLower.includes('status');
+}
+
+function isDocumentOrNumberField(name) {
+  return name === 'documentNo' || (name.endsWith('No') && name !== 'lineNo');
 }
 
 /**

--- a/cli/src/generation-log.js
+++ b/cli/src/generation-log.js
@@ -116,7 +116,7 @@ export function compareGenerated(windowName, oldFiles, newFiles) {
     const newContent = newFiles[filename];
 
     // New file
-    if (!oldContent && newContent) {
+    if (hasFileBeenAdded(oldContent, newContent)) {
       changes.push({
         entity: extractEntityFromFilename(filename),
         field: null,
@@ -129,7 +129,7 @@ export function compareGenerated(windowName, oldFiles, newFiles) {
     }
 
     // Removed file
-    if (oldContent && !newContent) {
+    if (hasFileBeenRemoved(oldContent, newContent)) {
       changes.push({
         entity: extractEntityFromFilename(filename),
         field: null,
@@ -151,35 +151,12 @@ export function compareGenerated(windowName, oldFiles, newFiles) {
       const oldCols = parseFieldArray(oldContent, 'columns');
       const newCols = parseFieldArray(newContent, 'columns');
       const fieldChanges = diffFields(oldCols, newCols, filename, entity, 'column');
-      if (fieldChanges.length > 0) {
-        changes.push(...fieldChanges);
-      } else {
-        // Content changed but not columns — structural change
-        changes.push({
-          entity,
-          field: null,
-          file: filename,
-          change: 'component-changed',
-          before: null,
-          after: 'table structure changed',
-        });
-      }
+      handleFieldChanges(fieldChanges, changes, entity, filename);
     } else if (type === 'form') {
       const oldFields = parseFieldArray(oldContent, 'fields');
       const newFields = parseFieldArray(newContent, 'fields');
       const fieldChanges = diffFields(oldFields, newFields, filename, entity, 'form');
-      if (fieldChanges.length > 0) {
-        changes.push(...fieldChanges);
-      } else {
-        changes.push({
-          entity,
-          field: null,
-          file: filename,
-          change: 'component-changed',
-          before: null,
-          after: 'form structure changed',
-        });
-      }
+      handleFormFieldChanges(fieldChanges, changes, entity, filename);
     } else {
       // Page, index, other
       changes.push({
@@ -196,6 +173,45 @@ export function compareGenerated(windowName, oldFiles, newFiles) {
   return changes;
 }
 
+function handleFormFieldChanges(fieldChanges, changes, entity, filename) {
+  if (fieldChanges.length > 0) {
+    changes.push(...fieldChanges);
+  } else {
+    changes.push({
+      entity,
+      field: null,
+      file: filename,
+      change: 'component-changed',
+      before: null,
+      after: 'form structure changed',
+    });
+  }
+}
+
+function handleFieldChanges(fieldChanges, changes, entity, filename) {
+  if (fieldChanges.length > 0) {
+    changes.push(...fieldChanges);
+  } else {
+    // Content changed but not columns — structural change
+    changes.push({
+      entity,
+      field: null,
+      file: filename,
+      change: 'component-changed',
+      before: null,
+      after: 'table structure changed',
+    });
+  }
+}
+
+function hasFileBeenRemoved(oldContent, newContent) {
+  return oldContent && !newContent;
+}
+
+function hasFileBeenAdded(oldContent, newContent) {
+  return !oldContent && newContent;
+}
+
 /**
  * Create full log entries with run metadata.
  */
@@ -205,9 +221,9 @@ export function createLogEntries(windowName, trigger, oldFiles, newFiles, existi
   // Auto-increment runId
   const existingRunIds = existingLog
     .map(e => e.runId)
-    .filter(id => id && id.startsWith('run-'))
-    .map(id => parseInt(id.replace('run-', ''), 10))
-    .filter(n => !isNaN(n));
+    .filter(id => id?.startsWith('run-'))
+    .map(id => Number.parseInt(id.replace('run-', ''), 10))
+    .filter(n => !Number.isNaN(n));
   const nextRun = existingRunIds.length > 0 ? Math.max(...existingRunIds) + 1 : 1;
   const runId = `run-${String(nextRun).padStart(3, '0')}`;
   const run = new Date().toISOString();
@@ -286,12 +302,7 @@ export function generateWindowView(windowName, logPath, outPath) {
 
   for (const [runId, entries] of runs) {
     const first = entries[0];
-    lines.push(`## ${runId} (${first.run})`);
-    lines.push('');
-    lines.push(`**Trigger:** ${first.trigger}`);
-    lines.push('');
-    lines.push('| File | Field | Change | Before | After |');
-    lines.push('|------|-------|--------|--------|-------|');
+    lines.push(`## ${runId} (${first.run})`, '', `**Trigger:** ${first.trigger}`, '', '| File | Field | Change | Before | After |', '|------|-------|--------|--------|-------|');
     for (const e of entries) {
       const field = e.field ?? '-';
       const before = e.before ?? '-';
@@ -339,23 +350,14 @@ export function generateRunsView(logPath, outPath) {
       .map(([k, v]) => `${v} ${k}`)
       .join(', ');
 
-    lines.push(`## ${runId} - ${first.run}`);
-    lines.push('');
-    lines.push(`- **Trigger:** ${first.trigger}`);
-    lines.push(`- **Windows:** ${windows.join(', ')}`);
-    lines.push(`- **Changes:** ${summary}`);
-    lines.push('');
-    lines.push('| Window | File | Field | Change | Before | After |');
-    lines.push('|--------|------|-------|--------|--------|-------|');
+    lines.push(`## ${runId} - ${first.run}`, '', `- **Trigger:** ${first.trigger}`, `- **Windows:** ${windows.join(', ')}`, `- **Changes:** ${summary}`, '', '| Window | File | Field | Change | Before | After |', '|--------|------|-------|--------|--------|-------|');
     for (const e of entries) {
       const field = e.field ?? '-';
       const before = e.before ?? '-';
       const after = e.after ?? '-';
       lines.push(`| ${e.window} | ${e.file} | ${field} | ${e.change} | ${before} | ${after} |`);
     }
-    lines.push('');
-    lines.push('<!-- AI Summary: TODO -->');
-    lines.push('');
+    lines.push('', '<!-- AI Summary: TODO -->', '');
   }
 
   mkdirSync(dirname(outPath), { recursive: true });

--- a/cli/src/migrations/v1-to-v2.js
+++ b/cli/src/migrations/v1-to-v2.js
@@ -95,6 +95,12 @@ export function migrate(decisions, context = {}) {
   }
 
   // Remap entity keys
+  remapEntityKeys(decisions, keyMap, allRemap);
+
+  return decisions;
+}
+
+function remapEntityKeys(decisions, keyMap, allRemap) {
   const newEntities = {};
   for (const [oldKey, value] of Object.entries(decisions.entities)) {
     const newKey = keyMap[oldKey] || oldKey;
@@ -116,6 +122,4 @@ export function migrate(decisions, context = {}) {
       decisions.window.secondaryTabs = newTabs;
     }
   }
-
-  return decisions;
 }

--- a/cli/src/pipeline.js
+++ b/cli/src/pipeline.js
@@ -44,14 +44,17 @@ export function validatePipelineInput(input) {
   if (input.menuId || input.menuName) {
     return { valid: true, mode: 'menu' };
   }
+
   if (input.reportId) {
     if (!input.reportName) return { valid: false, error: 'reportName is required for report mode' };
     return { valid: true, mode: 'report' };
   }
+
   if (input.processId) {
     if (!input.processName) return { valid: false, error: 'processName is required for process mode' };
     return { valid: true, mode: 'process' };
   }
+
   if (!input.windowId) return { valid: false, error: 'windowId is required' };
   if (!input.windowName) return { valid: false, error: 'windowName is required' };
   return { valid: true, mode: 'window' };
@@ -92,32 +95,64 @@ export function parseArgs(argv) {
   const result = {};
 
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === '--menu-id' && args[i + 1]) {
+    if (isMenuIdArgument(args, i)) {
       result.menuId = args[++i];
-    } else if (args[i] === '--menu-name' && args[i + 1]) {
+    } else if (isMenuNameArgument(args, i)) {
       result.menuName = args[++i];
-    } else if (args[i] === '--process-id' && args[i + 1]) {
+    } else if (isProcessIdArgument(args, i)) {
       result.processId = args[++i];
-    } else if (args[i] === '--process-name' && args[i + 1]) {
+    } else if (isProcessNameArgument(args, i)) {
       result.processName = args[++i];
-    } else if (args[i] === '--report-id' && args[i + 1]) {
+    } else if (isReportIdArgument(args, i)) {
       result.reportId = args[++i];
-    } else if (args[i] === '--report-name' && args[i + 1]) {
+    } else if (isReportNameArgument(args, i)) {
       result.reportName = args[++i];
     } else if (args[i] === '--dry-run') {
       result.dryRun = true;
-    } else if (args[i] === '--skip-to' && args[i + 1]) {
+    } else if (isSkipToArgument(args, i)) {
       result.skipTo = args[++i];
     } else if (args[i] === '--skip-interactive') {
       result.skipInteractive = true;
     } else if (!args[i].startsWith('--') && !result.windowId) {
       result.windowId = args[i];
-    } else if (!args[i].startsWith('--') && result.windowId && !result.windowName) {
+    } else if (isWindowNameSet(args, i, result)) {
       result.windowName = args[i];
     }
   }
 
   return result;
+}
+
+function isWindowNameSet(args, i, result) {
+  return !args[i].startsWith('--') && result.windowId && !result.windowName;
+}
+
+function isSkipToArgument(args, i) {
+  return args[i] === '--skip-to' && args[i + 1];
+}
+
+function isReportNameArgument(args, i) {
+  return args[i] === '--report-name' && args[i + 1];
+}
+
+function isReportIdArgument(args, i) {
+  return args[i] === '--report-id' && args[i + 1];
+}
+
+function isProcessNameArgument(args, i) {
+  return args[i] === '--process-name' && args[i + 1];
+}
+
+function isProcessIdArgument(args, i) {
+  return args[i] === '--process-id' && args[i + 1];
+}
+
+function isMenuNameArgument(args, i) {
+  return args[i] === '--menu-name' && args[i + 1];
+}
+
+function isMenuIdArgument(args, i) {
+  return args[i] === '--menu-id' && args[i + 1];
 }
 
 /**
@@ -208,7 +243,7 @@ async function runProcessPipeline({ processId, processName, dryRun, isReport, sp
   const steps = buildProcessPipelineSteps();
   let pushToNeoRan = false;
   let frontendGenerated = false;
-  const pipelineLabel = isReport ? 'Report' : 'Process';
+  const pipelineLabel = getPipelineLabel(isReport);
   console.log(`\n=== Schema Forge ${pipelineLabel} Pipeline: ${processName} ===\n`);
 
   for (const step of steps) {
@@ -238,12 +273,8 @@ async function runProcessPipeline({ processId, processName, dryRun, isReport, sp
           const { pushProcessToNeo } = await import('./push-to-neo.js');
           const pushSpecType = specType || (isReport ? 'R' : 'P');
           const result = await pushProcessToNeo(processName, { dryRun, specType: pushSpecType });
-          if (dryRun) {
-            console.log(`  ✓ Dry run: push plan logged`);
-          } else {
-            console.log(`  ✓ NEO Headless configured (spec: ${result.specId})`);
-            pushToNeoRan = true;
-          }
+          logDryRunOutcome(dryRun, result);
+          pushToNeoRan = !dryRun; // Set to true if push was executed, false if dry run
           break;
         }
         case 'generate-process-frontend': {
@@ -253,10 +284,7 @@ async function runProcessPipeline({ processId, processName, dryRun, isReport, sp
           const generateFn = isReport ? generateAllReport : generateAllProcess;
           const files = generateFn(contract);
           const outDir = `artifacts/${processName}/generated/web/${processName}`;
-          await mkdir(outDir, { recursive: true });
-          for (const [filename, code] of Object.entries(files)) {
-            await writeFile(`${outDir}/${filename}`, code, 'utf8');
-          }
+          await createDirectoryAndWriteFiles(mkdir, outDir, files, writeFile);
           console.log(`  ✓ ${Object.keys(files).length} frontend components generated`);
           frontendGenerated = true;
           break;
@@ -267,10 +295,7 @@ async function runProcessPipeline({ processId, processName, dryRun, isReport, sp
           const contract = JSON.parse(await readFile(`artifacts/${processName}/contract.json`, 'utf8'));
           const result = runContractTests(contract);
           console.log(`  ✓ ${result.passed}/${result.total} passed, ${result.skipped} skipped`);
-          if (result.failed > 0) {
-            console.error(`  ✗ ${result.failed} tests failed`);
-            result.results.filter(r => !r.passed).forEach(r => console.error(`    - ${r.description}: ${r.reason}`));
-          }
+          logTestResults(result);
           break;
         }
       }
@@ -282,6 +307,33 @@ async function runProcessPipeline({ processId, processName, dryRun, isReport, sp
 
   console.log(`\n=== ${pipelineLabel} Pipeline complete ===\n`);
   printNextSteps({ pushToNeoRan, frontendGenerated });
+}
+
+function logTestResults(result) {
+  if (result.failed > 0) {
+    console.error(`  ✗ ${result.failed} tests failed`);
+    result.results.filter(r => !r.passed).forEach(r => console.error(`    - ${r.description}: ${r.reason}`));
+  }
+}
+
+function logDryRunOutcome(dryRun, result) {
+  if (dryRun) {
+    //dry run true, so the pushToneo is false
+    console.log(`  ✓ Dry run: push plan logged`);
+  } else {
+    console.log(`  ✓ NEO Headless configured (spec: ${result.specId})`);
+  }
+}
+
+function getPipelineLabel(isReport) {
+  return isReport ? 'Report' : 'Process';
+}
+
+async function createDirectoryAndWriteFiles(mkdir, outDir, files, writeFile) {
+  await mkdir(outDir, { recursive: true });
+  for (const [filename, code] of Object.entries(files)) {
+    await writeFile(`${outDir}/${filename}`, code, 'utf8');
+  }
 }
 
 /**
@@ -483,6 +535,7 @@ async function runWindowPipeline({ windowId, windowName, skipTo, skipInteractive
           } catch {
             // No existing contract — first generation, no prev needed
           }
+
           const contract = generateContract(schema, Array.isArray(rules) ? rules : rules.rules || [], processes.processes || [], prevVersion, prevContract);
           await writeFile(`artifacts/${windowName}/contract.json`, JSON.stringify(contract, null, 2) + '\n');
           console.log(`  ✓ Contract generated (${contract.testManifest.summary.total} tests)`);

--- a/cli/src/quality-gate.js
+++ b/cli/src/quality-gate.js
@@ -274,27 +274,31 @@ if (isMain) {
     process.exit(1);
   }
 }
-function getWindowNames(options, availableWindows, detectWindows, changedFiles, config) {
-  return options.mode === 'window'
-    ? [options.windowName]
-    : options.mode === 'all'
-      ? availableWindows
-      : detectWindows({
-        changedFiles,
-        blastRadius: config.blastRadius ?? [],
-        availableWindows,
-      });
+export function getWindowNames(options, availableWindows, detectWindows, changedFiles, config) {
+  if (options.mode === 'window') {
+    return [options.windowName];
+  }
+  if (options.mode === 'all') {
+    return availableWindows;
+  }
+  return detectWindows({
+    changedFiles,
+    blastRadius: config.blastRadius ?? [],
+    availableWindows,
+  });
 }
 
-function getAffectedWindows(options, availableWindows, detectWindowsDetailed, changedFiles, config) {
-  return options.mode === 'window'
-    ? [{ window: options.windowName, source: 'direct' }]
-    : options.mode === 'all'
-      ? availableWindows.map((window) => ({ window, source: 'direct' }))
-      : detectWindowsDetailed({
-        changedFiles,
-        blastRadius: config.blastRadius ?? [],
-        availableWindows,
-      });
+export function getAffectedWindows(options, availableWindows, detectWindowsDetailed, changedFiles, config) {
+  if (options.mode === 'window') {
+    return [{ window: options.windowName, source: 'direct' }];
+  }
+  if (options.mode === 'all') {
+    return availableWindows.map((window) => ({ window, source: 'direct' }));
+  }
+  return detectWindowsDetailed({
+    changedFiles,
+    blastRadius: config.blastRadius ?? [],
+    availableWindows,
+  });
 }
 

--- a/cli/src/quality-gate.js
+++ b/cli/src/quality-gate.js
@@ -98,7 +98,7 @@ export function parseQualityGateArgs(argv) {
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    if (arg === '--window' && argv[index + 1]) {
+    if (isWindowFlagWithArgument(arg, argv, index)) {
       options.mode = 'window';
       options.windowName = argv[index + 1];
       index += 1;
@@ -106,19 +106,19 @@ export function parseQualityGateArgs(argv) {
       options.mode = 'all';
     } else if (arg === '--pr-affected') {
       options.mode = 'pr-affected';
-    } else if (arg === '--baseline-ref' && argv[index + 1]) {
+    } else if (isBaselineRefFlag(arg, argv, index)) {
       options.baselineRef = argv[index + 1];
       index += 1;
-    } else if (arg === '--head-ref' && argv[index + 1]) {
+    } else if (isHeadRefFlag(arg, argv, index)) {
       options.headRef = argv[index + 1];
       index += 1;
-    } else if (arg === '--format' && argv[index + 1]) {
+    } else if (isFormatFlagWithArgument(arg, argv, index)) {
       options.format = argv[index + 1];
       index += 1;
-    } else if (arg === '--output' && argv[index + 1]) {
+    } else if (isOutputFlagWithArgument(arg, argv, index)) {
       options.outputPath = argv[index + 1];
       index += 1;
-    } else if (arg === '--json' && argv[index + 1]) {
+    } else if (isJsonFlagWithArgument(arg, argv, index)) {
       options.jsonPath = argv[index + 1];
       index += 1;
     } else if (arg === '--analysis-dir' && argv[index + 1]) {
@@ -134,14 +134,40 @@ export function parseQualityGateArgs(argv) {
   return options;
 }
 
+function isJsonFlagWithArgument(arg, argv, index) {
+  return arg === '--json' && argv[index + 1];
+}
+
+function isOutputFlagWithArgument(arg, argv, index) {
+  return arg === '--output' && argv[index + 1];
+}
+
+function isFormatFlagWithArgument(arg, argv, index) {
+  return arg === '--format' && argv[index + 1];
+}
+
+function isHeadRefFlag(arg, argv, index) {
+  return arg === '--head-ref' && argv[index + 1];
+}
+
+function isBaselineRefFlag(arg, argv, index) {
+  return arg === '--baseline-ref' && argv[index + 1];
+}
+
+function isWindowFlagWithArgument(arg, argv, index) {
+  return arg === '--window' && argv[index + 1];
+}
+
 export async function runQualityGateCli({ args = process.argv.slice(2), rootDir = ROOT, deps = {} } = {}) {
   const options = parseQualityGateArgs(args);
+
   const loadConfig = deps.loadConfig ?? loadQualityGateConfig;
   const collectWindows = deps.collectDecisionWindows ?? collectDecisionWindows;
   const detectWindows = deps.detectAffectedWindows ?? detectAffectedWindows;
   const detectWindowsDetailed = deps.detectAffectedWindowsDetailed ?? detectAffectedWindowsDetailed;
   const changedFilesForPr = deps.getChangedFiles ?? getChangedFiles;
   const qualityRunner = deps.runQualityGate ?? ((params) => runQualityGate({ ...params, checkers: QUALITY_GATE_CHECKS }));
+
   const config = await loadConfig(rootDir);
   const baselineRef = options.baselineRef ?? config.gate?.baselineRef ?? 'origin/main';
 
@@ -153,25 +179,9 @@ export async function runQualityGateCli({ args = process.argv.slice(2), rootDir 
     ? await changedFilesForPr({ rootDir, baselineRef, headRef: options.headRef })
     : [];
 
-  const affectedWindowMetadata = options.mode === 'window'
-    ? [{ window: options.windowName, source: 'direct' }]
-    : options.mode === 'all'
-      ? availableWindows.map((window) => ({ window, source: 'direct' }))
-      : detectWindowsDetailed({
-          changedFiles,
-          blastRadius: config.blastRadius ?? [],
-          availableWindows,
-        });
+  const affectedWindowMetadata = getAffectedWindows(options, availableWindows, detectWindowsDetailed, changedFiles, config);
 
-  const windowNames = options.mode === 'window'
-    ? [options.windowName]
-    : options.mode === 'all'
-      ? availableWindows
-      : detectWindows({
-          changedFiles,
-          blastRadius: config.blastRadius ?? [],
-          availableWindows,
-        });
+  const windowNames = getWindowNames(options, availableWindows, detectWindows, changedFiles, config);
 
   if (windowNames.length === 0) {
     const stdout = '<!-- sfqg-report -->\nNo windows affected; gate skipped\n';
@@ -264,3 +274,27 @@ if (isMain) {
     process.exit(1);
   }
 }
+function getWindowNames(options, availableWindows, detectWindows, changedFiles, config) {
+  return options.mode === 'window'
+    ? [options.windowName]
+    : options.mode === 'all'
+      ? availableWindows
+      : detectWindows({
+        changedFiles,
+        blastRadius: config.blastRadius ?? [],
+        availableWindows,
+      });
+}
+
+function getAffectedWindows(options, availableWindows, detectWindowsDetailed, changedFiles, config) {
+  return options.mode === 'window'
+    ? [{ window: options.windowName, source: 'direct' }]
+    : options.mode === 'all'
+      ? availableWindows.map((window) => ({ window, source: 'direct' }))
+      : detectWindowsDetailed({
+        changedFiles,
+        blastRadius: config.blastRadius ?? [],
+        availableWindows,
+      });
+}
+

--- a/cli/src/quality-gate/checks/invariants.js
+++ b/cli/src/quality-gate/checks/invariants.js
@@ -93,35 +93,16 @@ export async function runInvariantsCheck(windowName, { rootDir, windowDir, confi
   }
 
   const violations = [];
+
   const entities = contract.frontendContract.entities ?? {};
   const primaryEntity = contract.frontendContract.window?.primaryEntity ?? Object.keys(entities)[0] ?? null;
   const headerEntity = primaryEntity ? entities[primaryEntity] : null;
   const anyDraftMode = Object.values(entities).some((entity) => entity?.draftMode?.enabled === true);
   const draftModeReadOnlyLogicAllowlist = config?.invariants?.draftModeReadOnlyLogicAllowlist ?? [];
 
-  if (config?.invariants?.draftModeReadOnlyLogic && anyDraftMode && headerEntity?.fields) {
-    for (const field of headerEntity.fields) {
-      if (!field.form || NON_EDITABLE_VISIBILITIES.has(field.visibility)) {
-        continue;
-      }
-      if (isDraftModeReadOnlyLogicAllowed(windowName, primaryEntity, field.name, draftModeReadOnlyLogicAllowlist)) {
-        continue;
-      }
-      if (!field.readOnlyLogic) {
-        violations.push(`${primaryEntity}.${field.name} missing readOnlyLogic while draftMode is enabled.`);
-      }
-    }
-  }
+  validateDraftModeReadOnlyLogic(config, anyDraftMode, headerEntity, windowName, primaryEntity, draftModeReadOnlyLogicAllowlist, violations);
 
-  if (config?.invariants?.notNullRequiresRequired) {
-    for (const [entityName, entity] of Object.entries(entities)) {
-      for (const field of entity.fields ?? []) {
-        if (field.sourceRequired === true && field.required !== true && !hasServerDefault(field)) {
-          violations.push(`${entityName}.${field.name} must remain required because the source column is NOT NULL.`);
-        }
-      }
-    }
-  }
+  validateNotNullRequirements(config, entities, violations);
 
   const detailEntityName = findDetailEntityName(entities, primaryEntity);
   const detailEntity = detailEntityName ? entities[detailEntityName] : null;
@@ -139,37 +120,13 @@ export async function runInvariantsCheck(windowName, { rootDir, windowDir, confi
       violations.push('lines.addLineFields.product must declare lookup: true.');
     }
 
-    if (config.invariants.addLineFields.quantityDefaultOne) {
-      const quantityEntrySource = findQuantityEntrySource(addLineFieldsSource);
-      if (quantityEntrySource && !/defaultValue:\s*1/.test(quantityEntrySource)) {
-        violations.push('lines.addLineFields quantity field must declare defaultValue: 1.');
-      }
-    }
+    validateAddLineFieldsDefaults(config, addLineFieldsSource, violations);
 
-    if (config.invariants.addLineFields.hiddenContainsGrossUnitPriceAndPriceList) {
-      if (detailFieldNames.has('grossUnitPrice') && !hasHiddenKey(addLineFieldsSource, 'grossUnitPrice')) {
-        violations.push("lines.addLineFields.hidden must include 'grossUnitPrice'.");
-      }
-      if (detailFieldNames.has('priceList') && !hasHiddenKey(addLineFieldsSource, 'priceList')) {
-        violations.push("lines.addLineFields.hidden must include 'priceList'.");
-      }
-    }
+    validateHiddenFields(config, detailFieldNames, addLineFieldsSource, violations);
   }
 
   const customFormPathRoot = config?.invariants?.customFormPathRoot ?? null;
-  for (const declaration of findCustomFormDeclarations(contract.frontendContract.window)) {
-    if (
-      customFormPathRoot
-      && (declaration.component.includes('/') || declaration.component.startsWith('@/'))
-      && !declaration.component.startsWith(customFormPathRoot)
-    ) {
-      violations.push(`${declaration.location} must stay under '${customFormPathRoot}'.`);
-      continue;
-    }
-    if (!customFormExists(rootDir, windowName, declaration.component)) {
-      violations.push(`${declaration.location} references '${declaration.component}', but no local custom form exists for ${windowName}.`);
-    }
-  }
+  validateCustomFormDeclarations(contract, customFormPathRoot, violations, rootDir, windowName);
 
   if (violations.length > 0) {
     return {
@@ -180,3 +137,65 @@ export async function runInvariantsCheck(windowName, { rootDir, windowDir, confi
 
   return { status: 'pass', detail: 'All invariants satisfied.' };
 }
+function validateCustomFormDeclarations(contract, customFormPathRoot, violations, rootDir, windowName) {
+  for (const declaration of findCustomFormDeclarations(contract.frontendContract.window)) {
+    if (customFormPathRoot
+      && (declaration.component.includes('/') || declaration.component.startsWith('@/'))
+      && !declaration.component.startsWith(customFormPathRoot)) {
+      violations.push(`${declaration.location} must stay under '${customFormPathRoot}'.`);
+      continue;
+    }
+    if (!customFormExists(rootDir, windowName, declaration.component)) {
+      violations.push(`${declaration.location} references '${declaration.component}', but no local custom form exists for ${windowName}.`);
+    }
+  }
+}
+
+function validateAddLineFieldsDefaults(config, addLineFieldsSource, violations) {
+  if (config.invariants.addLineFields.quantityDefaultOne) {
+    const quantityEntrySource = findQuantityEntrySource(addLineFieldsSource);
+    if (quantityEntrySource && !/defaultValue:\s*1/.test(quantityEntrySource)) {
+      violations.push('lines.addLineFields quantity field must declare defaultValue: 1.');
+    }
+  }
+}
+
+function validateHiddenFields(config, detailFieldNames, addLineFieldsSource, violations) {
+  if (config.invariants.addLineFields.hiddenContainsGrossUnitPriceAndPriceList) {
+    if (detailFieldNames.has('grossUnitPrice') && !hasHiddenKey(addLineFieldsSource, 'grossUnitPrice')) {
+      violations.push("lines.addLineFields.hidden must include 'grossUnitPrice'.");
+    }
+    if (detailFieldNames.has('priceList') && !hasHiddenKey(addLineFieldsSource, 'priceList')) {
+      violations.push("lines.addLineFields.hidden must include 'priceList'.");
+    }
+  }
+}
+
+function validateNotNullRequirements(config, entities, violations) {
+  if (config?.invariants?.notNullRequiresRequired) {
+    for (const [entityName, entity] of Object.entries(entities)) {
+      for (const field of entity.fields ?? []) {
+        if (field.sourceRequired === true && field.required !== true && !hasServerDefault(field)) {
+          violations.push(`${entityName}.${field.name} must remain required because the source column is NOT NULL.`);
+        }
+      }
+    }
+  }
+}
+
+function validateDraftModeReadOnlyLogic(config, anyDraftMode, headerEntity, windowName, primaryEntity, draftModeReadOnlyLogicAllowlist, violations) {
+  if (config?.invariants?.draftModeReadOnlyLogic && anyDraftMode && headerEntity?.fields) {
+    for (const field of headerEntity.fields) {
+      if (!field.form || NON_EDITABLE_VISIBILITIES.has(field.visibility)) {
+        continue;
+      }
+      if (isDraftModeReadOnlyLogicAllowed(windowName, primaryEntity, field.name, draftModeReadOnlyLogicAllowlist)) {
+        continue;
+      }
+      if (!field.readOnlyLogic) {
+        violations.push(`${primaryEntity}.${field.name} missing readOnlyLogic while draftMode is enabled.`);
+      }
+    }
+  }
+}
+

--- a/cli/src/resolve-curated.js
+++ b/cli/src/resolve-curated.js
@@ -137,7 +137,7 @@ function visibilityDefaults(visibility) {
 // Category inference
 // ---------------------------------------------------------------------------
 
-function inferCategory(windowName) {
+function inferCategory(windowName = '') {
   const name = windowName || '';
   if (/Sales/i.test(name)) return 'sales';
   if (/Purchase/i.test(name)) return 'purchases';
@@ -178,7 +178,7 @@ function resolveFieldVisibility(rawField, fieldDecision, discardPatterns) {
 }
 
 function decisionOrDefault(fieldDecision, key, defaults) {
-  return fieldDecision[key] !== undefined ? fieldDecision[key] : defaults[key];
+  return fieldDecision[key] === undefined ? defaults[key] : fieldDecision[key];
 }
 
 function buildBaseField(rawField, fieldDecision, visibility) {
@@ -189,7 +189,7 @@ function buildBaseField(rawField, fieldDecision, visibility) {
     label: fieldDecision.label || rawField.label,
     type: fieldDecision.type || (rawField.type === 'id' ? 'id' : rawField.type),
     visibility,
-    required: fieldDecision.required !== undefined ? fieldDecision.required : (rawField.mandatory || false),
+    required: fieldDecision.required === undefined ? (rawField.mandatory || false) : fieldDecision.required,
     grid: decisionOrDefault(fieldDecision, 'grid', defaults),
     form: decisionOrDefault(fieldDecision, 'form', defaults),
     searchable: decisionOrDefault(fieldDecision, 'searchable', defaults),
@@ -248,9 +248,9 @@ function applyForeignKeyProps(field, rawField, fieldDecision) {
 }
 
 function applyVisibleFieldProps(field, rawField, fieldDecision) {
-  const readOnlyLogic = fieldDecision.readOnlyLogic !== undefined
-    ? (fieldDecision.readOnlyLogic || rawField.readOnlyLogic || null)
-    : (rawField.readOnlyLogic || null);
+  const readOnlyLogic = fieldDecision.readOnlyLogic === undefined
+    ? (rawField.readOnlyLogic || null)
+    : (fieldDecision.readOnlyLogic || rawField.readOnlyLogic || null);
   if (readOnlyLogic) field.readOnlyLogic = readOnlyLogic;
 
   if (fieldDecision.displayLogic !== null) {
@@ -349,7 +349,7 @@ function resolveRules(rulesRaw, decisions) {
 
     const classified = classifyRule(rawRule);
     const decision = classified.tier === 'auto'
-      ? (classified.autoDecision === 'keep' ? 'Keep' : 'Omit')
+      ? determineAutoDecision(classified)
       : 'pending';
 
     result.push({
@@ -360,6 +360,10 @@ function resolveRules(rulesRaw, decisions) {
   }
 
   return result;
+}
+
+function determineAutoDecision(classified) {
+  return classified.autoDecision === 'keep' ? 'Keep' : 'Omit';
 }
 
 // ---------------------------------------------------------------------------
@@ -581,7 +585,7 @@ export function reorderKeys(obj, canonicalOrder) {
   const result = {};
   const seen = new Set();
   for (const key of canonicalOrder) {
-    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+    if (Object.hasOwn(obj, key)) {
       result[key] = obj[key];
       seen.add(key);
     }
@@ -786,6 +790,17 @@ async function runCli() {
     return;
   }
 
+  printSchemaAndRules(dump, schema, rules);
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  runCli().catch(err => {
+    console.error('Error:', err.message);
+    process.exit(1);
+  });
+}
+
+function printSchemaAndRules(dump, schema, rules) {
   if (dump) {
     console.log('--- schema ---');
     console.log(JSON.stringify(schema, null, 2));
@@ -799,11 +814,4 @@ async function runCli() {
     }
     console.log(`Rules: ${rules.length}`);
   }
-}
-
-if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
-  runCli().catch(err => {
-    console.error('Error:', err.message);
-    process.exit(1);
-  });
 }

--- a/cli/test/quality-gate-window-selection.test.js
+++ b/cli/test/quality-gate-window-selection.test.js
@@ -1,0 +1,152 @@
+import { describe, it } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { getWindowNames, getAffectedWindows } from '../src/quality-gate.js';
+
+function createSpy(returnValue) {
+  const calls = [];
+  const fn = (...args) => {
+    calls.push(args);
+    return returnValue;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+describe('getWindowNames', () => {
+  it('returns [windowName] when mode is "window"; detect fn NOT called', () => {
+    const detect = createSpy(['should-not-return-this']);
+    const result = getWindowNames(
+      { mode: 'window', windowName: 'sales-order' },
+      ['sales-order', 'purchase-order'],
+      detect,
+      ['file.js'],
+      { blastRadius: ['shared/foo.js'] },
+    );
+    assert.deepEqual(result, ['sales-order']);
+    assert.equal(detect.calls.length, 0);
+  });
+
+  it('returns all availableWindows when mode is "all"; detect fn NOT called', () => {
+    const detect = createSpy([]);
+    const result = getWindowNames(
+      { mode: 'all' },
+      ['sales-order', 'purchase-order'],
+      detect,
+      ['file.js'],
+      {},
+    );
+    assert.deepEqual(result, ['sales-order', 'purchase-order']);
+    assert.equal(detect.calls.length, 0);
+  });
+
+  it('calls detect fn with proper args when mode is "changed"', () => {
+    const sentinel = ['detected-window'];
+    const detect = createSpy(sentinel);
+    const changedFiles = ['a.js', 'b.js'];
+    const config = { blastRadius: ['shared/foo.js'] };
+    const availableWindows = ['sales-order', 'purchase-order'];
+    const result = getWindowNames(
+      { mode: 'changed' },
+      availableWindows,
+      detect,
+      changedFiles,
+      config,
+    );
+    assert.equal(result, sentinel);
+    assert.equal(detect.calls.length, 1);
+    assert.deepEqual(detect.calls[0][0], {
+      changedFiles,
+      blastRadius: ['shared/foo.js'],
+      availableWindows,
+    });
+  });
+
+  it('defaults blastRadius to [] when config.blastRadius is missing', () => {
+    const detect = createSpy([]);
+    getWindowNames({ mode: 'changed' }, ['w1'], detect, [], {});
+    assert.deepEqual(detect.calls[0][0].blastRadius, []);
+  });
+
+  it('passes config.blastRadius through when present', () => {
+    const detect = createSpy([]);
+    getWindowNames(
+      { mode: 'changed' },
+      ['w1'],
+      detect,
+      [],
+      { blastRadius: ['shared/foo.js', 'shared/bar.js'] },
+    );
+    assert.deepEqual(detect.calls[0][0].blastRadius, ['shared/foo.js', 'shared/bar.js']);
+  });
+});
+
+describe('getAffectedWindows', () => {
+  it('returns [{ window, source: "direct" }] when mode is "window"; detect fn NOT called', () => {
+    const detect = createSpy([]);
+    const result = getAffectedWindows(
+      { mode: 'window', windowName: 'sales-order' },
+      ['sales-order', 'purchase-order'],
+      detect,
+      [],
+      {},
+    );
+    assert.deepEqual(result, [{ window: 'sales-order', source: 'direct' }]);
+    assert.equal(detect.calls.length, 0);
+  });
+
+  it('maps all availableWindows to direct entries when mode is "all"; detect fn NOT called', () => {
+    const detect = createSpy([]);
+    const result = getAffectedWindows(
+      { mode: 'all' },
+      ['sales-order', 'purchase-order'],
+      detect,
+      [],
+      {},
+    );
+    assert.deepEqual(result, [
+      { window: 'sales-order', source: 'direct' },
+      { window: 'purchase-order', source: 'direct' },
+    ]);
+    assert.equal(detect.calls.length, 0);
+  });
+
+  it('calls detect fn with proper args when mode is "changed"', () => {
+    const sentinel = [{ window: 'sales-order', source: 'blast-radius' }];
+    const detect = createSpy(sentinel);
+    const changedFiles = ['a.js'];
+    const config = { blastRadius: ['shared/foo.js'] };
+    const availableWindows = ['sales-order'];
+    const result = getAffectedWindows(
+      { mode: 'changed' },
+      availableWindows,
+      detect,
+      changedFiles,
+      config,
+    );
+    assert.equal(result, sentinel);
+    assert.equal(detect.calls.length, 1);
+    assert.deepEqual(detect.calls[0][0], {
+      changedFiles,
+      blastRadius: ['shared/foo.js'],
+      availableWindows,
+    });
+  });
+
+  it('defaults blastRadius to [] when config.blastRadius is missing', () => {
+    const detect = createSpy([]);
+    getAffectedWindows({ mode: 'changed' }, ['w1'], detect, [], {});
+    assert.deepEqual(detect.calls[0][0].blastRadius, []);
+  });
+
+  it('passes config.blastRadius through when present', () => {
+    const detect = createSpy([]);
+    getAffectedWindows(
+      { mode: 'changed' },
+      ['w1'],
+      detect,
+      [],
+      { blastRadius: ['shared/foo.js'] },
+    );
+    assert.deepEqual(detect.calls[0][0].blastRadius, ['shared/foo.js']);
+  });
+});

--- a/tools/app-shell/src/hooks/useCallout.js
+++ b/tools/app-shell/src/hooks/useCallout.js
@@ -42,13 +42,8 @@ export function useCallout(entity, { token, apiBaseUrl }) {
       setCalloutLoading(true);
       try {
         // Extract auxiliary values from formState (keys like "businessPartner_LOC")
-        const auxiliaryValues = {};
         const state = formState ?? {};
-        for (const [key, val] of Object.entries(state)) {
-          if (/^[a-zA-Z]+_[A-Z]{2,4}$/.test(key) && val != null && val !== '') {
-            auxiliaryValues[key] = String(val);
-          }
-        }
+        const auxiliaryValues = extractAuxiliaryValues(state);
         const payload = {
           field,
           value,
@@ -105,3 +100,13 @@ export function useCallout(entity, { token, apiBaseUrl }) {
 
   return { calloutResult, calloutLoading, executeCallout };
 }
+function extractAuxiliaryValues(state) {
+  const auxiliaryValues = {};
+  for (const [key, val] of Object.entries(state)) {
+    if (/^[a-zA-Z]+_[A-Z]{2,4}$/.test(key) && val != null && val !== '') {
+      auxiliaryValues[key] = String(val);
+    }
+  }
+  return auxiliaryValues;
+}
+

--- a/tools/app-shell/src/lib/__tests__/getFilteredKey.test.js
+++ b/tools/app-shell/src/lib/__tests__/getFilteredKey.test.js
@@ -1,0 +1,76 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { getFilteredKey } from '../gridQuery.js';
+
+describe('getFilteredKey', () => {
+  describe('backendFilterKey precedence', () => {
+    it('returns backendFilterKey when set as a non-empty string (ignores mode/op)', () => {
+      const col = { key: 'businessPartner', backendFilterKey: 'bpartner_id' };
+      assert.equal(getFilteredKey(col, 'identifier', 'iContains'), 'bpartner_id');
+      assert.equal(getFilteredKey(col, 'value', 'equals'), 'bpartner_id');
+    });
+
+    it('returns empty string when backendFilterKey is "" (locks in != null semantics)', () => {
+      const col = { key: 'businessPartner', backendFilterKey: '' };
+      assert.equal(getFilteredKey(col, 'identifier', 'iContains'), '');
+      assert.equal(getFilteredKey(col, 'value', 'equals'), '');
+    });
+
+    it('falls through when backendFilterKey is null', () => {
+      const col = { key: 'businessPartner', backendFilterKey: null };
+      assert.equal(getFilteredKey(col, 'value', 'equals'), 'businessPartner');
+    });
+
+    it('falls through when backendFilterKey is undefined (omitted)', () => {
+      const col = { key: 'businessPartner' };
+      assert.equal(getFilteredKey(col, 'value', 'equals'), 'businessPartner');
+    });
+  });
+
+  describe('identifier mode + textual op', () => {
+    it('appends $_identifier for iContains', () => {
+      const col = { key: 'businessPartner' };
+      assert.equal(getFilteredKey(col, 'identifier', 'iContains'), 'businessPartner$_identifier');
+    });
+
+    it('appends $_identifier for iNotContains', () => {
+      const col = { key: 'businessPartner' };
+      assert.equal(getFilteredKey(col, 'identifier', 'iNotContains'), 'businessPartner$_identifier');
+    });
+
+    it('appends $_identifier for iEquals', () => {
+      const col = { key: 'businessPartner' };
+      assert.equal(getFilteredKey(col, 'identifier', 'iEquals'), 'businessPartner$_identifier');
+    });
+
+    it('appends $_identifier for iNotEqual', () => {
+      const col = { key: 'businessPartner' };
+      assert.equal(getFilteredKey(col, 'identifier', 'iNotEqual'), 'businessPartner$_identifier');
+    });
+  });
+
+  describe('identifier mode + non-textual op', () => {
+    it('returns col.key for equals', () => {
+      const col = { key: 'businessPartner' };
+      assert.equal(getFilteredKey(col, 'identifier', 'equals'), 'businessPartner');
+    });
+
+    it('returns col.key for greaterThan', () => {
+      const col = { key: 'amount' };
+      assert.equal(getFilteredKey(col, 'identifier', 'greaterThan'), 'amount');
+    });
+  });
+
+  describe('non-identifier mode', () => {
+    it('returns col.key when mode is "value" regardless of op', () => {
+      const col = { key: 'businessPartner' };
+      assert.equal(getFilteredKey(col, 'value', 'iContains'), 'businessPartner');
+      assert.equal(getFilteredKey(col, 'value', 'equals'), 'businessPartner');
+    });
+
+    it('returns col.key when mode is undefined', () => {
+      const col = { key: 'businessPartner' };
+      assert.equal(getFilteredKey(col, undefined, 'iContains'), 'businessPartner');
+    });
+  });
+});

--- a/tools/app-shell/src/lib/gridQuery.js
+++ b/tools/app-shell/src/lib/gridQuery.js
@@ -452,13 +452,11 @@ function buildRowCriteria(col, row) {
   // For identifier columns: textual ops filter against the $_identifier (user
   // typed free text → match BP display name). Discrete ops (equals/notEqual/
   // inSet, picked from the checkbox popover) filter against the ID directly.
-  const fieldName = col.backendFilterKey
-    ?? (mode === 'identifier'
-        ? (TEXTUAL_IDENTIFIER_OPS.has(op) ? `${col.key}$_identifier` : col.key)
-        : col.key);
+  const fieldName = getFilteredKey(col, mode, op);
 
-  if (op === 'isNull') return [{ fieldName, operator: 'isNull' }];
-  if (op === 'isNotNull') return [{ fieldName, operator: 'notNull' }];
+    if (op === 'isNull' || op === 'isNotNull') {
+    return createNullCriteria(fieldName, op);
+  }
 
   const val = row.value;
 
@@ -477,29 +475,19 @@ function buildRowCriteria(col, row) {
   }
 
   if (op === 'inSet') {
-    const items = Array.isArray(val)
-      ? val.filter((v) => v !== '' && v != null).map(String)
-      : String(val).split(',').map((s) => s.trim()).filter(Boolean);
-    if (items.length === 0) return null;
-    if (items.length === 1) return [{ fieldName, operator: 'equals', value: items[0] }];
-    return [{ fieldName, operator: 'inSet', value: items.join(',') }];
-  }
+    return generateInSetCriteria(val, fieldName);
 
+  }
+  
   // Multi-value via a checkbox picker: OR-compose the same operator across items.
   if (Array.isArray(val)) {
-    const items = val.filter((v) => v !== '' && v != null).map(String);
-    if (items.length === 0) return null;
-    if (items.length === 1) return [{ fieldName, operator: op, value: items[0] }];
-    const clauses = items.map((v) => ({ fieldName, operator: op, value: v }));
-    return [{ _constructor: 'AdvancedCriteria', operator: 'or', criteria: clauses }];
+    return buildOrCriteria(val, fieldName, op);
   }
 
   if (val === null || val === undefined || val === '') return null;
 
   if (mode === 'numeric') {
-    const num = coerceNumeric(val);
-    if (num === null) return null;
-    return [{ fieldName, operator: op, value: num }];
+    return buildNumericCriteria(val, fieldName, op);
   }
 
   if (mode === 'booleanLabel') {
@@ -508,6 +496,72 @@ function buildRowCriteria(col, row) {
   }
 
   return [{ fieldName, operator: op, value: val }];
+}
+
+function createNullCriteria(fieldName, op) {
+  return [{ fieldName, operator: op === 'isNull' ? 'isNull' : 'notNull' }];
+}
+
+function generateInSetCriteria(val, fieldName) {
+  const items = processInput(val);
+  let result;
+  if (items.length === 0) {
+    result = null;
+
+  } else {
+    if (items.length === 1) {
+      result = [{ fieldName, operator: 'equals', value: items[0] }];
+    } else {
+
+      result = [{ fieldName, operator: 'inSet', value: items.join(',') }];
+    }
+
+  }
+  return result;
+}
+
+function buildOrCriteria(val, fieldName, op) {
+  let result;
+  const items = filterAndMapToString(val);
+  if (items.length === 0) {
+    result = null;
+
+  } else {
+    if (items.length === 1) {
+      result = [{ fieldName, operator: op, value: items[0] }];
+    } else {
+      const clauses = items.map((v) => ({ fieldName, operator: op, value: v }));
+      result = [{ _constructor: 'AdvancedCriteria', operator: 'or', criteria: clauses }];
+    }
+  }
+  return result;
+}
+
+function processInput(val) {
+  return Array.isArray(val)
+    ? filterAndMapToString(val)
+    : splitAndTrimString(val).filter(Boolean);
+}
+
+function getFilteredKey(col, mode, op) {
+  return col.backendFilterKey
+    ?? (mode === 'identifier'
+      ? (TEXTUAL_IDENTIFIER_OPS.has(op) ? `${col.key}$_identifier` : col.key)
+      : col.key);
+}
+
+function splitAndTrimString(val) {
+  return String(val).split(',').map((s) => s.trim());
+}
+
+function filterAndMapToString(val) {
+  return val.filter((v) => v !== '' && v != null).map(String);
+}
+
+function buildNumericCriteria(val, fieldName, op) {
+  const num = coerceNumeric(val);
+
+  return (num === null) ? null : [{ fieldName, operator: op, value: num }];
 }
 
 function coerceNumeric(val) {
@@ -521,8 +575,8 @@ function inferSortMode(type, col) {
   if (col?.badgeLabels) return 'booleanLabel';
   switch (type) {
     case 'selector': return 'identifier';
-    case 'status':   return 'enumLabel';
-    case 'boolean':  return 'booleanLabel';
-    default:         return 'raw';
+    case 'status': return 'enumLabel';
+    case 'boolean': return 'booleanLabel';
+    default: return 'raw';
   }
 }

--- a/tools/app-shell/src/lib/gridQuery.js
+++ b/tools/app-shell/src/lib/gridQuery.js
@@ -543,11 +543,12 @@ function processInput(val) {
     : splitAndTrimString(val).filter(Boolean);
 }
 
-function getFilteredKey(col, mode, op) {
-  return col.backendFilterKey
-    ?? (mode === 'identifier'
-      ? (TEXTUAL_IDENTIFIER_OPS.has(op) ? `${col.key}$_identifier` : col.key)
-      : col.key);
+export function getFilteredKey(col, mode, op) {
+  if (col.backendFilterKey != null) return col.backendFilterKey;
+  if (mode === 'identifier' && TEXTUAL_IDENTIFIER_OPS.has(op)) {
+    return `${col.key}$_identifier`;
+  }
+  return col.key;
 }
 
 function splitAndTrimString(val) {


### PR DESCRIPTION
## Summary

Behavior-preserving refactors to reduce SonarQube cognitive complexity across CLI tooling and app-shell. No functional changes.

## Changes

**CLI (`cli/src/`)**
- `generate-aggregate.js` — extract `aggregateKpiSingleSections`
- `generate-mock-data.js` — extract `isDocumentOrNumberField`, `isDocumentStatus`, `resolveFieldDependentValue`
- `generation-log.js` — extract `handleFieldChanges`, `handleFormFieldChanges`, `hasFileBeenAdded/Removed`; collapse multiple `lines.push()` into single calls; modernize `parseInt`→`Number.parseInt`, `id && id.startsWith`→`id?.startsWith`
- `migrations/v1-to-v2.js` — extract `remapEntityKeys`
- `pipeline.js` — extract `isXArgument` helpers for `parseArgs`; extract `logDryRunOutcome`, `logTestResults`, `getPipelineLabel`, `createDirectoryAndWriteFiles`
- `quality-gate.js` — extract `isXFlagWithArgument` helpers; extract `getWindowNames` / `getAffectedWindows` (nested ternaries → early returns)
- `quality-gate/checks/invariants.js` — split `runInvariantsCheck` into `validateDraftModeReadOnlyLogic`, `validateNotNullRequirements`, `validateAddLineFieldsDefaults`, `validateHiddenFields`, `validateCustomFormDeclarations`
- `resolve-curated.js` — flip `!== undefined ? a : b` ternaries to `=== undefined ? b : a`; `Object.prototype.hasOwnProperty.call` → `Object.hasOwn`; default param `windowName = ''`; extract `determineAutoDecision`, `printSchemaAndRules`

**app-shell (`tools/app-shell/`)**
- `hooks/useCallout.js` — extract `extractAuxiliaryValues`
- `lib/gridQuery.js` — extract `getFilteredKey` (now exported), `createNullCriteria`, `generateInSetCriteria`, `buildOrCriteria`, `buildNumericCriteria`, `processInput`, `filterAndMapToString`, `splitAndTrimString`

**Tests added**
- `cli/test/quality-gate-window-selection.test.js` — covers `getWindowNames` / `getAffectedWindows`
- `tools/app-shell/src/lib/__tests__/getFilteredKey.test.js` — covers `getFilteredKey`, including the `backendFilterKey === ''` edge case (preserves prior `??` semantics)

## Test plan

- [x] `make test` (CLI unit tests pass)
- [x] Vitest suite for app-shell passes
- [x] Manual review confirms no behavior change
- [ ] CI green