### PR TITLE
Feature ETP-4104: Configure Private Package Publishing

### DIFF
--- a/.github/workflows/publish-private-packages.yml
+++ b/.github/workflows/publish-private-packages.yml
@@ -1,0 +1,73 @@
+name: Publish Private Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: npm dist-tag to publish
+        required: true
+        default: alpha
+        type: choice
+        options:
+          - alpha
+          - beta
+          - latest
+      dry_run:
+        description: Run npm publish with --dry-run
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Publish GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://npm.pkg.github.com
+          scope: '@etendosoftware'
+
+      - run: npm install
+
+      - name: Schema Forge core tests
+        run: npm test --workspace=packages/schema-forge-core
+
+      - name: App shell core tests
+        run: npm test --workspace=packages/app-shell-core
+
+      - name: App shell core consumer smoke
+        run: npm run test:consumer --workspace=packages/app-shell-core
+
+      - name: Pack packages
+        run: |
+          npm pack --workspace=packages/schema-forge-core --dry-run
+          npm pack --workspace=packages/app-shell-core --dry-run
+
+      - name: Publish schema forge core
+        run: |
+          DRY_RUN_ARGS=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            DRY_RUN_ARGS="--dry-run"
+          fi
+          npm publish --workspace=packages/schema-forge-core --tag "${{ inputs.tag }}" $DRY_RUN_ARGS
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish app shell core
+        run: |
+          DRY_RUN_ARGS=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            DRY_RUN_ARGS="--dry-run"
+          fi
+          npm publish --workspace=packages/app-shell-core --tag "${{ inputs.tag }}" $DRY_RUN_ARGS
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-private-packages.yml
+++ b/.github/workflows/publish-private-packages.yml
@@ -47,10 +47,18 @@ jobs:
       - name: App shell core consumer smoke
         run: npm run test:consumer --workspace=packages/app-shell-core
 
+      - name: Schema Forge agent context tests
+        run: npm test --workspace=packages/schema-forge-agent-context
+
+      - name: Schema Forge stack tests
+        run: npm test --workspace=packages/schema-forge-stack
+
       - name: Pack packages
         run: |
           npm pack --workspace=packages/schema-forge-core --dry-run
           npm pack --workspace=packages/app-shell-core --dry-run
+          npm pack --workspace=packages/schema-forge-agent-context --dry-run
+          npm pack --workspace=packages/schema-forge-stack --dry-run
 
       - name: Publish schema forge core
         run: |
@@ -69,5 +77,25 @@ jobs:
             DRY_RUN_ARGS="--dry-run"
           fi
           npm publish --workspace=packages/app-shell-core --tag "${{ inputs.tag }}" $DRY_RUN_ARGS
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish schema forge agent context
+        run: |
+          DRY_RUN_ARGS=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            DRY_RUN_ARGS="--dry-run"
+          fi
+          npm publish --workspace=packages/schema-forge-agent-context --tag "${{ inputs.tag }}" $DRY_RUN_ARGS
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish schema forge stack
+        run: |
+          DRY_RUN_ARGS=""
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            DRY_RUN_ARGS="--dry-run"
+          fi
+          npm publish --workspace=packages/schema-forge-stack --tag "${{ inputs.tag }}" $DRY_RUN_ARGS
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@etendosoftware:registry=https://npm.pkg.github.com

--- a/docs/contract-generation-ownership.md
+++ b/docs/contract-generation-ownership.md
@@ -1,0 +1,104 @@
+# Contract and Generated Output Ownership
+
+This document defines who produces contracts and generated outputs, who consumes them, and when regeneration is required. It is the operating model for keeping the monorepo split-ready without moving generated windows into reusable packages.
+
+## Ownership Model
+
+| Asset | Producer | Consumer | Regeneration trigger |
+|-------|----------|----------|----------------------|
+| `artifacts/<window>/schema-raw.json` | Schema Forge extractors (`extract-from-db`, cache-backed extractors) | Decision tooling, pipeline, reviewers | Etendo AD metadata changed, extraction cache refreshed, or a window is newly onboarded |
+| `artifacts/<window>/rules-raw.json` | Schema Forge rule extractors | Decision tooling, contract generator | Etendo rules/callouts changed or rule extraction logic changed |
+| `artifacts/<window>/decisions.json` | Human/agent curation through Schema Forge tooling | Contract generator, docs, tests | Functional UI/behavior decision changes, schema migration, or curated visibility/rule updates |
+| `artifacts/<window>/contract.json` | `generate-contract` step | NEO push, frontend generator, contract tests, app-shell runtime | Any upstream raw/decision/process input changed, contract generator changed, or contract version policy requires a bump |
+| `artifacts/<window>/contract.prev.json` and `contract-changelog.json` | `generate-contract` step | Reviewers and compatibility checks | Contract changes are generated after an existing contract is present |
+| `artifacts/<window>/generated/web/<window>/**` | `generate-frontend` step | `tools/app-shell` through `@generated`, downstream app-shell consumers after artifact sync | `contract.json` changed or frontend generator/templates changed |
+| `artifacts/<report>/report-contract.json` | Report pipeline/manual report authoring | Report API, report viewer, tests | Report inputs, SQL/NEO endpoint, output shape, parameters, or template behavior changed |
+| `tools/app-shell/src/windows/custom/<window>/**` | Humans/agents | App-shell runtime and users | Never generated. Edit manually and keep aligned with the window contract |
+| `tools/app-shell/src/windows/registry.js` | Humans/agents, occasionally generator-assisted | App-shell routing/build | New generated window, removed window, or loader ownership changes |
+| `@etendosoftware/app-shell-core` | App-shell platform maintainers | Monorepo app-shell and external app-shell consumers | Shared runtime/platform change only. It must not include generated contracts or generated windows |
+| `@etendosoftware/schema-forge-core` | Schema Forge generator/platform maintainers | CI, boundary checks, package consumers | Reusable generator/validation logic changes |
+| `@etendosoftware/schema-forge-stack` | Package maintainers | External consumers | Package composition, doctor checks, or setup commands changed |
+
+## Producer and Consumer Contract
+
+Schema Forge is the only producer of generated contracts and generated frontend outputs. A consumer may import and render those outputs, but it must not mutate them in place.
+
+The app-shell runtime consumes generated windows through an artifact boundary:
+
+```text
+artifacts/<window>/contract.json
+        │
+        ├── generate-frontend
+        ▼
+artifacts/<window>/generated/web/<window>/index.jsx
+        │
+        └── tools/app-shell registry imports through @generated
+```
+
+Reusable packages deliberately stop before generated business assets:
+
+```text
+@etendosoftware/app-shell-core
+  owns runtime, layout, auth, reports, styles, reusable UI
+
+consumer repo or monorepo artifacts
+  owns contract.json and generated/web/<window> outputs
+```
+
+That means an external project can consume the app shell package, but it still needs a contract/artifact producer path: either generated artifacts copied from Schema Forge, generated in its own repo through Schema Forge tooling, or delivered by a future artifact package.
+
+## Regeneration Rules
+
+Regenerate a window contract when any of these change:
+
+- `schema-raw.json`, `rules-raw.json`, `processes.json`, or `decisions.json`.
+- Contract generator code or contract schema.
+- Contract versioning policy, compatibility metadata, or test manifest rules.
+- NEO-facing configuration that changes endpoint shape, field visibility, process behavior, or report descriptors.
+
+Regenerate frontend outputs when any of these change:
+
+- `contract.json`.
+- Frontend generator code, shared generated templates, or generated component conventions.
+- App-shell platform APIs used by generated components.
+
+Do not regenerate just because these changed:
+
+- Custom window code under `tools/app-shell/src/windows/custom/**`.
+- Reusable package docs.
+- CI wiring, unless it changes generator behavior or artifact expectations.
+- App-shell-core internals that preserve the public runtime and generated component contract.
+
+## Split-Ready Repo Rule
+
+If the repo is split later, generated artifacts must move as an explicit deliverable, not as hidden app-shell-core source.
+
+Allowed split models:
+
+- **Consumer-owned artifacts:** the downstream app repo runs Schema Forge tooling and commits its own `artifacts/**`.
+- **Published artifact package:** a package such as `@etendosoftware/schema-forge-artifacts-<domain>` ships contracts/generated outputs for one domain or release train.
+- **Release bundle:** a release job emits app-shell packages plus artifact tarballs; consumers install packages and unpack artifacts as a controlled step.
+
+Not allowed:
+
+- Moving generated windows into `@etendosoftware/app-shell-core`.
+- Importing generated windows through monorepo-relative paths from a package.
+- Manually editing `artifacts/*/generated/**` to fix runtime issues.
+- Publishing a stack package that silently vendors generated business windows.
+
+## Review Checklist
+
+Every PR that touches contracts or generated outputs must answer:
+
+- Which windows/reports/processes are affected?
+- Which producer step was run?
+- Which generated outputs changed because of that producer step?
+- Which consumers were validated?
+- Are custom manual changes separated from generator outputs?
+
+Minimum validation:
+
+- Contract/generator change: run package tests for `schema-forge-core` and affected contract tests.
+- Window artifact change: run pipeline validation and affected app-shell build/smoke.
+- App-shell-core change that affects generated outputs: run app-shell-core tests and at least one generated-window consumer build.
+- External consumer package change: validate a consumer from package/tarball, not from monorepo-relative source.

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,7 @@
 | [ui-design-guidelines.md](ui-design-guidelines.md) | **UI design guidelines**: z-index scale, scrim opacity, overlay/drawer patterns, monetary amount formatting (`formatCurrency` vs `formatDashboardAmount`), column alignment |
 | [list-filters.md](list-filters.md) | **List view filters reference**: subset filters, quick filters, document-type filters, advanced filter popover — composition rules, URL-param hooks, when to use which |
 | [pipeline-validator-reference.md](pipeline-validator-reference.md) | **Pipeline completeness validator**: rules F1–F10, artifact classification, CLI flags, exit codes, and troubleshooting |
