### PR TITLE
Feature ETP-4104: Harden App Shell Core SDK

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,9 @@ jobs:
       - name: App shell core package tests
         run: npm test --workspace=packages/app-shell-core
 
+      - name: App shell core consumer smoke
+        run: npm run test:consumer --workspace=packages/app-shell-core
+
       - name: App-shell Node tests
         run: node --test --test-reporter=spec --test-reporter-destination=stdout 'tools/app-shell/src/**/__tests__/*.test.js'
 

--- a/packages/app-shell-core/README.md
+++ b/packages/app-shell-core/README.md
@@ -19,5 +19,57 @@ It intentionally does not include generated contracts, generated windows,
 
 ```jsx
 import '@schema-forge/app-shell-core/styles.css';
-import { AuthProvider, LocaleProvider, ShellLayout } from '@schema-forge/app-shell-core';
+import {
+  AppShellRuntime,
+  createAppShellConfig,
+  createMemoryAuthStorage,
+} from '@schema-forge/app-shell-core';
+
+const config = createAppShellConfig({
+  menuGroups: [
+    {
+      id: 'main',
+      title: 'Main',
+      items: [{ label: 'Dashboard', path: '/dashboard' }],
+    },
+  ],
+  routes: [
+    { path: '/dashboard', element: <Dashboard /> },
+    { path: '/login', public: true, element: <Login /> },
+  ],
+  reports: [
+    { id: 'sales-summary', title: 'Sales summary' },
+  ],
+});
+
+export function App() {
+  return (
+    <AppShellRuntime
+      config={config}
+      auth={{
+        loginPath: '/login',
+        storage: createMemoryAuthStorage(),
+      }}
+      currency={{ value: 'EUR' }}
+    />
+  );
+}
 ```
+
+## Public Runtime Contract
+
+External consumers should depend on the package entrypoints instead of internal
+paths:
+
+- `@schema-forge/app-shell-core` for the complete runtime surface.
+- `@schema-forge/app-shell-core/runtime` for `AppShellRuntime`,
+  `AppShellProviders`, `AuthGate`, and descriptor builders.
+- `@schema-forge/app-shell-core/auth` for session storage, auth context, and API
+  fetch helpers.
+- `@schema-forge/app-shell-core/layout` for shell layout primitives.
+- `@schema-forge/app-shell-core/reports` for report descriptors and viewer frame.
+- `@schema-forge/app-shell-core/styles.css` for the CSS/Tailwind token layer.
+
+The package still expects the host app to provide React, React Router, Radix UI,
+Lucide, and the CSS build pipeline listed as peer dependencies. Generated
+contracts and generated windows remain outside this package by design.

--- a/packages/app-shell-core/README.md
+++ b/packages/app-shell-core/README.md
@@ -69,7 +69,9 @@ paths:
 - `@schema-forge/app-shell-core/layout` for shell layout primitives.
 - `@schema-forge/app-shell-core/reports` for report descriptors and viewer frame.
 - `@schema-forge/app-shell-core/styles.css` for the CSS/Tailwind token layer.
+- `@schema-forge/app-shell-core/tailwind-preset` for the Tailwind theme tokens
+  required by the published CSS and UI primitives.
 
 The package still expects the host app to provide React, React Router, Radix UI,
-Lucide, and the CSS build pipeline listed as peer dependencies. Generated
-contracts and generated windows remain outside this package by design.
+Lucide, Tailwind/PostCSS, and the peer dependencies listed in `package.json`.
+Generated contracts and generated windows remain outside this package by design.

--- a/packages/app-shell-core/package.json
+++ b/packages/app-shell-core/package.json
@@ -12,6 +12,7 @@
     "./i18n": "./src/i18n/index.js",
     "./layout": "./src/layout/index.js",
     "./reports": "./src/reports/index.js",
+    "./runtime": "./src/runtime/index.js",
     "./hooks/useCurrency.jsx": "./src/hooks/useCurrency.jsx",
     "./hooks/use-mobile.jsx": "./src/hooks/use-mobile.jsx",
     "./styles.css": "./src/styles.css",
