### PR TITLE
Feature ETP-4092 Add Mixpanel env vars to SPA build

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -88,6 +88,11 @@ jobs:
           # Sentry — DSN as variable (public, baked into JS bundle), token as secret
           VITE_SENTRY_DSN: ${{ vars.VITE_SENTRY_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          # Mixpanel — token as secret, API host as variable
+          VITE_MIXPANEL_ENABLED: "true"
+          VITE_MIXPANEL_TOKEN: ${{ secrets.VITE_MIXPANEL_TOKEN }}
+          VITE_MIXPANEL_DEBUG: "false"
+          VITE_MIXPANEL_API_HOST: ${{ vars.VITE_MIXPANEL_API_HOST }}
         # .env.production (committed) provides VITE_MOCK=false and VITE_API_BASE=/etendo
 
       - name: Generate reports manifest


### PR DESCRIPTION
## Summary

- Add `VITE_MIXPANEL_ENABLED`, `VITE_MIXPANEL_TOKEN`, `VITE_MIXPANEL_DEBUG`, and `VITE_MIXPANEL_API_HOST` to the "Build app-shell" step in `deploy-staging.yml`
- Token is read from the `VITE_MIXPANEL_TOKEN` GitHub secret; API host from the `VITE_MIXPANEL_API_HOST` repository variable; enabled/debug flags are hardcoded

## Test plan

- [ ] Merge to `epic/ETP-3504` and trigger the Deploy SPA workflow (experimental environment)
- [ ] Confirm the built JS bundle connects to `https://api-eu.mixpanel.com` and sends events
- [ ] Confirm no Mixpanel token appears in plain text in the S3 artifacts