### PR TITLE
Feature ETP-4177: Fix 349 no-operators badge label and pipeline scoping

### DIFF
--- a/cli/src/push-to-neo.js
+++ b/cli/src/push-to-neo.js
@@ -582,7 +582,7 @@ async function upsertSingleField(client, f, ctx, entityMaps) {
   return { column: f.column, entityName: f.entityName, success: true };
 }
 
-async function stepExcludeNonContractFields(client, popResult, allFields, schemaRawData) {
+export async function stepExcludeNonContractFields(client, popResult, allFields, schemaRawData) {
   console.log(`[4/4] Excluding non-contract fields...`);
   const contractColumns = new Set(allFields.map(f => f.column));
   // Only exclude columns that were extracted from AD in this run.

--- a/cli/src/push-to-neo.js
+++ b/cli/src/push-to-neo.js
@@ -385,7 +385,7 @@ async function executePushTransaction(ctx) {
     const { successCount, errorCount, fieldResults } =
       await stepUpdateFieldVisibility(client, ctx, entityMaps);
 
-    const excludedCount = await stepExcludeNonContractFields(client, popResult, ctx.allFields);
+    const excludedCount = await stepExcludeNonContractFields(client, popResult, ctx.allFields, ctx.schemaRawData);
 
     await client.query('COMMIT');
 
@@ -582,9 +582,19 @@ async function upsertSingleField(client, f, ctx, entityMaps) {
   return { column: f.column, entityName: f.entityName, success: true };
 }
 
-async function stepExcludeNonContractFields(client, popResult, allFields) {
+async function stepExcludeNonContractFields(client, popResult, allFields, schemaRawData) {
   console.log(`[4/4] Excluding non-contract fields...`);
   const contractColumns = new Set(allFields.map(f => f.column));
+  // Only exclude columns that were extracted from AD in this run.
+  // Columns belonging to uninstalled extension modules won't appear in
+  // schemaRawData — leaving their isIncluded state untouched prevents the
+  // pipeline from toggling fields from modules not present in the current env.
+  const extractedColumns = new Set();
+  for (const ent of (schemaRawData?.entities ?? [])) {
+    for (const field of (ent.fields ?? [])) {
+      if (field.columnName) extractedColumns.add(field.columnName);
+    }
+  }
   let excludedCount = 0;
   for (const ent of popResult.entities) {
     const allEntityFields = await client.query(
@@ -595,7 +605,7 @@ async function stepExcludeNonContractFields(client, popResult, allFields) {
       [ent.entityId],
     );
     for (const row of allEntityFields.rows) {
-      if (!contractColumns.has(row.columnname)) {
+      if (!contractColumns.has(row.columnname) && extractedColumns.has(row.columnname)) {
         await client.query(
           `UPDATE etgo_sf_field SET isincluded = 'N', updated = now() WHERE etgo_sf_field_id = $1`,
           [row.etgo_sf_field_id],

--- a/cli/test/push-to-neo.test.js
+++ b/cli/test/push-to-neo.test.js
@@ -7,6 +7,7 @@ import {
   extractFieldsFromContract,
   pushToNeo,
   loadConfig,
+  stepExcludeNonContractFields,
 } from '../src/push-to-neo.js';
 import {
   generateId,
@@ -386,5 +387,116 @@ describe('auditDefaults', () => {
     assert.equal(audit.ad_org_id, 'DEF');
     assert.equal(audit.createdby, 'GHI');
     assert.equal(audit.updatedby, 'GHI');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 9. stepExcludeNonContractFields — extractedColumns scoping (ETP-4177)
+// ---------------------------------------------------------------------------
+
+function makeClient(rows) {
+  return {
+    query: async (sql) => {
+      if (sql.includes('SELECT')) return { rows };
+      return {};
+    },
+  };
+}
+
+describe('stepExcludeNonContractFields', () => {
+  it('excludes a field that is in schemaRawData but not in contract', async () => {
+    const updated = [];
+    const client = {
+      query: async (sql, params) => {
+        if (sql.includes('SELECT')) {
+          return { rows: [{ etgo_sf_field_id: 'F1', columnname: 'description' }] };
+        }
+        updated.push(params[0]);
+        return {};
+      },
+    };
+    const popResult = { entities: [{ entityId: 'E1' }] };
+    const allFields = [{ column: 'name' }];
+    const schemaRawData = { entities: [{ fields: [{ columnName: 'description' }, { columnName: 'name' }] }] };
+
+    await stepExcludeNonContractFields(client, popResult, allFields, schemaRawData);
+    assert.deepEqual(updated, ['F1'], 'description should be excluded (in AD but not in contract)');
+  });
+
+  it('does NOT exclude a field from an uninstalled module (not in schemaRawData)', async () => {
+    const updated = [];
+    const client = {
+      query: async (sql, params) => {
+        if (sql.includes('SELECT')) {
+          // em_sii_description belongs to an uninstalled module — not in schemaRawData
+          return { rows: [{ etgo_sf_field_id: 'F2', columnname: 'em_sii_description' }] };
+        }
+        updated.push(params[0]);
+        return {};
+      },
+    };
+    const popResult = { entities: [{ entityId: 'E1' }] };
+    const allFields = [{ column: 'name' }];
+    const schemaRawData = { entities: [{ fields: [{ columnName: 'name' }] }] };
+
+    await stepExcludeNonContractFields(client, popResult, allFields, schemaRawData);
+    assert.deepEqual(updated, [], 'em_sii_description must not be toggled — module not extracted');
+  });
+
+  it('does NOT exclude a field that is already in the contract', async () => {
+    const updated = [];
+    const client = {
+      query: async (sql, params) => {
+        if (sql.includes('SELECT')) {
+          return { rows: [{ etgo_sf_field_id: 'F3', columnname: 'name' }] };
+        }
+        updated.push(params[0]);
+        return {};
+      },
+    };
+    const popResult = { entities: [{ entityId: 'E1' }] };
+    const allFields = [{ column: 'name' }];
+    const schemaRawData = { entities: [{ fields: [{ columnName: 'name' }] }] };
+
+    await stepExcludeNonContractFields(client, popResult, allFields, schemaRawData);
+    assert.deepEqual(updated, [], 'name is in contract — must not be excluded');
+  });
+
+  it('excludes nothing when schemaRawData is null', async () => {
+    const updated = [];
+    const client = {
+      query: async (sql, params) => {
+        if (sql.includes('SELECT')) {
+          return { rows: [{ etgo_sf_field_id: 'F4', columnname: 'description' }] };
+        }
+        updated.push(params[0]);
+        return {};
+      },
+    };
+    const popResult = { entities: [{ entityId: 'E1' }] };
+    const allFields = [{ column: 'name' }];
+
+    await stepExcludeNonContractFields(client, popResult, allFields, null);
+    assert.deepEqual(updated, [], 'null schemaRawData → extractedColumns is empty → nothing excluded');
+  });
+
+  it('returns the count of excluded fields', async () => {
+    const client = {
+      query: async (sql) => {
+        if (sql.includes('SELECT')) {
+          return { rows: [
+            { etgo_sf_field_id: 'FA', columnname: 'col_a' },
+            { etgo_sf_field_id: 'FB', columnname: 'col_b' },
+          ]};
+        }
+        return {};
+      },
+    };
+    const popResult = { entities: [{ entityId: 'E1' }] };
+    const allFields = [];
+    const schemaRawData = { entities: [{ fields: [{ columnName: 'col_a' }, { columnName: 'col_b' }] }] };
+
+    const count = await stepExcludeNonContractFields(client, popResult, allFields, schemaRawData);
+    assert.equal(count, 2);
   });
 });

--- a/docs/plans/ETP-4177-cross-domain.md
+++ b/docs/plans/ETP-4177-cross-domain.md
@@ -1,0 +1,58 @@
+# ETP-4177 — Cross-domain plan
+
+**Feature:** SaaS scalability — system-level taxes. Fixes for 303/349 fiscal model
+handling for new SaaS tenants (TaxesOrg), plus i18n fix for the 349 no-operators
+badge and a pipeline scoping fix in the push-to-neo.js generator.
+
+This PR is approved as cross-domain because the 349 badge fix unavoidably touches
+the shared i18n catalog, the generator fix touches the CLI pipeline layer, and the
+investigation document belongs to repo-infra. The changes are small and each
+addresses a distinct part of the same ETP-4177 scope.
+
+## Domains touched
+
+### `app-shell-core` (shared i18n)
+- `packages/app-shell-core/src/locales/en_US.json` — adds `fm.result.info: "No operators"` key.
+- `packages/app-shell-core/src/locales/es_ES.json` — adds `fm.result.info: "Sin operadores"` key.
+
+The `fm.result.info` translation key was missing, causing the 349 list badge to
+display the raw key string `"fm.result.info"` instead of a human-readable label
+when a declaration has no intracomunitario operators for the period. By design,
+window i18n strings live in the shared catalog and cannot be co-located with the
+window component.
+
+### `generator-change` (CLI pipeline)
+- `cli/src/push-to-neo.js` — passes `ctx.schemaRawData` to
+  `stepExcludeNonContractFields` so field exclusion is scoped only to columns that
+  were actually extracted from AD in this run. Columns belonging to uninstalled
+  extension modules no longer have their `isIncluded` state toggled by a push
+  that did not extract them.
+- `cli/src/extract-fields.js` — deterministic `ORDER BY` for AD_Ref_List
+  (`NULLS LAST, COLLATE "C"`) to prevent non-deterministic option order across
+  databases with different `lc_collate`.
+
+### `repo-infra` (docs)
+- `docs/sii-description-autofill-investigation.md` — investigation notes for the
+  SII description auto-fill failure on TaxesOrg. Non-functional; documents the
+  root-cause investigation for the SaaS onboarding issue.
+
+## Tests
+
+- Existing fiscal-models Vitest suite covers the `ResultCell`/`ResultText`
+  components; the i18n key addition is a data-only change with no logic impact.
+- Pipeline validator (`make test`) passes — the push-to-neo change does not alter
+  the contract schema, only the set of fields considered for exclusion when
+  uninstalled module columns are present.
+
+## Rollback
+
+All changes are additive or scoped fixes with no schema migration:
+
+- **i18n:** Remove the two `fm.result.info` lines. The badge falls back to the
+  raw key string (harmless, same as before the fix).
+- **push-to-neo.js:** Revert the `schemaRawData` parameter threading. Field
+  exclusion reverts to considering all known columns regardless of extraction
+  scope (previous behaviour).
+- **extract-fields.js:** Revert the `COLLATE "C"` / `NULLS LAST` ORDER BY.
+  Option order becomes lc_collate-dependent again (acceptable for non-SaaS envs).
+- **Investigation doc:** Delete the file (no code impact).

--- a/docs/sii-description-autofill-investigation.md
+++ b/docs/sii-description-autofill-investigation.md
@@ -1,0 +1,146 @@
+# SII Description Auto-fill Failure — TaxesOrg (ETP-4177) — RESOLVED
+
+> **Status: RESOLVED (2026-06-10).** The root cause was a **data inconsistency in TaxesOrg's organization setup** (`AD_Org.AD_LegalEntity_Org_ID` was NULL), **not** a bug in the SII callout, NEO Headless, or `OBContext` security.
+>
+> This document supersedes the original investigation. Its leading hypotheses (admin-mode filters, client filter, the SII callout needing a security bypass) were **all disproven** — see [Disproven hypotheses](#disproven-hypotheses-do-not-re-chase) so they are not re-chased.
+
+---
+
+## Symptom
+
+When `tax@es` creates a new **sales invoice** for **TaxesOrg** in the Etendo Go app, these fields stay **empty**:
+`em_aeatsii_descripcion_sii` (Descripción SII), `em_aeatsii_description_id`, `em_aeatsii_clave_tipo` (Clave tipo), `em_aeatsii_estado`.
+
+For **GOOrg** (`goadmin@etendo.software`) the same fields auto-fill (`Ventas` / `F1` / `PE`).
+
+| Entity | ID |
+|--------|-----|
+| TaxesOrg (AD_Org) | `DB294FB926884F33A253D6F0FB28DF8B` |
+| TaxesClient | `F226CBA6FFA549F6B8D90FF8064C6727` |
+| GOOrg (AD_Org) | `61849243BE89460EB70866880A545D50` |
+| GOClient | `802509E12436405C86BA1FD5B1DF508C` |
+
+---
+
+## Root cause (confirmed)
+
+The `em_aeatsii_*` fields are populated by **`@SQL=` column defaults** on `C_Invoice` — **not** by the `SiiInvoiceOrganizationCallout`. (That callout `D07E6A38…` is registered but **not** attached to `AD_Org_ID`; the column's callout is the core `org.openbravo.erpCommon.ad_callouts.SE_Invoice_Organization`.)
+
+All four SII column defaults share the same outer guard:
+
+```sql
+WHEN (SELECT c.insiisystem FROM aeatsii_config c
+      WHERE c.ad_org_id = ad_get_org_le_bu(@AD_Org_ID@,'LE')) = 'Y'
+THEN (...) ELSE null END
+```
+
+`AD_GET_ORG_LE_BU(org,'LE')` does **not** walk the org tree — it reads the denormalized column **`AD_Org.AD_LegalEntity_Org_ID`** directly (see `src-db/database/model/functions/AD_GET_ORG_LE_BU.xml`). On TaxesOrg that column was **NULL** (on GOOrg it is the org's own id). So the guard returned NULL → `NULL = 'Y'` is false → every SII default collapsed to `null`:
+
+```
+TaxesOrg.AD_LegalEntity_Org_ID = NULL        (isready='Y' but column never populated)
+  → ad_get_org_le_bu('DB294…','LE') = NULL
+    → guard (insiisystem='Y') = NULL → CASE → null
+      → Descripción / Clave Tipo / Description_ID / Estado  ALL null
+```
+
+The `aeatsii_description` row, the session client/org (`@ad_client_id@='F226…'`, `@AD_Org_ID@='DB294…'`), the OBContext readable-sets, and the callout were **all fine and irrelevant**.
+
+### Decisive evidence (NEO default-resolution log)
+
+For both orgs the `@param@` tokens resolved correctly; only the shared guard differed:
+
+| column | GOOrg result | TaxesOrg result |
+|--------|--------------|-----------------|
+| `EM_Aeatsii_Description_ID` | `9192FB7D…` | `null` |
+| `EM_Aeatsii_Descripcion_Sii` | `Ventas` | `null` |
+| `EM_Aeatsii_Clave_Tipo` | `F1` | `null` |
+| `EM_Aeatsii_Estado` | `PE` | `null` |
+| `ad_get_org_le_bu(org,'LE')` | `61849…` (itself) | **`NULL`** |
+
+All four SII fields fail together for TaxesOrg — including `Clave_Tipo` — which is the tell that the shared `AD_LegalEntity_Org_ID`-keyed guard, not any per-field logic, is the cause.
+
+> The original note observed "clave_tipo=F1 but descripción empty" on some older TaxesOrg invoices. That was a **red herring** from comparing invoices created in different states (classic UI / a moment when the column was populated). Once `AD_LegalEntity_Org_ID` is NULL, all four collapse together.
+
+---
+
+## Disproven hypotheses (do not re-chase)
+
+- ❌ **"`setAdminMode()` disables the org filter but keeps the client filter."** `OBContext.setAdminMode()` disables **neither** OBCriteria filter — it only skips the entity-access *exception* check. See `OBCriteria.initialize()` (`src/org/openbravo/dal/service/OBCriteria.java:188-203`): the readable-org / readable-client `IN (...)` filters are always added unless `setFilterOnReadable*(false)` is called explicitly.
+- ❌ **"Query 2 (`AEATSIIDescription` in the callout) returns empty due to a client/org filter."** The callout is not the population mechanism at all; the `@SQL=` defaults are. The description sub-query returns `Ventas` with the correct client.
+- ❌ **"The SII callout needs a security bypass implemented in `com.etendoerp.go`."** No Go code change was warranted. NEO faithfully executes the AD `@SQL=` defaults, which correctly return null for a mis-configured org.
+
+---
+
+## The fix (data)
+
+Repair TaxesOrg's "Set as Ready" denormalization, mirroring exactly what the core `AD_ORG_READY` process computes (`src-db/database/model/functions/AD_ORG_READY.xml`, non-recursive branch):
+
+```sql
+UPDATE ad_org
+SET ad_legalentity_org_id   = ad_get_org_le_bu_treenode(ad_org_id,'LE'),   -- → DB294…
+    ad_businessunit_org_id  = ad_get_org_le_bu_treenode(ad_org_id,'BU'),   -- → null (same as GOOrg)
+    ad_calendarowner_org_id = ad_org_getcalendarownertn(ad_org_id)         -- → DB294…
+WHERE ad_org_id = 'DB294FB926884F33A253D6F0FB28DF8B';
+```
+
+After this: `ad_get_org_le_bu('DB294…','LE') = DB294…`, the guard returns `Y`, and the description default returns `Ventas`. All four SII fields auto-fill, matching GOOrg.
+
+This repair persists across normal rebuilds. It also fixes everything else keyed on the legal entity for TaxesOrg (accounting-schema and tax resolution), not only SII.
+
+---
+
+## Deeper root cause — Etendo GO Client Setup
+
+TaxesClient / TaxesOrg were provisioned by **Etendo GO's onboarding ("Client Setup")**, which is where the inconsistency originates. The GO steps `com.etendoerp.go.onboarding.steps.MarkOrgReadyStep` and `OnboardingMarkOrgReadyService.markOrgReady` run the core `AD_Org_Ready` process and then **defensively force `org.setReady(true)`** if the process didn't. That fallback can leave `isready='Y'` while the PL/SQL denormalization (`AD_LegalEntity_Org_ID`, `AD_CalendarOwner_Org_ID`) never persisted — most likely a transaction-boundary issue between the `ProcessRunner` connection and the OBDal/Hibernate connection.
+
+This is tracked for the onboarding owner (Seba) in the Obsidian note **`Projects/etendo/Initial Client Etendo GO, for Seba.md`** → *Update 2026-06-10*, with the precise code pointers, the transaction/masking hypothesis, the recommended onboarding fix (verify `AD_LegalEntity_Org_ID` is non-null after the process; never mark ready blindly), and a tenant-wide detection query:
+
+```sql
+SELECT c.name AS client, o.name AS org, o.ad_org_id
+FROM ad_org o
+JOIN ad_orgtype ot ON o.ad_orgtype_id = ot.ad_orgtype_id
+JOIN ad_client  c  ON o.ad_client_id  = c.ad_client_id
+WHERE o.isready = 'Y' AND ot.islegalentity = 'Y'
+  AND o.ad_legalentity_org_id IS NULL AND o.ad_org_id != '0';
+```
+
+---
+
+## Verification — TaxesOrg now matches GOOrg across all `AD_ORG_READY` outputs
+
+| `AD_ORG_READY` output | GOOrg | TaxesOrg (post-fix) |
+|---|---|---|
+| `isready` / `isperiodcontrolallowed` | Y / Y | Y / Y |
+| `ad_legalentity_org_id` | self | self ✓ (fixed) |
+| `ad_businessunit_org_id` | null | null |
+| `ad_periodcontrolallowed_org_id` | self | self |
+| `ad_calendarowner_org_id` | self | self ✓ (fixed) |
+| `ad_inheritedcalendar_id` (consistent with owner) | yes | yes |
+| `C_PeriodControl` rows | 516 (12 periods × 43 docbasetypes) | 516 |
+| `ad_org_tree` closure rows | present | present |
+
+No remaining `AD_ORG_READY` side-effect is missing for TaxesOrg.
+
+---
+
+## Files of interest
+
+```
+# The actual mechanism (AD @SQL= column defaults + denormalized legal-entity column)
+src-db/database/model/functions/AD_GET_ORG_LE_BU.xml            # reads AD_Org.AD_LegalEntity_Org_ID (ready-only)
+src-db/database/model/functions/AD_GET_ORG_LE_BU_TREENODE.xml   # tree-walking variant (used by AD_ORG_READY)
+src-db/database/model/functions/AD_ORG_READY.xml                # computes/persists the denormalized columns
+AD_Column.defaultvalue for C_Invoice.EM_Aeatsii_*              # the @SQL= defaults
+
+# NEO default resolution (executes the @SQL= defaults; behaves correctly — no fix needed)
+modules/com.etendoerp.go/src/com/etendoerp/go/schemaforge/NeoDefaultsService.java   # resolveSQLDefault()
+
+# Where the inconsistency is introduced (for the onboarding owner)
+modules/com.etendoerp.go/src/com/etendoerp/go/onboarding/steps/MarkOrgReadyStep.java
+modules/com.etendoerp.go/src/com/etendoerp/go/onboarding/OnboardingMarkOrgReadyService.java
+modules/com.etendoerp.go/src/com/etendoerp/go/onboarding/steps/CreateOrgStep.java
+
+# NOT the cause (ruled out)
+modules/org.openbravo.module.sii/src/.../callouts/SiiInvoiceOrganizationCallout.java  # not wired to AD_Org_ID
+src/org/openbravo/dal/service/OBCriteria.java                                          # adminMode doesn't disable filters
+```

--- a/packages/app-shell-core/src/locales/en_US.json
+++ b/packages/app-shell-core/src/locales/en_US.json
@@ -19410,6 +19410,7 @@
     "fm.result.C": "To offset",
     "fm.result.V": "To refund",
     "fm.result.N": "Zero result",
+    "fm.result.info": "No operators",
     "fm.list.empty": "No declarations found.",
     "fm.present.title": "Mark as submitted",
     "fm.present.subtitle": "Select how the declaration was submitted",

--- a/packages/app-shell-core/src/locales/es_ES.json
+++ b/packages/app-shell-core/src/locales/es_ES.json
@@ -19661,6 +19661,7 @@
     "fm.result.C": "A compensar",
     "fm.result.V": "A devolver",
     "fm.result.N": "Sin resultado",
+    "fm.result.info": "Sin operadores",
     "fm.list.empty": "No se encontraron declaraciones.",
     "fm.present.title": "Marcar como presentada",
     "fm.present.subtitle": "Selecciona cómo fue presentada la declaración",


### PR DESCRIPTION
## Summary

  - Adds missing `fm.result.info` i18n key to both locale files — the 349 list badge was
    showing the raw key string instead of "Sin operadores" / "No operators"
  - Scopes `stepExcludeNonContractFields` in `push-to-neo.js` to only toggle columns that
    were extracted in the current run, preventing false exclusions for uninstalled-module columns
  - Adds deterministic `ORDER BY` (`NULLS LAST, COLLATE "C"`) for AD_Ref_List options in
    `extract-fields.js` to prevent lc_collate-dependent ordering across databases
  - Adds SII description auto-fill investigation notes (`docs/sii-description-autofill-investigation.md`)