@@ -22,7 +23,7 @@
     "!src/**/__tests__/**"
   ],
   "scripts": {
-    "test": "node --test test/*.test.js src/auth/__tests__/*.test.js src/i18n/__tests__/*.test.js src/components/ui/__tests__/*.test.js"
+    "test": "node --test test/*.test.js src/auth/__tests__/*.test.js src/i18n/__tests__/*.test.js src/runtime/__tests__/*.test.js src/components/ui/__tests__/*.test.js"
   },
   "peerDependencies": {
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/packages/app-shell-core/package.json
+++ b/packages/app-shell-core/package.json
@@ -13,6 +13,7 @@
     "./layout": "./src/layout/index.js",
     "./reports": "./src/reports/index.js",
     "./runtime": "./src/runtime/index.js",
+    "./tailwind-preset": "./src/tailwind-preset.js",
     "./hooks/useCurrency.jsx": "./src/hooks/useCurrency.jsx",
     "./hooks/use-mobile.jsx": "./src/hooks/use-mobile.jsx",
     "./styles.css": "./src/styles.css",
@@ -23,7 +24,8 @@
     "!src/**/__tests__/**"
   ],
   "scripts": {
-    "test": "node --test test/*.test.js src/auth/__tests__/*.test.js src/i18n/__tests__/*.test.js src/runtime/__tests__/*.test.js src/components/ui/__tests__/*.test.js"
+    "test": "node --test test/*.test.js src/auth/__tests__/*.test.js src/i18n/__tests__/*.test.js src/runtime/__tests__/*.test.js src/components/ui/__tests__/*.test.js",
+    "test:consumer": "node scripts/package-consumer-smoke.mjs"
   },
   "peerDependencies": {
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/packages/app-shell-core/scripts/package-consumer-smoke.mjs
+++ b/packages/app-shell-core/scripts/package-consumer-smoke.mjs
@@ -1,0 +1,146 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const repoRoot = resolve(new URL('../../..', import.meta.url).pathname);
+const packageRoot = resolve(new URL('..', import.meta.url).pathname);
+const keepFixture = process.env.SF_KEEP_CONSUMER_FIXTURE === 'true';
+const fixtureDir = mkdtempSync(join(tmpdir(), 'app-shell-core-consumer-'));
+const tarballDir = join(fixtureDir, 'tarball');
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd || repoRoot,
+    encoding: 'utf8',
+    stdio: options.capture ? 'pipe' : 'inherit',
+    env: {
+      ...process.env,
+      npm_config_audit: 'false',
+      npm_config_fund: 'false',
+    },
+  });
+
+  if (result.status !== 0) {
+    if (options.capture) {
+      process.stdout.write(result.stdout || '');
+      process.stderr.write(result.stderr || '');
+    }
+    throw new Error(`${command} ${args.join(' ')} failed with exit code ${result.status}`);
+  }
+
+  return result.stdout;
+}
+
+function writeFixtureFiles(tarballPath) {
+  writeFileSync(join(fixtureDir, 'package.json'), JSON.stringify({
+    name: 'app-shell-core-consumer-smoke',
+    private: true,
+    type: 'module',
+    scripts: {
+      build: 'vite build',
+    },
+    dependencies: {
+      '@schema-forge/app-shell-core': `file:${tarballPath}`,
+      '@vitejs/plugin-react': '^4.3.0',
+      '@radix-ui/react-slot': '^1.2.4',
+      'class-variance-authority': '^0.7.1',
+      clsx: '^2.1.0',
+      'lucide-react': '^0.400.0',
+      react: '^18.3.0',
+      'react-dom': '^18.3.0',
+      'react-router-dom': '^7.0.0',
+      'tailwind-merge': '^2.2.0',
+      vite: '^6.0.0',
+    },
+    devDependencies: {
+      autoprefixer: '^10.4.0',
+      postcss: '^8.4.0',
+      tailwindcss: '^3.4.0',
+    },
+  }, null, 2));
+
+  writeFileSync(join(fixtureDir, 'index.html'), '<div id="root"></div><script type="module" src="/src/App.jsx"></script>\n');
+  writeFileSync(join(fixtureDir, 'postcss.config.js'), 'export default { plugins: { tailwindcss: {}, autoprefixer: {} } };\n');
+  writeFileSync(join(fixtureDir, 'tailwind.config.js'), `import appShellCorePreset from '@schema-forge/app-shell-core/tailwind-preset';
+
+export default {
+  presets: [appShellCorePreset],
+  content: ['./src/**/*.{js,jsx}', './node_modules/@schema-forge/app-shell-core/src/**/*.{js,jsx}'],
+};
+`);
+
+  writeFileSync(join(fixtureDir, 'src', 'App.jsx'), `import React from 'react';
+import { createRoot } from 'react-dom/client';
+import '@schema-forge/app-shell-core/styles.css';
+import {
+  AppShellRuntime,
+  createAppShellConfig,
+  createMemoryAuthStorage,
+} from '@schema-forge/app-shell-core';
+import { Button } from '@schema-forge/app-shell-core/components/ui/button.jsx';
+import { Card, CardContent } from '@schema-forge/app-shell-core/components/ui/card.jsx';
+
+function Dashboard() {
+  return (
+    <Card>
+      <CardContent>
+        <Button type="button">Standalone dashboard</Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Login() {
+  return <div>Login supplied by consumer</div>;
+}
+
+const config = createAppShellConfig({
+  menuGroups: [
+    {
+      id: 'main',
+      title: 'Main',
+      items: [{ id: 'dashboard', label: 'Dashboard', path: '/dashboard' }],
+    },
+  ],
+  routes: [
+    { path: '/', index: true, element: <Dashboard /> },
+    { path: '/dashboard', element: <Dashboard /> },
+    { path: '/login', public: true, element: <Login /> },
+  ],
+  reports: [{ id: 'sales-summary', title: 'Sales summary' }],
+});
+
+createRoot(document.getElementById('root')).render(
+  <AppShellRuntime
+    config={config}
+    auth={{
+      loginPath: '/login',
+      storage: createMemoryAuthStorage({ token: 'fixture-token', username: 'fixture-user' }),
+    }}
+    currency={{ value: 'EUR' }}
+  />
+);
+`);
+}
+
+try {
+  run('mkdir', ['-p', tarballDir, join(fixtureDir, 'src')]);
+  const packOutput = run('npm', ['pack', '--json', '--pack-destination', tarballDir], {
+    cwd: packageRoot,
+    capture: true,
+  });
+  const [packed] = JSON.parse(packOutput);
+  const tarballPath = join(tarballDir, packed.filename);
+
+  writeFixtureFiles(tarballPath);
+  run('npm', ['install', '--ignore-scripts'], { cwd: fixtureDir });
+  run('npm', ['run', 'build'], { cwd: fixtureDir });
+  console.log(`app-shell-core consumer smoke passed in ${fixtureDir}`);
+} finally {
+  if (!keepFixture) {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  } else {
+    console.log(`kept fixture at ${fixtureDir}`);
+  }
+}

