### PR TITLE
Feature ETP-4151: Cache Email Preview Before Send

### DIFF
--- a/docs/email-contracts.md
+++ b/docs/email-contracts.md
@@ -51,6 +51,8 @@ The browser must not send provider API keys, sender addresses, raw templates, or
 
 For the app-shell document send flow, `SendDocumentModal` posts only the contract command to `/sws/neo/email-contracts/{document-contract}/send`, such as `sales-invoice-send`, `sales-order-send`, or `sales-quotation-send`. The UI must not include `to`, `template`, `data`, `subject`, `body`, sender, Reply-To, or provider metadata in that request; those values are resolved by the server-side contract.
 
+Temporary preview-cache bridge: until document email downloads are stored in S3-backed storage, app-shell may cache an already generated PDF blob through `/sws/neo/preview-file` immediately before calling the email contract. This is only file preparation for the backend signed download link; it must not add provider payload fields or caller-provided download links to the contract command.
+
 For auth email flows, the browser does not send an email contract command at all. It calls `/sws/go/register`, `/sws/go/password-reset/request`, `/sws/go/password-reset/confirm`, or `/sws/go/change-password`; Etendo Go builds the `new-account`, `reset-password`, `password-changed`, and `environment-ready` commands server-side from trusted account/onboarding records.
 
 ## Response Contract

--- a/tools/app-shell/src/components/contract-ui/SendDocumentModal.jsx
+++ b/tools/app-shell/src/components/contract-ui/SendDocumentModal.jsx
@@ -2,32 +2,7 @@ import { useState, useCallback, useEffect } from 'react';
 import { toast } from 'sonner';
 import { Mail, Search } from 'lucide-react';
 import { useUI } from '@/i18n';