+| [contract-generation-ownership.md](contract-generation-ownership.md) | **Contract/generated output ownership**: producers, consumers, regeneration triggers, and split-ready artifact rules |
 | [line-pricing-model.md](line-pricing-model.md) | **Line pricing model**: client-side lineGrossAmount calculation for orders/quotations, field roles, callout vs client-side split, invoice refactor checklist |
 
 ## Design Specs

--- a/docs/ops/domain-boundary-check.md
+++ b/docs/ops/domain-boundary-check.md
@@ -17,18 +17,18 @@ make domain-boundary-check BASE=origin/epic/ETP-3504
 ```
 
 The implementation lives only in the publishable workspace package
-`@schema-forge/core`. This repository executes that package binary via `npx`;
+`@etendosoftware/schema-forge-core`. This repository executes that package binary via `npx`;
 other repositories can consume the same policy as a Node module or executable:
 
 ```bash
-npm install @schema-forge/core
+npm install @etendosoftware/schema-forge-core
 npx sf-domain-boundary-check --base origin/main
 ```
 
 Programmatic usage:
 
 ```js
-import { analyzeBoundary } from '@schema-forge/core/domain-boundary';
+import { analyzeBoundary } from '@etendosoftware/schema-forge-core/domain-boundary';
 
 const report = analyzeBoundary({
   changedFiles: ['artifacts/sales-order/contract.json'],

--- a/docs/plans/ETP-4104-cross-domain.md
+++ b/docs/plans/ETP-4104-cross-domain.md
@@ -4,8 +4,8 @@
 
 - `repo-infra`: GitHub Actions workflow, CODEOWNERS, Makefile target, and ops docs.
 - `generator-change`: CLI package metadata and the Node-based boundary check wrapper.
-- `sdk-or-external-app`: publishable `@schema-forge/core` workspace package.
-- `platform-change`: reusable `@schema-forge/app-shell-core` package and the app-shell imports that consume it.
+- `sdk-or-external-app`: publishable `@etendosoftware/schema-forge-core` workspace package.
+- `platform-change`: reusable `@etendosoftware/app-shell-core` package and the app-shell imports that consume it.
 
 ## Why This Cannot Be Split Cleanly
 
@@ -25,7 +25,7 @@ PR classified as unknown and would force a false-positive exception.
 2. Review workflow behavior, especially that it runs on every PR and merge group
    without `paths:` filters.
 3. Review CODEOWNERS and Makefile wiring.
-4. Review `@schema-forge/app-shell-core` package API: auth, i18n, shell layout,
+4. Review `@etendosoftware/app-shell-core` package API: auth, i18n, shell layout,
    report frame, styles, and absence of `@generated` imports.
 5. Review this plan and the ops documentation.
 
@@ -46,5 +46,5 @@ revert the CLI, tests, docs, Makefile target, package bin entry, and CODEOWNERS
 updates together.
 
 For the app-shell extraction, revert app-shell imports to local auth/i18n/currency
-providers first, then remove the `@schema-forge/app-shell-core` workspace
+providers first, then remove the `@etendosoftware/app-shell-core` workspace
 dependency and package.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2442,8 +2442,16 @@
       "resolved": "packages/app-shell-core",
       "link": true
     },
+    "node_modules/@etendosoftware/schema-forge-agent-context": {
+      "resolved": "packages/schema-forge-agent-context",
+      "link": true
+    },
     "node_modules/@etendosoftware/schema-forge-core": {
       "resolved": "packages/schema-forge-core",
+      "link": true
+    },
+    "node_modules/@etendosoftware/schema-forge-stack": {
+      "resolved": "packages/schema-forge-stack",
       "link": true
     },
     "node_modules/@exodus/bytes": {
@@ -13537,6 +13545,16 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "packages/schema-forge-agent-context": {
+      "name": "@etendosoftware/schema-forge-agent-context",
+      "version": "0.1.0",
+      "bin": {
+        "sf-agent-context": "bin/sf-agent-context.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "packages/schema-forge-core": {
       "name": "@etendosoftware/schema-forge-core",
       "version": "0.1.0",
@@ -13545,6 +13563,45 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "packages/schema-forge-stack": {
+      "name": "@etendosoftware/schema-forge-stack",
+      "version": "0.1.0",
+      "dependencies": {
+        "@etendosoftware/app-shell-core": "0.1.0",
+        "@etendosoftware/schema-forge-agent-context": "0.1.0",
+        "@etendosoftware/schema-forge-core": "0.1.0"
+      },
+      "bin": {
+        "sf-stack": "bin/sf-stack.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@radix-ui/react-collapsible": "^1.1.12",
+        "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-popover": "^1.1.15",
+        "@radix-ui/react-select": "^2.2.6",
+        "@radix-ui/react-separator": "^1.1.8",
+        "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
+        "@radix-ui/react-tooltip": "^1.2.8",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.0",
+        "cmdk": "^1.1.1",
+        "date-fns": "^4.1.0",
+        "lucide-react": "^0.400.0",
+        "next-themes": "^0.4.6",
+        "react": "^18.3.0",
+        "react-day-picker": "^9.14.0",
+        "react-dom": "^18.3.0",
+        "react-router-dom": "^7.0.0",
+        "sonner": "^2.0.7",
+        "tailwind-merge": "^2.2.0"
       }
     },
     "tools/app-shell": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "e2e"
       ],
       "devDependencies": {
-        "@schema-forge/core": "0.1.0",
+        "@etendosoftware/schema-forge-core": "0.1.0",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "shadcn": "^4.0.2"
@@ -2438,6 +2438,14 @@
       "resolved": "packages/apps-sdk-bff",
       "link": true
     },
+    "node_modules/@etendosoftware/app-shell-core": {
+      "resolved": "packages/app-shell-core",
+      "link": true
+    },
+    "node_modules/@etendosoftware/schema-forge-core": {
+      "resolved": "packages/schema-forge-core",
+      "link": true
+    },
     "node_modules/@exodus/bytes": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
@@ -3938,16 +3946,8 @@
       "resolved": "tools/app-shell",
       "link": true
     },
-    "node_modules/@schema-forge/app-shell-core": {
-      "resolved": "packages/app-shell-core",
-      "link": true
-    },
     "node_modules/@schema-forge/cli": {
       "resolved": "cli",
-      "link": true
-    },
-    "node_modules/@schema-forge/core": {
-      "resolved": "packages/schema-forge-core",
       "link": true
     },
     "node_modules/@schema-forge/decision-panel": {
@@ -13185,7 +13185,7 @@
       }
     },
     "packages/app-shell-core": {
-      "name": "@schema-forge/app-shell-core",
+      "name": "@etendosoftware/app-shell-core",
       "version": "0.1.0",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -13538,7 +13538,7 @@
       }
     },
     "packages/schema-forge-core": {
-      "name": "@schema-forge/core",
+      "name": "@etendosoftware/schema-forge-core",
       "version": "0.1.0",
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13551,6 +13551,7 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
+        "@etendosoftware/app-shell-core": "0.1.0",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -13563,7 +13564,6 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
         "@radix-ui/react-tooltip": "^1.2.8",
-        "@schema-forge/app-shell-core": "0.1.0",
         "@sentry/react": "^10.53.0",
         "aws-rum-web": "^1.18.0",
         "class-variance-authority": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "mkdir -p artifacts && node --test --test-reporter=spec --test-reporter-destination=stdout --test-reporter=junit --test-reporter-destination=artifacts/test-report.xml 'cli/test/*.test.js' && node cli/src/test-report-html.js"
   },
   "devDependencies": {
-    "@schema-forge/core": "0.1.0",
+    "@etendosoftware/schema-forge-core": "0.1.0",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "shadcn": "^4.0.2"

--- a/packages/app-shell-core/README.md
+++ b/packages/app-shell-core/README.md
@@ -1,4 +1,4 @@
-# @schema-forge/app-shell-core
+# @etendosoftware/app-shell-core
 
 Reusable runtime package for Schema Forge apps.
 
@@ -12,18 +12,18 @@ It intentionally does not include generated contracts, generated windows,
 ```json
 {
   "dependencies": {
-    "@schema-forge/app-shell-core": "0.1.0"
+    "@etendosoftware/app-shell-core": "0.1.0"
   }
 }
 ```
 
 ```jsx
-import '@schema-forge/app-shell-core/styles.css';
+import '@etendosoftware/app-shell-core/styles.css';
 import {
   AppShellRuntime,
   createAppShellConfig,
   createMemoryAuthStorage,
-} from '@schema-forge/app-shell-core';
+} from '@etendosoftware/app-shell-core';
 
 const config = createAppShellConfig({
   menuGroups: [
@@ -61,15 +61,15 @@ export function App() {
 External consumers should depend on the package entrypoints instead of internal
 paths:
 
-- `@schema-forge/app-shell-core` for the complete runtime surface.
-- `@schema-forge/app-shell-core/runtime` for `AppShellRuntime`,
+- `@etendosoftware/app-shell-core` for the complete runtime surface.
+- `@etendosoftware/app-shell-core/runtime` for `AppShellRuntime`,
   `AppShellProviders`, `AuthGate`, and descriptor builders.
-- `@schema-forge/app-shell-core/auth` for session storage, auth context, and API
+- `@etendosoftware/app-shell-core/auth` for session storage, auth context, and API
   fetch helpers.
-- `@schema-forge/app-shell-core/layout` for shell layout primitives.
-- `@schema-forge/app-shell-core/reports` for report descriptors and viewer frame.
-- `@schema-forge/app-shell-core/styles.css` for the CSS/Tailwind token layer.
-- `@schema-forge/app-shell-core/tailwind-preset` for the Tailwind theme tokens
+- `@etendosoftware/app-shell-core/layout` for shell layout primitives.
+- `@etendosoftware/app-shell-core/reports` for report descriptors and viewer frame.
+- `@etendosoftware/app-shell-core/styles.css` for the CSS/Tailwind token layer.
+- `@etendosoftware/app-shell-core/tailwind-preset` for the Tailwind theme tokens
   required by the published CSS and UI primitives.
 
 The package still expects the host app to provide React, React Router, Radix UI,

--- a/packages/app-shell-core/package.json
+++ b/packages/app-shell-core/package.json
@@ -1,8 +1,12 @@
 {
-  "name": "@schema-forge/app-shell-core",
+  "name": "@etendosoftware/app-shell-core",
   "version": "0.1.0",
   "description": "Reusable Schema Forge app shell runtime without generated contracts or windows.",
   "type": "module",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
   "sideEffects": [
     "./src/styles.css"
   ],

--- a/packages/app-shell-core/scripts/package-consumer-smoke.mjs
+++ b/packages/app-shell-core/scripts/package-consumer-smoke.mjs
@@ -41,7 +41,7 @@ function writeFixtureFiles(tarballPath) {
       build: 'vite build',
     },
     dependencies: {
-      '@schema-forge/app-shell-core': `file:${tarballPath}`,
+      '@etendosoftware/app-shell-core': `file:${tarballPath}`,
       '@vitejs/plugin-react': '^4.3.0',
       '@radix-ui/react-slot': '^1.2.4',
       'class-variance-authority': '^0.7.1',
@@ -62,24 +62,24 @@ function writeFixtureFiles(tarballPath) {
 
   writeFileSync(join(fixtureDir, 'index.html'), '<div id="root"></div><script type="module" src="/src/App.jsx"></script>\n');
   writeFileSync(join(fixtureDir, 'postcss.config.js'), 'export default { plugins: { tailwindcss: {}, autoprefixer: {} } };\n');
-  writeFileSync(join(fixtureDir, 'tailwind.config.js'), `import appShellCorePreset from '@schema-forge/app-shell-core/tailwind-preset';
+  writeFileSync(join(fixtureDir, 'tailwind.config.js'), `import appShellCorePreset from '@etendosoftware/app-shell-core/tailwind-preset';
 
 export default {
   presets: [appShellCorePreset],
-  content: ['./src/**/*.{js,jsx}', './node_modules/@schema-forge/app-shell-core/src/**/*.{js,jsx}'],
+  content: ['./src/**/*.{js,jsx}', './node_modules/@etendosoftware/app-shell-core/src/**/*.{js,jsx}'],
 };
 `);
 
   writeFileSync(join(fixtureDir, 'src', 'App.jsx'), `import React from 'react';
 import { createRoot } from 'react-dom/client';
-import '@schema-forge/app-shell-core/styles.css';
+import '@etendosoftware/app-shell-core/styles.css';
 import {
   AppShellRuntime,
   createAppShellConfig,
   createMemoryAuthStorage,
-} from '@schema-forge/app-shell-core';
-import { Button } from '@schema-forge/app-shell-core/components/ui/button.jsx';
-import { Card, CardContent } from '@schema-forge/app-shell-core/components/ui/card.jsx';
+} from '@etendosoftware/app-shell-core';
+import { Button } from '@etendosoftware/app-shell-core/components/ui/button.jsx';
+import { Card, CardContent } from '@etendosoftware/app-shell-core/components/ui/card.jsx';
 
 function Dashboard() {
   return (

--- a/packages/app-shell-core/test/public-api.test.js
+++ b/packages/app-shell-core/test/public-api.test.js
@@ -6,7 +6,7 @@ import { join } from 'node:path';
 test('public package exports the expected runtime entrypoints', async () => {
   const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8'));
 
-  assert.equal(pkg.name, '@schema-forge/app-shell-core');
+  assert.equal(pkg.name, '@etendosoftware/app-shell-core');
   assert.equal(pkg.exports['.'], './src/index.js');
   assert.equal(pkg.exports['./auth'], './src/auth/index.js');
   assert.equal(pkg.exports['./i18n'], './src/i18n/index.js');

--- a/packages/schema-forge-agent-context/bin/sf-agent-context.js
+++ b/packages/schema-forge-agent-context/bin/sf-agent-context.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { runAgentContextCli } from '../src/index.js';
+
+runAgentContextCli(process.argv.slice(2)).catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/packages/schema-forge-agent-context/context/.github/copilot-instructions.md
+++ b/packages/schema-forge-agent-context/context/.github/copilot-instructions.md
@@ -1,0 +1,8 @@
+# Copilot Instructions - Schema Forge Consumers
+
+- Treat Schema Forge packages as public package boundaries.
+- Prefer package imports over copied source or monorepo-relative paths.
+- Keep generated contracts and generated windows in the consuming project.
+- Keep `@etendosoftware/app-shell-core` free of app-specific business logic.
+- Use `sf-stack doctor` to check package and peer dependency resolution.
+- Use `sf-stack install-agent-context --dry-run` before installing packaged agent context.

--- a/packages/schema-forge-agent-context/context/.github/copilot-review-instructions.md
+++ b/packages/schema-forge-agent-context/context/.github/copilot-review-instructions.md
@@ -1,0 +1,10 @@
+# Copilot Review Instructions - Schema Forge Consumers
+
+Flag these issues in downstream projects:
+
+- Imports from internal monorepo paths instead of package names.
+- Generated windows or contracts placed inside reusable core packages.
+- Runtime code that assumes a specific generated window exists in app-shell core.
+- Missing peer dependencies required by `@etendosoftware/app-shell-core`.
+- Agent context installers that overwrite existing files without explicit force.
+- Package changes without pack or consumer smoke validation.

--- a/packages/schema-forge-agent-context/context/AGENTS.md
+++ b/packages/schema-forge-agent-context/context/AGENTS.md
@@ -15,6 +15,7 @@ Use this packaged context as the default orientation when working on a consumer 
 - Etendo Go serves runtime API behavior through NEO Headless.
 - External app-shell consumers receive the reusable shell runtime, shared styles, UI primitives, reporting frame, auth helpers, and menu/layout contracts.
 - Generated contracts and generated windows stay outside `@etendosoftware/app-shell-core`.
+- Schema Forge remains the producer of generated contracts and generated outputs unless a consumer repo explicitly owns its own artifact generation.
 
 ## Hard Rules
 
@@ -31,3 +32,4 @@ Use this packaged context as the default orientation when working on a consumer 
 - `.github/copilot-review-instructions.md`
 - `docs/agent-context-index.md`
 - `docs/architecture-overview.md`
+- `docs/contract-generation-ownership.md`

--- a/packages/schema-forge-agent-context/context/AGENTS.md
+++ b/packages/schema-forge-agent-context/context/AGENTS.md
@@ -1,0 +1,33 @@
+# Schema Forge Agent Context
+
+Use this packaged context as the default orientation when working on a consumer project that depends on Schema Forge packages.
+
+## Core Workflow
+
+- Keep implementation changes, tests, and documentation aligned.
+- Use feature branches and pull requests for all repository changes.
+- Prefer deterministic checks in code over complex shell logic embedded in workflows.
+- Keep committed code, comments, filenames, commit messages, and documentation in English.
+
+## Architecture Context
+
+- Schema Forge defines contracts, generated UI inputs, validation policy, and packaging boundaries.
+- Etendo Go serves runtime API behavior through NEO Headless.
+- External app-shell consumers receive the reusable shell runtime, shared styles, UI primitives, reporting frame, auth helpers, and menu/layout contracts.
+- Generated contracts and generated windows stay outside `@etendosoftware/app-shell-core`.
+
+## Hard Rules
+
+- Do not hardcode or guess window, process, or menu IDs.
+- Do not manually edit generated files under `artifacts/*/generated/`.
+- If a task touches a generated/custom window, update the related functional documentation in the same change.
+- Prefer public package imports such as `@etendosoftware/app-shell-core` over monorepo-relative imports.
+- Do not add frontend business logic to `@etendosoftware/app-shell-core` when it belongs to a specific window.
+
+## References
+
+- `CLAUDE.md`
+- `.github/copilot-instructions.md`
+- `.github/copilot-review-instructions.md`
+- `docs/agent-context-index.md`
+- `docs/architecture-overview.md`

--- a/packages/schema-forge-agent-context/context/CLAUDE.md
+++ b/packages/schema-forge-agent-context/context/CLAUDE.md
@@ -1,0 +1,24 @@
+# Schema Forge Claude Context
+
+This package contains the portable subset of the Schema Forge repository guidance for agent-assisted work in downstream projects.
+
+## Package Boundaries
+
+- `@etendosoftware/schema-forge-core` owns reusable Node tooling and deterministic validation.
+- `@etendosoftware/app-shell-core` owns reusable shell runtime, styles, UI primitives, auth/menu/layout/report contracts, and Tailwind preset.
+- `@etendosoftware/schema-forge-agent-context` owns portable agent instructions and curated reference docs.
+- `@etendosoftware/schema-forge-stack` ties those packages together and exposes verification/install commands.
+
+## Consumer Expectations
+
+- Consumers import runtime and UI directly from `@etendosoftware/app-shell-core`.
+- Consumers provide generated contracts, generated windows, and app-specific business logic.
+- React, React DOM, Tailwind, Radix, and other browser runtime dependencies remain peer dependencies of the app-shell core package.
+- The stack package should help verify setup; it should not hide package boundaries behind broad reexports.
+
+## Validation Habits
+
+- Run package tests for changed workspaces.
+- Run pack or publish dry-runs before publishing private packages.
+- Validate a real external consumer with local tarballs before treating the package contract as stable.
+- Use safe installers for docs/context: list first, dry-run when possible, and never overwrite user files unless explicitly forced.

--- a/packages/schema-forge-agent-context/context/docs/agent-context-index.md
+++ b/packages/schema-forge-agent-context/context/docs/agent-context-index.md
@@ -1,0 +1,17 @@
+# Schema Forge Agent Context Index
+
+This package installs a curated context set for downstream agent work.
+
+## Files
+
+- `AGENTS.md`: default operational rules and architecture boundaries.
+- `CLAUDE.md`: package split, consumer expectations, and validation habits.
+- `.github/copilot-instructions.md`: short coding guidance for consumer repos.
+- `.github/copilot-review-instructions.md`: review checklist for package-boundary regressions.
+- `docs/architecture-overview.md`: compact architecture summary.
+
+## Usage
+
+Run `sf-agent-context list` to inspect packaged files.
+Run `sf-agent-context install --target <repo> --dry-run` before installing.
+Run `sf-agent-context install --target <repo> --force` only when replacing existing context files is intentional.

--- a/packages/schema-forge-agent-context/context/docs/agent-context-index.md
+++ b/packages/schema-forge-agent-context/context/docs/agent-context-index.md
@@ -9,6 +9,7 @@ This package installs a curated context set for downstream agent work.
 - `.github/copilot-instructions.md`: short coding guidance for consumer repos.
 - `.github/copilot-review-instructions.md`: review checklist for package-boundary regressions.
 - `docs/architecture-overview.md`: compact architecture summary.
+- `docs/contract-generation-ownership.md`: producer/consumer rules for contracts and generated outputs.
 
 ## Usage
 

--- a/packages/schema-forge-agent-context/context/docs/architecture-overview.md
+++ b/packages/schema-forge-agent-context/context/docs/architecture-overview.md
@@ -1,0 +1,26 @@
+# Schema Forge Portable Architecture Overview
+
+Schema Forge and Etendo Go form one system with separate responsibilities.
+
+Schema Forge owns:
+
+- extraction and generation tooling,
+- contracts and validation rules,
+- generated/custom window artifacts,
+- app-shell source and reusable packages,
+- documentation and agent workflows.
+
+Etendo Go owns:
+
+- NEO Headless runtime APIs,
+- auth enforcement,
+- selector/process/report execution,
+- persisted `ETGO_SF_*` configuration,
+- server-side extension hooks.
+
+The reusable package boundary is intentionally narrower than the monorepo:
+
+- app-shell core is reusable shell runtime and shared UI infrastructure,
+- generated windows and contracts remain consumer-owned,
+- generator/core validation logic is packaged separately,
+- agent context is shipped as docs/tooling rather than mixed into runtime code.

--- a/packages/schema-forge-agent-context/context/docs/contract-generation-ownership.md
+++ b/packages/schema-forge-agent-context/context/docs/contract-generation-ownership.md
@@ -1,0 +1,38 @@
+# Contract and Generated Output Ownership
+
+Schema Forge is the producer of contracts and generated window outputs. Consumers can import, render, package, or deploy those outputs, but they should not patch generated files directly.
+
+## Package Boundary
+
+| Package or asset | Owns | Does not own |
+|------------------|------|--------------|
+| `@etendosoftware/schema-forge-core` | reusable generator/validation logic and CI checks | generated business windows |
+| `@etendosoftware/app-shell-core` | shell runtime, auth/menu/layout/report contracts, styles, reusable UI | generated contracts, generated windows, app-specific business logic |
+| `@etendosoftware/schema-forge-agent-context` | portable agent instructions and reference docs | runtime code |
+| `@etendosoftware/schema-forge-stack` | package composition and setup/doctor commands | vendored business artifacts |
+| consumer repo artifacts | generated contracts and generated windows for that app/domain | reusable app-shell platform internals |
+
+## Regeneration Rules
+
+Regenerate contracts when raw schema, raw rules, processes, decisions, contract schema, or generator behavior changes.
+
+Regenerate frontend outputs when `contract.json`, frontend generator code, templates, or generated component conventions change.
+
+Do not regenerate generated outputs for custom-only changes, documentation-only changes, or app-shell-core internals that preserve the generated component contract.
+
+## Split-Ready Rule
+
+Generated artifacts must be delivered explicitly if repositories split. Use one of these models:
+
+- consumer-owned `artifacts/**`,
+- published artifact packages by domain or release train,
+- release bundles that include app-shell packages plus artifact tarballs.
+
+Do not move generated windows into `@etendosoftware/app-shell-core`, import generated windows through monorepo-relative package paths, or publish a stack package that silently vendors generated business windows.
+
+## PR Checklist
+
+- Name the affected windows, reports, or processes.
+- Name the producer step that was run.
+- Keep generated outputs separate from manual custom code.
+- Validate the relevant consumer: app-shell build, package/tarball consumer, or downstream app CI.

--- a/packages/schema-forge-agent-context/package.json
+++ b/packages/schema-forge-agent-context/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@etendosoftware/schema-forge-agent-context",
+  "version": "0.1.0",
+  "description": "Packaged Schema Forge agent context for external consumers.",
+  "type": "module",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "bin": {
+    "sf-agent-context": "bin/sf-agent-context.js"
+  },
+  "files": [
+    "bin",
+    "context",
+    "src"
+  ],
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/schema-forge-agent-context/src/index.js
+++ b/packages/schema-forge-agent-context/src/index.js
@@ -1,0 +1,101 @@
+import { copyFile, mkdir, readdir, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = fileURLToPath(new URL('../', import.meta.url));
+const contextRoot = path.join(packageRoot, 'context');
+
+export const DEFAULT_CONTEXT_FILES = [
+  'AGENTS.md',
+  'CLAUDE.md',
+  '.github/copilot-instructions.md',
+  '.github/copilot-review-instructions.md',
+  'docs/agent-context-index.md',
+  'docs/architecture-overview.md',
+];
+
+function resolveInside(baseDir, relativePath) {
+  const resolved = path.resolve(baseDir, relativePath);
+  const relative = path.relative(baseDir, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error(`Refusing to access path outside ${baseDir}: ${relativePath}`);
+  }
+  return resolved;
+}
+
+export async function listAgentContextFiles() {
+  const files = [];
+
+  async function walk(dir) {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+        continue;
+      }
+      if (entry.isFile()) {
+        files.push(path.relative(contextRoot, fullPath).split(path.sep).join('/'));
+      }
+    }
+  }
+
+  await walk(contextRoot);
+  return files.sort();
+}
+
+export async function installAgentContext({
+  targetDir = process.cwd(),
+  force = false,
+  dryRun = false,
+  files = DEFAULT_CONTEXT_FILES,
+} = {}) {
+  const targetRoot = path.resolve(targetDir);
+  const results = [];
+
+  for (const file of files) {
+    const source = resolveInside(contextRoot, file);
+    const target = resolveInside(targetRoot, file);
+    const targetExists = await stat(target).then(() => true, () => false);
+    const status = targetExists && !force ? 'skipped' : dryRun ? 'planned' : 'installed';
+
+    if (!dryRun && status === 'installed') {
+      await mkdir(path.dirname(target), { recursive: true });
+      await copyFile(source, target);
+    }
+
+    results.push({ file, status });
+  }
+
+  return results;
+}
+
+function readOptionValue(args, name, fallback) {
+  const index = args.indexOf(name);
+  if (index === -1) {
+    return fallback;
+  }
+  return args[index + 1] ?? fallback;
+}
+
+export async function runAgentContextCli(args = []) {
+  const [command = 'list'] = args;
+
+  if (command === 'list') {
+    const files = await listAgentContextFiles();
+    console.log(files.join('\n'));
+    return;
+  }
+
+  if (command === 'install') {
+    const targetDir = readOptionValue(args, '--target', process.cwd());
+    const force = args.includes('--force');
+    const dryRun = args.includes('--dry-run');
+    const results = await installAgentContext({ targetDir, force, dryRun });
+    for (const result of results) {
+      console.log(`${result.status}\t${result.file}`);
+    }
+    return;
+  }
+
+  throw new Error(`Unknown sf-agent-context command: ${command}`);
+}

--- a/packages/schema-forge-agent-context/src/index.js
+++ b/packages/schema-forge-agent-context/src/index.js
@@ -12,6 +12,7 @@ export const DEFAULT_CONTEXT_FILES = [
   '.github/copilot-review-instructions.md',
   'docs/agent-context-index.md',
   'docs/architecture-overview.md',
+  'docs/contract-generation-ownership.md',
 ];
 
 function resolveInside(baseDir, relativePath) {

--- a/packages/schema-forge-agent-context/test/agent-context.test.js
+++ b/packages/schema-forge-agent-context/test/agent-context.test.js
@@ -14,6 +14,7 @@ describe('schema forge agent context', () => {
     assert.ok(files.includes('CLAUDE.md'));
     assert.ok(files.includes('.github/copilot-instructions.md'));
     assert.ok(files.includes('docs/agent-context-index.md'));
+    assert.ok(files.includes('docs/contract-generation-ownership.md'));
   });
 
   it('installs context without overwriting existing files by default', async () => {

--- a/packages/schema-forge-agent-context/test/agent-context.test.js
+++ b/packages/schema-forge-agent-context/test/agent-context.test.js
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, it } from 'node:test';
+
+import { installAgentContext, listAgentContextFiles } from '../src/index.js';
+
+describe('schema forge agent context', () => {
+  it('lists packaged context files', async () => {
+    const files = await listAgentContextFiles();
+
+    assert.ok(files.includes('AGENTS.md'));
+    assert.ok(files.includes('CLAUDE.md'));
+    assert.ok(files.includes('.github/copilot-instructions.md'));
+    assert.ok(files.includes('docs/agent-context-index.md'));
+  });
+
+  it('installs context without overwriting existing files by default', async () => {
+    const targetDir = await mkdtemp(path.join(os.tmpdir(), 'sf-agent-context-'));
+    await writeFile(path.join(targetDir, 'AGENTS.md'), 'local context');
+
+    const results = await installAgentContext({ targetDir });
+    const agentsResult = results.find((result) => result.file === 'AGENTS.md');
+    const claudeResult = results.find((result) => result.file === 'CLAUDE.md');
+
+    assert.equal(agentsResult.status, 'skipped');
+    assert.equal(claudeResult.status, 'installed');
+    assert.equal(await readFile(path.join(targetDir, 'AGENTS.md'), 'utf8'), 'local context');
+  });
+
+  it('supports dry-run installs', async () => {
+    const targetDir = await mkdtemp(path.join(os.tmpdir(), 'sf-agent-context-'));
+    const results = await installAgentContext({ targetDir, dryRun: true });
+
+    assert.ok(results.every((result) => result.status === 'planned'));
+  });
+});

--- a/packages/schema-forge-core/README.md
+++ b/packages/schema-forge-core/README.md
@@ -1,4 +1,4 @@
-# @schema-forge/core
+# @etendosoftware/schema-forge-core
 
 Reusable JavaScript core for Schema Forge automation.
 
@@ -7,14 +7,14 @@ Reusable JavaScript core for Schema Forge automation.
 Install in another repository and run the packaged binary:
 
 ```bash
-npm install @schema-forge/core
+npm install @etendosoftware/schema-forge-core
 npx sf-domain-boundary-check --base origin/main
 ```
 
 Use it from code:
 
 ```js
-import { analyzeBoundary } from '@schema-forge/core/domain-boundary';
+import { analyzeBoundary } from '@etendosoftware/schema-forge-core/domain-boundary';
 
 const report = analyzeBoundary({
   changedFiles: ['artifacts/sales-order/contract.json'],
@@ -29,8 +29,8 @@ functions directly with their own changed-file list and known windows.
 
 ## Local Workspace Consumption
 
-Inside this monorepo, root tooling depends on `@schema-forge/core` by package
-name and matching version, for example `"@schema-forge/core": "0.1.0"`. npm then
+Inside this monorepo, root tooling depends on `@etendosoftware/schema-forge-core` by package
+name and matching version, for example `"@etendosoftware/schema-forge-core": "0.1.0"`. npm then
 links the workspace package from `packages/schema-forge-core` in
 `package-lock.json`, avoiding relative imports while staying compatible with the
 npm version used by this repository. For command-line use inside this repo,

--- a/packages/schema-forge-core/package.json
+++ b/packages/schema-forge-core/package.json
@@ -1,7 +1,11 @@
 {
-  "name": "@schema-forge/core",
+  "name": "@etendosoftware/schema-forge-core",
   "version": "0.1.0",
   "type": "module",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
   "main": "src/index.js",
   "exports": {
     ".": "./src/index.js",

--- a/packages/schema-forge-core/package.json
+++ b/packages/schema-forge-core/package.json
@@ -13,7 +13,7 @@
     "./domain-boundary-check": "./src/domain-boundary-check.js"
   },
   "bin": {
-    "sf-domain-boundary-check": "./bin/sf-domain-boundary-check.js"
+    "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
   },
   "files": [
     "bin",

--- a/packages/schema-forge-core/src/domain-boundary/classifier.js
+++ b/packages/schema-forge-core/src/domain-boundary/classifier.js
@@ -188,6 +188,18 @@ const CORE_PACKAGE_PATTERNS = [
   /^packages\/schema-forge-core\//,
 ];
 
+const STACK_PACKAGE_PATTERNS = [
+  /^packages\/schema-forge-agent-context\//,
+  /^packages\/schema-forge-stack\//,
+];
+
+const BOUNDARY_GATE_PATTERNS = [
+  /^packages\/schema-forge-core\/bin\/sf-domain-boundary-check\.js$/,
+  /^packages\/schema-forge-core\/src\/domain-boundary(?:\/|$)/,
+  /^packages\/schema-forge-core\/src\/domain-boundary-check\.js$/,
+  /^packages\/schema-forge-core\/test\/domain-boundary-check\.test\.js$/,
+];
+
 function matchesAny(path, patterns) {
   return patterns.some((pattern) => pattern.test(path));
 }
@@ -313,6 +325,14 @@ export function classifyPath(path, { knownWindows = [] } = {}) {
     return { kind: 'platform-change', scope: 'platform-change' };
   }
 
+  if (matchesAny(normalized, STACK_PACKAGE_PATTERNS)) {
+    return { kind: 'schema-forge-stack-package', scope: 'repo-infra' };
+  }
+
+  if (matchesAny(normalized, BOUNDARY_GATE_PATTERNS)) {
+    return { kind: 'domain-boundary-gate', scope: 'repo-infra' };
+  }
+
   if (matchesAny(normalized, CORE_PACKAGE_PATTERNS)) {
     return { kind: 'schema-forge-core', scope: 'generator-change' };
   }
@@ -391,6 +411,9 @@ function isRootSensitiveAllowedWithSingleScope({ rootSensitiveFiles, nonRootScop
     }
     if (scope === 'generator-change') {
       return changedFiles.some((path) => path === 'cli/package.json');
+    }
+    if (scope === 'repo-infra') {
+      return changedFiles.some((path) => /^packages\/(?:schema-forge-agent-context|schema-forge-stack)\/package\.json$/.test(path));
     }
   }
 

--- a/packages/schema-forge-core/src/domain-boundary/classifier.js
+++ b/packages/schema-forge-core/src/domain-boundary/classifier.js
@@ -171,6 +171,7 @@ const REPO_INFRA_PATTERNS = [
   /^schema_forge\.properties$/,
   /^ETENDO_VERSION$/,
   /^\.env\.example$/,
+  /^\.npmrc$/,
   /^\.nvmrc$/,
   /^AGENTS\.md$/,
   /^CLAUDE\.md$/,

--- a/packages/schema-forge-core/test/domain-boundary-check.test.js
+++ b/packages/schema-forge-core/test/domain-boundary-check.test.js
@@ -152,6 +152,13 @@ describe('domain boundary classification', () => {
     );
   });
 
+  it('classifies npm registry config as repo infra', () => {
+    assert.deepEqual(
+      classifyPath('.npmrc', { knownWindows: WINDOWS }),
+      { kind: 'repo-infra', scope: 'repo-infra' },
+    );
+  });
+
   it('allows registry registration with a single window slice', () => {
     const report = analyzeBoundary({
       knownWindows: WINDOWS,

--- a/packages/schema-forge-core/test/domain-boundary-check.test.js
+++ b/packages/schema-forge-core/test/domain-boundary-check.test.js
@@ -159,6 +159,28 @@ describe('domain boundary classification', () => {
     );
   });
 
+  it('classifies stack publishing packages as repo infra', () => {
+    assert.deepEqual(
+      classifyPath('packages/schema-forge-stack/src/index.js', { knownWindows: WINDOWS }),
+      { kind: 'schema-forge-stack-package', scope: 'repo-infra' },
+    );
+    assert.deepEqual(
+      classifyPath('packages/schema-forge-agent-context/src/index.js', { knownWindows: WINDOWS }),
+      { kind: 'schema-forge-stack-package', scope: 'repo-infra' },
+    );
+  });
+
+  it('classifies domain boundary gate implementation as repo infra', () => {
+    assert.deepEqual(
+      classifyPath('packages/schema-forge-core/src/domain-boundary/classifier.js', { knownWindows: WINDOWS }),
+      { kind: 'domain-boundary-gate', scope: 'repo-infra' },
+    );
+    assert.deepEqual(
+      classifyPath('packages/schema-forge-core/test/domain-boundary-check.test.js', { knownWindows: WINDOWS }),
+      { kind: 'domain-boundary-gate', scope: 'repo-infra' },
+    );
+  });
+
   it('allows registry registration with a single window slice', () => {
     const report = analyzeBoundary({
       knownWindows: WINDOWS,
@@ -232,6 +254,19 @@ describe('domain boundary classification', () => {
       changedFiles: [
         'package-lock.json',
         'packages/app-shell-core/package.json',
+      ],
+    });
+
+    assert.equal(report.decision, 'pass');
+  });
+
+  it('allows a root lockfile with stack package metadata', () => {
+    const report = analyzeBoundary({
+      knownWindows: WINDOWS,
+      changedFiles: [
+        'package-lock.json',
+        'packages/schema-forge-stack/package.json',
+        'packages/schema-forge-stack/src/index.js',
       ],
     });
 

--- a/packages/schema-forge-stack/bin/sf-stack.js
+++ b/packages/schema-forge-stack/bin/sf-stack.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { runStackCli } from '../src/index.js';
+
+runStackCli(process.argv.slice(2)).catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});

--- a/packages/schema-forge-stack/package.json
+++ b/packages/schema-forge-stack/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@etendosoftware/schema-forge-stack",
+  "version": "0.1.0",
+  "description": "Private Schema Forge stack meta-package for external consumers.",
+  "type": "module",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com",
+    "access": "restricted"
+  },
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "bin": {
+    "sf-stack": "bin/sf-stack.js"
+  },
+  "files": [
+    "bin",
+    "src"
+  ],
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  },
+  "dependencies": {
+    "@etendosoftware/app-shell-core": "0.1.0",
+    "@etendosoftware/schema-forge-agent-context": "0.1.0",
+    "@etendosoftware/schema-forge-core": "0.1.0"
+  },
+  "peerDependencies": {
+    "@radix-ui/react-collapsible": "^1.1.12",
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-popover": "^1.1.15",
+    "@radix-ui/react-select": "^2.2.6",
+    "@radix-ui/react-separator": "^1.1.8",
+    "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
+    "@radix-ui/react-tooltip": "^1.2.8",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.0",
+    "cmdk": "^1.1.1",
+    "date-fns": "^4.1.0",
+    "lucide-react": "^0.400.0",
+    "next-themes": "^0.4.6",
+    "react": "^18.3.0",
+    "react-day-picker": "^9.14.0",
+    "react-dom": "^18.3.0",
+    "react-router-dom": "^7.0.0",
+    "sonner": "^2.0.7",
+    "tailwind-merge": "^2.2.0"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/packages/schema-forge-stack/src/index.js
+++ b/packages/schema-forge-stack/src/index.js
@@ -1,0 +1,116 @@
+import { installAgentContext } from '@etendosoftware/schema-forge-agent-context';
+
+export const STACK_PACKAGES = [
+  '@etendosoftware/schema-forge-core',
+  '@etendosoftware/app-shell-core',
+  '@etendosoftware/schema-forge-agent-context',
+];
+
+export const APP_SHELL_PEERS = [
+  '@radix-ui/react-collapsible',
+  '@radix-ui/react-dialog',
+  '@radix-ui/react-dropdown-menu',
+  '@radix-ui/react-label',
+  '@radix-ui/react-popover',
+  '@radix-ui/react-select',
+  '@radix-ui/react-separator',
+  '@radix-ui/react-slot',
+  '@radix-ui/react-switch',
+  '@radix-ui/react-tooltip',
+  'class-variance-authority',
+  'clsx',
+  'cmdk',
+  'date-fns',
+  'lucide-react',
+  'next-themes',
+  'react',
+  'react-day-picker',
+  'react-dom',
+  'react-router-dom',
+  'sonner',
+  'tailwind-merge',
+];
+
+async function resolvePackage(name) {
+  try {
+    return { name, ok: true, resolved: import.meta.resolve(name) };
+  } catch (error) {
+    return { name, ok: false, error: error.message };
+  }
+}
+
+export async function doctorStack({ includePeers = true } = {}) {
+  const packages = await Promise.all(STACK_PACKAGES.map(resolvePackage));
+  const peers = includePeers ? await Promise.all(APP_SHELL_PEERS.map(resolvePackage)) : [];
+  return {
+    ok: [...packages, ...peers].every((item) => item.ok),
+    packages,
+    peers,
+  };
+}
+
+export async function verifyStack() {
+  const report = await doctorStack();
+  if (!report.ok) {
+    return report;
+  }
+
+  await import('@etendosoftware/schema-forge-core');
+  await import('@etendosoftware/app-shell-core/tailwind-preset');
+  await import('@etendosoftware/schema-forge-agent-context');
+
+  return report;
+}
+
+function readOptionValue(args, name, fallback) {
+  const index = args.indexOf(name);
+  if (index === -1) {
+    return fallback;
+  }
+  return args[index + 1] ?? fallback;
+}
+
+function printResolutionReport(report) {
+  for (const item of report.packages) {
+    console.log(`${item.ok ? 'ok' : 'missing'}\tpackage\t${item.name}`);
+  }
+  for (const item of report.peers) {
+    console.log(`${item.ok ? 'ok' : 'missing'}\tpeer\t${item.name}`);
+  }
+}
+
+export async function runStackCli(args = []) {
+  const [command = 'doctor'] = args;
+
+  if (command === 'doctor') {
+    const report = await doctorStack({ includePeers: !args.includes('--no-peers') });
+    printResolutionReport(report);
+    if (!report.ok) {
+      throw new Error('Schema Forge stack doctor failed.');
+    }
+    return;
+  }
+
+  if (command === 'verify') {
+    const report = await verifyStack();
+    printResolutionReport(report);
+    if (!report.ok) {
+      throw new Error('Schema Forge stack verify failed.');
+    }
+    console.log('verified\tstack package imports');
+    return;
+  }
+
+  if (command === 'install-agent-context') {
+    const targetDir = readOptionValue(args, '--target', process.cwd());
+    const force = args.includes('--force');
+    const dryRun = args.includes('--dry-run');
+    const results = await installAgentContext({ targetDir, force, dryRun });
+    for (const result of results) {
+      console.log(`${result.status}\t${result.file}`);
+    }
+    return;
+  }
+
+  throw new Error(`Unknown sf-stack command: ${command}`);
+}

--- a/packages/schema-forge-stack/test/stack.test.js
+++ b/packages/schema-forge-stack/test/stack.test.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { APP_SHELL_PEERS, STACK_PACKAGES, doctorStack, verifyStack } from '../src/index.js';
+
+describe('schema forge stack', () => {
+  it('declares stack package dependencies', () => {
+    assert.deepEqual(STACK_PACKAGES, [
+      '@etendosoftware/schema-forge-core',
+      '@etendosoftware/app-shell-core',
+      '@etendosoftware/schema-forge-agent-context',
+    ]);
+  });
+
+  it('tracks app shell peer dependencies for doctor checks', () => {
+    assert.ok(APP_SHELL_PEERS.includes('react'));
+    assert.ok(APP_SHELL_PEERS.includes('react-dom'));
+    assert.ok(APP_SHELL_PEERS.includes('@radix-ui/react-dialog'));
+  });
+
+  it('resolves stack packages in the workspace', async () => {
+    const report = await doctorStack({ includePeers: false });
+
+    assert.equal(report.ok, true);
+    assert.equal(report.packages.length, 3);
+  });
+
+  it('verifies package imports when peers are installed', async () => {
+    const report = await verifyStack();
+
+    assert.equal(report.ok, true);
+  });
+});

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -27,7 +27,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.2.8",
-    "@schema-forge/app-shell-core": "0.1.0",
+    "@etendosoftware/app-shell-core": "0.1.0",
     "@sentry/react": "^10.53.0",
     "aws-rum-web": "^1.18.0",
     "class-variance-authority": "^0.7.1",

--- a/tools/app-shell/src/auth/AuthContext.jsx
+++ b/tools/app-shell/src/auth/AuthContext.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/auth';
+export * from '@etendosoftware/app-shell-core/auth';

--- a/tools/app-shell/src/auth/api.js
+++ b/tools/app-shell/src/auth/api.js
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/auth';
+export * from '@etendosoftware/app-shell-core/auth';

--- a/tools/app-shell/src/auth/useApiFetch.js
+++ b/tools/app-shell/src/auth/useApiFetch.js
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/auth';
+export * from '@etendosoftware/app-shell-core/auth';

--- a/tools/app-shell/src/components/ui/add-line-button-tokens.js
+++ b/tools/app-shell/src/components/ui/add-line-button-tokens.js
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/add-line-button-tokens.js';
+export * from '@etendosoftware/app-shell-core/components/ui/add-line-button-tokens.js';

--- a/tools/app-shell/src/components/ui/add-line-button.jsx
+++ b/tools/app-shell/src/components/ui/add-line-button.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/add-line-button.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/add-line-button.jsx';

--- a/tools/app-shell/src/components/ui/badge.jsx
+++ b/tools/app-shell/src/components/ui/badge.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/badge.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/badge.jsx';

--- a/tools/app-shell/src/components/ui/button.jsx
+++ b/tools/app-shell/src/components/ui/button.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/button.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/button.jsx';

--- a/tools/app-shell/src/components/ui/calendar.jsx
+++ b/tools/app-shell/src/components/ui/calendar.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/calendar.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/calendar.jsx';

--- a/tools/app-shell/src/components/ui/card.jsx
+++ b/tools/app-shell/src/components/ui/card.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/card.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/card.jsx';

--- a/tools/app-shell/src/components/ui/checkbox.jsx
+++ b/tools/app-shell/src/components/ui/checkbox.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/checkbox.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/checkbox.jsx';

--- a/tools/app-shell/src/components/ui/collapsible.jsx
+++ b/tools/app-shell/src/components/ui/collapsible.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/collapsible.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/collapsible.jsx';

--- a/tools/app-shell/src/components/ui/command.jsx
+++ b/tools/app-shell/src/components/ui/command.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/command.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/command.jsx';

--- a/tools/app-shell/src/components/ui/custom-icons.jsx
+++ b/tools/app-shell/src/components/ui/custom-icons.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/custom-icons.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/custom-icons.jsx';

--- a/tools/app-shell/src/components/ui/date-field.jsx
+++ b/tools/app-shell/src/components/ui/date-field.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/date-field.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/date-field.jsx';

--- a/tools/app-shell/src/components/ui/dialog.jsx
+++ b/tools/app-shell/src/components/ui/dialog.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/dialog.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/dialog.jsx';

--- a/tools/app-shell/src/components/ui/dropdown-menu.jsx
+++ b/tools/app-shell/src/components/ui/dropdown-menu.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/dropdown-menu.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/dropdown-menu.jsx';

--- a/tools/app-shell/src/components/ui/input.jsx
+++ b/tools/app-shell/src/components/ui/input.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/input.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/input.jsx';

--- a/tools/app-shell/src/components/ui/label.jsx
+++ b/tools/app-shell/src/components/ui/label.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/label.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/label.jsx';

--- a/tools/app-shell/src/components/ui/popover.jsx
+++ b/tools/app-shell/src/components/ui/popover.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/popover.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/popover.jsx';

--- a/tools/app-shell/src/components/ui/select.jsx
+++ b/tools/app-shell/src/components/ui/select.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/select.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/select.jsx';

--- a/tools/app-shell/src/components/ui/separator.jsx
+++ b/tools/app-shell/src/components/ui/separator.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/separator.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/separator.jsx';

--- a/tools/app-shell/src/components/ui/sheet.jsx
+++ b/tools/app-shell/src/components/ui/sheet.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/sheet.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/sheet.jsx';

--- a/tools/app-shell/src/components/ui/sidebar.jsx
+++ b/tools/app-shell/src/components/ui/sidebar.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/sidebar.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/sidebar.jsx';

--- a/tools/app-shell/src/components/ui/skeleton.jsx
+++ b/tools/app-shell/src/components/ui/skeleton.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/skeleton.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/skeleton.jsx';

--- a/tools/app-shell/src/components/ui/sonner.jsx
+++ b/tools/app-shell/src/components/ui/sonner.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/sonner.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/sonner.jsx';

--- a/tools/app-shell/src/components/ui/status-tag-tokens.js
+++ b/tools/app-shell/src/components/ui/status-tag-tokens.js
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/status-tag-tokens.js';
+export * from '@etendosoftware/app-shell-core/components/ui/status-tag-tokens.js';

--- a/tools/app-shell/src/components/ui/status-tag.jsx
+++ b/tools/app-shell/src/components/ui/status-tag.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/status-tag.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/status-tag.jsx';

--- a/tools/app-shell/src/components/ui/switch.jsx
+++ b/tools/app-shell/src/components/ui/switch.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/switch.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/switch.jsx';

--- a/tools/app-shell/src/components/ui/table.jsx
+++ b/tools/app-shell/src/components/ui/table.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/table.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/table.jsx';

--- a/tools/app-shell/src/components/ui/tag-tokens.js
+++ b/tools/app-shell/src/components/ui/tag-tokens.js
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/tag-tokens.js';
+export * from '@etendosoftware/app-shell-core/components/ui/tag-tokens.js';

--- a/tools/app-shell/src/components/ui/tag.jsx
+++ b/tools/app-shell/src/components/ui/tag.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/tag.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/tag.jsx';

--- a/tools/app-shell/src/components/ui/tooltip.jsx
+++ b/tools/app-shell/src/components/ui/tooltip.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/components/ui/tooltip.jsx';
+export * from '@etendosoftware/app-shell-core/components/ui/tooltip.jsx';

--- a/tools/app-shell/src/hooks/use-mobile.jsx
+++ b/tools/app-shell/src/hooks/use-mobile.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/hooks/use-mobile.jsx';
+export * from '@etendosoftware/app-shell-core/hooks/use-mobile.jsx';

--- a/tools/app-shell/src/hooks/useCurrency.jsx
+++ b/tools/app-shell/src/hooks/useCurrency.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/hooks/useCurrency.jsx';
+export * from '@etendosoftware/app-shell-core/hooks/useCurrency.jsx';

--- a/tools/app-shell/src/i18n/LocaleProvider.jsx
+++ b/tools/app-shell/src/i18n/LocaleProvider.jsx
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/i18n';
+export * from '@etendosoftware/app-shell-core/i18n';

--- a/tools/app-shell/src/i18n/index.js
+++ b/tools/app-shell/src/i18n/index.js
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/i18n';
+export * from '@etendosoftware/app-shell-core/i18n';

--- a/tools/app-shell/src/i18n/resolveLabel.js
+++ b/tools/app-shell/src/i18n/resolveLabel.js
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/i18n';
+export * from '@etendosoftware/app-shell-core/i18n';

--- a/tools/app-shell/src/i18n/resolveUI.js
+++ b/tools/app-shell/src/i18n/resolveUI.js
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/i18n';
+export * from '@etendosoftware/app-shell-core/i18n';

--- a/tools/app-shell/src/i18n/useLabel.js
+++ b/tools/app-shell/src/i18n/useLabel.js
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/i18n';
+export * from '@etendosoftware/app-shell-core/i18n';

--- a/tools/app-shell/src/i18n/useLocaleState.js
+++ b/tools/app-shell/src/i18n/useLocaleState.js
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/i18n';
+export * from '@etendosoftware/app-shell-core/i18n';

--- a/tools/app-shell/src/i18n/useMenuLabel.js
+++ b/tools/app-shell/src/i18n/useMenuLabel.js
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/i18n';
+export * from '@etendosoftware/app-shell-core/i18n';

--- a/tools/app-shell/src/i18n/useUI.js
+++ b/tools/app-shell/src/i18n/useUI.js
@@ -1,1 +1,1 @@
-export * from '@schema-forge/app-shell-core/i18n';
+export * from '@etendosoftware/app-shell-core/i18n';

--- a/tools/app-shell/src/index.css
+++ b/tools/app-shell/src/index.css
@@ -1,1 +1,1 @@
-@import '@schema-forge/app-shell-core/styles.css';
+@import '@etendosoftware/app-shell-core/styles.css';


### PR DESCRIPTION
## Summary

Configures private GitHub Packages publishing for the extracted core packages while keeping the monorepo as the source of truth.

## Changes

- Renames publishable packages to the Etendo GitHub Packages scope:
  - `@etendosoftware/schema-forge-core`
  - `@etendosoftware/app-shell-core`
- Updates internal app-shell imports and workspace dependencies to the new package names.
- Adds root `.npmrc` for the private `@etendosoftware` npm scope.
- Adds `publishConfig` for GitHub Packages restricted publishing.
- Adds a manual `Publish Private Packages` workflow with dry-run default.
- Updates docs and consumer smoke to use the private package scope.
- Classifies `.npmrc` as repo infra in the boundary gate.

## Cross-Domain Plan

- Domains touched: schema-forge core package, app-shell-core package, app-shell consumer wiring, repo CI/publishing config.
- Reason indivisible: package scope rename must update producers, consumers, docs, lockfile, and publish workflow in one atomic change.
- Review order: package metadata and workflow first, then app-shell import rewiring, then boundary classifier update.
- Required tests: package tests, app-shell-core consumer smoke, app-shell build, package dry-runs, domain boundary check.
- Rollback: revert this PR to restore the previous `@schema-forge/*` workspace package names and remove the private publish workflow.

## Validation

- `npm test --workspace=packages/schema-forge-core`
- `npm test --workspace=packages/app-shell-core`
- `npm run test:consumer --workspace=packages/app-shell-core`
- `npm run build --workspace=tools/app-shell`
- `npm pack --workspace=packages/schema-forge-core --dry-run`
- `npm pack --workspace=packages/app-shell-core --dry-run`
- `npx sf-domain-boundary-check --base origin/feature/app-shell-core-hardening --labels scope:platform-change,scope:generator-change,cross-domain-approved`
- `git diff --check`
