### PR TITLE
Feature ETP-3965: Migrate error tracking to GlitchTip

### DIFF
--- a/tools/app-shell/src/lib/sentry.js
+++ b/tools/app-shell/src/lib/sentry.js
@@ -30,6 +30,7 @@ export function createSentryProvider({
         tracesSampleRate: 0.1,
         tracePropagationTargets: [/core\..+\.etendo\.cloud/, 'core.etendo.cloud'],
         sendDefaultPii: true,
+        autoSessionTracking: false,
       });
     },
 


### PR DESCRIPTION
## Summary
Adds `autoSessionTracking: false` to GlitchTip/Sentry init (GlitchTip does not support session tracking).

Backend DSN already updated in AWS Secrets Manager for all 3 environments.
Frontend DSN requires updating the `VITE_SENTRY_DSN` GitHub Actions variable.