### PR TITLE
Feature ETP-4104: Track Onboarding Events

### DIFF
--- a/docs/ops/app-shell-observability.md
+++ b/docs/ops/app-shell-observability.md
@@ -41,16 +41,34 @@ is lazy-loaded only when the provider is enabled and used.
 
 ## Events
 
-V1 emits only:
+V1 emits these base lifecycle events:
 
 | Event | When |
 |-------|------|
 | `app_started` | After browser observability initialization completes. |
 | `page_view` | On initial route mount and each pathname change. |
 
-Route tracking ignores query-string and hash-only changes. Business events such
-as CRUD actions, filters, document processing, and menu clicks are out of scope
-for v1.
+Route tracking ignores query-string and hash-only changes.
+
+V1 also includes onboarding product events as the first business-event example:
+
+| Event | When |
+|-------|------|
+| `onboarding_auth_submitted` | Login or registration is submitted. |
+| `onboarding_auth_succeeded` | Login or registration succeeds. |
+| `onboarding_auth_failed` | Login or registration fails. |
+| `onboarding_auth_logout` | The user logs out from onboarding. |
+| `onboarding_setup_step_completed` | A setup step is completed. |
+| `onboarding_setup_step_back` | The user moves back from a setup step. |
+| `onboarding_run_started` | Environment creation starts. |
+| `onboarding_run_succeeded` | Environment creation succeeds. |
+| `onboarding_run_failed` | Environment creation fails. |
+| `onboarding_environment_enter_submitted` | Environment entry starts. |
+| `onboarding_environment_enter_succeeded` | Environment entry succeeds. |
+| `onboarding_environment_enter_failed` | Environment entry fails. |
+
+Broad business events such as CRUD actions, filters, document processing, and
+menu clicks are still out of scope for v1 unless explicitly added and tested.
 
 ## Privacy Rules
 
@@ -67,6 +85,58 @@ Payloads are normalized before providers receive them:
 Do not pass free-form user-entered values to `track`, `page`, or future business
 events. Add new event fields to the allowlist only when they are stable,
 non-sensitive product metadata.
+
+## Adding Business Events
+
+Use the shared API from the app-shell observability facade:
+
+```js
+import { track } from '../lib/observability.js';
+```
+
+Event names should be lowercase `snake_case`, describe the product action, and
+avoid implementation details. Prefer names such as `onboarding_setup_step_completed`
+or `fiscal_setup_started`; avoid names with route IDs, document numbers, user
+names, or UI copy.
+
+Business event payloads are allowlisted. Only these keys are emitted:
+
+`action`, `app`, `component`, `enabled`, `environment`, `event`, `hostname`,
+`locale`, `mockMode`, `provider`, `route`, `routePattern`, `source`, `status`,
+`timestamp`, `type`, and `windowName`.
+
+Values must be stable, low-cardinality product metadata. Do not send PII,
+free-form text, raw URLs, OAuth values, tokens, record IDs, document IDs,
+document numbers, customer names, labels, or user-entered values. Unknown keys
+and denylisted keys are stripped before providers receive the payload, but call
+sites should still avoid constructing sensitive payloads.
+
+Prefer fire-and-forget dispatch from UI handlers so analytics never blocks the
+workflow:
+
+```js
+void track('onboarding_step_completed', {
+  action: 'complete',
+  component: 'onboarding_wizard',
+  source: 'company_profile',
+  status: 'success',
+  type: 'initial_setup',
+});
+```
+
+Do not await `track` in render paths or user-facing flows unless the caller is a
+test or an explicit observability lifecycle step. Provider failures are logged
+and isolated by the registry.
+
+Expected tests for new instrumentation:
+
+- Unit test the caller with a mocked `track` and assert the event name and safe
+  payload.
+- Add payload normalization coverage when a new allowed field is needed.
+- Assert sensitive values are not passed by the caller, not only that the
+  sanitizer removes them.
+- Keep disabled-provider and provider-failure behavior covered in observability
+  adapter tests when provider behavior changes.
 
 ## Adding A Provider
 