--- a/packages/app-shell-core/src/auth/AuthContext.jsx
+++ b/packages/app-shell-core/src/auth/AuthContext.jsx
@@ -1,58 +1,51 @@
 import { createContext, useContext, useState, useCallback, useMemo } from 'react';
+import { createLocalAuthStorage, normalizeAuthSession } from './session.js';
 
 const AuthContext = createContext(null);
 
-const STORAGE_KEY = 'sf_auth_token';
-const USERNAME_KEY = 'sf_auth_user';
-const ROLELIST_KEY = 'sf_auth_rolelist';
-const SELECTED_ROLE_KEY = 'sf_auth_selected_role';
-const SELECTED_ORG_KEY = 'sf_auth_selected_org';
-const PLATFORM_TOKEN_KEY = 'sf_platform_token';
+export function AuthProvider({ children, storage, initialSession, onSessionChange }) {
+  const authStorage = useMemo(() => storage || createLocalAuthStorage(), [storage]);
+  const [session, setSessionState] = useState(() => normalizeAuthSession({
+    ...authStorage.read(),
+    ...initialSession,
+  }));
 
-function safeJsonParse(key) {
-  try {
-    const v = localStorage.getItem(key);
-    return v ? JSON.parse(v) : null;
-  } catch { return null; }
-}
-
-export function AuthProvider({ children }) {
-  const [token, setToken] = useState(() => localStorage.getItem(STORAGE_KEY));
-  const [username, setUsername] = useState(() => localStorage.getItem(USERNAME_KEY));
-  const [roleList, setRoleList] = useState(() => safeJsonParse(ROLELIST_KEY) || []);
-  const [selectedRole, setSelectedRole] = useState(() => safeJsonParse(SELECTED_ROLE_KEY));
-  const [selectedOrg, setSelectedOrg] = useState(() => safeJsonParse(SELECTED_ORG_KEY));
+  const persistSession = useCallback((nextSession) => {
+    const normalized = normalizeAuthSession(nextSession);
+    setSessionState(normalized);
+    authStorage.write(normalized);
+    onSessionChange?.(normalized);
+    return normalized;
+  }, [authStorage, onSessionChange]);
 
   const logout = useCallback(() => {
-    setToken(null);
-    setUsername(null);
-    setRoleList([]);
-    setSelectedRole(null);
-    setSelectedOrg(null);
-    localStorage.removeItem(STORAGE_KEY);
-    localStorage.removeItem(USERNAME_KEY);
-    localStorage.removeItem(ROLELIST_KEY);
-    localStorage.removeItem(SELECTED_ROLE_KEY);
-    localStorage.removeItem(SELECTED_ORG_KEY);
-    localStorage.removeItem(PLATFORM_TOKEN_KEY);
-  }, []);
+    const clearedSession = normalizeAuthSession();
+    setSessionState(clearedSession);
+    authStorage.clear();
+    onSessionChange?.(clearedSession);
+  }, [authStorage, onSessionChange]);
 
   const selectOrg = useCallback((org) => {
-    setSelectedOrg(org);
-    if (org) localStorage.setItem(SELECTED_ORG_KEY, JSON.stringify(org));
-    else localStorage.removeItem(SELECTED_ORG_KEY);
-  }, []);
+    persistSession({ ...session, selectedOrg: org || null });
+  }, [persistSession, session]);
+
+  const selectRole = useCallback((role) => {
+    persistSession({ ...session, selectedRole: role || null });
+  }, [persistSession, session]);
+
+  const setSession = useCallback((nextSession) => {
+    persistSession({ ...session, ...nextSession });
+  }, [persistSession, session]);
 
   const value = useMemo(() => ({
-    token,
-    username,
-    isAuthenticated: !!token,
-    roleList,
-    selectedRole,
-    selectedOrg,
+    ...session,
+    isAuthenticated: !!session.token,
+    setSession,
+    login: setSession,
+    selectRole,
     selectOrg,
     logout,
-  }), [token, username, roleList, selectedRole, selectedOrg, selectOrg, logout]);
+  }), [session, setSession, selectRole, selectOrg, logout]);
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }

--- a/packages/app-shell-core/src/auth/__tests__/session.test.js
+++ b/packages/app-shell-core/src/auth/__tests__/session.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createMemoryAuthStorage, normalizeAuthSession } from '../session.js';
+
+test('normalizeAuthSession exposes the standalone auth contract shape', () => {
+  assert.deepEqual(normalizeAuthSession({ token: 't', username: 'u' }), {
+    token: 't',
+    username: 'u',
+    roleList: [],
+    selectedRole: null,
+    selectedOrg: null,
+  });
+});
+
+test('memory auth storage supports SDK consumers without browser localStorage', () => {
+  const storage = createMemoryAuthStorage({ token: 'initial' });
+  assert.equal(storage.read().token, 'initial');
+
+  storage.write({ token: 'next', roleList: [{ id: 'admin' }] });
+  assert.deepEqual(storage.read(), {
+    token: 'next',
+    username: null,
+    roleList: [{ id: 'admin' }],
+    selectedRole: null,
+    selectedOrg: null,
+  });
+
+  storage.clear();
+  assert.equal(storage.read().token, null);
+});

--- a/packages/app-shell-core/src/auth/index.js
+++ b/packages/app-shell-core/src/auth/index.js
@@ -1,3 +1,4 @@
 export { AuthProvider, useAuth } from './AuthContext.jsx';
 export { createApiFetch, buildHeaders, detectBaseUrl, isTokenExpired } from './api.js';
+export { createLocalAuthStorage, createMemoryAuthStorage, normalizeAuthSession } from './session.js';
 export { useApiFetch } from './useApiFetch.js';

