### PR TITLE
Feature ETP-4059: Stabilize Vitest localStorage

### DIFF
--- a/tools/app-shell/src/test/__tests__/localStorage.vitest.js
+++ b/tools/app-shell/src/test/__tests__/localStorage.vitest.js
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { createMemoryStorage, installMemoryLocalStorage } from '../localStorage.js';
+
+describe('test localStorage setup', () => {
+  it('provides browser-like storage operations', () => {
+    const storage = createMemoryStorage();
+
+    expect(storage.length).toBe(0);
+    expect(storage.getItem('missing')).toBeNull();
+
+    storage.setItem('number', 10);
+    storage.setItem('boolean', false);
+
+    expect(storage.length).toBe(2);
+    expect(storage.getItem('number')).toBe('10');
+    expect(storage.getItem('boolean')).toBe('false');
+    expect(storage.key(0)).toBe('number');
+
+    storage.removeItem('number');
+
+    expect(storage.length).toBe(1);
+    expect(storage.getItem('number')).toBeNull();
+
+    storage.clear();
+
+    expect(storage.length).toBe(0);
+  });
+
+  it('installs storage without reading an existing localStorage getter', () => {
+    const target = {};
+    let getterWasRead = false;
+
+    Object.defineProperty(target, 'localStorage', {
+      configurable: true,
+      get() {
+        getterWasRead = true;
+        throw new Error('localStorage getter should not be read');
+      },
+    });
+
+    installMemoryLocalStorage(target);
+
+    expect(getterWasRead).toBe(false);
+    expect(target.localStorage.getItem('missing')).toBeNull();
+    target.localStorage.setItem('token', 'abc');
+    expect(target.localStorage.getItem('token')).toBe('abc');
+  });
+});

--- a/tools/app-shell/src/test/localStorage.js
+++ b/tools/app-shell/src/test/localStorage.js
@@ -1,0 +1,32 @@
+export function createMemoryStorage() {
+  const storage = new Map();
+
+  return {
+    getItem(key) {
+      return storage.get(String(key)) ?? null;
+    },
+    setItem(key, value) {
+      storage.set(String(key), String(value));
+    },
+    removeItem(key) {
+      storage.delete(String(key));
+    },
+    clear() {
+      storage.clear();
+    },
+    key(index) {
+      return Array.from(storage.keys())[index] ?? null;
+    },
+    get length() {
+      return storage.size;
+    },
+  };
+}
+
+export function installMemoryLocalStorage(target = globalThis) {
+  Object.defineProperty(target, 'localStorage', {
+    configurable: true,
+    writable: true,
+    value: createMemoryStorage(),
+  });
+}

--- a/tools/app-shell/src/test/setup.js
+++ b/tools/app-shell/src/test/setup.js
@@ -1,15 +1,4 @@
 import '@testing-library/jest-dom/vitest';
+import { installMemoryLocalStorage } from './localStorage.js';
 
-if (typeof globalThis.localStorage === 'undefined') {
-  const storage = new Map();
-  globalThis.localStorage = {
-    getItem: (key) => storage.get(String(key)) ?? null,
-    setItem: (key, value) => storage.set(String(key), String(value)),
-    removeItem: (key) => storage.delete(String(key)),
-    clear: () => storage.clear(),
-    key: (index) => Array.from(storage.keys())[index] ?? null,
-    get length() {
-      return storage.size;
-    },
-  };
-}
+installMemoryLocalStorage();


### PR DESCRIPTION
## Summary
- Centralizes the app-shell Vitest `localStorage` setup in a reusable memory storage helper.
- Installs the test storage without reading Node's experimental Web Storage getter.
- Adds regression coverage for storage behavior and getter-safe installation.

## Root Cause
Node 22 can expose an experimental `globalThis.localStorage` getter when Web Storage is enabled. The previous setup used `typeof globalThis.localStorage`, which reads that getter and can fail before the jsdom/Vitest setup installs a stable browser-like storage implementation.

## Validation
- `NODE_OPTIONS=--experimental-webstorage npx vitest run src/components/dashboard/__tests__/FinancialTrendChart.vitest.jsx`
- `npx vitest run src/test/__tests__/localStorage.vitest.js`
- `npx vitest run src/pages/__tests__/OnboardingPage.vitest.jsx src/components/dashboard/__tests__/FinancialTrendChart.vitest.jsx src/components/contract-ui/__tests__/ListView.vitest.jsx`
- `make test`
- Pre-push checks passed: conflict check, data-testid, domain boundary, unit tests/Sonar, offline regeneration.