--- a/tools/app-shell/src/pages/OnboardingPage.jsx
+++ b/tools/app-shell/src/pages/OnboardingPage.jsx
@@ -21,6 +21,7 @@ import {
 import { checkSalesInvoiceReadiness } from './onboarding/onboardingReadiness.js';
 import { useLocaleSwitch, useUI } from '../i18n/index.js';
 import { buildAppReturnToHref, getSafeReturnTo } from '../lib/oauthReturnTo.js';
+import { track } from '../lib/observability.js';
 import {
   applyProgressMessage,
   buildEnvironmentSessionStorage,
@@ -50,6 +51,11 @@ const LOCALE_CODES = ['es_ES', 'en_US'];
 const COUNTRY_CODES = ['ES'];
 const SECTOR_CODES = ['technology', 'services', 'commerce', 'manufacturing'];
 const BUSINESS_TYPE_VALUES = ['company', 'freelancer', 'advisory'];
+const ONBOARDING_EVENT_CONTEXT = {
+  component: 'OnboardingPage',
+  source: 'onboarding',
+  windowName: 'onboarding',
+};
 const DEFAULT_ONBOARDING_FORM = {
   fullName: '',
   businessType: 'company',
@@ -62,6 +68,13 @@ const DEFAULT_ONBOARDING_FORM = {
   address: '',
   sector: 'technology',
 };
+
+function trackOnboarding(eventName, properties = {}) {
+  void track(eventName, {
+    ...ONBOARDING_EVENT_CONTEXT,
+    ...properties,
+  });
+}
 
 function formatMs(ms) {
   if (ms == null) return null;
@@ -572,6 +585,10 @@ export default function OnboardingPage() {
   };
 
   const handleLogout = () => {
+    trackOnboarding('onboarding_auth_logout', {
+      action: 'logout',
+      status: 'success',
+    });
     localStorage.removeItem('sf_platform_token');
     setAccountName(null);
     setRegisterForm({ name: '', email: '', password: '' });
@@ -589,16 +606,32 @@ export default function OnboardingPage() {
   // Register
   const handleRegister = async (e) => {
     e.preventDefault();
+    trackOnboarding('onboarding_auth_submitted', {
+      action: 'register',
+      status: 'started',
+    });
     setRegisterError(null);
     setRegisterLoading(true);
     try {
       const data = await registerAccount(fetch, BASE_URL, registerForm);
       if (data.token) {
+        trackOnboarding('onboarding_auth_succeeded', {
+          action: 'register',
+          status: 'success',
+        });
         handleRegisterSuccess(data.token, data.account);
       } else {
+        trackOnboarding('onboarding_auth_failed', {
+          action: 'register',
+          status: 'failed',
+        });
         setRegisterError(ui('onboardingRegisterFailed'));
       }
     } catch (err) {
+      trackOnboarding('onboarding_auth_failed', {
+        action: 'register',
+        status: 'failed',
+      });
       setRegisterError(err.userMessage || ui(err.code || 'onboardingConnectionError'));
     } finally {
       setRegisterLoading(false);
@@ -608,16 +641,32 @@ export default function OnboardingPage() {
   // Login
   const handleLogin = async (e) => {
     e.preventDefault();
+    trackOnboarding('onboarding_auth_submitted', {
+      action: 'login',
+      status: 'started',
+    });
     setLoginError(null);
     setLoginLoading(true);
     try {
       const data = await loginAccount(fetch, BASE_URL, loginForm);
       if (data.token) {
+        trackOnboarding('onboarding_auth_succeeded', {
+          action: 'login',
+          status: 'success',
+        });
         handleAuthSuccess(data.token, data.account);
       } else {
+        trackOnboarding('onboarding_auth_failed', {
+          action: 'login',
+          status: 'failed',
+        });
         setLoginError(ui('onboardingInvalidCredentials'));
       }
     } catch (err) {
+      trackOnboarding('onboarding_auth_failed', {
+        action: 'login',
+        status: 'failed',
+      });
       setLoginError(err.userMessage || ui(err.code || 'onboardingConnectionError'));
     } finally {
       setLoginLoading(false);
@@ -626,6 +675,10 @@ export default function OnboardingPage() {
 
   const loginToEnvironment = async (env, { requireReadiness = false } = {}) => {
     const token = getPlatformToken();
+    trackOnboarding('onboarding_environment_enter_submitted', {
+      action: 'enter_environment',
+      status: 'started',
+    });
     setLoggingIn(env.clientId);
     try {
       const data = await loginEnvironment(fetch, BASE_URL, token, env);
@@ -646,6 +699,10 @@ export default function OnboardingPage() {
         if (requireReadiness) {
           const readiness = await checkSalesInvoiceReadiness(fetch, BASE_URL, data.token);
           if (!readiness.ready) {
+            trackOnboarding('onboarding_environment_enter_failed', {
+              action: 'enter_environment',
+              status: 'failed',
+            });
             setResult({
               status: 'failed',
               readinessFailures: readiness.failures,
@@ -654,14 +711,26 @@ export default function OnboardingPage() {
             return;
           }
         }
+        trackOnboarding('onboarding_environment_enter_succeeded', {
+          action: 'enter_environment',
+          status: 'success',
+        });
         window.location.href = buildAppReturnToHref(
           getSafeReturnTo(window.location.search),
           window.location.pathname
         );
         return;
       }
+      trackOnboarding('onboarding_environment_enter_failed', {
+        action: 'enter_environment',
+        status: 'failed',
+      });
       alert(ui('onboardingEnvironmentLoginFailed'));
     } catch (err) {
+      trackOnboarding('onboarding_environment_enter_failed', {
+        action: 'enter_environment',
+        status: 'failed',
+      });
       if (requireReadiness) {
         setResult({ status: 'failed', error: err.userMessage || ui(err.code || 'onboardingEnvironmentLoginFailed') });
       } else {
@@ -674,6 +743,10 @@ export default function OnboardingPage() {
 
   const runOnboarding = useCallback(async () => {
     const token = getPlatformToken();
+    trackOnboarding('onboarding_run_started', {
+      action: 'create_environment',
+      status: 'started',
+    });
     setRunning(true);
     setResult(null);
     setFormSubmitted(true);
@@ -688,12 +761,27 @@ export default function OnboardingPage() {
             error: msg.success ? null : msg.message,
           };
           setResult(resultObj);
-          if (msg.success) succeeded = true;
+          if (msg.success) {
+            trackOnboarding('onboarding_run_succeeded', {
+              action: 'create_environment',
+              status: 'success',
+            });
+            succeeded = true;
+          } else {
+            trackOnboarding('onboarding_run_failed', {
+              action: 'create_environment',
+              status: 'failed',
+            });
+          }
         } else if (msg.type === 'progress' && msg.step) {
           setSteps(prev => applyProgressMessage(prev, msg));
         }
       });
     } catch (err) {
+      trackOnboarding('onboarding_run_failed', {
+        action: 'create_environment',
+        status: 'failed',
+      });
       setResult({ status: 'failed', error: err.userMessage || ui(err.code || 'onboardingGenericError') });
     } finally {
       setRunning(false);
@@ -1187,7 +1275,14 @@ export default function OnboardingPage() {
           <div className="mt-8 flex justify-end">
             <Button
               type="button"
-              onClick={() => setCreateStep(2)}
+              onClick={() => {
+                trackOnboarding('onboarding_setup_step_completed', {
+                  action: 'continue',
+                  status: 'success',
+                  type: 'profile',
+                });
+                setCreateStep(2);
+              }}
               disabled={!isStepOneValid}
               className="h-12 rounded-2xl bg-gray-900 px-6 text-base font-medium text-white hover:bg-gray-800"
             >
@@ -1265,7 +1360,15 @@ export default function OnboardingPage() {
           <div className="mt-8 flex items-center justify-between gap-4">
             <button
               type="button"
-              onClick={() => !running && setCreateStep(1)}
+              onClick={() => {
+                if (running) return;
+                trackOnboarding('onboarding_setup_step_back', {
+                  action: 'back',
+                  status: 'success',
+                  type: 'company',
+                });
+                setCreateStep(1);
+              }}
               disabled={running}
               className="text-base font-medium tracking-[-0.02em] text-slate-900 transition hover:text-slate-600 disabled:opacity-50 sm:text-lg"
             >

--- a/tools/app-shell/src/pages/__tests__/OnboardingPage.vitest.jsx
+++ b/tools/app-shell/src/pages/__tests__/OnboardingPage.vitest.jsx
@@ -1,4 +1,30 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const localStorageMock = (() => {
+  let store = {};
+  return {
+    clear: vi.fn(() => {
+      store = {};
+    }),
+    getItem: vi.fn((key) => store[key] ?? null),
+    removeItem: vi.fn((key) => {
+      delete store[key];
+    }),
+    setItem: vi.fn((key, value) => {
+      store[key] = String(value);
+    }),
+  };
+})();
+
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: localStorageMock,
+});
+
+Object.defineProperty(globalThis, 'alert', {
+  configurable: true,
+  value: vi.fn(),
+});
 
 // Mock i18n
 vi.mock('@/i18n', () => ({
@@ -49,6 +75,10 @@ vi.mock('../onboarding/onboardingState.js', () => ({
   isProfileStepValid: () => true,
 }));
 
+vi.mock('../../lib/observability.js', () => ({
+  track: vi.fn(),
+}));
+
 // Mock UI components
 vi.mock('@/components/ui/button', () => ({
   Button: ({ children, ...props }) => <button {...props}>{children}</button>,
@@ -61,15 +91,28 @@ vi.mock('@/components/ui/label', () => ({
 }));
 
 import OnboardingPage from '../OnboardingPage.jsx';
-import { fetchAccount } from '../onboarding/onboardingApi.js';
+import {
+  fetchAccount,
+  fetchEnvironments,
+  loginAccount,
+  loginEnvironment,
+  registerAccount,
+  runOnboardingStream,
+} from '../onboarding/onboardingApi.js';
+import { track } from '../../lib/observability.js';
 
 describe('OnboardingPage', () => {
   beforeEach(() => {
     localStorage.clear();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    fetchAccount.mockReset();
+    fetchEnvironments.mockReset();
+    fetchEnvironments.mockResolvedValue([]);
+    loginAccount.mockReset();
+    loginEnvironment.mockReset();
+    registerAccount.mockReset();
+    runOnboardingStream.mockReset();
+    window.history.replaceState(null, '', '/onboarding');
   });
 
   it('renders without crashing', () => {
@@ -119,5 +162,206 @@ describe('OnboardingPage', () => {
     render(<OnboardingPage />);
     expect(screen.getByText('onboardingSwitchToLoginPrompt')).toBeInTheDocument();
     expect(screen.getByText('onboardingSwitchToLoginAction')).toBeInTheDocument();
+  });
+
+  it('tracks registration submission and success without user-entered values', async () => {
+    registerAccount.mockResolvedValue({
+      token: 'platform-token',
+      account: { name: 'Ada Lovelace', email: 'ada@example.com' },
+    });
+
+    localStorage.removeItem('sf_platform_token');
+    render(<OnboardingPage />);
+
+    fireEvent.submit(screen.getByTestId('action-register-submit').closest('form'));
+
+    await waitFor(() => {
+      expect(track).toHaveBeenCalledWith('onboarding_auth_submitted', {
+        action: 'register',
+        component: 'OnboardingPage',
+        source: 'onboarding',
+        status: 'started',
+        windowName: 'onboarding',
+      });
+      expect(track).toHaveBeenCalledWith('onboarding_auth_succeeded', {
+        action: 'register',
+        component: 'OnboardingPage',
+        source: 'onboarding',
+        status: 'success',
+        windowName: 'onboarding',
+      });
+    });
+
+    const serializedCalls = JSON.stringify(track.mock.calls);
+    expect(serializedCalls).not.toContain('Ada Lovelace');
+    expect(serializedCalls).not.toContain('ada@example.com');
+    expect(serializedCalls).not.toContain('platform-token');
+  });
+
+  it('tracks onboarding setup step navigation', async () => {
+    localStorage.setItem('sf_platform_token', 'platform-token');
+    fetchAccount.mockResolvedValue({ name: 'Ada Lovelace' });
+    fetchEnvironments.mockResolvedValue([]);
+
+    render(<OnboardingPage />);
+
+    const continueButton = await screen.findByText('onboardingContinueAction');
+    fireEvent.click(continueButton);
+
+    expect(track).toHaveBeenCalledWith('onboarding_setup_step_completed', {
+      action: 'continue',
+      component: 'OnboardingPage',
+      source: 'onboarding',
+      status: 'success',
+      type: 'profile',
+      windowName: 'onboarding',
+    });
+  });
+
+  it('tracks login failures without credentials', async () => {
+    loginAccount.mockResolvedValue({});
+
+    localStorage.removeItem('sf_platform_token');
+    render(<OnboardingPage />);
+
+    fireEvent.click(screen.getByTestId('action-switch-to-login'));
+    fireEvent.submit(screen.getByTestId('action-login-submit').closest('form'));
+
+    await waitFor(() => {
+      expect(track).toHaveBeenCalledWith('onboarding_auth_submitted', {
+        action: 'login',
+        component: 'OnboardingPage',
+        source: 'onboarding',
+        status: 'started',
+        windowName: 'onboarding',
+      });
+      expect(track).toHaveBeenCalledWith('onboarding_auth_failed', {
+        action: 'login',
+        component: 'OnboardingPage',
+        source: 'onboarding',
+        status: 'failed',
+        windowName: 'onboarding',
+      });
+    });
+
+    expect(JSON.stringify(track.mock.calls)).not.toContain('password');
+  });
+
+  it('tracks setup back navigation from company step', async () => {
+    localStorage.setItem('sf_platform_token', 'platform-token');
+    fetchAccount.mockResolvedValue({ name: 'Ada Lovelace' });
+    fetchEnvironments.mockResolvedValue([]);
+
+    render(<OnboardingPage />);
+
+    fireEvent.click(await screen.findByText('onboardingContinueAction'));
+    fireEvent.click(await screen.findByText('back'));
+
+    expect(track).toHaveBeenCalledWith('onboarding_setup_step_back', {
+      action: 'back',
+      component: 'OnboardingPage',
+      source: 'onboarding',
+      status: 'success',
+      type: 'company',
+      windowName: 'onboarding',
+    });
+  });
+
+  it('tracks onboarding run success without company or fiscal values', async () => {
+    localStorage.setItem('sf_platform_token', 'platform-token');
+    fetchAccount.mockResolvedValue({ name: 'Ada Lovelace' });
+    fetchEnvironments.mockResolvedValue([]);
+    runOnboardingStream.mockImplementation(async (_fetch, _baseUrl, _token, _form, onMessage) => {
+      onMessage({ type: 'result', success: true });
+    });
+
+    render(<OnboardingPage />);
+
+    fireEvent.click(await screen.findByText('onboardingContinueAction'));
+    fireEvent.change(screen.getByLabelText(/onboardingCompanyNameLabel/), {
+      target: { value: 'Secret Company' },
+    });
+    fireEvent.change(screen.getByLabelText(/onboardingFiscalIdLabel/), {
+      target: { value: 'B12345678' },
+    });
+    fireEvent.click(screen.getByText('onboardingStartAction'));
+
+    await waitFor(() => {
+      expect(track).toHaveBeenCalledWith('onboarding_run_started', {
+        action: 'create_environment',
+        component: 'OnboardingPage',
+        source: 'onboarding',
+        status: 'started',
+        windowName: 'onboarding',
+      });
+      expect(track).toHaveBeenCalledWith('onboarding_run_succeeded', {
+        action: 'create_environment',
+        component: 'OnboardingPage',
+        source: 'onboarding',
+        status: 'success',
+        windowName: 'onboarding',
+      });
+    });
+
+    const serializedCalls = JSON.stringify(track.mock.calls);
+    expect(serializedCalls).not.toContain('Secret Company');
+    expect(serializedCalls).not.toContain('B12345678');
+  });
+
+  it('tracks onboarding run failures', async () => {
+    localStorage.setItem('sf_platform_token', 'platform-token');
+    fetchAccount.mockResolvedValue({ name: 'Ada Lovelace' });
+    fetchEnvironments.mockResolvedValue([]);
+    runOnboardingStream.mockImplementation(async (_fetch, _baseUrl, _token, _form, onMessage) => {
+      onMessage({ type: 'result', success: false, message: 'failed' });
+    });
+
+    render(<OnboardingPage />);
+
+    fireEvent.click(await screen.findByText('onboardingContinueAction'));
+    fireEvent.click(screen.getByText('onboardingStartAction'));
+
+    await waitFor(() => {
+      expect(track).toHaveBeenCalledWith('onboarding_run_failed', {
+        action: 'create_environment',
+        component: 'OnboardingPage',
+        source: 'onboarding',
+        status: 'failed',
+        windowName: 'onboarding',
+      });
+    });
+  });
+
+  it('tracks environment entry success without environment identifiers', async () => {
+    localStorage.setItem('sf_platform_token', 'platform-token');
+    fetchAccount.mockResolvedValue({ name: 'Ada Lovelace' });
+    fetchEnvironments.mockResolvedValue([
+      { clientId: 'client-secret', clientName: 'Secret Client', orgName: 'Org', adminUser: 'admin' },
+    ]);
+    loginEnvironment.mockResolvedValue({ token: 'environment-token' });
+
+    render(<OnboardingPage />);
+
+    await waitFor(() => {
+      expect(track).toHaveBeenCalledWith('onboarding_environment_enter_submitted', {
+        action: 'enter_environment',
+        component: 'OnboardingPage',
+        source: 'onboarding',
+        status: 'started',
+        windowName: 'onboarding',
+      });
+      expect(track).toHaveBeenCalledWith('onboarding_environment_enter_succeeded', {
+        action: 'enter_environment',
+        component: 'OnboardingPage',
+        source: 'onboarding',
+        status: 'success',
+        windowName: 'onboarding',
+      });
+    });
+
+    const serializedCalls = JSON.stringify(track.mock.calls);
+    expect(serializedCalls).not.toContain('client-secret');
+    expect(serializedCalls).not.toContain('Secret Client');
+    expect(serializedCalls).not.toContain('environment-token');
   });
 });


### PR DESCRIPTION
## Summary
- Adds developer documentation for tracking new business events through the App Shell observability API.
- Instruments privacy-safe onboarding events through the shared `track` facade.
- Adds onboarding tests that verify emitted events do not include names, emails, or tokens.

## QA / Mixpanel
- Deploy this branch to Experimental/QA.
- Configure Mixpanel with `VITE_MIXPANEL_ENABLED=true`, `VITE_MIXPANEL_TOKEN`, and `VITE_MIXPANEL_API_HOST=https://api-eu.mixpanel.com`.
- Open Mixpanel Live View and exercise `/onboarding`.
- Expected events include `page_view`, `onboarding_auth_submitted`, `onboarding_auth_succeeded`/`onboarding_auth_failed`, `onboarding_setup_step_completed`, `onboarding_run_started`, `onboarding_run_succeeded`/`onboarding_run_failed`, and environment entry events.
- Event properties should only include safe metadata such as `action`, `component`, `source`, `status`, `type`, and `windowName`.

## Validation
- `node --test src/lib/__tests__/observability*.test.js`
- `npm --workspace @schema-forge/app-shell run test:vitest -- src/pages/__tests__/OnboardingPage.vitest.jsx src/lib/__tests__/ObservabilityRouteTracker.vitest.jsx`
- `git diff --check`
- `npm --workspace @schema-forge/app-shell run build`

Jira: ETP-4104