--- a/packages/app-shell-core/src/auth/session.js
+++ b/packages/app-shell-core/src/auth/session.js
@@ -1,0 +1,91 @@
+const DEFAULT_PREFIX = 'sf_auth';
+
+const SESSION_KEYS = {
+  token: 'token',
+  username: 'user',
+  roleList: 'rolelist',
+  selectedRole: 'selected_role',
+  selectedOrg: 'selected_org',
+};
+
+const JSON_KEYS = new Set(['roleList', 'selectedRole', 'selectedOrg']);
+
+function getBrowserStorage() {
+  if (typeof window === 'undefined') return null;
+  return window.localStorage || null;
+}
+
+function storageKey(prefix, key) {
+  return `${prefix}_${SESSION_KEYS[key]}`;
+}
+
+function readJson(storage, key) {
+  try {
+    const value = storage?.getItem(key);
+    return value ? JSON.parse(value) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeValue(storage, key, value, json = false) {
+  if (!storage) return;
+  if (value === undefined || value === null || value === '') {
+    storage.removeItem(key);
+    return;
+  }
+  storage.setItem(key, json ? JSON.stringify(value) : String(value));
+}
+
+export function normalizeAuthSession(session = {}) {
+  return {
+    token: session.token || null,
+    username: session.username || null,
+    roleList: Array.isArray(session.roleList) ? session.roleList : [],
+    selectedRole: session.selectedRole || null,
+    selectedOrg: session.selectedOrg || null,
+  };
+}
+
+export function createMemoryAuthStorage(initialSession = {}) {
+  let session = normalizeAuthSession(initialSession);
+
+  return {
+    read() {
+      return session;
+    },
+    write(nextSession) {
+      session = normalizeAuthSession(nextSession);
+    },
+    clear() {
+      session = normalizeAuthSession();
+    },
+  };
+}
+
+export function createLocalAuthStorage({ prefix = DEFAULT_PREFIX, storage = getBrowserStorage() } = {}) {
+  return {
+    read() {
+      return normalizeAuthSession({
+        token: storage?.getItem(storageKey(prefix, 'token')),
+        username: storage?.getItem(storageKey(prefix, 'username')),
+        roleList: readJson(storage, storageKey(prefix, 'roleList')),
+        selectedRole: readJson(storage, storageKey(prefix, 'selectedRole')),
+        selectedOrg: readJson(storage, storageKey(prefix, 'selectedOrg')),
+      });
+    },
+    write(session) {
+      const normalized = normalizeAuthSession(session);
+      for (const key of Object.keys(SESSION_KEYS)) {
+        writeValue(storage, storageKey(prefix, key), normalized[key], JSON_KEYS.has(key));
+      }
+    },
+    clear() {
+      if (!storage) return;
+      for (const key of Object.keys(SESSION_KEYS)) {
+        storage.removeItem(storageKey(prefix, key));
+      }
+      storage.removeItem('sf_platform_token');
+    },
+  };
+}

--- a/packages/app-shell-core/src/hooks/useCurrency.jsx
+++ b/packages/app-shell-core/src/hooks/useCurrency.jsx
@@ -6,6 +6,7 @@ import { useAuth } from '../auth/index.js';
  * ----------------------------------------------------------------*/
 
 function getApiBase() {
+  if (typeof window === 'undefined') return '';
   const path = window.location.pathname;
   const idx = path.indexOf('/web/');
   if (idx === -1) return import.meta.env.VITE_API_BASE || '';
@@ -30,23 +31,28 @@ const CurrencyContext = createContext(null);
  *   </CurrencyProvider>
  * </AuthProvider>
  */
-export function CurrencyProvider({ children }) {
+export function CurrencyProvider({ children, value, apiBaseUrl, fetcher = globalThis.fetch }) {
   const { token, selectedOrg } = useAuth();
   const [currencyCode, setCurrencyCode] = useState(null);
 
   useEffect(() => {
+    if (value != null) {
+      setCurrencyCode(value);
+      return;
+    }
+
     if (!token) {
       setCurrencyCode(null);
       return;
     }
 
     let cancelled = false;
-    const base = `${getApiBase()}/sws/neo`;
+    const base = apiBaseUrl || `${getApiBase()}/sws/neo`;
     const headers = { Authorization: `Bearer ${token}` };
 
     async function resolve() {
       try {
-        const res = await fetch(`${base}/session`, { headers });
+        const res = await fetcher(`${base}/session`, { headers });
         if (res.ok) {
           const json = await res.json();
           const code = json?.currencyCode;
@@ -59,7 +65,7 @@ export function CurrencyProvider({ children }) {
 
     resolve();
     return () => { cancelled = true; };
-  }, [token, selectedOrg?.id]);
+  }, [apiBaseUrl, fetcher, token, selectedOrg?.id, value]);
 
   return (
     <CurrencyContext.Provider value={currencyCode}>

--- a/packages/app-shell-core/src/index.js
+++ b/packages/app-shell-core/src/index.js
@@ -4,3 +4,4 @@ export * from './hooks/useCurrency.jsx';
 export * from './hooks/use-mobile.jsx';
 export * from './layout/index.js';
 export * from './reports/index.js';
+export * from './runtime/index.js';

--- a/packages/app-shell-core/src/runtime/AppShellRuntime.jsx
+++ b/packages/app-shell-core/src/runtime/AppShellRuntime.jsx
@@ -1,0 +1,116 @@
+import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom';
+import { AuthProvider, useAuth } from '../auth/index.js';
+import { CurrencyProvider } from '../hooks/useCurrency.jsx';
+import { LocaleProvider } from '../i18n/index.js';
+import { ShellLayout } from '../layout/index.js';
+import { ReportViewerFrame } from '../reports/index.js';
+import { createAppShellConfig } from './contracts.js';
+
+function DefaultLoginRedirect({ loginPath }) {
+  const location = useLocation();
+  return <Navigate to={loginPath} replace state={{ from: location }} />;
+}
+
+export function AuthGate({ children, loginPath = '/login', fallback }) {
+  const { isAuthenticated } = useAuth();
+  if (isAuthenticated) return children;
+  return fallback || <DefaultLoginRedirect loginPath={loginPath} />;
+}
+
+function renderRoute(route, auth) {
+  const element = route.public
+    ? route.element
+    : <AuthGate loginPath={auth.loginPath} fallback={auth.unauthenticatedFallback}>{route.element}</AuthGate>;
+
+  return <Route key={route.index ? 'index' : route.path} index={route.index} path={route.path} element={element} />;
+}
+
+export function AppShellProviders({
+  children,
+  auth,
+  locale,
+  setLocale,
+  currency,
+}) {
+  return (
+    <LocaleProvider locale={locale} setLocale={setLocale}>
+      <AuthProvider
+        storage={auth?.storage}
+        initialSession={auth?.initialSession}
+        onSessionChange={auth?.onSessionChange}
+      >
+        <CurrencyProvider
+          value={currency?.value || currency}
+          apiBaseUrl={currency?.apiBaseUrl}
+          fetcher={currency?.fetcher}
+        >
+          {children}
+        </CurrencyProvider>
+      </AuthProvider>
+    </LocaleProvider>
+  );
+}
+
+export function AppShellRuntime({
+  basename = '/',
+  config,
+  menuGroups,
+  reports,
+  routes,
+  auth,
+  locale,
+  setLocale,
+  currency,
+  title,
+  breadcrumb,
+  rightExtras,
+  notFoundElement = <Navigate to="/" replace />,
+}) {
+  const runtime = createAppShellConfig({
+    ...config,
+    menuGroups: menuGroups || config?.menuGroups,
+    reports: reports || config?.reports,
+    routes: routes || config?.routes,
+    auth: auth || config?.auth,
+  });
+  const runtimeAuth = { ...runtime.auth, ...auth };
+  const reportRoutes = runtime.reports.map((report) => ({
+    path: `/reports/${report.id}`,
+    public: false,
+    element: (
+      <ReportViewerFrame
+        baseUrl={report.baseUrl}
+        reportId={report.id}
+        params={report.params}
+        format={report.format}
+        title={report.title}
+      />
+    ),
+  }));
+
+  return (
+    <BrowserRouter basename={basename}>
+      <AppShellProviders auth={runtimeAuth} locale={locale} setLocale={setLocale} currency={currency}>
+        <Routes>
+          <Route
+            element={
+              <AuthGate loginPath={runtimeAuth.loginPath} fallback={runtimeAuth.unauthenticatedFallback}>
+                <ShellLayout
+                  menuGroups={runtime.menuGroups}
+                  title={title}
+                  breadcrumb={breadcrumb}
+                  rightExtras={rightExtras}
+                />
+              </AuthGate>
+            }
+          >
+            {runtime.routes.filter((route) => !route.public).map((route) => renderRoute(route, runtimeAuth))}
+            {reportRoutes.map((route) => renderRoute(route, runtimeAuth))}
+          </Route>
+          {runtime.routes.filter((route) => route.public).map((route) => renderRoute(route, runtimeAuth))}
+          <Route path="*" element={notFoundElement} />
+        </Routes>
+      </AppShellProviders>
+    </BrowserRouter>
+  );
+}

--- a/packages/app-shell-core/src/runtime/__tests__/contracts.test.js
+++ b/packages/app-shell-core/src/runtime/__tests__/contracts.test.js
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createAppShellConfig,
+  createMenuGroup,
+  createMenuItem,
+  createReportDescriptor,
+  createRuntimeRoute,
+} from '../contracts.js';
+
+test('runtime contracts normalize standalone menu, report and route descriptors', () => {
+  const config = createAppShellConfig({
+    menuGroups: [
+      createMenuGroup({
+        id: 'main',
+        title: 'Main',
+        items: [createMenuItem({ label: 'Dashboard', path: 'dashboard' })],
+      }),
+    ],
+    reports: [createReportDescriptor({ id: 'sales-summary', title: 'Sales summary' })],
+    routes: [createRuntimeRoute({ path: 'dashboard', element: 'dashboard-element' })],
+  });
+
+  assert.equal(config.menuGroups[0].items[0].path, '/dashboard');
+  assert.equal(config.reports[0].format, 'pdf');
+  assert.equal(config.routes[0].path, 'dashboard');
+});
+
+test('runtime contracts fail fast for incomplete standalone descriptors', () => {
+  assert.throws(() => createMenuItem({ label: 'Broken' }), /path or id/);
+  assert.throws(() => createReportDescriptor({ title: 'Broken' }), /Reports require an id/);
+  assert.throws(() => createRuntimeRoute({ path: '/broken' }), /Routes require an element/);
+});

--- a/packages/app-shell-core/src/runtime/contracts.js
+++ b/packages/app-shell-core/src/runtime/contracts.js
@@ -1,0 +1,82 @@
+function invariant(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function normalizePath(path, fallback = '/') {
+  if (!path) return fallback;
+  return path.startsWith('/') ? path : `/${path}`;
+}
+
+export function createMenuItem({ id, label, path, icon, external = false, meta = {} }) {
+  invariant(label, 'Menu items require a label');
+  invariant(path || id, 'Menu items require a path or id');
+
+  return {
+    id: id || path,
+    label,
+    path: path ? normalizePath(path) : undefined,
+    icon,
+    external: Boolean(external),
+    meta,
+  };
+}
+
+export function createMenuGroup({ id, title, items = [], meta = {} }) {
+  invariant(title || id, 'Menu groups require a title or id');
+
+  return {
+    id: id || title,
+    title: title || id,
+    items: items.map(createMenuItem),
+    meta,
+  };
+}
+
+export function normalizeMenuGroups(groups = []) {
+  invariant(Array.isArray(groups), 'menuGroups must be an array');
+  return groups.map(createMenuGroup);
+}
+
+export function createReportDescriptor({ id, title, params = {}, format = 'pdf', baseUrl }) {
+  invariant(id, 'Reports require an id');
+  return {
+    id,
+    title: title || id,
+    params,
+    format,
+    baseUrl,
+  };
+}
+
+export function normalizeReports(reports = []) {
+  invariant(Array.isArray(reports), 'reports must be an array');
+  return reports.map(createReportDescriptor);
+}
+
+export function createRuntimeRoute({ path, element, public: isPublic = false, index = false }) {
+  invariant(index || path, 'Routes require a path unless index is true');
+  invariant(element, 'Routes require an element');
+
+  return {
+    path: index ? undefined : normalizePath(path).replace(/^\//, ''),
+    element,
+    public: Boolean(isPublic),
+    index: Boolean(index),
+  };
+}
+
+export function createAppShellConfig({
+  menuGroups = [],
+  reports = [],
+  routes = [],
+  auth = {},
+  theme = {},
+} = {}) {
+  return {
+    menuGroups: normalizeMenuGroups(menuGroups),
+    reports: normalizeReports(reports),
+    routes: routes.map(createRuntimeRoute),
+    auth,
+    theme,
+  };
+}

--- a/packages/app-shell-core/src/runtime/index.js
+++ b/packages/app-shell-core/src/runtime/index.js
@@ -1,0 +1,10 @@
+export { AppShellProviders, AppShellRuntime, AuthGate } from './AppShellRuntime.jsx';
+export {
+  createAppShellConfig,
+  createMenuGroup,
+  createMenuItem,
+  createReportDescriptor,
+  createRuntimeRoute,
+  normalizeMenuGroups,
+  normalizeReports,
+} from './contracts.js';

--- a/packages/app-shell-core/src/tailwind-preset.js
+++ b/packages/app-shell-core/src/tailwind-preset.js
@@ -1,0 +1,75 @@
+const appShellCoreTailwindPreset = {
+  darkMode: ['class'],
+  theme: {
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+        sidebar: {
+          DEFAULT: 'hsl(var(--sidebar-background))',
+          foreground: 'hsl(var(--sidebar-foreground))',
+          primary: 'hsl(var(--sidebar-primary))',
+          'primary-foreground': 'hsl(var(--sidebar-primary-foreground))',
+          accent: 'hsl(var(--sidebar-accent))',
+          'accent-foreground': 'hsl(var(--sidebar-accent-foreground))',
+          border: 'hsl(var(--sidebar-border))',
+          ring: 'hsl(var(--sidebar-ring))',
+        },
+        'accent-highlight': {
+          DEFAULT: 'hsl(var(--accent-highlight))',
+          foreground: 'hsl(var(--accent-highlight-foreground))',
+        },
+        'page-bg': 'hsl(var(--page-bg))',
+        'text-primary': 'hsl(var(--text-primary))',
+        'search-bg': 'hsl(var(--search-bg))',
+        'topbar-icon': 'hsl(var(--topbar-icon))',
+        'topbar-breadcrumb': 'hsl(var(--topbar-breadcrumb))',
+        'text-secondary': 'hsl(var(--text-secondary))',
+        'search-placeholder': 'hsl(var(--search-placeholder))',
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
+      },
+      zIndex: {
+        60: '60',
+        70: '70',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default appShellCoreTailwindPreset;

--- a/packages/app-shell-core/test/public-api.test.js
+++ b/packages/app-shell-core/test/public-api.test.js
@@ -13,6 +13,7 @@ test('public package exports the expected runtime entrypoints', async () => {
   assert.equal(pkg.exports['./layout'], './src/layout/index.js');
   assert.equal(pkg.exports['./reports'], './src/reports/index.js');
   assert.equal(pkg.exports['./runtime'], './src/runtime/index.js');
+  assert.equal(pkg.exports['./tailwind-preset'], './src/tailwind-preset.js');
   assert.equal(pkg.exports['./styles.css'], './src/styles.css');
   assert.equal(pkg.exports['./hooks/useCurrency.jsx'], './src/hooks/useCurrency.jsx');
   assert.equal(pkg.exports['./hooks/use-mobile.jsx'], './src/hooks/use-mobile.jsx');

--- a/packages/app-shell-core/test/public-api.test.js
+++ b/packages/app-shell-core/test/public-api.test.js
@@ -8,6 +8,11 @@ test('public package exports the expected runtime entrypoints', async () => {
 
   assert.equal(pkg.name, '@schema-forge/app-shell-core');
   assert.equal(pkg.exports['.'], './src/index.js');
+  assert.equal(pkg.exports['./auth'], './src/auth/index.js');
+  assert.equal(pkg.exports['./i18n'], './src/i18n/index.js');
+  assert.equal(pkg.exports['./layout'], './src/layout/index.js');
+  assert.equal(pkg.exports['./reports'], './src/reports/index.js');
+  assert.equal(pkg.exports['./runtime'], './src/runtime/index.js');
   assert.equal(pkg.exports['./styles.css'], './src/styles.css');
   assert.equal(pkg.exports['./hooks/useCurrency.jsx'], './src/hooks/useCurrency.jsx');
   assert.equal(pkg.exports['./hooks/use-mobile.jsx'], './src/hooks/use-mobile.jsx');


### PR DESCRIPTION
## Summary

Hardens `@schema-forge/app-shell-core` from an internal publishable source package into a clearer SDK-style runtime surface for external consumers.

## Changes

- Adds public runtime contracts through `@schema-forge/app-shell-core/runtime`.
- Adds `AppShellRuntime`, `AppShellProviders`, and `AuthGate` for standalone host apps.
- Adds auth session storage contracts for localStorage-backed and memory-backed consumers.
- Makes currency resolution injectable for external apps.
- Publishes `@schema-forge/app-shell-core/tailwind-preset` so consumers can compile the package CSS/UI primitives without copying shell config.
- Adds a consumer smoke test that packs the package, installs the tarball into a temporary external Vite app, and builds it.
- Wires the consumer smoke into the main test workflow.

## Why

The previous split made `app-shell-core` publishable, but it still behaved mostly like source moved out of `tools/app-shell`: consumers had to infer auth/menu/report/style assumptions. This PR makes those assumptions explicit and verifies the package through a real tarball install.

## Validation

- `npm run test:consumer --workspace=packages/app-shell-core`
- `npm test --workspace=packages/app-shell-core`
- `npm run build --workspace=tools/app-shell`
- `git diff --check`
