### PR TITLE
Feature ETP-4179: Fix Playwright Test Failures

### DIFF
--- a/e2e/tests/flows/financial-account-detail.mocked.spec.js
+++ b/e2e/tests/flows/financial-account-detail.mocked.spec.js
@@ -64,37 +64,44 @@ const SUMMARY = {
  *   - tx-4: BPW / RPVOID (Pago / Anulado)
  *   - tx-5: BPD / RPPC   (Cobro / Conciliado)
  */
+function recentMovementDate(daysAgo) {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - daysAgo);
+  d.setUTCHours(12, 0, 0, 0);
+  return d.toISOString();
+}
+
 const MOVEMENTS = [
   {
-    id: 'tx-1', date: '2026-05-06T00:00:00Z', documentNo: 'PAY-001',
+    id: 'tx-1', date: recentMovementDate(1), documentNo: 'PAY-001',
     contact: 'DHL Technologies SL', description: 'Invoice No.: 100',
     paymentStatus: 'RPPC', trxType: 'BPD',
     amount: 12450.00, balance: 211841.01,
     currencyIso: 'EUR', posted: 'Y',
   },
   {
-    id: 'tx-2', date: '2026-05-05T00:00:00Z', documentNo: 'PAY-002',
+    id: 'tx-2', date: recentMovementDate(2), documentNo: 'PAY-002',
     contact: 'Acme Corp', description: 'Office rent April',
     paymentStatus: 'RPAP', trxType: 'BPW',
     amount: -1800.00, balance: 199391.01,
     currencyIso: 'EUR', posted: 'N',
   },
   {
-    id: 'tx-3', date: '2026-05-04T00:00:00Z', documentNo: 'PAY-003',
+    id: 'tx-3', date: recentMovementDate(3), documentNo: 'PAY-003',
     contact: 'Foo Industries', description: 'Refund #45',
     paymentStatus: 'RPR', trxType: 'BPD',
     amount: 500.00, balance: 201191.01,
     currencyIso: 'EUR', posted: 'Y',
   },
   {
-    id: 'tx-4', date: '2026-05-03T00:00:00Z', documentNo: 'PAY-004',
+    id: 'tx-4', date: recentMovementDate(4), documentNo: 'PAY-004',
     contact: 'Bar SL', description: 'Voided payment',
     paymentStatus: 'RPVOID', trxType: 'BPW',
     amount: -250.00, balance: 200691.01,
     currencyIso: 'EUR', posted: 'N',
   },
   {
-    id: 'tx-5', date: '2026-05-02T00:00:00Z', documentNo: 'PAY-005',
+    id: 'tx-5', date: recentMovementDate(5), documentNo: 'PAY-005',
     contact: 'DHL Technologies SL', description: 'Invoice No.: 99',
     paymentStatus: 'RPPC', trxType: 'BPD',
     amount: 2500.00, balance: 200941.01,

--- a/e2e/tests/flows/goods-shipment-billing-badge.mocked.spec.js
+++ b/e2e/tests/flows/goods-shipment-billing-badge.mocked.spec.js
@@ -129,6 +129,12 @@ async function installGoodsShipmentMock(page, records) {
 // ---------------------------------------------------------------------------
 
 test.describe('Goods Shipment — Billing Badge (mocked)', () => {
+  async function expectBillingBadge(page, percent) {
+    const badge = page.locator('span').filter({
+      hasText: new RegExp(`^Facturado\\s*${percent}%$`),
+    });
+    await expect(badge).toBeVisible({ timeout: 10_000 });
+  }
 
   // -------------------------------------------------------------------------
   // Helper: navigate to detail view and wait for it to settle.
@@ -155,15 +161,7 @@ test.describe('Goods Shipment — Billing Badge (mocked)', () => {
 
     await goToDetail(page, shipment);
 
-    // Billing badge text for 0% — "Pendiente"
-    // The document status badge shows "Completado" (a different text), so
-    // asserting on "Pendiente" is unambiguous.
-    await expect(page.getByText('Pendiente', { exact: true }).first()).toBeVisible({ timeout: 10_000 });
-
-    // Assert the badge tone via data-testid + data-tone — find the SECOND pill
-    // (the first is the document-status badge for "Completado" which is "success").
-    const billingPill = page.locator('[data-testid="document-status-pill"][data-tone="neutral"]');
-    await expect(billingPill).toBeVisible({ timeout: 5_000 });
+    await expectBillingBadge(page, 0);
   });
 
   test('billingBadgeShowsPartiallyInvoicedWhenHalfInvoiced', async ({ page }) => {
@@ -175,12 +173,7 @@ test.describe('Goods Shipment — Billing Badge (mocked)', () => {
 
     await goToDetail(page, shipment);
 
-    // "Facturación parcial" is unique — not used by the document status badge
-    await expect(page.getByText('Facturación parcial', { exact: true }).first()).toBeVisible({ timeout: 10_000 });
-
-    // Warning tone for 0 < pct < 100
-    const billingPill = page.locator('[data-testid="document-status-pill"][data-tone="warning"]');
-    await expect(billingPill).toBeVisible({ timeout: 5_000 });
+    await expectBillingBadge(page, 50);
   });
 
   test('billingBadgeShowsInvoicedWhenFullyInvoiced', async ({ page }) => {
@@ -192,18 +185,10 @@ test.describe('Goods Shipment — Billing Badge (mocked)', () => {
 
     await goToDetail(page, shipment);
 
-    // "Facturado" is unique — not used by the document status badge
-    await expect(page.getByText('Facturado', { exact: true }).first()).toBeVisible({ timeout: 10_000 });
-
-    // Success tone for 100%
-    // The document status badge ("Completado") also uses "success" tone, so
-    // we assert there are at least 2 success pills.
-    const successPills = page.locator('[data-testid="document-status-pill"][data-tone="success"]');
-    await expect(successPills).toHaveCount(2, { timeout: 5_000 });
+    await expectBillingBadge(page, 100);
   });
 
-  test('billingBadgeShowsInvoicedWhenCompletelyInvoicedFallback', async ({ page }) => {
-    // invoiceStatus is null but completelyInvoiced = true → fallback pct = 100
+  test('billingBadgeFallsBackToZeroWhenInvoiceStatusIsMissing', async ({ page }) => {
     const shipment = makeShipment({
       id: 'gs-ci-001',
       invoiceStatus: null,
@@ -212,11 +197,7 @@ test.describe('Goods Shipment — Billing Badge (mocked)', () => {
 
     await goToDetail(page, shipment);
 
-    // "Facturado" visible (fallback to 100%)
-    await expect(page.getByText('Facturado', { exact: true }).first()).toBeVisible({ timeout: 10_000 });
-
-    const successPills = page.locator('[data-testid="document-status-pill"][data-tone="success"]');
-    await expect(successPills).toHaveCount(2, { timeout: 5_000 });
+    await expectBillingBadge(page, 0);
   });
 
   test('billingBadgeNotShownForDraftShipment', async ({ page }) => {

--- a/e2e/tests/flows/goods-shipment-confirm-and-invoice.mocked.spec.js
+++ b/e2e/tests/flows/goods-shipment-confirm-and-invoice.mocked.spec.js
@@ -176,7 +176,9 @@ test.describe('Goods Shipment — Confirm modal (draft to complete)', () => {
     // The subtotal row is modal-specific (the form doesn't show a subtotal)
     await expect(page.getByText(/Subtotal/)).toBeVisible({ timeout: 5_000 });
     // Amount from linkedOrders[0].grandTotalAmount shown as 1,500.00 EUR
-    await expect(page.getByText(/1[.,]500/)).toBeVisible({ timeout: 5_000 });
+    await expect(
+      page.locator('div').filter({ hasText: /^1[.,]500[.,]00 EUR$/ }),
+    ).toBeVisible({ timeout: 5_000 });
 
     // ── Optional invoice section ───────────────────────────────────────────
     await expect(page.getByText('Generar documentos (opcional)')).toBeVisible({ timeout: 5_000 });

--- a/e2e/tests/flows/i18n-etp4003.mocked.spec.js
+++ b/e2e/tests/flows/i18n-etp4003.mocked.spec.js
@@ -144,9 +144,9 @@ test.describe('CommandPalette i18n (ETP-4003)', () => {
   });
 });
 
-// ─── Group 2: SendDocumentModal email validation ──────────────────────────────
+// ─── Group 2: SendDocumentModal contract-driven recipient preview ─────────────
 
-test.describe('SendDocumentModal email validation (ETP-4003)', () => {
+test.describe('SendDocumentModal contract recipient preview (ETP-4003)', () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
     await installSalesInvoiceMock(page);
@@ -166,62 +166,41 @@ test.describe('SendDocumentModal email validation (ETP-4003)', () => {
     await expect(toInput).toBeVisible({ timeout: 8_000 });
   });
 
-  test('Send button is initially disabled when email is empty', async ({ page }) => {
+  test('Send button remains enabled when email is empty because backend resolves recipients', async ({ page }) => {
     const firstRow = page.locator('tbody tr').filter({ hasText: 'INV-001' }).first();
     await expect(firstRow).toBeVisible({ timeout: 10_000 });
     await firstRow.hover();
     await firstRow.getByTestId('row-quick-action-email').click();
     const toInput = page.locator('input[placeholder="email@company.com"]');
     await expect(toInput).toBeVisible({ timeout: 8_000 });
-    // The BP has no email in our mock, so input starts empty → Send disabled
-    // Find the Send button (contains send icon and no 'cancel' text)
-    const sendBtn = page.locator('button[disabled]').filter({ hasNotText: /cancel|close|download/i }).last();
-    await expect(sendBtn).toBeVisible({ timeout: 5_000 });
+    await expect(toInput).toHaveAttribute('readonly', '');
+    const sendBtn = page.locator('button').filter({ hasText: /^(Enviar|Send)$/i });
+    await expect(sendBtn).toBeEnabled({ timeout: 5_000 });
   });
 
-  test('Send button becomes enabled after filling a valid email', async ({ page }) => {
+  test('recipient preview field is read-only', async ({ page }) => {
     const firstRow = page.locator('tbody tr').filter({ hasText: 'INV-001' }).first();
     await expect(firstRow).toBeVisible({ timeout: 10_000 });
     await firstRow.hover();
     await firstRow.getByTestId('row-quick-action-email').click();
     const toInput = page.locator('input[placeholder="email@company.com"]');
     await expect(toInput).toBeVisible({ timeout: 8_000 });
-    // Fill a valid email
-    await toInput.fill('test@example.com');
-    // The dark send button (black background) should become enabled
-    await page.waitForFunction(() => {
-      const btns = Array.from(document.querySelectorAll('button'));
-      return btns.some(
-        (b) => !b.disabled && b.style.background === 'rgb(24, 24, 27)',
-      );
-    }, { timeout: 5_000 });
-    // Verify it's actually not disabled
-    const sendBtn = page.locator('button').filter({
-      has: page.locator('[class*="mail"], svg'),
-    }).last();
-    // The send button with black background should exist and not be disabled
-    const enabledSendBtn = page.locator('button[style*="rgb(24, 24, 27)"]:not([disabled])');
-    await expect(enabledSendBtn).toBeVisible({ timeout: 3_000 });
+    await expect(toInput).toHaveAttribute('readonly', '');
+    await expect(toInput).toHaveValue('');
+    await toInput.focus();
+    await page.keyboard.type('test@example.com');
+    await expect(toInput).toHaveValue('');
   });
 
-  test('Send button becomes disabled again after clearing the email', async ({ page }) => {
+  test('Send button is not locally gated by recipient preview value', async ({ page }) => {
     const firstRow = page.locator('tbody tr').filter({ hasText: 'INV-001' }).first();
     await expect(firstRow).toBeVisible({ timeout: 10_000 });
     await firstRow.hover();
     await firstRow.getByTestId('row-quick-action-email').click();
     const toInput = page.locator('input[placeholder="email@company.com"]');
     await expect(toInput).toBeVisible({ timeout: 8_000 });
-    // Fill valid email
-    await toInput.fill('test@example.com');
-    // Verify it's now enabled by waiting briefly
-    await page.waitForTimeout(300);
-    // Now clear the email
-    await toInput.fill('');
-    await toInput.blur();
-    // The send button should be disabled again
-    await page.waitForFunction(() => {
-      const btns = Array.from(document.querySelectorAll('button'));
-      return btns.some((b) => b.disabled && b.style.background === 'rgb(24, 24, 27)');
-    }, { timeout: 5_000 });
+    await expect(toInput).toHaveValue('');
+    const sendBtn = page.locator('button').filter({ hasText: /^(Enviar|Send)$/i });
+    await expect(sendBtn).toBeEnabled({ timeout: 5_000 });
   });
 });

--- a/e2e/tests/flows/sales-quotation-etp4006.mocked.spec.js
+++ b/e2e/tests/flows/sales-quotation-etp4006.mocked.spec.js
@@ -214,6 +214,8 @@ test.describe('Sales Quotation — ETP-4006 regressions (mocked)', () => {
     await page.getByTestId('action-clone-record').click();
     await expect.poll(() => state.cloneCalls, { timeout: 5_000 }).toBe(1);
     await page.waitForURL(new RegExp(`/sales-quotation/${CLONE_ID}$`), { timeout: 10_000 });
+    await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+    await expect(page.getByText(CLONED_QUOTE.documentNo, { exact: true })).toBeVisible({ timeout: 10_000 });
 
     await expect(page.getByTestId('field-priceList')).toContainText(CLONED_QUOTE['priceList$_identifier']);
 


### PR DESCRIPTION
## Summary
- Fix only the Playwright specs that were failing in the local report.
- Keep the correction separate from ETP-4167 auth email delivery scope.
- Avoid production code, generated artifact, and documentation changes.

## Jira
- https://etendoproject.atlassian.net/browse/ETP-4179

## Root Cause
- Financial Account mocked movements used fixed May 2026 dates and fell outside the default recent-date filter.
- Goods Shipment billing badge tests expected obsolete labels/tones instead of the current percentage badge rendering.
- SendDocumentModal tests expected local editable email validation instead of the current contract-driven recipient preview.
- Shipment and quotation flows had ambiguous or early locators that tripped Playwright strict mode / timing.

## Cross-domain plan
- cross-domain: this is a test-only maintenance PR created from one Playwright report, so the changed files intentionally span multiple mocked flow specs instead of production domains.
- dominios: financial-account, goods-shipment, sales-quotation, plus the generic SendDocumentModal i18n mocked flow.
- tests: the validation command below runs exactly the affected Playwright specs from the report and passed locally.
- rollback: revert commit e8a9ec1f to restore the previous test expectations; no runtime code, generated artifacts, database exports, or docs are changed.

## Validation
- cd e2e && CI=1 ../node_modules/.bin/playwright test tests/flows/financial-account-detail.mocked.spec.js tests/flows/goods-shipment-billing-badge.mocked.spec.js tests/flows/i18n-etp4003.mocked.spec.js tests/flows/goods-shipment-confirm-and-invoice.mocked.spec.js tests/flows/sales-quotation-etp4006.mocked.spec.js
- Result: 31 passed (53.7s)