### PR TITLE
Feature ETP-3778: Auto-compute Modelo 303 boxes on load

### DIFF
--- a/docs/generated-custom-windows/INDEX.md
+++ b/docs/generated-custom-windows/INDEX.md
@@ -96,6 +96,7 @@ This folder is the entry point for documentation that describes how generated an
 | [unit-of-measure.md](unit-of-measure.md) | Generated unit-of-measure window with conversion metadata notes |
 | [user.md](user.md) | Generated user window with roles child surface and defaults dependencies |
 | [fiscal-config.md](fiscal-config.md) | Custom fiscal configuration window — onboarding wizard (SII/TBAI/Verifactu) and ongoing config maintenance |
+| [fiscal-models.md](fiscal-models.md) | Custom fiscal models window — declaration list and per-model detail pages (303, 349) with auto-compute and file generation |
 | [fiscal-monitor.md](fiscal-monitor.md) | Custom fiscal monitor window — real-time invoice submission status for SII, TBAI, and Verifactu |
 | [sii-monitor.md](sii-monitor.md) | API-only sub-window — SII invoice submission records consumed by FiscalMonitorPage |
 | [monitor-verifactu.md](monitor-verifactu.md) | API-only sub-window — Verifactu invoice submission records consumed by FiscalMonitorPage |

