### PR TITLE
Feature ETP-4207: Fix Google SSO FedCM fallback in Brave

### DIFF
--- a/tools/app-shell/src/pages/onboarding/onboardingSso.js
+++ b/tools/app-shell/src/pages/onboarding/onboardingSso.js
@@ -66,6 +66,12 @@ export async function renderSsoProviderButton(provider, container, handlers, run
   const documentRef = runtime.documentRef || document;
   const windowRef = runtime.windowRef || window;
   const google = await loadGoogleIdentityScript(documentRef, windowRef);
+  // Only opt into FedCM when the browser actually supports it. Browsers that
+  // disable FedCM (e.g. Brave) do not expose `IdentityCredential`; forcing
+  // `use_fedcm_for_button: true` there makes GSI reject with
+  // "FedCM is not supported" instead of falling back to the popup flow.
+  const fedcmSupported = typeof windowRef !== 'undefined'
+    && typeof windowRef.IdentityCredential !== 'undefined';
   google.accounts.id.initialize({
     client_id: provider.clientId,
     callback: (response) => {
@@ -75,7 +81,7 @@ export async function renderSsoProviderButton(provider, container, handlers, run
         handlers?.onError?.(error);
       }
     },
-    use_fedcm_for_button: true,
+    use_fedcm_for_button: fedcmSupported,
   });
   container.replaceChildren();
   google.accounts.id.renderButton(container, {


### PR DESCRIPTION
## Summary
Google SSO login fails in browsers that disable FedCM (Brave) with:
`[GSI_LOGGER]: FedCM get() rejects with NotSupportedError: FedCM is not supported.`

## Root cause
`onboardingSso.js` initialized Google Identity Services with `use_fedcm_for_button: true`, forcing FedCM. Brave disables FedCM for privacy, so GSI rejects instead of falling back to the popup flow.

## Fix
Feature-detect FedCM support (`window.IdentityCredential`) and enable `use_fedcm_for_button` only when the browser supports it. Browsers without FedCM (Brave) use the standard popup flow; Chrome keeps FedCM.

- File: `tools/app-shell/src/pages/onboarding/onboardingSso.js`
- Unit tests: `onboardingSso.test.js` — 6/6 passing.

## Verification
- Brave: clicking the Google button opens the popup instead of erroring.
- Chrome: FedCM flow unchanged (no regression).

Jira: ETP-4207