### PR TITLE
Feature ETP-3965: Migrate error tracking to GlitchTip

### DIFF
--- a/tools/app-shell/src/lib/sentry.js
+++ b/tools/app-shell/src/lib/sentry.js
@@ -17,5 +17,6 @@ export function initSentry() {
     tracesSampleRate: 0.1,
     tracePropagationTargets: [/core\..+\.etendo\.cloud/, 'core.etendo.cloud'],
     sendDefaultPii: true,
+    autoSessionTracking: false,
   });
 }


### PR DESCRIPTION
## Summary
Migrates error tracking from Sentry (trial expired) to GlitchTip (free, Sentry-compatible).

- Adds `autoSessionTracking: false` to `sentry.js` (GlitchTip does not support session tracking)
- Backend DSN already updated in AWS Secrets Manager for all 3 environments
- Frontend DSN requires updating the `VITE_SENTRY_DSN` GitHub Actions variable to:
  `https://5fc6a24fba5646d8bc629501660548af@app.glitchtip.com/24322`