--- a/docs/generated-custom-windows/fiscal-models.md
+++ b/docs/generated-custom-windows/fiscal-models.md
@@ -9,7 +9,7 @@ The window supports two data modes: **demo** (read-only mock data for exploratio
 ## What this window should allow
 
 - Switch between demo and real data modes via a toolbar toggle; mode persists in `sessionStorage` across navigation.
-- In real mode, fetch all declarations from `GET /fiscal303/declarations` and keep status changes in sync via `PATCH /fiscal303/declarations?id=`.
+- In real mode, fetch all declarations from `GET /fiscal303/declarations` and keep status changes in sync via `PUT /fiscal303/declarations?id=`.
 - Auto-compute fiscal boxes for Modelo 303 draft declarations in the background every 3 minutes, updating the result column in the list without user interaction.
 - Display an upcoming deadlines panel for unsubmitted declarations.
 - Filter declarations by model type (303, 349) and status.
@@ -23,7 +23,7 @@ The window supports two data modes: **demo** (read-only mock data for exploratio
 | Mode | Source | Auto-compute | Status writes |
 |------|--------|--------------|---------------|
 | `demo` | `MOCK_DECLARATIONS` constant in `FmListPage.jsx` | Disabled | Local state only |
-| `real` | `GET /fiscal303/declarations` (NEO Headless) | Enabled for 303 borrador | `PATCH /fiscal303/declarations?id=` |
+| `real` | `GET /fiscal303/declarations` (NEO Headless) | Enabled for 303 borrador | `PUT /fiscal303/declarations?id=` |
 
 The toggle renders as `Demo` / `Real` pill in the toolbar. The selected mode is stored in `sessionStorage` under key `fm-data-mode` so it survives page navigation within the session.
 

--- a/docs/generated-custom-windows/fiscal-models.md
+++ b/docs/generated-custom-windows/fiscal-models.md
@@ -1,0 +1,131 @@
+# Fiscal Models
+
+## Intent
+
+Use this window to manage Spanish tax declarations (modelos fiscales) — creating, tracking, and filing periodic returns such as Modelo 303 (quarterly VAT) and Modelo 349 (intra-community operations). It combines a declaration list with per-model detail pages that guide the user through a status lifecycle ending in submission.
+
+The window supports two data modes: **demo** (read-only mock data for exploration) and **real** (live declarations fetched from the NEO Headless fiscal API). In real mode, fiscal boxes are auto-computed in the background by polling for invoice changes.
+
+## What this window should allow
+
+- Switch between demo and real data modes via a toolbar toggle; mode persists in `sessionStorage` across navigation.
+- In real mode, fetch all declarations from `GET /fiscal303/declarations` and keep status changes in sync via `PATCH /fiscal303/declarations?id=`.
+- Auto-compute fiscal boxes for Modelo 303 draft declarations in the background every 3 minutes, updating the result column in the list without user interaction.
+- Display an upcoming deadlines panel for unsubmitted declarations.
+- Filter declarations by model type (303, 349) and status.
+- Navigate into a per-model detail page when a declaration row is clicked, passing precomputed box data so the detail page renders immediately without a duplicate fetch.
+- In detail pages, guide the user through the submission lifecycle via a numbered stepper.
+- Generate and download the submission file (`.txt`) for Modelo 303.
+- Show blocking and warning incident counts inline; a blocking count prevents file generation.
+
+## Data modes
+
+| Mode | Source | Auto-compute | Status writes |
+|------|--------|--------------|---------------|
+| `demo` | `MOCK_DECLARATIONS` constant in `FmListPage.jsx` | Disabled | Local state only |
+| `real` | `GET /fiscal303/declarations` (NEO Headless) | Enabled for 303 borrador | `PATCH /fiscal303/declarations?id=` |
+
+The toggle renders as `Demo` / `Real` pill in the toolbar. The selected mode is stored in `sessionStorage` under key `fm-data-mode` so it survives page navigation within the session.
+
+## Auto-compute architecture (`useFiscalAutoCompute`)
+
+```
+FmListPage
+  └── useFiscalAutoCompute(decls, { computeFn, checkModifiedFn, token, apiBaseUrl, pollIntervalMs=180_000 })
+        ├── On mount: calls computeFn for every decl in parallel
+        │     result → computedMap[decl.id] = { boxes, summary, error, computedAt }
+        │     null result → { boxes: null, summary: null, error: null, computedAt }  ← not "computing"
+        └── Polling (every 3 min): calls checkModifiedFn per decl
+              if modified → calls computeFn and updates computedMap
+```
+
+- `computeFn` = `computeBoxes303(decl, { token, apiBaseUrl })` → `GET /fiscal303/boxes?year=&period=`
+- `checkModifiedFn` = `checkModified303(decl, sinceMs, { token, apiBaseUrl })` → `GET /fiscal303/modified?year=&period=&since=`
+- `computedAtRef` tracks the last successful (or errored) compute timestamp per declaration to bound the `since` query parameter.
+- The hook is disabled (`enabled=false`) in demo mode.
+- Precomputed data (`decl._precomputed`) is seeded from `computedMap` when a row is opened, so the detail page loads instantly.
+
+## Status lifecycle
+
+```
+(new) → borrador → listo → presentado
+                         ↘ presentadoOtra
+                         ↘ presentadoAcuse
+         ↓
+       omitido  (can be set from any non-submitted state)
+```
+
+| Status | Color | Meaning |
+|--------|-------|---------|
+| `borrador` | blue | Draft — boxes may still be computing |
+| `listo` | green | Ready — review complete, file can be generated |
+| `presentado` | teal | Filed via the standard channel |
+| `presentadoOtra` | violet | Filed via an alternative channel |
+| `presentadoAcuse` | emerald | Filed with receipt acknowledgement |
+| `omitido` | grey | Intentionally skipped |
+
+Status transitions are driven by `StatusPillMenu` inline in the list and by the detail page action buttons.
+
+## Modelo 303 detail page (`FmModel303Page`)
+
+### Stepper
+
+Three steps (0-based index):
+
+| Step | Index | Status |
+|------|-------|--------|
+| Borrador | 0 | `borrador` |
+| Listo | 1 | `listo` |
+| Presentado | 2 | `presentado*` |
+
+(`omitido` uses index `-1` — no step is highlighted.)
+
+### Tabs
+
+| Tab | Content |
+|-----|---------|
+| Boxes | `FmBoxes303` — grid of fiscal box values |
+| Sources | Invoice rows that feed the boxes, filterable by incidents |
+| Files | Generated `.txt` file download |
+| Incidents | Blocking and warning validation messages |
+
+### Live data
+
+When in real mode, `FmModel303Page` reads `liveBoxes` / `liveSummary` from the `_precomputed` field passed at navigation. The compute button triggers a fresh `computeBoxes303` call. File generation calls `generate303File(decl, { token, apiBaseUrl })` → `GET /fiscal303/generate?year=&period=&tipo=`.
+
+### Organization identity
+
+A `GET /session` call on mount populates the NIF/nombre fields used in the generated `.txt` header when `token` and `apiBaseUrl` are provided.
+
+## Modelo 349 detail page (`FmModel349Page`)
+
+Uses a 4-step stepper including `pendiente` (index 0). The 349 page is structurally similar to 303 but does not have the auto-compute mechanism.
+
+## Key files
+
+| File | Role |
+|------|------|
+| `FiscalModelsPage.jsx` | Root — routes between list and per-model detail |
+| `FmListPage.jsx` | Declaration table, toolbar, data mode toggle, auto-compute wiring |
+| `useFiscalAutoCompute.js` | Background compute + polling hook |
+| `fiscalModelsUtils.js` | `computeBoxes303`, `checkModified303`, `generate303File`, formatters, deadline logic |
+| `models/303/FmModel303Page.jsx` | Modelo 303 detail — boxes, sources, stepper, file gen |
+| `models/303/FmBoxes303.jsx` | Box grid renderer |
+| `models/303/fm303Layouts.js` | Box layout definition (sections, rows, labels) |
+| `models/349/FmModel349Page.jsx` | Modelo 349 detail |
+| `FmCommon.jsx` | Shared components: `NumberedStepper`, `ResultPill`, `StatusPillMenu`, `SummaryCard` |
+| `FmOverlays.jsx` | Modals and drawers: `PresentModal`, `FileGenModal`, `ConfigDrawer`, `CompareDrawer` |
+| `FmDebugPanel.jsx` | Developer panel (keystroke-activated) for testing with fixture data |
+
+## NEO Headless endpoints
+
+| Method | Path | Used by |
+|--------|------|---------|
+| `GET` | `/fiscal303/declarations` | FmListPage — fetch all declarations |
+| `PATCH` | `/fiscal303/declarations?id=` | FmListPage — persist status change |
+| `GET` | `/fiscal303/boxes?year=&period=` | `computeBoxes303` |
+| `GET` | `/fiscal303/modified?year=&period=&since=` | `checkModified303` |
+| `GET` | `/fiscal303/generate?year=&period=&tipo=` | `generate303File` |
+| `GET` | `/session` | FmModel303Page — org NIF/nombre for file header |
+
+All query parameters are built with `URLSearchParams` to ensure correct encoding.

--- a/tools/app-shell/src/locales/en_US.json
+++ b/tools/app-shell/src/locales/en_US.json
@@ -18844,6 +18844,7 @@
     "fm.status.presentado": "Submitted",
     "fm.status.presentadoOtra": "Submitted · other platform",
     "fm.status.presentadoAcuse": "Submitted · acknowledged",
+    "fm.status.error": "Compute error",
     "fm.kpi.m303_open": "Open Model 303",
     "fm.kpi.m303_open_sub": "declarations in progress",
     "fm.kpi.m349_pending": "Pending Model 349",

--- a/tools/app-shell/src/locales/es_ES.json
+++ b/tools/app-shell/src/locales/es_ES.json
@@ -19094,6 +19094,7 @@
     "fm.status.presentado": "Presentado",
     "fm.status.presentadoOtra": "Presentado · otra plataforma",
     "fm.status.presentadoAcuse": "Presentado · con acuse",
+    "fm.status.error": "Error de cálculo",
     "fm.kpi.m303_open": "Modelo 303 abiertas",
     "fm.kpi.m303_open_sub": "declaraciones en curso",
     "fm.kpi.m349_pending": "Modelo 349 pendientes",

--- a/tools/app-shell/src/pages/OnboardingPage.jsx
+++ b/tools/app-shell/src/pages/OnboardingPage.jsx
@@ -3,13 +3,14 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
-  Loader2, Check, ChevronRight,
+  Loader2, Check, ChevronRight, ChevronDown,
   Plus, Building2, RefreshCw,
   Settings,
   UserPlus, Mail, Lock, Eye, EyeOff, Sparkles,
   ArrowRight, User, MessageCircle,
 } from 'lucide-react';
 import {
+  ONBOARDING_ERROR_CODES,
   fetchAccount,
   fetchEnvironments,
   loginAccount,
@@ -402,63 +403,6 @@ function PageHeader({ accountName, onLogout, isAuthenticated, logoutLabel, brand
   );
 }
 
-function getBusinessTypeIcon(value) {
-  if (value === 'company') return Building2;
-  if (value === 'freelancer') return User;
-  return MessageCircle;
-}
-
-function getSetupProgressState(result, activeSetupStep, ui, countryCode) {
-  if (result?.status === 'success') {
-    return {
-      progress: 100,
-      title: ui('onboardingSuccessTitle'),
-      description: ui('onboardingSuccessDescription'),
-      leading: <Check className="h-8 w-8 text-[#54b56a]" strokeWidth={3} />,
-      statusLabel: ui('onboardingCompleted'),
-      success: true,
-    };
-  }
-  if (activeSetupStep === 'client') {
-    return {
-      progress: 50,
-      title: ui('onboardingPreparingTitle'),
-      description: ui('onboardingPreparingActivatingDescription'),
-      leading: <Sparkles className="h-8 w-8 text-slate-400" />,
-      statusLabel: ui('loading'),
-      success: false,
-    };
-  }
-  if (activeSetupStep === 'sequences') {
-    return {
-      progress: 80,
-      title: ui('onboardingPreparingTitle'),
-      description: ui('onboardingPreparingSequencesDescription'),
-      leading: <Settings className="h-8 w-8 text-slate-400" />,
-      statusLabel: ui('loading'),
-      success: false,
-    };
-  }
-  if (activeSetupStep === 'organization' || activeSetupStep === 'finalize') {
-    return {
-      progress: 80,
-      title: ui('onboardingPreparingTitle'),
-      description: ui('onboardingPreparingFinishingDescription'),
-      leading: <Check className="h-8 w-8 text-slate-400" strokeWidth={3} />,
-      statusLabel: ui('loading'),
-      success: false,
-    };
-  }
-  return {
-    progress: 20,
-    title: ui('onboardingPreparingTitle'),
-    description: ui('onboardingPreparingTaxesDescription'),
-    leading: countryCode === 'ES' ? '🇪🇸' : '🌍',
-    statusLabel: ui('loading'),
-    success: false,
-  };
-}
-
 export default function OnboardingPage() {
   const [view, setView] = useState(null); // null = loading initial state
   const [accountName, setAccountName] = useState(null);
@@ -489,6 +433,7 @@ export default function OnboardingPage() {
   const [steps, setSteps] = useState(() => initialSetupSteps());
   const [result, setResult] = useState(null);
   const [running, setRunning] = useState(false);
+  const [formSubmitted, setFormSubmitted] = useState(false);
   const ui = useUI();
   const { locale, setLocale } = useLocaleSwitch();
 
@@ -559,6 +504,7 @@ export default function OnboardingPage() {
     setRegisterError(null);
     setLoginError(null);
     setResult(null);
+    setFormSubmitted(false);
     setRunning(false);
     setCreateStep(1);
     setSteps(initialSetupSteps());
@@ -736,6 +682,7 @@ export default function OnboardingPage() {
     });
     setRunning(true);
     setResult(null);
+    setFormSubmitted(true);
     setSteps(initialSetupSteps());
 
     let succeeded = false;
@@ -810,7 +757,7 @@ export default function OnboardingPage() {
   const businessTypeOptions = BUSINESS_TYPE_VALUES.map((value) => ({
     value,
     label: ui(`onboardingBusinessType${value.charAt(0).toUpperCase()}${value.slice(1)}`),
-    icon: getBusinessTypeIcon(value),
+    icon: value === 'company' ? Building2 : value === 'freelancer' ? User : MessageCircle,
   }));
   const authFeatureLabels = AUTH_FEATURE_KEYS.map((key) => ui(key));
   const languageOptions = LOCALE_CODES.map((code) => ({
@@ -830,7 +777,50 @@ export default function OnboardingPage() {
   const setupGreetingName = (form.fullName || accountName || ui('onboardingGreetingFallback')).trim().split(/\s+/)[0];
   const activeSetupStep = steps.find((step) => step.status === 'running')?.name;
   const readinessFailureText = (result?.readinessFailures ?? []).map((failure) => ui(failure.key)).join(' ');
-  const setupProgressState = getSetupProgressState(result, activeSetupStep, ui, form.countryCode);
+  const setupProgressState = result?.status === 'success'
+    ? {
+      progress: 100,
+      title: ui('onboardingSuccessTitle'),
+      description: ui('onboardingSuccessDescription'),
+      leading: <Check className="h-8 w-8 text-[#54b56a]" strokeWidth={3} />,
+      statusLabel: ui('onboardingCompleted'),
+      success: true,
+    }
+    : activeSetupStep === 'client'
+      ? {
+        progress: 50,
+        title: ui('onboardingPreparingTitle'),
+        description: ui('onboardingPreparingActivatingDescription'),
+        leading: <Sparkles className="h-8 w-8 text-slate-400" />,
+        statusLabel: ui('loading'),
+        success: false,
+      }
+      : activeSetupStep === 'sequences'
+        ? {
+          progress: 80,
+          title: ui('onboardingPreparingTitle'),
+          description: ui('onboardingPreparingSequencesDescription'),
+          leading: <Settings className="h-8 w-8 text-slate-400" />,
+          statusLabel: ui('loading'),
+          success: false,
+        }
+        : activeSetupStep === 'organization' || activeSetupStep === 'finalize'
+        ? {
+          progress: 80,
+          title: ui('onboardingPreparingTitle'),
+          description: ui('onboardingPreparingFinishingDescription'),
+          leading: <Check className="h-8 w-8 text-slate-400" strokeWidth={3} />,
+          statusLabel: ui('loading'),
+          success: false,
+        }
+        : {
+          progress: 20,
+          title: ui('onboardingPreparingTitle'),
+          description: ui('onboardingPreparingTaxesDescription'),
+          leading: form.countryCode === 'ES' ? '🇪🇸' : '🌍',
+          statusLabel: ui('loading'),
+          success: false,
+        };
 
 
   // ── LOADING (initial token check) ──

--- a/tools/app-shell/src/pages/OnboardingPage.jsx
+++ b/tools/app-shell/src/pages/OnboardingPage.jsx
@@ -3,14 +3,13 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
-  Loader2, Check, ChevronRight, ChevronDown,
+  Loader2, Check, ChevronRight,
   Plus, Building2, RefreshCw,
   Settings,
   UserPlus, Mail, Lock, Eye, EyeOff, Sparkles,
   ArrowRight, User, MessageCircle,
 } from 'lucide-react';
 import {
-  ONBOARDING_ERROR_CODES,
   fetchAccount,
   fetchEnvironments,
   loginAccount,
@@ -403,6 +402,63 @@ function PageHeader({ accountName, onLogout, isAuthenticated, logoutLabel, brand
   );
 }
 
+function getBusinessTypeIcon(value) {
+  if (value === 'company') return Building2;
+  if (value === 'freelancer') return User;
+  return MessageCircle;
+}
+
+function getSetupProgressState(result, activeSetupStep, ui, countryCode) {
+  if (result?.status === 'success') {
+    return {
+      progress: 100,
+      title: ui('onboardingSuccessTitle'),
+      description: ui('onboardingSuccessDescription'),
+      leading: <Check className="h-8 w-8 text-[#54b56a]" strokeWidth={3} />,
+      statusLabel: ui('onboardingCompleted'),
+      success: true,
+    };
+  }
+  if (activeSetupStep === 'client') {
+    return {
+      progress: 50,
+      title: ui('onboardingPreparingTitle'),
+      description: ui('onboardingPreparingActivatingDescription'),
+      leading: <Sparkles className="h-8 w-8 text-slate-400" />,
+      statusLabel: ui('loading'),
+      success: false,
+    };
+  }
+  if (activeSetupStep === 'sequences') {
+    return {
+      progress: 80,
+      title: ui('onboardingPreparingTitle'),
+      description: ui('onboardingPreparingSequencesDescription'),
+      leading: <Settings className="h-8 w-8 text-slate-400" />,
+      statusLabel: ui('loading'),
+      success: false,
+    };
+  }
+  if (activeSetupStep === 'organization' || activeSetupStep === 'finalize') {
+    return {
+      progress: 80,
+      title: ui('onboardingPreparingTitle'),
+      description: ui('onboardingPreparingFinishingDescription'),
+      leading: <Check className="h-8 w-8 text-slate-400" strokeWidth={3} />,
+      statusLabel: ui('loading'),
+      success: false,
+    };
+  }
+  return {
+    progress: 20,
+    title: ui('onboardingPreparingTitle'),
+    description: ui('onboardingPreparingTaxesDescription'),
+    leading: countryCode === 'ES' ? '🇪🇸' : '🌍',
+    statusLabel: ui('loading'),
+    success: false,
+  };
+}
+
 export default function OnboardingPage() {
   const [view, setView] = useState(null); // null = loading initial state
   const [accountName, setAccountName] = useState(null);
@@ -433,7 +489,6 @@ export default function OnboardingPage() {
   const [steps, setSteps] = useState(() => initialSetupSteps());
   const [result, setResult] = useState(null);
   const [running, setRunning] = useState(false);
-  const [formSubmitted, setFormSubmitted] = useState(false);
   const ui = useUI();
   const { locale, setLocale } = useLocaleSwitch();
 
@@ -504,7 +559,6 @@ export default function OnboardingPage() {
     setRegisterError(null);
     setLoginError(null);
     setResult(null);
-    setFormSubmitted(false);
     setRunning(false);
     setCreateStep(1);
     setSteps(initialSetupSteps());
@@ -682,7 +736,6 @@ export default function OnboardingPage() {
     });
     setRunning(true);
     setResult(null);
-    setFormSubmitted(true);
     setSteps(initialSetupSteps());
 
     let succeeded = false;
@@ -757,7 +810,7 @@ export default function OnboardingPage() {
   const businessTypeOptions = BUSINESS_TYPE_VALUES.map((value) => ({
     value,
     label: ui(`onboardingBusinessType${value.charAt(0).toUpperCase()}${value.slice(1)}`),
-    icon: value === 'company' ? Building2 : value === 'freelancer' ? User : MessageCircle,
+    icon: getBusinessTypeIcon(value),
   }));
   const authFeatureLabels = AUTH_FEATURE_KEYS.map((key) => ui(key));
   const languageOptions = LOCALE_CODES.map((code) => ({
@@ -777,50 +830,7 @@ export default function OnboardingPage() {
   const setupGreetingName = (form.fullName || accountName || ui('onboardingGreetingFallback')).trim().split(/\s+/)[0];
   const activeSetupStep = steps.find((step) => step.status === 'running')?.name;
   const readinessFailureText = (result?.readinessFailures ?? []).map((failure) => ui(failure.key)).join(' ');
-  const setupProgressState = result?.status === 'success'
-    ? {
-      progress: 100,
-      title: ui('onboardingSuccessTitle'),
-      description: ui('onboardingSuccessDescription'),
-      leading: <Check className="h-8 w-8 text-[#54b56a]" strokeWidth={3} />,
-      statusLabel: ui('onboardingCompleted'),
-      success: true,
-    }
-    : activeSetupStep === 'client'
-      ? {
-        progress: 50,
-        title: ui('onboardingPreparingTitle'),
-        description: ui('onboardingPreparingActivatingDescription'),
-        leading: <Sparkles className="h-8 w-8 text-slate-400" />,
-        statusLabel: ui('loading'),
-        success: false,
-      }
-      : activeSetupStep === 'sequences'
-        ? {
-          progress: 80,
-          title: ui('onboardingPreparingTitle'),
-          description: ui('onboardingPreparingSequencesDescription'),
-          leading: <Settings className="h-8 w-8 text-slate-400" />,
-          statusLabel: ui('loading'),
-          success: false,
-        }
-        : activeSetupStep === 'organization' || activeSetupStep === 'finalize'
-        ? {
-          progress: 80,
-          title: ui('onboardingPreparingTitle'),
-          description: ui('onboardingPreparingFinishingDescription'),
-          leading: <Check className="h-8 w-8 text-slate-400" strokeWidth={3} />,
-          statusLabel: ui('loading'),
-          success: false,
-        }
-        : {
-          progress: 20,
-          title: ui('onboardingPreparingTitle'),
-          description: ui('onboardingPreparingTaxesDescription'),
-          leading: form.countryCode === 'ES' ? '🇪🇸' : '🌍',
-          statusLabel: ui('loading'),
-          success: false,
-        };
+  const setupProgressState = getSetupProgressState(result, activeSetupStep, ui, form.countryCode);
 
 
   // ── LOADING (initial token check) ──

--- a/tools/app-shell/src/windows/custom/fiscal-models/FmListPage.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/FmListPage.jsx
@@ -215,10 +215,16 @@ export default function FmListPage({ declarations: propDecls, onSelect, onStatus
   const ui = useUI();
   const t  = ui;
 
-  const [dataMode, setDataMode]          = useState('demo');
+  const [dataMode, setDataMode]          = useState(() => {
+    try { return sessionStorage.getItem('fm-data-mode') ?? 'demo'; } catch { return 'demo'; }
+  });
   const [demoDecls, setDemoDecls]        = useState(propDecls ?? MOCK_DECLARATIONS);
   const [realDecls, setRealDecls]        = useState([]);
   const decls = dataMode === 'demo' ? demoDecls : realDecls;
+
+  useEffect(() => {
+    try { sessionStorage.setItem('fm-data-mode', dataMode); } catch {}
+  }, [dataMode]);
 
   useEffect(() => {
     if (dataMode !== 'real' || !token || !apiBaseUrl) return;

--- a/tools/app-shell/src/windows/custom/fiscal-models/FmListPage.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/FmListPage.jsx
@@ -255,7 +255,7 @@ export default function FmListPage({ declarations: propDecls, onSelect, onStatus
       headers: { Authorization: `Bearer ${token}` },
     })
       .then(r => r.ok ? r.json() : Promise.reject(r.status))
-      .then(data => setRealDecls((data.data ?? []).map(normDecl)))
+      .then(data => setRealDecls((Array.isArray(data) ? data : (data?.data ?? [])).map(normDecl)))
       .catch(() => {});
   }, [dataMode, token, apiBaseUrl]);
 
@@ -308,7 +308,7 @@ export default function FmListPage({ declarations: propDecls, onSelect, onStatus
         body: JSON.stringify({ model, year: parseInt(year, 10), period, status }),
       })
         .then(r => r.ok ? r.json() : Promise.reject(r.status))
-        .then(created => setRealDecls(ds => [normDecl(created), ...ds]))
+        .then(created => setRealDecls(ds => [normDecl(created?.data ?? created), ...ds]))
         .catch(() => {
           const id = `${model}-${year}-${period}`;
           setRealDecls(ds => [

--- a/tools/app-shell/src/windows/custom/fiscal-models/FmListPage.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/FmListPage.jsx
@@ -124,6 +124,15 @@ const MOCK_DECLARATIONS = [
 
 const DEFAULT_ACTIVE = { '303': true, '349': true };
 
+function normDecl(d) {
+  return {
+    ...d,
+    updatedAt: d.updatedAt ? new Date(d.updatedAt).toLocaleDateString('es-ES') : '—',
+    result: d.result ?? null,
+    incidents: d.incidents ?? { blocking: 0, warning: 0 },
+  };
+}
+
 // ── Upcoming deadlines helpers ───────────────────────────────────
 const MONTH_NAMES_ES = ['ENERO','FEBRERO','MARZO','ABRIL','MAYO','JUNIO','JULIO','AGOSTO','SEPTIEMBRE','OCTUBRE','NOVIEMBRE','DICIEMBRE'];
 const MONTH_LABELS_ES = ['', 'Enero','Febrero','Marzo','Abril','Mayo','Junio','Julio','Agosto','Septiembre','Octubre','Noviembre','Diciembre'];
@@ -208,17 +217,19 @@ export default function FmListPage({ declarations: propDecls, onSelect, onStatus
 
   const [dataMode, setDataMode]          = useState('demo');
   const [demoDecls, setDemoDecls]        = useState(propDecls ?? MOCK_DECLARATIONS);
-  const [realDecls, setRealDecls]        = useState(() => {
-    try {
-      const stored = localStorage.getItem('fm-real-decls');
-      return stored ? JSON.parse(stored) : [];
-    } catch { return []; }
-  });
+  const [realDecls, setRealDecls]        = useState([]);
   const decls = dataMode === 'demo' ? demoDecls : realDecls;
 
   useEffect(() => {
-    try { localStorage.setItem('fm-real-decls', JSON.stringify(realDecls)); } catch { /* quota */ }
-  }, [realDecls]);
+    if (dataMode !== 'real' || !token || !apiBaseUrl) return;
+    const base = apiBaseUrl.replace(/\/[^/]+$/, '');
+    fetch(`${base}/fiscal303/declarations`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+      .then(r => r.ok ? r.json() : Promise.reject(r.status))
+      .then(data => setRealDecls((data.data ?? []).map(normDecl)))
+      .catch(() => {});
+  }, [dataMode, token, apiBaseUrl]);
 
   const draftDecls303 = useMemo(
     () => realDecls.filter(d => d.model === '303' && d.status === 'borrador'),
@@ -244,15 +255,51 @@ export default function FmListPage({ declarations: propDecls, onSelect, onStatus
   const [selected,     setSelected]     = useState(new Set());
 
   const handleStatusChange = useCallback((id, newStatus) => {
-    (dataMode === 'demo' ? setDemoDecls : setRealDecls)(ds => ds.map(d => d.id === id ? { ...d, status: newStatus } : d));
+    (dataMode === 'demo' ? setDemoDecls : setRealDecls)(ds =>
+      ds.map(d => d.id === id
+        ? { ...d, status: newStatus, updatedAt: new Date().toLocaleDateString('es-ES') }
+        : d)
+    );
     onStatusChange?.(id, newStatus);
-  }, [dataMode, onStatusChange]);
+    if (dataMode === 'real' && token && apiBaseUrl) {
+      const base = apiBaseUrl.replace(/\/[^/]+$/, '');
+      fetch(`${base}/fiscal303/declarations?id=${encodeURIComponent(id)}`, {
+        method: 'PUT',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ status: newStatus }),
+      }).catch(() => {});
+    }
+  }, [dataMode, onStatusChange, token, apiBaseUrl]);
 
   const handleNewDecl = useCallback(({ model, year, period, status }) => {
-    const id = `${model}-${year}-${period}`;
-    const newDecl = { id, model, year, period, type:'ord', status, result:{kind:'informativa',amount:0}, incidents:{blocking:0,warning:0}, file:null, updatedAt: new Date().toLocaleDateString('es-ES') };
-    (dataMode === 'demo' ? setDemoDecls : setRealDecls)(ds => [newDecl, ...ds]);
-  }, [dataMode]);
+    if (dataMode === 'real' && token && apiBaseUrl) {
+      const base = apiBaseUrl.replace(/\/[^/]+$/, '');
+      fetch(`${base}/fiscal303/declarations`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ model, year: parseInt(year, 10), period, status }),
+      })
+        .then(r => r.ok ? r.json() : Promise.reject(r.status))
+        .then(created => setRealDecls(ds => [normDecl(created), ...ds]))
+        .catch(() => {
+          const id = `${model}-${year}-${period}`;
+          setRealDecls(ds => [
+            { id, model, year, period, type: 'ord', status, result: null,
+              incidents: { blocking: 0, warning: 0 }, file: null,
+              updatedAt: new Date().toLocaleDateString('es-ES') },
+            ...ds,
+          ]);
+        });
+    } else {
+      const id = `${model}-${year}-${period}`;
+      setDemoDecls(ds => [
+        { id, model, year, period, type: 'ord', status,
+          result: { kind: 'informativa', amount: 0 }, incidents: { blocking: 0, warning: 0 },
+          file: null, updatedAt: new Date().toLocaleDateString('es-ES') },
+        ...ds,
+      ]);
+    }
+  }, [dataMode, token, apiBaseUrl]);
 
   const years = ['all', ...Array.from(new Set(decls.map(d => String(d.year)))).sort((a,b) => b - a)];
   const statuses = ['all', ...Array.from(new Set(decls.map(d => d.status)))];

--- a/tools/app-shell/src/windows/custom/fiscal-models/FmListPage.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/FmListPage.jsx
@@ -208,8 +208,17 @@ export default function FmListPage({ declarations: propDecls, onSelect, onStatus
 
   const [dataMode, setDataMode]          = useState('demo');
   const [demoDecls, setDemoDecls]        = useState(propDecls ?? MOCK_DECLARATIONS);
-  const [realDecls, setRealDecls]        = useState([]);
+  const [realDecls, setRealDecls]        = useState(() => {
+    try {
+      const stored = localStorage.getItem('fm-real-decls');
+      return stored ? JSON.parse(stored) : [];
+    } catch { return []; }
+  });
   const decls = dataMode === 'demo' ? demoDecls : realDecls;
+
+  useEffect(() => {
+    try { localStorage.setItem('fm-real-decls', JSON.stringify(realDecls)); } catch { /* quota */ }
+  }, [realDecls]);
 
   const draftDecls303 = useMemo(
     () => realDecls.filter(d => d.model === '303' && d.status === 'borrador'),

--- a/tools/app-shell/src/windows/custom/fiscal-models/FmListPage.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/FmListPage.jsx
@@ -110,7 +110,7 @@ const MOCK_DECLARATIONS = [
       { date:'19/05/2026', ref:'10000039', type:'Venta',  party:'Juan Perez',            regime:'Exportación (%N→0%)',       base:36.00, vat:0,       total:36.00,     boxes:'60' },
     ],
     updatedAt:'19/05/2026' },
-  { id:'349-2026-T1', model:'349', year:2026, period:'T1', type:'ord', status:'pendiente',   result:{kind:'informativa',amount:0}, incidents:{blocking:0,warning:0}, file:null, updatedAt:'—' },
+  { id:'349-2026-T1', model:'349', year:2026, period:'T1', type:'ord', status:'borrador',    result:{kind:'informativa',amount:0}, incidents:{blocking:0,warning:0}, file:null, updatedAt:'—' },
   { id:'303-2026-T1', model:'303', year:2026, period:'T1', type:'ord', status:'presentadoAcuse',         result:{kind:'compensar',amount:2816.31}, incidents:{blocking:2,warning:3,items:[
     { severity:'block', origin:'Casilla 28', message:'El total de cuota devengada no coincide con la suma de las cuotas parciales', suggestion:'Revisa las cuotas de los tipos 21%, 10% y 4%' },
     { severity:'block', origin:'Casilla 69', message:'El resultado de la liquidación está pendiente de confirmar', suggestion:'Verifica que el resultado neto sea correcto antes de generar el fichero' },

--- a/tools/app-shell/src/windows/custom/fiscal-models/FmListPage.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/FmListPage.jsx
@@ -210,6 +210,28 @@ function IncidentsCell({ blocking, warning, t }) {
   );
 }
 
+function ResultCell({ isComputing, error, result, t }) {
+  if (isComputing) return <span style={{ color: '#6b7280', fontSize: 12 }}>…</span>;
+  if (error) {
+    return (
+      <span className="fm-status-pill fm-status-pill--red" title={error} style={{ fontSize: 11 }}>
+        {t('fm.status.error')}
+      </span>
+    );
+  }
+  if (!result?.kind) return <span style={{ color: '#9ca3af' }}>—</span>;
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 3 }}>
+      <ResultPill kind={result.kind} label={t(`fm.result.${result.kind}`) ?? result.kind} />
+      {result.kind !== 'informativa' && result.amount != null && (
+        <span style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: 12 }}>
+          {formatAmount(result.amount)}
+        </span>
+      )}
+    </div>
+  );
+}
+
 // ── Main component ───────────────────────────────────────────────
 export default function FmListPage({ declarations: propDecls, onSelect, onStatusChange, token, apiBaseUrl }) {
   const ui = useUI();
@@ -436,7 +458,10 @@ export default function FmListPage({ declarations: propDecls, onSelect, onStatus
                   let displayResult = decl.result;
                   if (computed?.summary && !computed.error) {
                     const r = computed.summary.result;
-                    const kind = r > 0 ? 'ingresar' : r < 0 ? 'compensar' : 'informativa';
+                    let kind;
+                    if (r > 0) kind = 'ingresar';
+                    else if (r < 0) kind = 'compensar';
+                    else kind = 'informativa';
                     displayResult = { kind, amount: Math.abs(r) };
                   }
 
@@ -459,26 +484,7 @@ export default function FmListPage({ declarations: propDecls, onSelect, onStatus
                       <StatusPillMenu status={decl.status} onStatusChange={s => handleStatusChange(decl.id, s)} />
                     </td>
                     <td style={{ textAlign: 'right' }}>
-                      {isComputingThis ? (
-                        <span style={{ color: '#6b7280', fontSize: 12 }}>…</span>
-                      ) : computeError ? (
-                        <span
-                          className="fm-status-pill fm-status-pill--red"
-                          title={computeError}
-                          style={{ fontSize: 11 }}
-                        >
-                          {t('fm.status.error')}
-                        </span>
-                      ) : displayResult?.kind ? (
-                        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 3 }}>
-                          <ResultPill kind={displayResult.kind} label={t(`fm.result.${displayResult.kind}`) ?? displayResult.kind} />
-                          {displayResult.kind !== 'informativa' && displayResult.amount != null && (
-                            <span style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: 12 }}>
-                              {formatAmount(displayResult.amount)}
-                            </span>
-                          )}
-                        </div>
-                      ) : <span style={{ color: '#9ca3af' }}>—</span>}
+                      <ResultCell isComputing={isComputingThis} error={computeError} result={displayResult} t={t} />
                     </td>
                     <td>
                       <IncidentsCell blocking={decl.incidents?.blocking ?? 0} warning={decl.incidents?.warning ?? 0} t={t} />

--- a/tools/app-shell/src/windows/custom/fiscal-models/FmListPage.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/FmListPage.jsx
@@ -1,10 +1,11 @@
-import React, { useState, useCallback, useRef, useEffect } from 'react';
+import React, { useState, useCallback, useRef, useEffect, useMemo } from 'react';
 import { useUI } from '@/i18n';
 import { LayoutGrid, Settings2, ListFilter, ArrowUpDown } from 'lucide-react';
 import { StatusPillMenu, ResultPill, EmptyState } from './FmCommon.jsx';
 import { ConfigDrawer, NewDeclModal } from './FmOverlays.jsx';
 import FmCatalogPage from './FmCatalogPage.jsx';
-import { formatAmount, STATUS_COLOR, computeUpcomingDeadlines } from './fiscalModelsUtils.js';
+import { formatAmount, STATUS_COLOR, computeUpcomingDeadlines, computeBoxes303, checkModified303 } from './fiscalModelsUtils.js';
+import useFiscalAutoCompute from './useFiscalAutoCompute.js';
 
 function StatusSelect({ value, options, onChange }) {
   const t = useUI();
@@ -209,6 +210,21 @@ export default function FmListPage({ declarations: propDecls, onSelect, onStatus
   const [demoDecls, setDemoDecls]        = useState(propDecls ?? MOCK_DECLARATIONS);
   const [realDecls, setRealDecls]        = useState([]);
   const decls = dataMode === 'demo' ? demoDecls : realDecls;
+
+  const draftDecls303 = useMemo(
+    () => realDecls.filter(d => d.model === '303' && d.status === 'borrador'),
+    [realDecls]
+  );
+
+  const { computedMap } = useFiscalAutoCompute(draftDecls303, {
+    computeFn:       computeBoxes303,
+    checkModifiedFn: checkModified303,
+    token,
+    apiBaseUrl,
+    enabled:         dataMode === 'real',
+    pollIntervalMs:  180_000,
+  });
+
   const [modelFilter, setModelFilter]   = useState('all');
   const [yearFilter,  setYearFilter]    = useState('all');
   const [statusFilter, setStatusFilter] = useState('all');
@@ -309,7 +325,11 @@ export default function FmListPage({ declarations: propDecls, onSelect, onStatus
       {/* ── Body: sidebar + main ─────────────────────────────────── */}
       <div className="fm-list-body">
 
-        <UpcomingDeadlines decls={modelYearFiltered} onSelect={onSelect} t={t} />
+        <UpcomingDeadlines
+          decls={modelYearFiltered}
+          onSelect={decl => onSelect?.({ ...decl, _precomputed: computedMap[decl.id] })}
+          t={t}
+        />
 
         <div className="fm-list-main">
           {/* ── Section header ─────────────────────────────────── */}
@@ -345,11 +365,24 @@ export default function FmListPage({ declarations: propDecls, onSelect, onStatus
                 </tr>
               </thead>
               <tbody>
-                {filtered.map(decl => (
+                {filtered.map(decl => {
+                  const computed = computedMap[decl.id];
+                  const isComputingThis = dataMode === 'real' && decl.model === '303'
+                    && decl.status === 'borrador' && !computed;
+                  const computeError = computed?.error ?? null;
+
+                  let displayResult = decl.result;
+                  if (computed?.summary && !computed.error) {
+                    const r = computed.summary.result;
+                    const kind = r > 0 ? 'ingresar' : r < 0 ? 'compensar' : 'informativa';
+                    displayResult = { kind, amount: Math.abs(r) };
+                  }
+
+                  return (
                   <tr
                     key={decl.id}
                     className={decl.current ? 'fm-table__row--current' : ''}
-                    onClick={() => onSelect?.(decl)}
+                    onClick={() => onSelect?.({ ...decl, _precomputed: computedMap[decl.id] })}
                   >
                     <td onClick={e => e.stopPropagation()}>
                       <input type="checkbox" className="fm-table__cb" checked={selected.has(decl.id)} onChange={() => toggleSelect(decl.id)} />
@@ -364,12 +397,22 @@ export default function FmListPage({ declarations: propDecls, onSelect, onStatus
                       <StatusPillMenu status={decl.status} onStatusChange={s => handleStatusChange(decl.id, s)} />
                     </td>
                     <td style={{ textAlign: 'right' }}>
-                      {decl.result?.kind ? (
+                      {isComputingThis ? (
+                        <span style={{ color: '#6b7280', fontSize: 12 }}>…</span>
+                      ) : computeError ? (
+                        <span
+                          className="fm-status-pill fm-status-pill--red"
+                          title={computeError}
+                          style={{ fontSize: 11 }}
+                        >
+                          {t('fm.status.error')}
+                        </span>
+                      ) : displayResult?.kind ? (
                         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 3 }}>
-                          <ResultPill kind={decl.result.kind} label={t(`fm.result.${decl.result.kind}`) ?? decl.result.kind} />
-                          {decl.result.kind !== 'informativa' && decl.result.amount != null && (
+                          <ResultPill kind={displayResult.kind} label={t(`fm.result.${displayResult.kind}`) ?? displayResult.kind} />
+                          {displayResult.kind !== 'informativa' && displayResult.amount != null && (
                             <span style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: 12 }}>
-                              {formatAmount(decl.result.amount)}
+                              {formatAmount(displayResult.amount)}
                             </span>
                           )}
                         </div>
@@ -381,12 +424,13 @@ export default function FmListPage({ declarations: propDecls, onSelect, onStatus
                     <td><FileCell file={decl.file} fileExternal={decl.fileExternal} /></td>
                     <td><span className="fm-date">{decl.updatedAt ?? '—'}</span></td>
                     <td onClick={e => e.stopPropagation()}>
-                      <button className="fm-table-action" onClick={() => onSelect?.(decl)}>
+                      <button className="fm-table-action" onClick={() => onSelect?.({ ...decl, _precomputed: computedMap[decl.id] })}>
                         {t('fm.action.open')} ›
                       </button>
                     </td>
                   </tr>
-                ))}
+                  );
+                })}
               </tbody>
             </table>
           )}

--- a/tools/app-shell/src/windows/custom/fiscal-models/FmOverlays.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/FmOverlays.jsx
@@ -172,7 +172,7 @@ export function NewDeclModal({ onConfirm, onClose }) {
           <button className="fm-present-modal__btn" onClick={onClose}>{t('fm.action.cancel')}</button>
           <button
             className="fm-present-modal__btn fm-present-modal__btn--primary"
-            onClick={() => { onConfirm?.({ model, year, period, status: 'pendiente' }); onClose(); }}
+            onClick={() => { onConfirm?.({ model, year, period, status: 'borrador' }); onClose(); }}
           >
             {t('fm.action.create')}
           </button>

--- a/tools/app-shell/src/windows/custom/fiscal-models/__tests__/FmListPageAutoCompute.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/__tests__/FmListPageAutoCompute.vitest.jsx
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import FmListPage from '../FmListPage.jsx';
+
+vi.mock('../useFiscalAutoCompute.js', () => ({
+  default: vi.fn(() => ({ computedMap: {} })),
+}));
+vi.mock('@/i18n', () => ({ useUI: () => (key) => key }));
+
+import useFiscalAutoCompute from '../useFiscalAutoCompute.js';
+
+describe('FmListPage — auto-compute wiring', () => {
+  it('calls useFiscalAutoCompute with enabled=false in demo mode', () => {
+    render(<FmListPage token="tok" apiBaseUrl="http://host/neo/fiscal-models" />);
+    const calls = useFiscalAutoCompute.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const lastCall = calls[calls.length - 1];
+    expect(lastCall[1].enabled).toBe(false);
+  });
+});

--- a/tools/app-shell/src/windows/custom/fiscal-models/__tests__/checkModified303.vitest.js
+++ b/tools/app-shell/src/windows/custom/fiscal-models/__tests__/checkModified303.vitest.js
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { checkModified303 } from '../fiscalModelsUtils.js';
+
+const DECL = { id: '303-2026-T2', model: '303', year: 2026, period: 'T2' };
+const OPTS  = { token: 'tok', apiBaseUrl: 'http://host/neo/fiscal-models' };
+
+describe('checkModified303', () => {
+  beforeEach(() => { vi.spyOn(global, 'fetch'); });
+  afterEach(() => { vi.restoreAllMocks(); });
+
+  it('returns false when token is absent', async () => {
+    const result = await checkModified303(DECL, 0, {});
+    expect(result).toBe(false);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('returns false when fetch throws', async () => {
+    fetch.mockRejectedValueOnce(new Error('network down'));
+    const result = await checkModified303(DECL, 1000, OPTS);
+    expect(result).toBe(false);
+  });
+
+  it('returns false when API returns modified: false', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ modified: false, count: 0 }),
+    });
+    const result = await checkModified303(DECL, 1000, OPTS);
+    expect(result).toBe(false);
+  });
+
+  it('returns true when API returns modified: true', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ modified: true, count: 3 }),
+    });
+    const result = await checkModified303(DECL, 1000, OPTS);
+    expect(result).toBe(true);
+  });
+
+  it('builds correct URL with since param', async () => {
+    fetch.mockResolvedValueOnce({ ok: true, json: async () => ({ modified: false }) });
+    await checkModified303(DECL, 1748000000000, OPTS);
+    const url = fetch.mock.calls[0][0];
+    expect(url).toContain('/fiscal303/modified');
+    expect(url).toContain('year=2026');
+    expect(url).toContain('period=T2');
+    expect(url).toContain('since=1748000000000');
+  });
+});

--- a/tools/app-shell/src/windows/custom/fiscal-models/__tests__/fiscalModelsStatus.vitest.js
+++ b/tools/app-shell/src/windows/custom/fiscal-models/__tests__/fiscalModelsStatus.vitest.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { STATUSES, STATUS_COLOR, STATUS_ICON, STATUS_ORDER } from '../fiscalModelsUtils.js';
+
+describe('STATUSES — status unification', () => {
+  it('does not contain pendiente', () => {
+    expect(STATUSES).not.toContain('pendiente');
+  });
+
+  it('still contains borrador', () => {
+    expect(STATUSES).toContain('borrador');
+  });
+
+  it('STATUS_COLOR does not have a pendiente entry', () => {
+    expect(STATUS_COLOR).not.toHaveProperty('pendiente');
+  });
+
+  it('STATUS_ICON does not have a pendiente entry', () => {
+    expect(STATUS_ICON).not.toHaveProperty('pendiente');
+  });
+
+  it('STATUS_ORDER mirrors STATUSES', () => {
+    expect(STATUS_ORDER).toEqual(STATUSES);
+  });
+});

--- a/tools/app-shell/src/windows/custom/fiscal-models/__tests__/fiscalModelsUtils.vitest.js
+++ b/tools/app-shell/src/windows/custom/fiscal-models/__tests__/fiscalModelsUtils.vitest.js
@@ -617,6 +617,157 @@ describe('deriveBoxes303', () => {
     });
   });
 
+  describe('snapshot — 2026 T2 screenshot values', () => {
+    const data = {
+      salesByRate: {
+        '4':  { base: 44,     tax: 1.76   },
+        '10': { base: 201,    tax: 20.10  },
+        '21': { base: 982.60, tax: 206.35 },
+      },
+      purchNormal:    { base: 99, tax: 20.79 },
+      intracommSales: 23,
+      exports:        36,
+    };
+
+    it('box 1 = 44, box 3 = 1.76', () => {
+      const { boxes } = deriveBoxes303(data);
+      expect(boxes[1]).toBe(44);
+      expect(boxes[3]).toBe(1.76);
+    });
+
+    it('box 4 = 201, box 6 = 20.10', () => {
+      const { boxes } = deriveBoxes303(data);
+      expect(boxes[4]).toBe(201);
+      expect(boxes[6]).toBe(20.10);
+    });
+
+    it('box 7 = 982.60, box 9 = 206.35', () => {
+      const { boxes } = deriveBoxes303(data);
+      expect(boxes[7]).toBe(982.60);
+      expect(boxes[9]).toBe(206.35);
+    });
+
+    it('box 27 = 228.21 (sum of tax boxes 3 + 6 + 9)', () => {
+      const { boxes } = deriveBoxes303(data);
+      expect(boxes[27]).toBe(228.21);
+    });
+
+    it('box 28 = 99, box 29 = 20.79', () => {
+      const { boxes } = deriveBoxes303(data);
+      expect(boxes[28]).toBe(99);
+      expect(boxes[29]).toBe(20.79);
+    });
+
+    it('box 45 = 20.79', () => {
+      const { boxes } = deriveBoxes303(data);
+      expect(boxes[45]).toBe(20.79);
+    });
+
+    it('box 46 = 207.42 (228.21 - 20.79)', () => {
+      const { boxes } = deriveBoxes303(data);
+      expect(boxes[46]).toBe(207.42);
+    });
+
+    it('box 59 = 23, box 60 = 36', () => {
+      const { boxes } = deriveBoxes303(data);
+      expect(boxes[59]).toBe(23);
+      expect(boxes[60]).toBe(36);
+    });
+
+    it('summary matches box 27/45/46', () => {
+      const { summary } = deriveBoxes303(data);
+      expect(summary.accrued).toBe(228.21);
+      expect(summary.deductible).toBe(20.79);
+      expect(summary.result).toBe(207.42);
+    });
+  });
+
+  describe('all accrued boxes feed into box 27', () => {
+    it('box 27 equals the exact sum of every contributing tax input', () => {
+      const data = {
+        salesByRate: {
+          '21': { base: 100, tax: 10 },
+          '10': { base: 100, tax: 10 },
+          '4':  { base: 100, tax: 10 },
+          '5':  { base: 100, tax: 10 },
+          '0':  { base: 100, tax: 10 },
+          '2':  { base: 100, tax: 10 },
+        },
+        ecByRate: {
+          '1.4':  { base: 100, tax: 10 },
+          '5.2':  { base: 100, tax: 10 },
+          '0.5':  { base: 100, tax: 10 },
+          '1.75': { base: 100, tax: 10 },
+        },
+        euPurch:  { base: 100, tax: 10 },
+        ispPurch: { base: 100, tax: 10 },
+      };
+      const { boxes } = deriveBoxes303(data);
+      // accruedBoxes in source: [3,6,9,11,13,15,18,21,24,26,152,155,158,167,170]
+      // inputs above map to boxes: 3(4%+5%), 6(10%+7%+8%), 9(21%), 11(euPurch),
+      //   13(ispPurch), 18(EC 0.5%), 21(EC 1.4%), 24(EC 5.2%), 152(0%), 158(EC 1.75%), 167(2%)
+      const accruedBoxes = [3, 6, 9, 11, 13, 15, 18, 21, 24, 26, 152, 155, 158, 167, 170];
+      const expectedSum = Math.round(accruedBoxes.reduce((s, box) => s + (boxes[box] ?? 0), 0) * 100) / 100;
+      expect(boxes[27]).toBe(expectedSum);
+    });
+
+    it('no tax input is silently dropped — 4% and 5% merge into box 3 (20), ten others each 10 → 27 = 120', () => {
+      const data = {
+        salesByRate: {
+          '21': { base: 100, tax: 10 },
+          '10': { base: 100, tax: 10 },
+          '4':  { base: 100, tax: 10 },
+          '5':  { base: 100, tax: 10 },
+          '0':  { base: 100, tax: 10 },
+          '2':  { base: 100, tax: 10 },
+        },
+        ecByRate: {
+          '1.4':  { base: 100, tax: 10 },
+          '5.2':  { base: 100, tax: 10 },
+          '0.5':  { base: 100, tax: 10 },
+          '1.75': { base: 100, tax: 10 },
+        },
+        euPurch:  { base: 100, tax: 10 },
+        ispPurch: { base: 100, tax: 10 },
+      };
+      const { boxes } = deriveBoxes303(data);
+      // box 3 = 4%+5% merged = 20; boxes 6,9,11,13,18,21,24,152,158,167 = 10 each
+      expect(boxes[27]).toBe(120);
+    });
+  });
+
+  describe('RE + IVA combined — same invoice data', () => {
+    const data = {
+      salesByRate: { '21': { base: 1000, tax: 210 } },
+      ecByRate:    { '5.2': { base: 1000, tax: 52 } },
+    };
+
+    it('box 7 = 1000 (IVA base at 21%)', () => {
+      const { boxes } = deriveBoxes303(data);
+      expect(boxes[7]).toBe(1000);
+    });
+
+    it('box 9 = 210 (IVA cuota at 21%)', () => {
+      const { boxes } = deriveBoxes303(data);
+      expect(boxes[9]).toBe(210);
+    });
+
+    it('box 22 = 1000 (RE base at 5.2%)', () => {
+      const { boxes } = deriveBoxes303(data);
+      expect(boxes[22]).toBe(1000);
+    });
+
+    it('box 24 = 52 (RE cuota at 5.2%)', () => {
+      const { boxes } = deriveBoxes303(data);
+      expect(boxes[24]).toBe(52);
+    });
+
+    it('box 27 = 262 (both IVA and RE tax contribute)', () => {
+      const { boxes } = deriveBoxes303(data);
+      expect(boxes[27]).toBe(262);
+    });
+  });
+
   describe('rounding', () => {
     it('rounds to 2 decimal places', () => {
       const data = { salesByRate: { '21': { base: 100.005, tax: 21.005 } } };

--- a/tools/app-shell/src/windows/custom/fiscal-models/__tests__/fiscalModelsUtils.vitest.js
+++ b/tools/app-shell/src/windows/custom/fiscal-models/__tests__/fiscalModelsUtils.vitest.js
@@ -15,14 +15,14 @@ import {
 // ── STATUSES ──────────────────────────────────────────────────────────────────
 
 describe('STATUSES', () => {
-  it('is an array with 7 entries', () => {
+  it('is an array with 6 entries', () => {
     expect(Array.isArray(STATUSES)).toBe(true);
-    expect(STATUSES).toHaveLength(7);
+    expect(STATUSES).toHaveLength(6);
   });
 
   it('contains all expected status values', () => {
     expect(STATUSES).toContain('omitido');
-    expect(STATUSES).toContain('pendiente');
+    expect(STATUSES).not.toContain('pendiente');
     expect(STATUSES).toContain('borrador');
     expect(STATUSES).toContain('listo');
     expect(STATUSES).toContain('presentado');
@@ -47,7 +47,7 @@ describe('STATUS_COLOR', () => {
 
   it('maps specific statuses to expected color names', () => {
     expect(STATUS_COLOR.omitido).toBe('grey');
-    expect(STATUS_COLOR.pendiente).toBe('orange');
+    expect(STATUS_COLOR.pendiente).toBeUndefined();
     expect(STATUS_COLOR.borrador).toBe('blue');
     expect(STATUS_COLOR.listo).toBe('green');
     expect(STATUS_COLOR.presentado).toBe('teal');
@@ -78,8 +78,8 @@ describe('STATUS_ORDER', () => {
     expect(Array.isArray(STATUS_ORDER)).toBe(true);
   });
 
-  it('contains all 7 statuses', () => {
-    expect(STATUS_ORDER).toHaveLength(7);
+  it('contains all 6 statuses', () => {
+    expect(STATUS_ORDER).toHaveLength(6);
     for (const s of STATUSES) {
       expect(STATUS_ORDER).toContain(s);
     }
@@ -839,10 +839,6 @@ describe('computeUpcomingDeadlines', () => {
       expect(computeUpcomingDeadlines([D('303', 2026, 'T1', 'borrador')])).toHaveLength(1);
     });
 
-    it('includes pendiente', () => {
-      expect(computeUpcomingDeadlines([D('303', 2026, 'T1', 'pendiente')])).toHaveLength(1);
-    });
-
     it('includes listo', () => {
       expect(computeUpcomingDeadlines([D('303', 2026, 'T1', 'listo')])).toHaveLength(1);
     });
@@ -880,7 +876,7 @@ describe('computeUpcomingDeadlines', () => {
     });
 
     it('T4 → deadline January 20 of next year', () => {
-      const [{ deadline }] = computeUpcomingDeadlines([D('303', 2025, 'T4', 'pendiente')]);
+      const [{ deadline }] = computeUpcomingDeadlines([D('303', 2025, 'T4', 'borrador')]);
       expect(deadline.getFullYear()).toBe(2026);
       expect(deadline.getMonth()).toBe(0);
       expect(deadline.getDate()).toBe(20);
@@ -889,28 +885,28 @@ describe('computeUpcomingDeadlines', () => {
 
   describe('monthly period deadlines', () => {
     it('"03" → deadline April 20 (month index 3)', () => {
-      const [{ deadline }] = computeUpcomingDeadlines([D('349', 2026, '03', 'pendiente')]);
+      const [{ deadline }] = computeUpcomingDeadlines([D('349', 2026, '03', 'borrador')]);
       expect(deadline.getFullYear()).toBe(2026);
       expect(deadline.getMonth()).toBe(3);
       expect(deadline.getDate()).toBe(20);
     });
 
     it('"12" → deadline January 20 of next year', () => {
-      const [{ deadline }] = computeUpcomingDeadlines([D('349', 2025, '12', 'pendiente')]);
+      const [{ deadline }] = computeUpcomingDeadlines([D('349', 2025, '12', 'borrador')]);
       expect(deadline.getFullYear()).toBe(2026);
       expect(deadline.getMonth()).toBe(0);
       expect(deadline.getDate()).toBe(20);
     });
 
     it('"01" → deadline February 20', () => {
-      const [{ deadline }] = computeUpcomingDeadlines([D('349', 2026, '01', 'pendiente')]);
+      const [{ deadline }] = computeUpcomingDeadlines([D('349', 2026, '01', 'borrador')]);
       expect(deadline.getFullYear()).toBe(2026);
       expect(deadline.getMonth()).toBe(1);
       expect(deadline.getDate()).toBe(20);
     });
 
     it('"06" → deadline July 20 (month index 6)', () => {
-      const [{ deadline }] = computeUpcomingDeadlines([D('349', 2026, '06', 'pendiente')]);
+      const [{ deadline }] = computeUpcomingDeadlines([D('349', 2026, '06', 'borrador')]);
       expect(deadline.getFullYear()).toBe(2026);
       expect(deadline.getMonth()).toBe(6);
       expect(deadline.getDate()).toBe(20);
@@ -941,14 +937,14 @@ describe('computeUpcomingDeadlines', () => {
 
   describe('limit parameter', () => {
     it('respects the default limit of 5', () => {
-      const decls = ['T1', 'T2', 'T3', 'T4'].map(p => D('303', 2026, p, 'pendiente'))
-        .concat(['01', '02'].map(p => D('349', 2026, p, 'pendiente')));
+      const decls = ['T1', 'T2', 'T3', 'T4'].map(p => D('303', 2026, p, 'borrador'))
+        .concat(['01', '02'].map(p => D('349', 2026, p, 'borrador')));
       const result = computeUpcomingDeadlines(decls);
       expect(result).toHaveLength(5);
     });
 
     it('respects a custom limit of 2', () => {
-      const decls = ['T1', 'T2', 'T3', 'T4'].map(p => D('303', 2026, p, 'pendiente'));
+      const decls = ['T1', 'T2', 'T3', 'T4'].map(p => D('303', 2026, p, 'borrador'));
       expect(computeUpcomingDeadlines(decls, 2)).toHaveLength(2);
     });
 

--- a/tools/app-shell/src/windows/custom/fiscal-models/__tests__/fiscalModelsUtils.vitest.js
+++ b/tools/app-shell/src/windows/custom/fiscal-models/__tests__/fiscalModelsUtils.vitest.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   STATUSES,
   STATUS_COLOR,
@@ -10,6 +10,7 @@ import {
   fmtDecl,
   deriveBoxes303,
   computeUpcomingDeadlines,
+  generate303File,
 } from '../fiscalModelsUtils.js';
 
 // ── STATUSES ──────────────────────────────────────────────────────────────────
@@ -975,5 +976,84 @@ describe('computeUpcomingDeadlines', () => {
       const [item] = computeUpcomingDeadlines([decl]);
       expect(item.decl).toBe(decl);
     });
+  });
+});
+
+// ── generate303File ───────────────────────────────────────────────────────────
+
+describe('generate303File', () => {
+  const DECL = { id: '303-2026-T2', model: '303', year: 2026, period: 'T2', result: { kind: 'ingresar' } };
+  const TOKEN = 'test-token';
+  const API_BASE = 'http://host/neo/fiscal-models';
+
+  afterEach(() => vi.restoreAllMocks());
+
+  function mockFetchOk(blob = new Blob(['data'])) {
+    const objectUrl = 'blob:mock';
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, blob: () => Promise.resolve(blob) }));
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn().mockReturnValue(objectUrl),
+      revokeObjectURL: vi.fn(),
+    });
+    const anchor = { href: '', download: '', click: vi.fn() };
+    vi.spyOn(document.body, 'appendChild').mockImplementation(() => {});
+    vi.spyOn(document.body, 'removeChild').mockImplementation(() => {});
+    vi.spyOn(document, 'createElement').mockReturnValue(anchor);
+    return { anchor, objectUrl };
+  }
+
+  it('returns false when token is missing', async () => {
+    expect(await generate303File(DECL, { token: '', apiBaseUrl: API_BASE })).toBe(false);
+    expect(await generate303File(DECL, { apiBaseUrl: API_BASE })).toBe(false);
+  });
+
+  it('returns false when apiBaseUrl is missing', async () => {
+    expect(await generate303File(DECL, { token: TOKEN })).toBe(false);
+  });
+
+  it('builds the correct URL with URLSearchParams', async () => {
+    mockFetchOk();
+    await generate303File(DECL, { token: TOKEN, apiBaseUrl: API_BASE });
+    const calledUrl = vi.mocked(fetch).mock.calls[0][0];
+    expect(calledUrl).toContain('/fiscal303/generate?');
+    expect(calledUrl).toContain('year=2026');
+    expect(calledUrl).toContain('period=T2');
+    expect(calledUrl).toContain('tipo=ingresar');
+  });
+
+  it('uses the result.kind from decl as tipo', async () => {
+    mockFetchOk();
+    await generate303File({ ...DECL, result: { kind: 'compensar' } }, { token: TOKEN, apiBaseUrl: API_BASE });
+    expect(vi.mocked(fetch).mock.calls[0][0]).toContain('tipo=compensar');
+  });
+
+  it('defaults tipo to N when result.kind is absent', async () => {
+    mockFetchOk();
+    await generate303File({ ...DECL, result: null }, { token: TOKEN, apiBaseUrl: API_BASE });
+    expect(vi.mocked(fetch).mock.calls[0][0]).toContain('tipo=N');
+  });
+
+  it('sends Authorization header', async () => {
+    mockFetchOk();
+    await generate303File(DECL, { token: TOKEN, apiBaseUrl: API_BASE });
+    expect(vi.mocked(fetch).mock.calls[0][1].headers.Authorization).toBe(`Bearer ${TOKEN}`);
+  });
+
+  it('returns true and triggers download on success', async () => {
+    const { anchor } = mockFetchOk();
+    const result = await generate303File(DECL, { token: TOKEN, apiBaseUrl: API_BASE });
+    expect(result).toBe(true);
+    expect(anchor.download).toBe('303_T2_2026.txt');
+    expect(anchor.click).toHaveBeenCalled();
+  });
+
+  it('returns false when fetch responds not ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }));
+    expect(await generate303File(DECL, { token: TOKEN, apiBaseUrl: API_BASE })).toBe(false);
+  });
+
+  it('returns false when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')));
+    expect(await generate303File(DECL, { token: TOKEN, apiBaseUrl: API_BASE })).toBe(false);
   });
 });

--- a/tools/app-shell/src/windows/custom/fiscal-models/__tests__/useFiscalAutoCompute.vitest.js
+++ b/tools/app-shell/src/windows/custom/fiscal-models/__tests__/useFiscalAutoCompute.vitest.js
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import useFiscalAutoCompute from '../useFiscalAutoCompute.js';
+
+const DECL_A = { id: '303-2026-T2', model: '303', year: 2026, period: 'T2' };
+const DECL_B = { id: '303-2026-T1', model: '303', year: 2026, period: 'T1' };
+const BOXES  = { 7: 100, 9: 21 };
+const SUMMARY = { accrued: 21, deductible: 200, result: -179 };
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('useFiscalAutoCompute — initial compute', () => {
+  it('calls computeFn for every decl on mount', async () => {
+    const computeFn = vi.fn().mockResolvedValue({ boxes: BOXES, summary: SUMMARY });
+    const { result } = renderHook(() =>
+      useFiscalAutoCompute([DECL_A, DECL_B], {
+        computeFn,
+        checkModifiedFn: vi.fn(),
+        token: 'tok',
+        apiBaseUrl: 'http://host/neo/fiscal-models',
+        enabled: true,
+        pollIntervalMs: 100_000,
+      })
+    );
+    await waitFor(() => expect(computeFn).toHaveBeenCalledTimes(2));
+    expect(result.current.computedMap[DECL_A.id]).toMatchObject({ summary: SUMMARY });
+    expect(result.current.computedMap[DECL_B.id]).toMatchObject({ summary: SUMMARY });
+  });
+
+  it('sets error entry when computeFn rejects', async () => {
+    const computeFn = vi.fn().mockRejectedValue(new Error('compute failed'));
+    const { result } = renderHook(() =>
+      useFiscalAutoCompute([DECL_A], {
+        computeFn,
+        checkModifiedFn: vi.fn(),
+        token: 'tok',
+        apiBaseUrl: 'http://host/neo/fiscal-models',
+        enabled: true,
+        pollIntervalMs: 100_000,
+      })
+    );
+    await waitFor(() =>
+      expect(result.current.computedMap[DECL_A.id]).toMatchObject({ error: 'Error: compute failed' })
+    );
+  });
+
+  it('does not call computeFn when enabled is false', async () => {
+    const computeFn = vi.fn();
+    renderHook(() =>
+      useFiscalAutoCompute([DECL_A], {
+        computeFn,
+        checkModifiedFn: vi.fn(),
+        token: 'tok',
+        apiBaseUrl: 'http://host/neo/fiscal-models',
+        enabled: false,
+        pollIntervalMs: 100_000,
+      })
+    );
+    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
+    expect(computeFn).not.toHaveBeenCalled();
+  });
+
+  it('does not call computeFn when decls is empty', async () => {
+    const computeFn = vi.fn();
+    renderHook(() =>
+      useFiscalAutoCompute([], {
+        computeFn,
+        checkModifiedFn: vi.fn(),
+        token: 'tok',
+        apiBaseUrl: 'http://host/neo/fiscal-models',
+        enabled: true,
+        pollIntervalMs: 100_000,
+      })
+    );
+    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
+    expect(computeFn).not.toHaveBeenCalled();
+  });
+});
+
+// Stable reference: a new array on every render resets the polling effect
+const DECL_A_LIST = [DECL_A];
+
+describe('useFiscalAutoCompute — polling', () => {
+  it('calls checkModifiedFn after interval and recomputes if modified', async () => {
+    const computeFn      = vi.fn().mockResolvedValue({ boxes: BOXES, summary: SUMMARY });
+    const checkModifiedFn = vi.fn().mockResolvedValue(true);
+
+    renderHook(() =>
+      useFiscalAutoCompute(DECL_A_LIST, {
+        computeFn,
+        checkModifiedFn,
+        token: 'tok',
+        apiBaseUrl: 'http://host/neo/fiscal-models',
+        enabled: true,
+        pollIntervalMs: 50, // short interval so the poll fires within the waitFor window
+      })
+    );
+
+    // wait for initial compute
+    await waitFor(() => expect(computeFn).toHaveBeenCalled());
+    const initialCalls = computeFn.mock.calls.length;
+
+    // wait for the poll to fire and trigger a recompute
+    await waitFor(() => {
+      expect(checkModifiedFn).toHaveBeenCalled();
+      expect(computeFn.mock.calls.length).toBeGreaterThan(initialCalls);
+    }, { timeout: 500 });
+  });
+});

--- a/tools/app-shell/src/windows/custom/fiscal-models/__tests__/useFiscalAutoCompute.vitest.js
+++ b/tools/app-shell/src/windows/custom/fiscal-models/__tests__/useFiscalAutoCompute.vitest.js
@@ -60,6 +60,23 @@ describe('useFiscalAutoCompute — initial compute', () => {
     expect(computeFn).not.toHaveBeenCalled();
   });
 
+  it('writes a null-result entry when computeFn returns null', async () => {
+    const computeFn = vi.fn().mockResolvedValue(null);
+    const { result } = renderHook(() =>
+      useFiscalAutoCompute([DECL_A], {
+        computeFn,
+        checkModifiedFn: vi.fn(),
+        token: 'tok',
+        apiBaseUrl: 'http://host/neo/fiscal-models',
+        enabled: true,
+        pollIntervalMs: 100_000,
+      })
+    );
+    await waitFor(() =>
+      expect(result.current.computedMap[DECL_A.id]).toMatchObject({ boxes: null, summary: null, error: null })
+    );
+  });
+
   it('does not call computeFn when decls is empty', async () => {
     const computeFn = vi.fn();
     renderHook(() =>

--- a/tools/app-shell/src/windows/custom/fiscal-models/fiscalModelsUtils.js
+++ b/tools/app-shell/src/windows/custom/fiscal-models/fiscalModelsUtils.js
@@ -64,13 +64,12 @@ export async function generate303File(decl, { token, apiBaseUrl } = {}) {
 }
 
 export const STATUSES = [
-  'omitido', 'pendiente', 'borrador', 'listo',
+  'omitido', 'borrador', 'listo',
   'presentado', 'presentadoOtra', 'presentadoAcuse',
 ];
 
 export const STATUS_COLOR = {
   omitido:         'grey',
-  pendiente:       'orange',
   borrador:        'blue',
   listo:           'green',
   presentado:      'teal',
@@ -80,7 +79,6 @@ export const STATUS_COLOR = {
 
 export const STATUS_ICON = {
   omitido:         '×',
-  pendiente:       '○',
   borrador:        '✎',
   listo:           '✓',
   presentado:      '✓',

--- a/tools/app-shell/src/windows/custom/fiscal-models/fiscalModelsUtils.js
+++ b/tools/app-shell/src/windows/custom/fiscal-models/fiscalModelsUtils.js
@@ -44,7 +44,8 @@ export async function generate303File(decl, { token, apiBaseUrl } = {}) {
   if (!token || !apiBaseUrl) return false;
   try {
     const base = apiBaseUrl.replace(/\/[^/]+$/, '');
-    const url = `${base}/fiscal303/generate?year=${decl.year}&period=${decl.period}`;
+    const tipo = decl.result?.kind ?? 'N';
+    const url = `${base}/fiscal303/generate?year=${decl.year}&period=${decl.period}&tipo=${tipo}`;
     const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
     if (!res.ok) return false;
     const blob = await res.blob();

--- a/tools/app-shell/src/windows/custom/fiscal-models/fiscalModelsUtils.js
+++ b/tools/app-shell/src/windows/custom/fiscal-models/fiscalModelsUtils.js
@@ -36,6 +36,32 @@ export async function computeBoxes303(decl, { token, apiBaseUrl } = {}) {
   return null;
 }
 
+/**
+ * Calls GET /neo/fiscal303/generate and triggers a browser file download.
+ * Returns true on success, false on error.
+ */
+export async function generate303File(decl, { token, apiBaseUrl } = {}) {
+  if (!token || !apiBaseUrl) return false;
+  try {
+    const base = apiBaseUrl.replace(/\/[^/]+$/, '');
+    const url = `${base}/fiscal303/generate?year=${decl.year}&period=${decl.period}`;
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+    if (!res.ok) return false;
+    const blob = await res.blob();
+    const objectUrl = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = objectUrl;
+    a.download = `303_${decl.period}_${decl.year}.txt`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(objectUrl);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
 export const STATUSES = [
   'omitido', 'pendiente', 'borrador', 'listo',
   'presentado', 'presentadoOtra', 'presentadoAcuse',

--- a/tools/app-shell/src/windows/custom/fiscal-models/fiscalModelsUtils.js
+++ b/tools/app-shell/src/windows/custom/fiscal-models/fiscalModelsUtils.js
@@ -45,7 +45,8 @@ export async function generate303File(decl, { token, apiBaseUrl } = {}) {
   try {
     const base = apiBaseUrl.replace(/\/[^/]+$/, '');
     const tipo = decl.result?.kind ?? 'N';
-    const url = `${base}/fiscal303/generate?year=${decl.year}&period=${decl.period}&tipo=${tipo}`;
+    const params = new URLSearchParams({ year: decl.year, period: decl.period, tipo });
+    const url = `${base}/fiscal303/generate?${params}`;
     const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
     if (!res.ok) return false;
     const blob = await res.blob();
@@ -266,7 +267,8 @@ export async function checkModified303(decl, sinceMs, { token, apiBaseUrl } = {}
   if (!token || !apiBaseUrl) return false;
   try {
     const base = apiBaseUrl.replace(/\/[^/]+$/, '');
-    const url = `${base}/fiscal303/modified?year=${decl.year}&period=${decl.period}&since=${sinceMs}`;
+    const params = new URLSearchParams({ year: decl.year, period: decl.period, since: sinceMs });
+    const url = `${base}/fiscal303/modified?${params}`;
     const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
     if (!res.ok) return false;
     const data = await res.json();

--- a/tools/app-shell/src/windows/custom/fiscal-models/fiscalModelsUtils.js
+++ b/tools/app-shell/src/windows/custom/fiscal-models/fiscalModelsUtils.js
@@ -258,6 +258,24 @@ function getDeadlineDate(model, year, period) {
   return null;
 }
 
+/**
+ * Returns true if any invoice affecting the given declaration's period was
+ * updated after sinceMs (Unix ms timestamp). Returns false on any error.
+ */
+export async function checkModified303(decl, sinceMs, { token, apiBaseUrl } = {}) {
+  if (!token || !apiBaseUrl) return false;
+  try {
+    const base = apiBaseUrl.replace(/\/[^/]+$/, '');
+    const url = `${base}/fiscal303/modified?year=${decl.year}&period=${decl.period}&since=${sinceMs}`;
+    const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
+    if (!res.ok) return false;
+    const data = await res.json();
+    return data.modified === true;
+  } catch (_) {
+    return false;
+  }
+}
+
 export function computeUpcomingDeadlines(decls, limit = 5) {
   return decls
     .filter(d => !COMPLETED_STATUSES.has(d.status))

--- a/tools/app-shell/src/windows/custom/fiscal-models/models/303/FmModel303Page.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/models/303/FmModel303Page.jsx
@@ -430,6 +430,7 @@ export default function FmModel303Page({ decl, onBack, onStatusChange, token, ap
               <button
                 className={`fm-349-header__btn${fileBlocked ? ' fm-303-header__btn--locked' : ''}`}
                 onClick={() => setShowFilegen(true)}
+                disabled={generating}
                 title={fileBlocked ? t('fm.incidents.block_sub') : ''}
                 style={fileBlocked ? { color: '#dc2626', borderColor: '#fca5a5', background: '#fef2f2' } : {}}
               >

--- a/tools/app-shell/src/windows/custom/fiscal-models/models/303/FmModel303Page.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/models/303/FmModel303Page.jsx
@@ -12,7 +12,7 @@ import {
 import FmBoxes303 from './FmBoxes303.jsx';
 import { PresentModal, FileGenModal, ConfigDrawer, CompareDrawer } from '../../FmOverlays.jsx';
 import { neoBase } from '@/components/related-documents/helpers.js';
-import { formatAmount, formatPeriod, computeBoxes303 } from '../../fiscalModelsUtils.js';
+import { formatAmount, formatPeriod, computeBoxes303, generate303File } from '../../fiscalModelsUtils.js';
 
 const STEPPER_INDEX = {
   pendiente: 0, borrador: 1, listo: 2,
@@ -294,6 +294,7 @@ export default function FmModel303Page({ decl, onBack, onStatusChange, token, ap
   const [liveSummary, setLiveSummary] = useState(null);
   const [liveSources, setLiveSources] = useState(null);
   const [computing,   setComputing]   = useState(false);
+  const [generating,  setGenerating]  = useState(false);
 
   async function handleCompute() {
     setComputing(true);
@@ -306,6 +307,15 @@ export default function FmModel303Page({ decl, onBack, onStatusChange, token, ap
       }
     } finally {
       setComputing(false);
+    }
+  }
+
+  async function handleGenerate() {
+    setGenerating(true);
+    const ok = await generate303File(decl, { token, apiBaseUrl });
+    setGenerating(false);
+    if (!ok) {
+      console.error('generate303File failed for', decl.year, decl.period);
     }
   }
 
@@ -573,7 +583,7 @@ export default function FmModel303Page({ decl, onBack, onStatusChange, token, ap
         <PresentModal decl={decl} onConfirm={handlePresent} onClose={() => setShowPresent(false)} />
       )}
       {showFilegen && (
-        <FileGenModal decl={decl} onConfirm={() => {}} onClose={() => setShowFilegen(false)} />
+        <FileGenModal decl={decl} onConfirm={handleGenerate} onClose={() => setShowFilegen(false)} />
       )}
       {showConfig && <ConfigDrawer onClose={() => setShowConfig(false)} token={token} apiBaseUrl={apiBaseUrl} />}
       {showCompare && <CompareDrawer decl={decl} onClose={() => setShowCompare(false)} />}

--- a/tools/app-shell/src/windows/custom/fiscal-models/models/303/FmModel303Page.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/models/303/FmModel303Page.jsx
@@ -312,7 +312,10 @@ export default function FmModel303Page({ decl, onBack, onStatusChange, token, ap
 
   async function handleGenerate() {
     setGenerating(true);
-    const ok = await generate303File(decl, { token, apiBaseUrl });
+    const result = liveSummary?.result ?? decl.summary?.result ?? 0;
+    const kind = decl.result?.kind ?? (result > 0 ? 'ingresar' : result < 0 ? 'compensar' : 'informativa');
+    const declForGenerate = { ...decl, result: { ...decl.result, kind } };
+    const ok = await generate303File(declForGenerate, { token, apiBaseUrl });
     setGenerating(false);
     if (!ok) {
       console.error('generate303File failed for', decl.year, decl.period);

--- a/tools/app-shell/src/windows/custom/fiscal-models/models/303/FmModel303Page.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/models/303/FmModel303Page.jsx
@@ -15,8 +15,8 @@ import { neoBase } from '@/components/related-documents/helpers.js';
 import { formatAmount, formatPeriod, computeBoxes303, generate303File } from '../../fiscalModelsUtils.js';
 
 const STEPPER_INDEX = {
-  borrador: 1, listo: 2,
-  presentado: 3, presentadoOtra: 3, presentadoAcuse: 3,
+  borrador: 0, listo: 1,
+  presentado: 2, presentadoOtra: 2, presentadoAcuse: 2,
   omitido: -1,
 };
 
@@ -313,7 +313,12 @@ export default function FmModel303Page({ decl, onBack, onStatusChange, token, ap
   async function handleGenerate() {
     setGenerating(true);
     const result = liveSummary?.result ?? decl.summary?.result ?? 0;
-    const kind = decl.result?.kind ?? (result > 0 ? 'ingresar' : result < 0 ? 'compensar' : 'informativa');
+    let kind = decl.result?.kind;
+    if (!kind) {
+      if (result > 0) kind = 'ingresar';
+      else if (result < 0) kind = 'compensar';
+      else kind = 'informativa';
+    }
     const declForGenerate = { ...decl, result: { ...decl.result, kind } };
     const ok = await generate303File(declForGenerate, { token, apiBaseUrl });
     setGenerating(false);
@@ -337,7 +342,6 @@ export default function FmModel303Page({ decl, onBack, onStatusChange, token, ap
   }, [token, apiBaseUrl]);
 
   const stepperSteps = [
-    t('fm.stepper.pending'),
     t('fm.stepper.draft'),
     t('fm.stepper.ready'),
     t('fm.stepper.presented'),

--- a/tools/app-shell/src/windows/custom/fiscal-models/models/303/FmModel303Page.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/models/303/FmModel303Page.jsx
@@ -15,7 +15,7 @@ import { neoBase } from '@/components/related-documents/helpers.js';
 import { formatAmount, formatPeriod, computeBoxes303, generate303File } from '../../fiscalModelsUtils.js';
 
 const STEPPER_INDEX = {
-  pendiente: 0, borrador: 1, listo: 2,
+  borrador: 1, listo: 2,
   presentado: 3, presentadoOtra: 3, presentadoAcuse: 3,
   omitido: -1,
 };
@@ -290,9 +290,9 @@ export default function FmModel303Page({ decl, onBack, onStatusChange, token, ap
   const [orgIdent, setOrgIdent] = useState({ nif: '', nombre: '' });
   const [identChecks, setIdentChecks] = useState(decl.identification ?? {});
   const handleIdentChange = (id, value) => setIdentChecks(prev => ({ ...prev, [id]: value }));
-  const [liveBoxes,   setLiveBoxes]   = useState(null);
-  const [liveSummary, setLiveSummary] = useState(null);
-  const [liveSources, setLiveSources] = useState(null);
+  const [liveBoxes,   setLiveBoxes]   = useState(decl._precomputed?.boxes   ?? null);
+  const [liveSummary, setLiveSummary] = useState(decl._precomputed?.summary ?? null);
+  const [liveSources, setLiveSources] = useState(decl._precomputed?.sources ?? null);
   const [computing,   setComputing]   = useState(false);
   const [generating,  setGenerating]  = useState(false);
 

--- a/tools/app-shell/src/windows/custom/fiscal-models/models/303/__tests__/FmModel303Page.precomputed.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/models/303/__tests__/FmModel303Page.precomputed.vitest.jsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import FmModel303Page from '../FmModel303Page.jsx';
+
+vi.mock('@/i18n', () => ({ useUI: () => (key) => key }));
+vi.mock('../../fiscalModelsUtils.js', () => ({
+  formatAmount:     (n) => String(n),
+  formatPeriod:     (p) => p,
+  computeBoxes303:  vi.fn(),
+  generate303File:  vi.fn(),
+  checkModified303: vi.fn(),
+}));
+vi.mock('@/components/related-documents/helpers.js', () => ({ neoBase: (u) => u }));
+
+const DECL = {
+  id: '303-2026-T2', model: '303', year: 2026, period: 'T2', type: 'ord',
+  status: 'borrador', result: null, incidents: { blocking: 0, warning: 0 },
+  _precomputed: {
+    boxes:   { 7: 100, 9: 21, 27: 21, 28: 500, 29: 105, 45: 105, 46: -84 },
+    summary: { accrued: 21, deductible: 105, result: -84 },
+    error:   null,
+    computedAt: Date.now(),
+  },
+};
+
+describe('FmModel303Page — precomputed data initialization', () => {
+  it('renders compute button without spinner when precomputed data is present', () => {
+    render(
+      <FmModel303Page
+        decl={DECL}
+        onBack={vi.fn()}
+        onStatusChange={vi.fn()}
+        token="tok"
+        apiBaseUrl="http://host/neo/fiscal-models"
+      />
+    );
+    const calcBtns = screen.queryAllByRole('button', { name: /fm\.action\.compute/i });
+    expect(calcBtns.length).toBeGreaterThan(0);
+  });
+});

--- a/tools/app-shell/src/windows/custom/fiscal-models/models/303/__tests__/FmModel303Page.precomputed.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/models/303/__tests__/FmModel303Page.precomputed.vitest.jsx
@@ -31,8 +31,6 @@ describe('FmModel303Page — precomputed data initialization', () => {
         decl={DECL}
         onBack={vi.fn()}
         onStatusChange={vi.fn()}
-        token="tok"
-        apiBaseUrl="http://host/neo/fiscal-models"
       />
     );
     const calcBtns = screen.queryAllByRole('button', { name: /fm\.action\.compute/i });

--- a/tools/app-shell/src/windows/custom/fiscal-models/useFiscalAutoCompute.js
+++ b/tools/app-shell/src/windows/custom/fiscal-models/useFiscalAutoCompute.js
@@ -1,0 +1,93 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Auto-computes fiscal boxes for a list of declarations on mount, then polls
+ * for data changes every pollIntervalMs and recomputes only modified ones.
+ *
+ * All function/token/apiBaseUrl arguments are captured via a ref, so the
+ * polling interval is never recreated due to prop changes.
+ *
+ * @param {Array} decls - Declarations to compute (should be a stable memoized array)
+ * @param {object} opts
+ * @param {Function} opts.computeFn - async (decl, { token, apiBaseUrl }) => { boxes, summary } | null
+ * @param {Function} opts.checkModifiedFn - async (decl, sinceMs, { token, apiBaseUrl }) => boolean
+ * @param {string}   opts.token
+ * @param {string}   opts.apiBaseUrl
+ * @param {number}   opts.pollIntervalMs - default 180_000 (3 min)
+ * @param {boolean}  opts.enabled - set false to disable all activity (e.g. in demo mode)
+ * @returns {{ computedMap: { [id]: { boxes, summary, error, computedAt } } }}
+ */
+export default function useFiscalAutoCompute(decls, {
+  computeFn,
+  checkModifiedFn,
+  token,
+  apiBaseUrl,
+  pollIntervalMs = 180_000,
+  enabled = true,
+} = {}) {
+  const [computedMap, setComputedMap] = useState({});
+  const computedAtRef = useRef({});
+
+  // Keep latest values accessible inside intervals without deps churn
+  const ctxRef = useRef({});
+  ctxRef.current = { computeFn, checkModifiedFn, token, apiBaseUrl };
+
+  // Initial compute: run in parallel for all decls on mount / when decls changes
+  useEffect(() => {
+    if (!enabled || !decls.length) return;
+    let cancelled = false;
+
+    (async () => {
+      await Promise.all(decls.map(async (decl) => {
+        const { computeFn: fn, token: t, apiBaseUrl: api } = ctxRef.current;
+        try {
+          const result = await fn(decl, { token: t, apiBaseUrl: api });
+          if (cancelled || !result) return;
+          const computedAt = Date.now();
+          computedAtRef.current[decl.id] = computedAt;
+          setComputedMap(m => ({ ...m, [decl.id]: { ...result, error: null, computedAt } }));
+        } catch (err) {
+          if (!cancelled) {
+            setComputedMap(m => ({
+              ...m,
+              [decl.id]: { boxes: null, summary: null, error: String(err), computedAt: Date.now() },
+            }));
+          }
+        }
+      }));
+    })();
+
+    return () => { cancelled = true; };
+  }, [enabled, decls]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Polling: check for modifications, recompute only changed declarations
+  useEffect(() => {
+    if (!enabled || !decls.length) return;
+
+    const interval = setInterval(() => {
+      decls.forEach(async (decl) => {
+        const { checkModifiedFn: checkFn, computeFn: fn, token: t, apiBaseUrl: api } = ctxRef.current;
+        if (!checkFn) return;
+        const sinceMs = computedAtRef.current[decl.id] ?? 0;
+        try {
+          const modified = await checkFn(decl, sinceMs, { token: t, apiBaseUrl: api });
+          if (!modified) return;
+          const result = await fn(decl, { token: t, apiBaseUrl: api });
+          if (!result) return;
+          const computedAt = Date.now();
+          computedAtRef.current[decl.id] = computedAt;
+          setComputedMap(m => ({ ...m, [decl.id]: { ...result, error: null, computedAt } }));
+        } catch (err) {
+          setComputedMap(m => ({
+            ...m,
+            [decl.id]: { boxes: null, summary: null, error: String(err), computedAt: Date.now() },
+          }));
+        }
+      });
+    }, pollIntervalMs);
+
+    return () => clearInterval(interval);
+  }, [enabled, decls, pollIntervalMs]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return { computedMap };
+}

--- a/tools/app-shell/src/windows/custom/fiscal-models/useFiscalAutoCompute.js
+++ b/tools/app-shell/src/windows/custom/fiscal-models/useFiscalAutoCompute.js
@@ -32,11 +32,11 @@ async function computeOne(decl, { fn, token, apiBaseUrl, isCancelled, computedAt
     }));
   } catch (err) {
     if (!isCancelled()) {
-      const computedAt = Date.now();
-      computedAtRef.current[decl.id] = computedAt;
+      // Do not update computedAtRef on error — sinceMs stays at the last
+      // successful compute time so any subsequent invoice change still triggers a retry.
       setComputedMap(m => ({
         ...m,
-        [decl.id]: { boxes: null, summary: null, error: String(err), computedAt },
+        [decl.id]: { boxes: null, summary: null, error: String(err), computedAt: Date.now() },
       }));
     }
   }

--- a/tools/app-shell/src/windows/custom/fiscal-models/useFiscalAutoCompute.js
+++ b/tools/app-shell/src/windows/custom/fiscal-models/useFiscalAutoCompute.js
@@ -42,15 +42,22 @@ export default function useFiscalAutoCompute(decls, {
         const { computeFn: fn, token: t, apiBaseUrl: api } = ctxRef.current;
         try {
           const result = await fn(decl, { token: t, apiBaseUrl: api });
-          if (cancelled || !result) return;
+          if (cancelled) return;
           const computedAt = Date.now();
           computedAtRef.current[decl.id] = computedAt;
-          setComputedMap(m => ({ ...m, [decl.id]: { ...result, error: null, computedAt } }));
+          setComputedMap(m => ({
+            ...m,
+            [decl.id]: result
+              ? { ...result, error: null, computedAt }
+              : { boxes: null, summary: null, error: null, computedAt },
+          }));
         } catch (err) {
           if (!cancelled) {
+            const computedAt = Date.now();
+            computedAtRef.current[decl.id] = computedAt;
             setComputedMap(m => ({
               ...m,
-              [decl.id]: { boxes: null, summary: null, error: String(err), computedAt: Date.now() },
+              [decl.id]: { boxes: null, summary: null, error: String(err), computedAt },
             }));
           }
         }
@@ -63,6 +70,7 @@ export default function useFiscalAutoCompute(decls, {
   // Polling: check for modifications, recompute only changed declarations
   useEffect(() => {
     if (!enabled || !decls.length) return;
+    let cancelled = false;
 
     const interval = setInterval(() => {
       decls.forEach(async (decl) => {
@@ -71,22 +79,31 @@ export default function useFiscalAutoCompute(decls, {
         const sinceMs = computedAtRef.current[decl.id] ?? 0;
         try {
           const modified = await checkFn(decl, sinceMs, { token: t, apiBaseUrl: api });
-          if (!modified) return;
+          if (cancelled || !modified) return;
           const result = await fn(decl, { token: t, apiBaseUrl: api });
-          if (!result) return;
+          if (cancelled) return;
           const computedAt = Date.now();
           computedAtRef.current[decl.id] = computedAt;
-          setComputedMap(m => ({ ...m, [decl.id]: { ...result, error: null, computedAt } }));
-        } catch (err) {
           setComputedMap(m => ({
             ...m,
-            [decl.id]: { boxes: null, summary: null, error: String(err), computedAt: Date.now() },
+            [decl.id]: result
+              ? { ...result, error: null, computedAt }
+              : { boxes: null, summary: null, error: null, computedAt },
           }));
+        } catch (err) {
+          if (!cancelled) {
+            const computedAt = Date.now();
+            computedAtRef.current[decl.id] = computedAt;
+            setComputedMap(m => ({
+              ...m,
+              [decl.id]: { boxes: null, summary: null, error: String(err), computedAt },
+            }));
+          }
         }
       });
     }, pollIntervalMs);
 
-    return () => clearInterval(interval);
+    return () => { cancelled = true; clearInterval(interval); };
   }, [enabled, decls, pollIntervalMs]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return { computedMap };

--- a/tools/app-shell/src/windows/custom/fiscal-models/useFiscalAutoCompute.js
+++ b/tools/app-shell/src/windows/custom/fiscal-models/useFiscalAutoCompute.js
@@ -17,6 +17,31 @@ import { useEffect, useRef, useState } from 'react';
  * @param {boolean}  opts.enabled - set false to disable all activity (e.g. in demo mode)
  * @returns {{ computedMap: { [id]: { boxes, summary, error, computedAt } } }}
  */
+
+async function computeOne(decl, { fn, token, apiBaseUrl, isCancelled, computedAtRef, setComputedMap }) {
+  try {
+    const result = await fn(decl, { token, apiBaseUrl });
+    if (isCancelled()) return;
+    const computedAt = Date.now();
+    computedAtRef.current[decl.id] = computedAt;
+    setComputedMap(m => ({
+      ...m,
+      [decl.id]: result
+        ? { ...result, error: null, computedAt }
+        : { boxes: null, summary: null, error: null, computedAt },
+    }));
+  } catch (err) {
+    if (!isCancelled()) {
+      const computedAt = Date.now();
+      computedAtRef.current[decl.id] = computedAt;
+      setComputedMap(m => ({
+        ...m,
+        [decl.id]: { boxes: null, summary: null, error: String(err), computedAt },
+      }));
+    }
+  }
+}
+
 export default function useFiscalAutoCompute(decls, {
   computeFn,
   checkModifiedFn,
@@ -38,30 +63,10 @@ export default function useFiscalAutoCompute(decls, {
     let cancelled = false;
 
     (async () => {
-      await Promise.all(decls.map(async (decl) => {
-        const { computeFn: fn, token: t, apiBaseUrl: api } = ctxRef.current;
-        try {
-          const result = await fn(decl, { token: t, apiBaseUrl: api });
-          if (cancelled) return;
-          const computedAt = Date.now();
-          computedAtRef.current[decl.id] = computedAt;
-          setComputedMap(m => ({
-            ...m,
-            [decl.id]: result
-              ? { ...result, error: null, computedAt }
-              : { boxes: null, summary: null, error: null, computedAt },
-          }));
-        } catch (err) {
-          if (!cancelled) {
-            const computedAt = Date.now();
-            computedAtRef.current[decl.id] = computedAt;
-            setComputedMap(m => ({
-              ...m,
-              [decl.id]: { boxes: null, summary: null, error: String(err), computedAt },
-            }));
-          }
-        }
-      }));
+      const { computeFn: fn, token: t, apiBaseUrl: api } = ctxRef.current;
+      await Promise.all(decls.map(decl =>
+        computeOne(decl, { fn, token: t, apiBaseUrl: api, isCancelled: () => cancelled, computedAtRef, setComputedMap })
+      ));
     })();
 
     return () => { cancelled = true; };
@@ -77,29 +82,9 @@ export default function useFiscalAutoCompute(decls, {
         const { checkModifiedFn: checkFn, computeFn: fn, token: t, apiBaseUrl: api } = ctxRef.current;
         if (!checkFn) return;
         const sinceMs = computedAtRef.current[decl.id] ?? 0;
-        try {
-          const modified = await checkFn(decl, sinceMs, { token: t, apiBaseUrl: api });
-          if (cancelled || !modified) return;
-          const result = await fn(decl, { token: t, apiBaseUrl: api });
-          if (cancelled) return;
-          const computedAt = Date.now();
-          computedAtRef.current[decl.id] = computedAt;
-          setComputedMap(m => ({
-            ...m,
-            [decl.id]: result
-              ? { ...result, error: null, computedAt }
-              : { boxes: null, summary: null, error: null, computedAt },
-          }));
-        } catch (err) {
-          if (!cancelled) {
-            const computedAt = Date.now();
-            computedAtRef.current[decl.id] = computedAt;
-            setComputedMap(m => ({
-              ...m,
-              [decl.id]: { boxes: null, summary: null, error: String(err), computedAt },
-            }));
-          }
-        }
+        const modified = await checkFn(decl, sinceMs, { token: t, apiBaseUrl: api });
+        if (cancelled || !modified) return;
+        await computeOne(decl, { fn, token: t, apiBaseUrl: api, isCancelled: () => cancelled, computedAtRef, setComputedMap });
       });
     }, pollIntervalMs);
 


### PR DESCRIPTION
## Summary

  - Adds `useFiscalAutoCompute` hook that computes 303 boxes for all `borrador` declarations in parallel on mount
  (real mode only), polls every 3 min for data changes, and recomputes only modified ones
  - `FmListPage` shows live computed results in the Result column; passes `_precomputed` to `onSelect` so the detail
  view is already populated when opened
  - `FmModel303Page` seeds `liveBoxes`/`liveSummary`/`liveSources` from `decl._precomputed` — no Calculate button
  click needed
  - Adds `generate303File` utility and wires the "Generar fichero" button in the 303 detail
  - Declarations in real mode are now persisted in `ETGO_FISCAL_DECL` (DB-backed): fetched on mount, created via POST,
   status changes via PUT; `dataMode` survives navigation via `sessionStorage`
  - Status `pendiente` removed; `borrador` is the only draft state

  ## Test plan

  - [ ] All 1420 Vitest tests pass (`npx vitest run` in `tools/app-shell`)
  - [ ] Switch to Real mode — borrador 303 declarations auto-compute without clicking Calculate
  - [ ] Open a 303 declaration — boxes are already populated
  - [ ] Navigate Back — app stays in Real mode; declarations still visible
  - [ ] Create a new 303 in Real — appears in list and auto-computes
  - [ ] Click "Generar fichero" on a calculated 303 — `.txt` file downloads
  - [ ] Demo mode — no network calls to `/fiscal303/boxes