-
-function resolveNeoBaseUrl(apiBaseUrl) {
-  return apiBaseUrl ? apiBaseUrl.replace(/\/[^/]+$/, '') : '/sws/neo';
-}
-
-function resolveDocumentEmailContract(windowName) {
-  return windowName === 'sales-invoice' ? 'sales-invoice-send' : `${windowName}-send`;
-}
-
-function buildEmailContractCommand(contractName, documentId) {
-  return {
-    version: 'v1',
-    recordId: documentId,
-    intent: 'send-document',
-    idempotencyKey: `${contractName}:${documentId}:send:v1`,
-  };
-}
-
-async function readEmailContractResponse(res) {
-  try {
-    const payload = await res.json();
-    return payload?.response?.data ?? payload?.data ?? payload ?? {};
-  } catch {
-    return {};
-  }
-}
+import { sendDocumentEmail } from './documentEmailSend.js';
 
 function resolveEmailSendErrorMessage(ui, data, documentType) {
   if (data?.status === 'THROTTLED') {
@@ -55,6 +30,53 @@ function resolveEmailSendErrorMessage(ui, data, documentType) {
     return ui('sendModalProviderFailed');
   }
   return data?.message || ui('sendModalSendFailed', { documentType });
+}
+
+function resolveEmailSendSuccessMessage(ui, status, documentType) {
+  return status === 'DUPLICATE'
+    ? ui('sendModalDuplicate', { documentType })
+    : ui('sendModalSentSuccess', { documentType });
+}
+
+function resolveEmailSendExceptionMessage(ui, documentType) {
+  return ui('sendModalSendFailed', { documentType });
+}
+
+async function sendDocumentFromModal({
+  apiBaseUrl,
+  token,
+  documentId,
+  windowName,
+  documentNo,
+  pdfBlob,
+  pdfBlobUrl,
+  cachePreviewBeforeSend,
+  documentType,
+  ui,
+  setSendFeedback,
+  onClose,
+}) {
+  const data = await sendDocumentEmail({
+    apiBaseUrl,
+    token,
+    documentId,
+    windowName,
+    documentNo,
+    pdfBlob: cachePreviewBeforeSend ? pdfBlob : null,
+    pdfBlobUrl: cachePreviewBeforeSend ? pdfBlobUrl : null,
+  });
+
+  if (data.status === 'SENT' || data.status === 'DUPLICATE') {
+    const successMessage = resolveEmailSendSuccessMessage(ui, data.status, documentType);
+    toast.success(successMessage);
+    setSendFeedback({ type: 'success', message: successMessage });
+    onClose();
+    return;
+  }
+
+  const errorMessage = resolveEmailSendErrorMessage(ui, data, documentType);
+  setSendFeedback({ type: 'error', message: errorMessage });
+  toast.error(errorMessage);
 }
 
 async function renderPdfIntoIframe(node, reportId, documentId, token, setPdfLoading, setPdfError) {
@@ -140,6 +162,54 @@ async function fetchAndDownloadPdf(reportId, documentId, windowName, documentNo,
   URL.revokeObjectURL(url);
 }
 
+function resolveInitialEmail(bpEmail) {
+  return bpEmail?.includes('@') ? bpEmail : '';
+}
+
+function resolveContactsBaseUrl(apiBaseUrl) {
+  return apiBaseUrl.replace(/\/[^/]+$/, '/contacts');
+}
+
+async function loadBusinessPartnerEmail({ apiBaseUrl, token, bPartnerId, hasEmail, setTo, isCancelled }) {
+  const contactsBaseUrl = resolveContactsBaseUrl(apiBaseUrl);
+  const response = await fetch(`${contactsBaseUrl}/businessPartner/${bPartnerId}`, {
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+  });
+  const data = response.ok ? await response.json() : null;
+  if (isCancelled()) return;
+  const records = data?.response?.data ?? data?.data ?? [];
+  const withEmail = records.filter(record => record?.etgoEmail?.includes('@'));
+  if (!hasEmail && withEmail.length > 0) setTo(withEmail[0].etgoEmail);
+}
+
+function renderPdfPreviewNode({ node, pdfBlobUrl, pdfBlobLoading, documentId, token, reportId, setPdfError, setPdfLoading }) {
+  if (pdfBlobUrl) {
+    node.src = `${pdfBlobUrl}#toolbar=0&navpanes=0&scrollbar=1`;
+    setPdfError(null);
+    setPdfLoading(false);
+    return;
+  }
+
+  if (pdfBlobLoading) {
+    setPdfError(null);
+    setPdfLoading(true);
+    return;
+  }
+
+  if (documentId && token) {
+    renderPdfIntoIframe(node, reportId, documentId, token, setPdfLoading, setPdfError);
+  }
+}
+
+function downloadExistingPdfBlobUrl(pdfBlobUrl, windowName, documentNo) {
+  const a = document.createElement('a');
+  a.href = pdfBlobUrl;
+  a.download = `${windowName || 'invoice'}-${documentNo}.pdf`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
 /**
  * Reusable Send/Download modal for any document (invoice, order, quotation, shipment).
  *
@@ -155,14 +225,19 @@ async function fetchAndDownloadPdf(reportId, documentId, windowName, documentNo,
  * - token: auth token
  * - onClose: callback to close modal
  *
- * pdfBlobUrl — optional blob URL from jsreport (e.g. from useInvoicePdf).
- * When provided, the preview uses it directly and download triggers on the blob,
- * bypassing the /api/reports render endpoint entirely.
+ * Optional PDF preview support:
+ * - pdfBlobUrl: object URL created from a pre-rendered PDF blob.
+ * - pdfBlob: pre-rendered PDF blob to cache before sending.
+ * - pdfBlobLoading: disables send while a cacheable preview is still loading.
+ * - cachePreviewBeforeSend: caches pdfBlob/pdfBlobUrl through /preview-file before sending.
+ * When pdfBlobUrl is provided, preview and download use it directly and bypass
+ * the /api/reports render endpoint.
  */
-export default function SendDocumentModal({ documentType = 'Document', documentNo, bpName, bpEmail, bPartnerId, apiBaseUrl, documentId, windowName, token, onClose, pdfBlobUrl, pdfBlobLoading = false, isClosing = false, allowEmail = true }) {
+export default function SendDocumentModal({ documentType = 'Document', documentNo, bpName, bpEmail, bPartnerId, apiBaseUrl, documentId, windowName, token, onClose, pdfBlobUrl, pdfBlob, pdfBlobLoading = false, cachePreviewBeforeSend = true, isClosing = false, allowEmail = true }) {
   const ui = useUI();
-  const hasEmail = bpEmail && bpEmail.includes('@');
-  const [to, setTo] = useState(hasEmail ? bpEmail : '');
+  const initialEmail = resolveInitialEmail(bpEmail);
+  const hasEmail = Boolean(initialEmail);
+  const [to, setTo] = useState(initialEmail);
   const [emailLoading, setEmailLoading] = useState(false);
 
   // Fetch trusted contact data only to display the server-resolved recipient preview.
@@ -170,17 +245,14 @@ export default function SendDocumentModal({ documentType = 'Document', documentN
     if (!bPartnerId || !apiBaseUrl || !token) return;
     let cancelled = false;
     setEmailLoading(true);
-    const contactsBaseUrl = apiBaseUrl.replace(/\/[^/]+$/, '/contacts');
-    fetch(`${contactsBaseUrl}/businessPartner/${bPartnerId}`, {
-      headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    loadBusinessPartnerEmail({
+      apiBaseUrl,
+      token,
+      bPartnerId,
+      hasEmail,
+      setTo,
+      isCancelled: () => cancelled,
     })
-      .then((r) => (r.ok ? r.json() : null))
-      .then((d) => {
-        if (cancelled) return;
-        const records = d?.response?.data ?? d?.data ?? [];
-        const withEmail = records.filter(r => r?.etgoEmail?.includes('@'));
-        if (!hasEmail && withEmail.length > 0) setTo(withEmail[0].etgoEmail);
-      })
       .catch(() => {})
       .finally(() => { if (!cancelled) setEmailLoading(false); });
     return () => { cancelled = true; };
@@ -201,25 +273,16 @@ export default function SendDocumentModal({ documentType = 'Document', documentN
 
   const iframeRef = useCallback(node => {
     if (!node) return;
-
-    // If a pre-rendered blob URL is provided, use it directly
-    if (pdfBlobUrl) {
-      node.src = `${pdfBlobUrl}#toolbar=0&navpanes=0&scrollbar=1`;
-      setPdfError(null);
-      setPdfLoading(false);
-      return;
-    }
-
-    // Parent indicated a blob is being generated — wait for it instead of falling
-    // back to /api/reports which would set pdfError and show the sad-page card.
-    if (pdfBlobLoading) {
-      setPdfError(null);
-      setPdfLoading(true);
-      return;
-    }
-
-    if (!documentId || !token) return;
-    renderPdfIntoIframe(node, reportId, documentId, token, setPdfLoading, setPdfError);
+    renderPdfPreviewNode({
+      node,
+      pdfBlobUrl,
+      pdfBlobLoading,
+      documentId,
+      token,
+      reportId,
+      setPdfError,
+      setPdfLoading,
+    });
   }, [documentId, token, reportId, pdfBlobUrl, pdfBlobLoading]);
 
   const handleDownload = async () => {
@@ -227,12 +290,7 @@ export default function SendDocumentModal({ documentType = 'Document', documentN
 
     // If a blob URL is already available, download it directly
     if (pdfBlobUrl) {
-      const a = document.createElement('a');
-      a.href = pdfBlobUrl;
-      a.download = `${windowName || 'invoice'}-${documentNo}.pdf`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
+      downloadExistingPdfBlobUrl(pdfBlobUrl, windowName, documentNo);
       return;
     }
 
@@ -249,32 +307,23 @@ export default function SendDocumentModal({ documentType = 'Document', documentN
     if (sending || !documentId) return;
     setSending(true);
     setSendFeedback(null);
-    const contractName = resolveDocumentEmailContract(windowName);
-    const endpoint = `${resolveNeoBaseUrl(apiBaseUrl)}/email-contracts/${contractName}/send`;
     try {
-      const res = await fetch(endpoint, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          ...(token ? { Authorization: `Bearer ${token}` } : {}),
-        },
-        body: JSON.stringify(buildEmailContractCommand(contractName, documentId)),
+      await sendDocumentFromModal({
+        apiBaseUrl,
+        token,
+        documentId,
+        windowName,
+        documentNo,
+        pdfBlob,
+        pdfBlobUrl,
+        cachePreviewBeforeSend,
+        documentType,
+        ui,
+        setSendFeedback,
+        onClose,
       });
-      const data = await readEmailContractResponse(res);
-      if (data.status === 'SENT' || data.status === 'DUPLICATE') {
-        const successMessage = data.status === 'DUPLICATE'
-          ? ui('sendModalDuplicate', { documentType })
-          : ui('sendModalSentSuccess', { documentType });
-        toast.success(successMessage);
-        setSendFeedback({ type: 'success', message: successMessage });
-        onClose();
-        return;
-      }
-      const errorMessage = resolveEmailSendErrorMessage(ui, data, documentType);
-      setSendFeedback({ type: 'error', message: errorMessage });
-      toast.error(errorMessage);
-    } catch (err) {
-      const errorMessage = err?.message || ui('sendModalSendFailed', { documentType });
+    } catch {
+      const errorMessage = resolveEmailSendExceptionMessage(ui, documentType);
       setSendFeedback({ type: 'error', message: errorMessage });
       toast.error(errorMessage);
     } finally {
@@ -282,7 +331,10 @@ export default function SendDocumentModal({ documentType = 'Document', documentN
     }
   };
 
-  const sendDisabled = !documentId || sending;
+  const shouldCachePreview = cachePreviewBeforeSend && Boolean(pdfBlob || pdfBlobUrl || pdfBlobLoading);
+  const hasCacheablePreview = Boolean(pdfBlob || pdfBlobUrl);
+  const waitingForCacheablePreview = shouldCachePreview && pdfBlobLoading && !hasCacheablePreview;
+  const sendDisabled = !documentId || sending || waitingForCacheablePreview;
 
   return (
     <>

--- a/tools/app-shell/src/components/contract-ui/__tests__/SendDocumentModal.test.js
+++ b/tools/app-shell/src/components/contract-ui/__tests__/SendDocumentModal.test.js
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const src = readFileSync(join(__dirname, '..', 'SendDocumentModal.jsx'), 'utf8');
+const sendSrc = readFileSync(join(__dirname, '..', 'documentEmailSend.js'), 'utf8');
 
 describe('SendDocumentModal', () => {
   it('exports a default function component', () => {
@@ -48,12 +49,14 @@ describe('SendDocumentModal', () => {
   });
 
   it('sends document email through the email contracts endpoint', () => {
-    assert.match(src, /email-contracts\/\$\{contractName\}\/send/);
-    assert.match(src, /buildEmailContractCommand/);
+    assert.match(src, /sendDocumentEmail/);
+    assert.match(sendSrc, /email-contracts\/\$\{contractName\}\/send/);
+    assert.match(sendSrc, /buildEmailContractCommand/);
   });
 
-  it('derives sales order email contract from the window name', () => {
-    assert.match(src, /windowName\s*===\s*'sales-invoice'\s*\?\s*'sales-invoice-send'\s*:\s*`\$\{windowName\}-send`/);
+  it('derives email contract names from the window name without document-specific branches', () => {
+    assert.match(sendSrc, /return `\$\{windowName\}-send`/);
+    assert.doesNotMatch(sendSrc, /windowName\s*===\s*'sales-invoice'/);
   });
 
   it('uses toast for send confirmation', () => {
@@ -85,9 +88,11 @@ describe('SendDocumentModal', () => {
   });
 
   it('does not send caller-provided provider payload fields', () => {
-    const commandStart = src.indexOf('function buildEmailContractCommand');
-    const commandEnd = src.indexOf('async function readEmailContractResponse');
-    const commandSrc = src.slice(commandStart, commandEnd);
+    const commandStart = sendSrc.indexOf('export function buildEmailContractCommand');
+    const commandEnd = sendSrc.indexOf('export async function readEmailContractResponse');
+    assert.ok(commandStart > -1, 'buildEmailContractCommand export not found');
+    assert.ok(commandEnd > commandStart, 'readEmailContractResponse export not found after command builder');
+    const commandSrc = sendSrc.slice(commandStart, commandEnd);
     assert.doesNotMatch(commandSrc, /\bto\b/);
     assert.doesNotMatch(commandSrc, /\btemplate\b/);
     assert.doesNotMatch(commandSrc, /\bdata\b/);

--- a/tools/app-shell/src/components/contract-ui/__tests__/SendDocumentModal.vitest.jsx
+++ b/tools/app-shell/src/components/contract-ui/__tests__/SendDocumentModal.vitest.jsx
@@ -28,6 +28,7 @@ const BASE = {
   onClose: vi.fn(),
   allowEmail: true,
   pdfBlobUrl: 'blob:test',
+  cachePreviewBeforeSend: false,
 };
 
 beforeEach(() => {
@@ -62,6 +63,34 @@ describe('SendDocumentModal', () => {
 
   it('Send button is enabled when bpEmail is a valid email', () => {
     render(<SendDocumentModal {...BASE} bpEmail="user@domain.com" />);
+    const btn = getSendButton();
+    expect(btn).not.toBeDisabled();
+  });
+
+  it('Send button is disabled while a cacheable preview is still loading', () => {
+    render(
+      <SendDocumentModal
+        {...BASE}
+        bpEmail="user@domain.com"
+        pdfBlobUrl={null}
+        pdfBlobLoading
+        cachePreviewBeforeSend
+      />,
+    );
+    const btn = getSendButton();
+    expect(btn).toBeDisabled();
+  });
+
+  it('Send button stays enabled while loading when a preview source is already available', () => {
+    render(
+      <SendDocumentModal
+        {...BASE}
+        bpEmail="user@domain.com"
+        pdfBlobUrl="blob:test"
+        pdfBlobLoading
+        cachePreviewBeforeSend
+      />,
+    );
     const btn = getSendButton();
     expect(btn).not.toBeDisabled();
   });
@@ -169,6 +198,43 @@ describe('SendDocumentModal', () => {
     expect(body.template).toBeUndefined();
     expect(body.data).toBeUndefined();
     expect(body.subject).toBeUndefined();
+    expect(toast.success).toHaveBeenCalledWith('sendModalSentSuccess:{"documentType":"Invoice"}');
+  });
+
+  it('caches the generated preview before sending when preview caching is enabled by default', async () => {
+    const user = userEvent.setup();
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        blob: async () => new Blob(['%PDF'], { type: 'application/pdf' }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ status: 'SENT' }) });
+
+    render(
+      <SendDocumentModal
+        {...BASE}
+        cachePreviewBeforeSend
+        bpEmail="user@domain.com"
+        apiBaseUrl="http://localhost:8080/etendo/neo/sales-invoice"
+      />,
+    );
+
+    await user.click(getSendButton());
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('blob:test');
+    });
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:8080/etendo/neo/preview-file',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      3,
+      'http://localhost:8080/etendo/neo/email-contracts/sales-invoice-send/send',
+      expect.objectContaining({ method: 'POST' }),
+    );
     expect(toast.success).toHaveBeenCalledWith('sendModalSentSuccess:{"documentType":"Invoice"}');
   });
 
@@ -343,5 +409,26 @@ describe('SendDocumentModal', () => {
       expect(toast.error).toHaveBeenCalledWith('sendModalProviderFailed');
     });
     expect(screen.getByRole('status')).toHaveTextContent('sendModalProviderFailed');
+  });
+
+  it('shows a user-facing send failure when preview cache throws internal diagnostics', async () => {
+    const user = userEvent.setup();
+    global.fetch.mockRejectedValueOnce(new Error('Preview file cache failed (500)'));
+
+    render(
+      <SendDocumentModal
+        {...BASE}
+        cachePreviewBeforeSend
+        bpEmail="user@domain.com"
+        apiBaseUrl="http://localhost:8080/etendo/neo/sales-invoice"
+      />,
+    );
+
+    await user.click(getSendButton());
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('sendModalSendFailed:{"documentType":"Invoice"}');
+    });
+    expect(screen.getByRole('status')).toHaveTextContent('sendModalSendFailed');
   });
 });

--- a/tools/app-shell/src/components/contract-ui/__tests__/documentEmailSend.test.js
+++ b/tools/app-shell/src/components/contract-ui/__tests__/documentEmailSend.test.js
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dirname, '..', 'documentEmailSend.js'), 'utf8');
+
+test('documentEmailSend exports preview cache and contract send helpers', () => {
+  assert.match(src, /export function buildPreviewFileName/);
+  assert.match(src, /export async function cacheDocumentPreviewFile/);
+  assert.match(src, /export async function sendDocumentEmail/);
+});
+
+test('documentEmailSend sanitizes preview file names before preview-file upload', () => {
+  assert.match(src, /function sanitizeFileNamePart/);
+  assert.match(src, /function isSafeFileNameChar/);
+  assert.match(src, /function trimDashes/);
+  assert.match(src, /fileName: buildPreviewFileName\(specName, documentNo, documentId\)/);
+});

--- a/tools/app-shell/src/components/contract-ui/__tests__/documentEmailSend.vitest.js
+++ b/tools/app-shell/src/components/contract-ui/__tests__/documentEmailSend.vitest.js
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import {
+  buildEmailContractCommand,
+  buildPreviewFileName,
+  cacheDocumentPreviewFile,
+  readEmailContractResponse,
+  resolveDocumentEmailContract,
+  resolveNeoBaseUrl,
+  sendDocumentEmail,
+} from '../documentEmailSend.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.fetch = vi.fn();
+});
+
+describe('documentEmailSend', () => {
+  it('builds the minimal contract command without provider payload fields', () => {
+    const command = buildEmailContractCommand('sales-invoice-send', 'invoice-1');
+
+    expect(command).toEqual({
+      version: 'v1',
+      recordId: 'invoice-1',
+      intent: 'send-document',
+      idempotencyKey: 'sales-invoice-send:invoice-1:send:v1',
+    });
+    expect(command.to).toBeUndefined();
+    expect(command.template).toBeUndefined();
+    expect(command.data).toBeUndefined();
+    expect(command.subject).toBeUndefined();
+  });
+
+  it('resolves sales document contract names', () => {
+    expect(resolveDocumentEmailContract('sales-invoice')).toBe('sales-invoice-send');
+    expect(resolveDocumentEmailContract('sales-order')).toBe('sales-order-send');
+    expect(resolveDocumentEmailContract('sales-quotation')).toBe('sales-quotation-send');
+  });
+
+  it('resolves NEO base URL with and without a window path', () => {
+    expect(resolveNeoBaseUrl('http://localhost:8080/etendo/neo/sales-invoice')).toBe('http://localhost:8080/etendo/neo');
+    expect(resolveNeoBaseUrl()).toBe('/sws/neo');
+  });
+
+  it('returns an empty response object when contract response JSON cannot be parsed', async () => {
+    await expect(readEmailContractResponse({ json: async () => { throw new Error('bad json'); } })).resolves.toEqual({});
+  });
+
+  it('builds a flat preview file name from document numbers with separators', () => {
+    expect(buildPreviewFileName('sales-invoice', 'FVE/2026/0001', 'invoice-1')).toBe('sales-invoice-FVE-2026-0001.pdf');
+  });
+
+  it('collapses repeated unsafe preview file name characters', () => {
+    expect(buildPreviewFileName('sales-invoice', 'INV///???001', 'invoice-1')).toBe('sales-invoice-INV-001.pdf');
+  });
+
+  it('preserves valid falsy document numbers in preview file names', () => {
+    expect(buildPreviewFileName('sales-invoice', 0, 'invoice-1')).toBe('sales-invoice-0.pdf');
+  });
+
+  it('falls back to a deterministic preview file name when sanitized content is empty', () => {
+    expect(buildPreviewFileName('', '///', 'invoice-1')).toBe('document-invoice-1.pdf');
+  });
+
+  it('caches a generated PDF before sending the email contract', async () => {
+    global.fetch
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ response: { data: { status: 'SENT' } } }) });
+
+    const result = await sendDocumentEmail({
+      apiBaseUrl: 'http://localhost:8080/etendo/neo/sales-invoice',
+      token: 'tok',
+      documentId: 'invoice-1',
+      windowName: 'sales-invoice',
+      documentNo: 'INV-001',
+      pdfBlob: new Blob(['%PDF'], { type: 'application/pdf' }),
+    });
+
+    expect(result).toEqual({ status: 'SENT' });
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      'http://localhost:8080/etendo/neo/preview-file',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:8080/etendo/neo/email-contracts/sales-invoice-send/send',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    const previewBody = JSON.parse(global.fetch.mock.calls[0][1].body);
+    expect(previewBody).toMatchObject({
+      specName: 'sales-invoice',
+      recordId: 'invoice-1',
+      fileName: 'sales-invoice-INV-001.pdf',
+      mimeType: 'application/pdf',
+    });
+    expect(previewBody.fileData).toBeTruthy();
+  });
+
+  it('uses an existing PDF blob URL as the default preview cache source', async () => {
+    global.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        blob: async () => new Blob(['%PDF'], { type: 'application/pdf' }),
+      })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({}) })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ response: { data: { status: 'SENT' } } }) });
+
+    await sendDocumentEmail({
+      apiBaseUrl: 'http://localhost:8080/etendo/neo/sales-invoice',
+      token: 'tok',
+      documentId: 'invoice-1',
+      windowName: 'sales-invoice',
+      documentNo: 'INV-001',
+      pdfBlobUrl: 'blob:invoice-preview',
+    });
+
+    expect(global.fetch).toHaveBeenNthCalledWith(1, 'blob:invoice-preview');
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      'http://localhost:8080/etendo/neo/preview-file',
+      expect.objectContaining({ method: 'POST' }),
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      3,
+      'http://localhost:8080/etendo/neo/email-contracts/sales-invoice-send/send',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('does not call preview-file when no PDF blob is available', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ response: { data: { status: 'SENT' } } }),
+    });
+
+    await sendDocumentEmail({
+      apiBaseUrl: 'http://localhost:8080/etendo/neo/sales-order',
+      token: 'tok',
+      documentId: 'order-1',
+      windowName: 'sales-order',
+      documentNo: 'SO-001',
+    });
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      'http://localhost:8080/etendo/neo/email-contracts/sales-order-send/send',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('stops the send when preview cache persistence fails', async () => {
+    global.fetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    await expect(cacheDocumentPreviewFile({
+      apiBaseUrl: 'http://localhost:8080/etendo/neo/sales-invoice',
+      token: 'tok',
+      specName: 'sales-invoice',
+      documentId: 'invoice-1',
+      documentNo: 'INV-001',
+      pdfBlob: new Blob(['%PDF'], { type: 'application/pdf' }),
+    })).rejects.toThrow('Preview file cache failed (500)');
+  });
+
+  it('stops the send when preview blob URL cannot be read', async () => {
+    global.fetch.mockResolvedValueOnce({ ok: false, status: 404 });
+
+    await expect(sendDocumentEmail({
+      apiBaseUrl: 'http://localhost:8080/etendo/neo/sales-invoice',
+      token: 'tok',
+      documentId: 'invoice-1',
+      windowName: 'sales-invoice',
+      documentNo: 'INV-001',
+      pdfBlobUrl: 'blob:missing',
+    })).rejects.toThrow('Preview PDF fetch failed (404)');
+  });
+});

--- a/tools/app-shell/src/components/contract-ui/documentEmailSend.js
+++ b/tools/app-shell/src/components/contract-ui/documentEmailSend.js
@@ -1,0 +1,148 @@
+export function resolveNeoBaseUrl(apiBaseUrl) {
+  return apiBaseUrl ? apiBaseUrl.replace(/\/[^/]+$/, '') : '/sws/neo';
+}
+
+export function resolveDocumentEmailContract(windowName) {
+  return `${windowName}-send`;
+}
+
+export function buildEmailContractCommand(contractName, documentId) {
+  return {
+    version: 'v1',
+    recordId: documentId,
+    intent: 'send-document',
+    idempotencyKey: `${contractName}:${documentId}:send:v1`,
+  };
+}
+
+export async function readEmailContractResponse(res) {
+  try {
+    const payload = await res.json();
+    return payload?.response?.data ?? payload?.data ?? payload ?? {};
+  } catch {
+    return {};
+  }
+}
+
+export async function blobToBase64(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result.split(',')[1]);
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}
+
+export function buildPreviewFileName(specName, documentNo, documentId) {
+  const safeSpecName = sanitizeFileNamePart(specName) || 'document';
+  const safeDocumentName = sanitizeFileNamePart(documentNo ?? documentId) || documentId;
+  return `${safeSpecName}-${safeDocumentName}.pdf`;
+}
+
+function sanitizeFileNamePart(value) {
+  const raw = String(value ?? '');
+  let safeValue = '';
+  let lastWasDash = false;
+
+  for (const char of raw) {
+    if (isSafeFileNameChar(char)) {
+      safeValue += char;
+      lastWasDash = false;
+    } else if (!lastWasDash) {
+      safeValue += '-';
+      lastWasDash = true;
+    }
+  }
+
+  return trimDashes(safeValue);
+}
+
+function isSafeFileNameChar(char) {
+  const code = char.charCodeAt(0);
+  return (code >= 48 && code <= 57)
+    || (code >= 65 && code <= 90)
+    || (code >= 97 && code <= 122)
+    || char === '.'
+    || char === '_'
+    || char === '-';
+}
+
+function trimDashes(value) {
+  let start = 0;
+  let end = value.length;
+  while (start < end && value[start] === '-') start += 1;
+  while (end > start && value[end - 1] === '-') end -= 1;
+  return value.slice(start, end);
+}
+
+export async function cacheDocumentPreviewFile({
+  apiBaseUrl,
+  token,
+  specName,
+  documentId,
+  documentNo,
+  pdfBlob,
+  pdfBlobUrl,
+}) {
+  const previewBlob = await resolvePreviewBlob(pdfBlob, pdfBlobUrl);
+  if (!previewBlob) return { skipped: true };
+  const fileData = await blobToBase64(previewBlob);
+  const res = await fetch(`${resolveNeoBaseUrl(apiBaseUrl)}/preview-file`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({
+      specName,
+      recordId: documentId,
+      fileName: buildPreviewFileName(specName, documentNo, documentId),
+      mimeType: previewBlob.type || 'application/pdf',
+      fileData,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`Preview file cache failed (${res.status})`);
+  }
+  return { skipped: false };
+}
+
+async function resolvePreviewBlob(pdfBlob, pdfBlobUrl) {
+  if (pdfBlob) return pdfBlob;
+  if (!pdfBlobUrl) return null;
+  const res = await fetch(pdfBlobUrl);
+  if (!res.ok) {
+    throw new Error(`Preview PDF fetch failed (${res.status})`);
+  }
+  return res.blob();
+}
+
+export async function sendDocumentEmail({
+  apiBaseUrl,
+  token,
+  documentId,
+  windowName,
+  documentNo,
+  pdfBlob,
+  pdfBlobUrl,
+}) {
+  const contractName = resolveDocumentEmailContract(windowName);
+  await cacheDocumentPreviewFile({
+    apiBaseUrl,
+    token,
+    specName: windowName,
+    documentId,
+    documentNo,
+    pdfBlob,
+    pdfBlobUrl,
+  });
+  const res = await fetch(`${resolveNeoBaseUrl(apiBaseUrl)}/email-contracts/${contractName}/send`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(buildEmailContractCommand(contractName, documentId)),
+  });
+  return readEmailContractResponse(res);
+}


### PR DESCRIPTION
## Summary
- Centralize the temporary document-email preview cache bridge in SendDocumentModal/documentEmailSend.
- Cache an already generated PDF blob or blob URL through /sws/neo/preview-file before calling the email contract.
- Keep email contract commands minimal and avoid per-preview wiring changes.

## Context
This is a temporary frontend bridge for ETP-4151 until document email downloads are stored in S3-backed storage server-side.

## Validation
- npm run test:vitest -- src/components/contract-ui/__tests__/SendDocumentModal.vitest.jsx src/components/contract-ui/__tests__/documentEmailSend.vitest.js
- node --test src/components/contract-ui/__tests__/SendDocumentModal.test.js
- npm run build
