### PR TITLE
Feature ETP-4122: Fix GET /certificate missing orgId query param

### DIFF
--- a/tools/app-shell/src/windows/custom/fiscal-config/CertSection.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-config/CertSection.jsx
@@ -14,7 +14,7 @@ export default function CertSection({ context, orgId, apiBaseUrl }) {
 
   useEffect(() => {
     if (!orgId || !apiBaseUrl) return;
-    apiFetch(`/certificate`)
+    apiFetch(`/certificate?${new URLSearchParams({ orgId })}`)
       .then(r => r.json())
       .then(data => {
         if (data?.exists) setCert({ name: ui('fiscal.cert.loaded'), validTo: data.validTo ?? '' });

--- a/tools/app-shell/src/windows/custom/fiscal-config/FiscalConfigPage.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-config/FiscalConfigPage.jsx
@@ -45,7 +45,7 @@ export default function FiscalConfigPage({ token, apiBaseUrl }) {
   const effectiveTbai     = mockOverride ? mockOverride.tbai     : tbaiRecord;
   const effectiveVerifactu= mockOverride ? mockOverride.verifactu: verifactuRecord;
 
-  const { daysLeft: certDaysLeft } = useCertExpiry(apiBaseUrl, { mockDaysLeft: mockCertDays });
+  const { daysLeft: certDaysLeft } = useCertExpiry(apiBaseUrl, { mockDaysLeft: mockCertDays, orgId });
 
   const siiRef  = useRef(null);
   const tbaiRef = useRef(null);

--- a/tools/app-shell/src/windows/custom/fiscal-config/OnboardingWizard.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-config/OnboardingWizard.jsx
@@ -353,7 +353,7 @@ function AppliedScreen({ orgId, orgName, selectedOrg, orgList, onSelectOrg, syst
     if (!orgId || !system) return;
     const certCtx = getCertificateContext(system);
     if (!certCtx) return;
-    apiFetch('/certificate')
+    apiFetch(`/certificate?${new URLSearchParams({ orgId })}`)
       .then(r => r.json())
       .then(data => {
         if (data?.exists) setCert({ name: ui('fiscal.cert.loaded'), validTo: data.validTo ?? '' });

--- a/tools/app-shell/src/windows/custom/fiscal-config/__tests__/OnboardingWizard.test.js
+++ b/tools/app-shell/src/windows/custom/fiscal-config/__tests__/OnboardingWizard.test.js
@@ -182,9 +182,8 @@ describe('OnboardingWizard — cert status fetch on applied step', () => {
     assert.match(src, /data\?\.exists[\s\S]*?setCert|setCert[\s\S]*?data\?\.exists/);
   });
 
-  it('fetches certificate via apiFetch without orgId query param', () => {
-    assert.match(src, /apiFetch\(['"]\/certificate['"]\)/);
-    assert.doesNotMatch(src, /certificate\?orgId/);
+  it('fetches certificate via apiFetch with orgId query param', () => {
+    assert.match(src, /apiFetch\(`\/certificate\?\$\{new URLSearchParams\(\{ orgId \}\)\}`\)/);
   });
 });
 

--- a/tools/app-shell/src/windows/custom/fiscal-config/__tests__/useCertExpiry.test.js
+++ b/tools/app-shell/src/windows/custom/fiscal-config/__tests__/useCertExpiry.test.js
@@ -23,13 +23,17 @@ describe('useCertExpiry — hook structure', () => {
     assert.match(src, /mockDaysLeft/);
   });
 
+  it('accepts orgId option and guards the fetch when orgId is absent', () => {
+    assert.match(src, /orgId = null/);
+    assert.match(src, /!\s*orgId/);
+  });
+
   it('returns daysLeft from the hook', () => {
     assert.match(src, /return.*daysLeft/);
   });
 
-  it('fetches from the /certificate endpoint without orgId query param', () => {
-    assert.match(src, /apiFetch\(['"]\/certificate['"]/);
-    assert.doesNotMatch(src, /certificate\?orgId/);
+  it('fetches from the /certificate endpoint with orgId query param', () => {
+    assert.match(src, /apiFetch\(`\/certificate\?\$\{new URLSearchParams\(\{ orgId \}\)\}`/);
   });
 
   it('uses useApiFetch to obtain the authenticated fetch function', () => {

--- a/tools/app-shell/src/windows/custom/fiscal-config/__tests__/useCertExpiry.test.js
+++ b/tools/app-shell/src/windows/custom/fiscal-config/__tests__/useCertExpiry.test.js
@@ -28,6 +28,14 @@ describe('useCertExpiry — hook structure', () => {
     assert.match(src, /!\s*orgId/);
   });
 
+  it('clears daysLeft when orgId or apiBaseUrl is absent (no stale state)', () => {
+    assert.match(src, /if \(!apiBaseUrl \|\| !orgId\) \{\s*setDaysLeft\(null\)/);
+  });
+
+  it('includes orgId in the effect dependency array', () => {
+    assert.match(src, /\[apiFetch,\s*mockDaysLeft,\s*apiBaseUrl,\s*orgId\]/);
+  });
+
   it('returns daysLeft from the hook', () => {
     assert.match(src, /return.*daysLeft/);
   });

--- a/tools/app-shell/src/windows/custom/fiscal-config/__tests__/useCertExpiry.vitest.js
+++ b/tools/app-shell/src/windows/custom/fiscal-config/__tests__/useCertExpiry.vitest.js
@@ -1,0 +1,136 @@
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/components/related-documents/helpers.js', () => ({
+  neoBase: (url) => url ?? '',
+}));
+
+vi.mock('@/auth/useApiFetch.js', () => ({
+  useApiFetch: vi.fn(),
+}));
+
+import { useCertExpiry } from '../useCertExpiry.js';
+import { useApiFetch } from '@/auth/useApiFetch.js';
+
+function makeApiFetch(body, { ok = true } = {}) {
+  return vi.fn(() => Promise.resolve({ ok, json: () => Promise.resolve(body) }));
+}
+
+const BASE = 'http://api.test/fiscal-config';
+const ORG = 'org-123';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useCertExpiry — mockDaysLeft', () => {
+  it('returns mockDaysLeft immediately without fetching', async () => {
+    const apiFetch = makeApiFetch({});
+    vi.mocked(useApiFetch).mockReturnValue(apiFetch);
+
+    const { result } = renderHook(() =>
+      useCertExpiry(BASE, { mockDaysLeft: 42, orgId: ORG }),
+    );
+
+    await waitFor(() => expect(result.current.daysLeft).toBe(42));
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('useCertExpiry — guard: missing orgId or apiBaseUrl', () => {
+  it('keeps daysLeft null and does not fetch when orgId is null', async () => {
+    const apiFetch = makeApiFetch({ exists: true, validTo: '2030-01-01' });
+    vi.mocked(useApiFetch).mockReturnValue(apiFetch);
+
+    const { result } = renderHook(() =>
+      useCertExpiry(BASE, { orgId: null }),
+    );
+
+    await act(async () => {});
+    expect(result.current.daysLeft).toBeNull();
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  it('keeps daysLeft null and does not fetch when apiBaseUrl is null', async () => {
+    const apiFetch = makeApiFetch({ exists: true, validTo: '2030-01-01' });
+    vi.mocked(useApiFetch).mockReturnValue(apiFetch);
+
+    const { result } = renderHook(() =>
+      useCertExpiry(null, { orgId: ORG }),
+    );
+
+    await act(async () => {});
+    expect(result.current.daysLeft).toBeNull();
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('useCertExpiry — fetch with orgId', () => {
+  it('fetches /certificate with orgId as query param', async () => {
+    const apiFetch = makeApiFetch({ exists: true, validTo: '2030-01-01' });
+    vi.mocked(useApiFetch).mockReturnValue(apiFetch);
+
+    renderHook(() => useCertExpiry(BASE, { orgId: ORG }));
+
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+    const url = apiFetch.mock.calls[0][0];
+    expect(url).toContain('/certificate?');
+    expect(url).toContain(`orgId=${ORG}`);
+  });
+
+  it('sets daysLeft when response has exists and validTo', async () => {
+    const future = new Date();
+    future.setDate(future.getDate() + 30);
+    const validTo = future.toISOString().slice(0, 10);
+
+    vi.mocked(useApiFetch).mockReturnValue(makeApiFetch({ exists: true, validTo }));
+
+    const { result } = renderHook(() => useCertExpiry(BASE, { orgId: ORG }));
+
+    await waitFor(() => expect(result.current.daysLeft).not.toBeNull());
+    expect(result.current.daysLeft).toBe(30);
+  });
+
+  it('sets daysLeft to null when response has exists: false', async () => {
+    vi.mocked(useApiFetch).mockReturnValue(makeApiFetch({ exists: false }));
+
+    const { result } = renderHook(() => useCertExpiry(BASE, { orgId: ORG }));
+
+    await act(async () => {});
+    expect(result.current.daysLeft).toBeNull();
+  });
+
+  it('sets daysLeft to null when response has no validTo', async () => {
+    vi.mocked(useApiFetch).mockReturnValue(makeApiFetch({ exists: true }));
+
+    const { result } = renderHook(() => useCertExpiry(BASE, { orgId: ORG }));
+
+    await act(async () => {});
+    expect(result.current.daysLeft).toBeNull();
+  });
+});
+
+describe('useCertExpiry — org change refetch', () => {
+  it('refetches when orgId changes and clears stale daysLeft', async () => {
+    const future = new Date();
+    future.setDate(future.getDate() + 10);
+    const validTo = future.toISOString().slice(0, 10);
+
+    const apiFetch = makeApiFetch({ exists: true, validTo });
+    vi.mocked(useApiFetch).mockReturnValue(apiFetch);
+
+    const { result, rerender } = renderHook(
+      ({ orgId }) => useCertExpiry(BASE, { orgId }),
+      { initialProps: { orgId: 'org-A' } },
+    );
+
+    await waitFor(() => expect(result.current.daysLeft).not.toBeNull());
+    const callsBefore = apiFetch.mock.calls.length;
+
+    rerender({ orgId: 'org-B' });
+
+    await waitFor(() => expect(apiFetch.mock.calls.length).toBeGreaterThan(callsBefore));
+    const lastUrl = apiFetch.mock.calls.at(-1)[0];
+    expect(lastUrl).toContain('orgId=org-B');
+  });
+});

--- a/tools/app-shell/src/windows/custom/fiscal-config/useCertExpiry.js
+++ b/tools/app-shell/src/windows/custom/fiscal-config/useCertExpiry.js
@@ -5,7 +5,7 @@ import { useApiFetch } from '@/auth/useApiFetch.js';
 
 export { daysUntil };
 
-export function useCertExpiry(apiBaseUrl, { mockDaysLeft = null } = {}) {
+export function useCertExpiry(apiBaseUrl, { mockDaysLeft = null, orgId = null } = {}) {
   const [daysLeft, setDaysLeft] = useState(null);
   const apiFetch = useApiFetch(neoBase(apiBaseUrl));
 
@@ -14,10 +14,10 @@ export function useCertExpiry(apiBaseUrl, { mockDaysLeft = null } = {}) {
       setDaysLeft(mockDaysLeft);
       return;
     }
-    if (!apiBaseUrl) return;
+    if (!apiBaseUrl || !orgId) return;
     setDaysLeft(null);
     const controller = new AbortController();
-    apiFetch('/certificate', { signal: controller.signal })
+    apiFetch(`/certificate?${new URLSearchParams({ orgId })}`, { signal: controller.signal })
       .then(r => r.json())
       .then(data => {
         if (controller.signal.aborted) return;

--- a/tools/app-shell/src/windows/custom/fiscal-config/useCertExpiry.js
+++ b/tools/app-shell/src/windows/custom/fiscal-config/useCertExpiry.js
@@ -14,7 +14,10 @@ export function useCertExpiry(apiBaseUrl, { mockDaysLeft = null, orgId = null } 
       setDaysLeft(mockDaysLeft);
       return;
     }
-    if (!apiBaseUrl || !orgId) return;
+    if (!apiBaseUrl || !orgId) {
+      setDaysLeft(null);
+      return;
+    }
     setDaysLeft(null);
     const controller = new AbortController();
     apiFetch(`/certificate?${new URLSearchParams({ orgId })}`, { signal: controller.signal })
@@ -29,7 +32,7 @@ export function useCertExpiry(apiBaseUrl, { mockDaysLeft = null, orgId = null } 
       })
       .catch(() => {});
     return () => controller.abort();
-  }, [apiFetch, mockDaysLeft, apiBaseUrl]);
+  }, [apiFetch, mockDaysLeft, apiBaseUrl, orgId]);
 
   return { daysLeft };
 }

--- a/tools/app-shell/src/windows/custom/fiscal-monitor/FiscalMonitorPage.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-monitor/FiscalMonitorPage.jsx
@@ -155,7 +155,7 @@ export default function FiscalMonitorPage({ token, apiBaseUrl }) {
     mockData, setMockData, debugOverrideActive,
   } = useDebugState(orgId, apiBaseUrl);
 
-  const { daysLeft: certDaysLeft } = useCertExpiry(apiBaseUrl, { mockDaysLeft: mockCertDays });
+  const { daysLeft: certDaysLeft } = useCertExpiry(apiBaseUrl, { mockDaysLeft: mockCertDays, orgId });
 
   function handleRefresh() {
     refetch();


### PR DESCRIPTION
## Summary
- GET `/certificate` calls in `CertSection`, `useCertExpiry`, and `OnboardingWizard` were not sending `orgId` as a query param, causing a `400: Required parameter: orgId` error
- Root cause: ETP-3998 migration to `useApiFetch` dropped `orgId` from the GET URL under the assumption the backend could infer it — it cannot, since the JWT is user-scoped, not org-scoped
- Also passes `orgId` into `useCertExpiry` from both call sites (`FiscalConfigPage`, `FiscalMonitorPage`)

## Test plan
- [ ] All 468 Node tests and 1421 Vitest tests pass (`make test`)
- [ ] Upload a certificate in fiscal config and verify the cert status loads correctly after upload
- [ ] Verify cert expiry banner displays on `FiscalConfigPage` and `FiscalMonitorPage`

Fixes ETP-4122