### PR TITLE
Feature ETP-4022: Refactor DataTable cell renderers

### DIFF
--- a/docs/superpowers/plans/2026-06-23-datatable-cell-renderers.md
+++ b/docs/superpowers/plans/2026-06-23-datatable-cell-renderers.md
@@ -1,0 +1,307 @@
+# DataTable Cell Renderer Registry Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:executing-plans` to implement this plan task-by-task. Use `superpowers:subagent-driven-development` only if subagents are available and useful for independent review. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve Jira ETP-4022 by refactoring `DataTable.renderCellValue` from type-specific branching into a renderer registry keyed by `col.type`, while preserving the current table output.
+
+**Architecture:** Move the cell-rendering variants into exported, stateless renderer functions in a dedicated module. `DataTable.jsx` remains responsible for component state, hooks, callbacks, and display resolution, then delegates to `CELL_RENDERERS[col.type] ?? CELL_RENDERERS.default`. Custom `col.render` keeps first priority because it is not a `col.type` renderer.
+
+**Tech Stack:** React 18, Vite, Vitest, Testing Library, Tailwind CSS.
+
+**Jira:** ETP-4022 (`[DataTable] Refactor renderCellValue a mapa de renderers por col.type`), under ETP-3504 / ETP-3955.
+
+**Delivery repository:** `schema-forge` at `/Users/sebastianbarrozo/Documents/work/epic/schema-forge`.
+
+**Branch:** `feature/ETP-4022`.
+
+---
+
+## Current State
+
+- `tools/app-shell/src/components/contract-ui/DataTable.jsx` still defines `renderCellValue` with sequential `if` branches for `enum`, `status`, `percent`, `boolean`, `date`, `amount`, and fallback.
+- Existing behavior-lock coverage already exists in `tools/app-shell/src/components/contract-ui/__tests__/DataTable.renderCellValue.vitest.jsx`.
+- The branch currently has no ETP-4022 implementation commits and no upstream configured.
+- There is an unrelated untracked file: `.claude/agents/workflow.md`. Do not include it in this task unless the owner explicitly asks.
+
+---
+
+## Acceptance Criteria Mapping
+
+- `renderCellValue` delegates by registry:
+  - Add `CELL_RENDERERS`.
+  - Use `CELL_RENDERERS[col.type] ?? CELL_RENDERERS.default`.
+- Renderer functions are exported and independent of `DataTable`:
+  - Create exported renderers in `DataTable.cellRenderers.jsx`.
+  - Pass runtime dependencies through a context object, not through component closure.
+- Sonar cognitive complexity is reduced:
+  - Keep `renderCellValue` to custom-render handling, display resolution, renderer lookup, and one call.
+- Unit coverage exists for the required types:
+  - Add focused unit tests for `enum`, `status`, `percent`, `boolean`, `date`, `amount`, and `default`.
+  - Keep existing behavior-lock component tests as regression coverage.
+- Visual behavior is unchanged:
+  - Existing `DataTable.renderCellValue.vitest.jsx` must pass unchanged or with import-only adjustments.
+
+---
+
+## File Structure
+
+### New Files
+
+- `tools/app-shell/src/components/contract-ui/DataTable.cellRenderers.jsx`
+  - Exports `CELL_RENDERERS`.
+  - Exports `renderEnumCell`, `renderStatusCell`, `renderPercentCell`, `renderBooleanCell`, `renderDateCell`, `renderAmountCell`, and `renderDefaultCell`.
+  - May also export small support helpers when tests need direct assertions.
+
+- `tools/app-shell/src/components/contract-ui/__tests__/DataTable.cellRenderers.vitest.jsx`
+  - Direct unit tests for the registry and required renderers.
+
+### Modified Files
+
+- `tools/app-shell/src/components/contract-ui/DataTable.jsx`
+  - Import `CELL_RENDERERS`.
+  - Remove renderer-specific branch logic from `renderCellValue`.
+  - Remove or relocate renderer-only helpers that move to `DataTable.cellRenderers.jsx`.
+
+---
+
+## Implementation Plan
+
+### Task 0: Confirm Scope And Baseline
+
+**Files:**
+- Read only: `tools/app-shell/src/components/contract-ui/DataTable.jsx`
+- Read only: `tools/app-shell/src/components/contract-ui/__tests__/DataTable.renderCellValue.vitest.jsx`
+- Read only: `tools/app-shell/package.json`
+
+- [ ] Confirm the repository root:
+
+```bash
+git rev-parse --show-toplevel
+```
+
+- [ ] Confirm the branch:
+
+```bash
+git branch --show-current
+```
+
+- [ ] Confirm local changes and keep unrelated files out of the task:
+
+```bash
+git status --short
+```
+
+- [ ] Run the existing behavior-lock test before changes:
+
+```bash
+cd tools/app-shell && npm run test:vitest -- src/components/contract-ui/__tests__/DataTable.renderCellValue.vitest.jsx
+```
+
+Expected result: PASS before refactor. If it fails, capture the failure before editing because the task is a refactor and needs a clean baseline.
+
+### Task 1: Extract The Renderer Registry
+
+**Files:**
+- Create: `tools/app-shell/src/components/contract-ui/DataTable.cellRenderers.jsx`
+- Modify: `tools/app-shell/src/components/contract-ui/DataTable.jsx`
+
+- [ ] Create `DataTable.cellRenderers.jsx`.
+
+- [ ] Move the type-specific rendering logic out of `DataTable.jsx` into exported functions:
+  - `renderEnumCell(context)`
+  - `renderStatusCell(context)`
+  - `renderPercentCell(context)`
+  - `renderBooleanCell(context)`
+  - `renderDateCell(context)`
+  - `renderAmountCell(context)`
+  - `renderDefaultCell(context)`
+
+- [ ] Export the registry:
+
+```jsx
+export const CELL_RENDERERS = {
+  enum: renderEnumCell,
+  status: renderStatusCell,
+  percent: renderPercentCell,
+  boolean: renderBooleanCell,
+  date: renderDateCell,
+  amount: renderAmountCell,
+  default: renderDefaultCell,
+};
+```
+
+- [ ] Preserve the current behavior in each renderer:
+  - `enum`: plain label, dot display, and `Tag` variants.
+  - `status`: dot display and `StatusTag`.
+  - `percent`: palette thresholds for `0`, partial values, `>= 100`, and non-numeric values.
+  - `boolean`: inline toggle, colored badges, variant badges, yes/no/dash fallback.
+  - `date`: date-only local parsing, full date parsing, optional dot, dash fallback.
+  - `amount`: `formatAmount(value, currency$_identifier)` inside `tabular-nums`.
+  - `default`: first visible string column pill, long-string truncation, and pass-through display.
+
+- [ ] Keep `col.render` outside the registry and ahead of all type renderers:
+
+```jsx
+if (typeof col.render === 'function') {
+  return col.render(row, { entity, token, apiBaseUrl });
+}
+```
+
+Rationale: custom renderers override the type system and are not keyed by `col.type`.
+
+- [ ] Update `DataTable.renderCellValue` to do only:
+  - custom-render check;
+  - `resolveCellDisplay(...)`;
+  - registry lookup;
+  - renderer invocation with an explicit context object.
+
+Target shape:
+
+```jsx
+const { display, rawValue, toggleKey } = resolveCellDisplay(row, col, optimisticToggles, displayCatalogMaps);
+const renderer = CELL_RENDERERS[col.type] ?? CELL_RENDERERS.default;
+return renderer({
+  row,
+  col,
+  display,
+  rawValue,
+  toggleKey,
+  visibleColumns,
+  tMenu,
+  dictionary,
+  savingToggles,
+  handleInlineToggle,
+  locale,
+  t,
+  ui,
+  dateFormatter,
+});
+```
+
+- [ ] Remove dead helpers from `DataTable.jsx` after extraction. Keep helpers in `DataTable.jsx` only when they are used by non-cell-rendering code.
+
+### Task 2: Add Direct Unit Tests For The Registry
+
+**Files:**
+- Create: `tools/app-shell/src/components/contract-ui/__tests__/DataTable.cellRenderers.vitest.jsx`
+- Keep: `tools/app-shell/src/components/contract-ui/__tests__/DataTable.renderCellValue.vitest.jsx`
+
+- [ ] Mock the same UI dependencies used by the behavior-lock test where needed:
+  - `@/components/ui/status-tag`
+  - `@/components/ui/tag`
+  - `@/components/ui/switch`
+  - `@/lib/statusBadge.js`
+  - `@/lib/formatAmount.js`
+
+- [ ] Add a registry contract test:
+  - `CELL_RENDERERS.enum` exists.
+  - `CELL_RENDERERS.status` exists.
+  - `CELL_RENDERERS.percent` exists.
+  - `CELL_RENDERERS.boolean` exists.
+  - `CELL_RENDERERS.date` exists.
+  - `CELL_RENDERERS.amount` exists.
+  - `CELL_RENDERERS.default` exists.
+
+- [ ] Add at least one direct renderer test per accepted type:
+  - `enum`: maps `enumLabels` and renders the label.
+  - `status`: renders `StatusTag` by default.
+  - `percent`: renders a numeric percentage and expected palette class.
+  - `boolean`: renders yes/no fallback or switch depending on column config.
+  - `date`: renders dash for null and preserves date-only local parsing behavior.
+  - `amount`: calls the formatted amount output with currency.
+  - `default`: truncates long strings or passes through short values.
+
+- [ ] Keep the existing `DataTable.renderCellValue.vitest.jsx` behavior-lock tests in place. These prove the full component output stayed compatible after the extraction.
+
+### Task 3: Run Verification
+
+**Files:**
+- Package: `tools/app-shell`
+
+- [ ] Run the targeted renderer tests:
+
+```bash
+cd tools/app-shell && npm run test:vitest -- src/components/contract-ui/__tests__/DataTable.cellRenderers.vitest.jsx
+```
+
+Expected result: PASS.
+
+- [ ] Run the existing behavior-lock tests:
+
+```bash
+cd tools/app-shell && npm run test:vitest -- src/components/contract-ui/__tests__/DataTable.renderCellValue.vitest.jsx
+```
+
+Expected result: PASS.
+
+- [ ] Run the broader contract-ui/DataTable test subset:
+
+```bash
+cd tools/app-shell && npm run test:vitest -- src/components/contract-ui/__tests__/DataTable*.vitest.jsx
+```
+
+Expected result: PASS.
+
+- [ ] If time permits, run the full app-shell Vitest suite:
+
+```bash
+cd tools/app-shell && npm run test:vitest
+```
+
+Expected result: PASS. If it is too slow or unrelated failures exist, record the exact reason and keep the targeted evidence.
+
+- [ ] Check the final diff:
+
+```bash
+git diff -- tools/app-shell/src/components/contract-ui/DataTable.jsx tools/app-shell/src/components/contract-ui/DataTable.cellRenderers.jsx tools/app-shell/src/components/contract-ui/__tests__/DataTable.cellRenderers.vitest.jsx
+```
+
+Expected result: only the renderer extraction and tests are changed.
+
+### Task 4: Delivery Evidence
+
+- [ ] Capture delivery repository evidence:
+  - repository root;
+  - branch;
+  - changed-file scope;
+  - relevant untracked files intentionally excluded.
+
+- [ ] Capture test evidence:
+  - exact command;
+  - PASS/FAIL result;
+  - if any suite is skipped, why.
+
+- [ ] Capture functional validation:
+  - `renderCellValue` delegates through `CELL_RENDERERS[col.type] ?? CELL_RENDERERS.default`;
+  - required renderer functions are exported;
+  - required renderer types have direct unit coverage;
+  - existing behavior-lock tests still pass.
+
+- [ ] QA status:
+  - Mark `Pending validation by QA: Matias Bernal / Emilio Polliotti` unless QA validates the branch before closure.
+
+---
+
+## Commit Plan
+
+Use the Etendo commit convention:
+
+```bash
+git add tools/app-shell/src/components/contract-ui/DataTable.jsx \
+  tools/app-shell/src/components/contract-ui/DataTable.cellRenderers.jsx \
+  tools/app-shell/src/components/contract-ui/__tests__/DataTable.cellRenderers.vitest.jsx
+git commit -m "Feature ETP-4022: Refactor DataTable cell renderers"
+```
+
+Do not include `.claude/agents/workflow.md` unless separately requested.
+
+---
+
+## Definition Of Done
+
+- `DataTable.jsx` no longer contains the type-specific `if` chain inside `renderCellValue`.
+- `CELL_RENDERERS` contains `enum`, `status`, `percent`, `boolean`, `date`, `amount`, and `default`.
+- Each renderer is exported from `DataTable.cellRenderers.jsx`.
+- Direct unit tests cover all required renderer types.
+- Existing `DataTable.renderCellValue.vitest.jsx` behavior-lock tests pass.
+- Delivery evidence includes repository, branch, changed files, exact test commands, and QA status.

--- a/tools/app-shell/src/components/contract-ui/DataTable.cellRenderers.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.cellRenderers.jsx
@@ -1,0 +1,243 @@
+import { Switch } from '@/components/ui/switch';
+import { StatusTag } from '@/components/ui/status-tag';
+import { Tag } from '@/components/ui/tag';
+import { formatAmount } from '@/lib/formatAmount.js';
+import { resolveColumnLabel } from '@/lib/resolveColumnLabel.js';
+import { getStatusDotColor, statusLabel } from '@/lib/statusBadge.js';
+
+function getDateDotColor(dateValue) {
+  if (!dateValue) return null;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const str = String(dateValue);
+  const d = /^\d{4}-\d{2}-\d{2}$/.test(str) ? new Date(str + 'T00:00:00') : new Date(str);
+  d.setHours(0, 0, 0, 0);
+  if (d.getTime() === today.getTime()) return null;
+  return d > today ? 'bg-emerald-500' : 'bg-red-500';
+}
+
+function isTruthyBoolean(value) {
+  return value === true || value === 'Y' || value === 'true';
+}
+
+function isFalsyBoolean(value) {
+  return value === false || value === 'N' || value === 'false';
+}
+
+function renderBooleanFallback(val, ui) {
+  if (isTruthyBoolean(val)) return <span className="text-emerald-600">{ui('yes')}</span>;
+  if (isFalsyBoolean(val)) return <span className="text-slate-400">{ui('no')}</span>;
+  return <span className="text-slate-300">&mdash;</span>;
+}
+
+function renderBooleanBadge(col, val, trueLabel, falseLabel) {
+  const trueVariant = col.badgeVariants?.true ?? 'green';
+  const falseVariant = col.badgeVariants?.false ?? 'neutral';
+  if (isTruthyBoolean(val)) return <Tag variant={trueVariant} label={trueLabel} data-testid="Tag__eb5261" />;
+  if (isFalsyBoolean(val)) return <Tag variant={falseVariant} label={falseLabel} data-testid="Tag__eb5261" />;
+  return null;
+}
+
+function renderColoredBooleanBadge(col, val, trueLabel, falseLabel) {
+  const trueColor = col.badgeColors.true ?? 'bg-emerald-100 text-emerald-800';
+  const falseColor = col.badgeColors.false ?? 'bg-amber-100 text-amber-700';
+  if (isTruthyBoolean(val)) return (
+    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${trueColor}`}>
+      {trueLabel}
+    </span>
+  );
+  if (isFalsyBoolean(val)) return (
+    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${falseColor}`}>
+      {falseLabel}
+    </span>
+  );
+  return null;
+}
+
+function parseDateValue(raw) {
+  if (!raw) return null;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    return new Date(raw + 'T00:00:00');
+  }
+  return new Date(raw);
+}
+
+function formatDateCellDisplay(row, col, dateFormatter) {
+  const raw = row[col.key];
+  const parsed = parseDateValue(raw);
+  const formatted = parsed && !Number.isNaN(parsed) ? dateFormatter.format(parsed) : '\u2014';
+  const dotColor = col.dot === false ? null : getDateDotColor(raw);
+  return { formatted, dotColor };
+}
+
+function createBadgeLabelResolver(locale) {
+  return (raw, fallback) => {
+    if (raw && typeof raw === 'object') return raw[locale] ?? raw.en_US ?? fallback;
+    return raw ?? fallback;
+  };
+}
+
+function renderBooleanBadgeCell(locale, col, ui, val) {
+  const resolveBadgeLabel = createBadgeLabelResolver(locale);
+  const trueLabel = resolveBadgeLabel(col.badgeLabels?.true, ui('statusComplete'));
+  const falseLabel = resolveBadgeLabel(col.badgeLabels?.false, ui('statusInProcess'));
+  if (col.badgeColors) {
+    return renderColoredBooleanBadge(col, val, trueLabel, falseLabel);
+  }
+  return renderBooleanBadge(col, val, trueLabel, falseLabel);
+}
+
+function getPillLabel(pill, row) {
+  return pill?.when(row) ? pill.label : null;
+}
+
+function isFirstVisibleStringColumn(col, visibleColumns) {
+  return col === visibleColumns[0] && col.type === 'string';
+}
+
+function getPercentCellPalette(row, col) {
+  const val = Number(row[col.key]);
+  const pct = Number.isNaN(val) ? 0 : val;
+  let color;
+  if (pct >= 100) {
+    color = 'bg-emerald-500';
+  } else if (pct > 0) {
+    color = 'bg-amber-400';
+  } else {
+    color = 'bg-slate-200';
+  }
+  let textColor;
+  if (pct >= 100) {
+    textColor = 'text-emerald-700';
+  } else if (pct > 0) {
+    textColor = 'text-amber-700';
+  } else {
+    textColor = 'text-slate-400';
+  }
+  return { color, pct, textColor };
+}
+
+export function renderEnumCell({ rawValue, tMenu, col }) {
+  const raw = rawValue;
+  const label = tMenu(col.enumLabels?.[raw] ?? raw);
+  if (col.display === 'dot') {
+    const dotColor = getStatusDotColor(raw);
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+        <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${dotColor}`} />
+        {label}
+      </span>
+    );
+  }
+  if (col.enumVariants) {
+    const variant = col.enumVariants[raw] ?? 'neutral';
+    return <Tag variant={variant} label={label} data-testid="Tag__eb5261" />;
+  }
+  return <span>{label}</span>;
+}
+
+export function renderStatusCell({ row, col, dictionary }) {
+  const raw = row[col.key];
+  const label = statusLabel(raw, dictionary);
+  if (col.display === 'dot') {
+    const dotColor = getStatusDotColor(raw);
+    return (
+      <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+        <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${dotColor}`} />
+        {label}
+      </span>
+    );
+  }
+  return <StatusTag status={raw} label={label} data-testid="StatusTag__eb5261" />;
+}
+
+export function renderPercentCell({ row, col }) {
+  const { color, pct, textColor } = getPercentCellPalette(row, col);
+  return (
+    <div className="flex items-center gap-2">
+      <div className="w-16 h-1.5 bg-slate-100 rounded-full overflow-hidden">
+        <div className={`h-full rounded-full ${color}`} style={{ width: `${Math.min(pct, 100)}%` }} />
+      </div>
+      <span className={`text-xs tabular-nums ${textColor}`}>{pct}%</span>
+    </div>
+  );
+}
+
+export function renderBooleanCell({
+  rawValue, col, savingToggles, toggleKey, handleInlineToggle, row, locale, t, ui,
+}) {
+  const val = rawValue;
+  if (col.toggle) {
+    const checked = isTruthyBoolean(val);
+    const disabled = !!savingToggles[toggleKey] || (!isTruthyBoolean(val) && !isFalsyBoolean(val));
+    return (
+      <div
+        className="flex items-center justify-center"
+        onClick={(e) => e.stopPropagation()}
+        onPointerDown={(e) => e.stopPropagation()}
+      >
+        <Switch
+          checked={checked}
+          disabled={disabled}
+          onCheckedChange={(nextChecked) => {
+            handleInlineToggle(row, col, nextChecked).catch((err) => {
+              console.error('Failed to toggle inline boolean cell:', err);
+            });
+          }}
+          aria-label={resolveColumnLabel(col, locale, t)}
+          data-testid="Switch__eb5261" />
+      </div>
+    );
+  }
+  if (col.badge) {
+    const badge = renderBooleanBadgeCell(locale, col, ui, val);
+    if (badge) return badge;
+  }
+  return renderBooleanFallback(val, ui);
+}
+
+export function renderDateCell({ row, col, dateFormatter }) {
+  const { formatted, dotColor } = formatDateCellDisplay(row, col, dateFormatter);
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      {dotColor && <span className={`inline-block h-2 w-2 rounded-full shrink-0 ${dotColor}`} />}
+      {formatted}
+    </span>
+  );
+}
+
+export function renderAmountCell({ row, col }) {
+  return <span className="tabular-nums">{formatAmount(row[col.key], row['currency$_identifier'])}</span>;
+}
+
+export function renderDefaultCell({ row, col, display, visibleColumns }) {
+  if (isFirstVisibleStringColumn(col, visibleColumns)) {
+    const pill = col.pill;
+    const pillLabel = getPillLabel(pill, row);
+    return (
+      <span className="inline-flex items-center gap-2">
+        <span>{display}</span>
+        {pillLabel && (
+          <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full border ${pill.className || 'bg-gray-50 text-gray-600 border-gray-200'}`} style={{ borderWidth: '0.5px' }}>
+            {pillLabel}
+          </span>
+        )}
+      </span>
+    );
+  }
+  const val = display;
+  if (typeof val === 'string' && val.length > 30) {
+    return <span className="block max-w-[200px] truncate" title={val}>{val}</span>;
+  }
+  return val;
+}
+
+export const CELL_RENDERERS = {
+  enum: renderEnumCell,
+  status: renderStatusCell,
+  percent: renderPercentCell,
+  boolean: renderBooleanCell,
+  date: renderDateCell,
+  amount: renderAmountCell,
+  default: renderDefaultCell,
+};

--- a/tools/app-shell/src/components/contract-ui/DataTable.jsx
+++ b/tools/app-shell/src/components/contract-ui/DataTable.jsx
@@ -3,21 +3,18 @@ import { createPortal } from 'react-dom';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow, TableFooter } from '@/components/ui/table';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Switch } from '@/components/ui/switch';
 import { Search, Inbox, X, ChevronDown, Trash2, Copy, Loader2, Pencil, Check } from 'lucide-react';
 import { toast } from 'sonner';
 import { useLabel, useUI, useLocale, useMenuLabel, useLocaleSwitch } from '@/i18n';
 import { buildUrlWithParams } from '@/lib/buildUrlWithParams.js';
 import { getCatalogOptions } from '@/lib/selectorCatalog.js';
-import { getStatusDotColor, statusLabel } from '@/lib/statusBadge.js';
-import { StatusTag } from '@/components/ui/status-tag';
-import { Tag } from '@/components/ui/tag';
 import { resolveIdentifier } from '@/lib/resolveIdentifier.js';
 import { resolveColumnLabel } from '@/lib/resolveColumnLabel.js';
 import { formatAmount } from '@/lib/formatAmount.js';
 import { applyCalloutUpdates } from '@/lib/applyCalloutUpdates.js';
 import { columnMinWidthPx, columnFlex } from '@/lib/linesColumnWidth.js';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { CELL_RENDERERS } from './DataTable.cellRenderers.jsx';
 
 // Extracts grow flag and basis (px) from a columnFlex() shorthand string.
 function flexSpec(col, idx) {
@@ -109,25 +106,6 @@ export function buildDisplayCatalogMaps(visibleColumns, addRow, entity) {
   return out;
 }
 
-
-function getDateDotColor(dateValue) {
-  if (!dateValue) return null;
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  const str = String(dateValue);
-  const d = /^\d{4}-\d{2}-\d{2}$/.test(str) ? new Date(str + 'T00:00:00') : new Date(str);
-  d.setHours(0, 0, 0, 0);
-  if (d.getTime() === today.getTime()) return null;
-  return d > today ? 'bg-emerald-500' : 'bg-red-500';
-}
-
-function isTruthyBoolean(value) {
-  return value === true || value === 'Y' || value === 'true';
-}
-
-function isFalsyBoolean(value) {
-  return value === false || value === 'N' || value === 'false';
-}
 
 const INLINE_ADD_IGNORED_PORTAL_SELECTORS = [
   '[role="dialog"]',
@@ -1077,137 +1055,6 @@ function getRowClassName(onRowClick, onNavigate, isChecked, selectedRowBg, selec
   ].filter(Boolean).join(' ');
 }
 
-function renderBooleanFallback(val, ui) {
-  if (isTruthyBoolean(val)) return <span className="text-emerald-600">{ui('yes')}</span>;
-  if (isFalsyBoolean(val)) return <span className="text-slate-400">{ui('no')}</span>;
-  return <span className="text-slate-300">&mdash;</span>;
-}
-
-function renderBooleanBadge(col, val, trueLabel, falseLabel) {
-  const trueVariant = col.badgeVariants?.true ?? 'green';
-  const falseVariant = col.badgeVariants?.false ?? 'neutral';
-  if (isTruthyBoolean(val)) return <Tag variant={trueVariant} label={trueLabel} data-testid="Tag__eb5261" />;
-  if (isFalsyBoolean(val)) return <Tag variant={falseVariant} label={falseLabel} data-testid="Tag__eb5261" />;
-  // Unknown value: caller falls through to em-dash fallback.
-  return null;
-}
-
-function renderColoredBooleanBadge(col, val, trueLabel, falseLabel) {
-  const trueColor = col.badgeColors.true ?? 'bg-emerald-100 text-emerald-800';
-  const falseColor = col.badgeColors.false ?? 'bg-amber-100 text-amber-700';
-  if (isTruthyBoolean(val)) return (
-    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${trueColor}`}>
-      {trueLabel}
-    </span>
-  );
-  if (isFalsyBoolean(val)) return (
-    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${falseColor}`}>
-      {falseLabel}
-    </span>
-  );
-  // Unknown value: caller falls through to em-dash fallback.
-  return null;
-}
-
-function parseDateValue(raw) {
-  if (raw) {
-    if (/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
-      return new Date(raw + 'T00:00:00');
-    } else {
-      return new Date(raw);
-    }
-  } else {
-    return null;
-  }
-}
-
-function formatDateCellDisplay(row, col, dateFormatter) {
-  const raw = row[col.key];
-  // Parse date-only strings (yyyy-MM-dd) as local to avoid timezone shift
-  const parsed = parseDateValue(raw);
-  const formatted = parsed && !Number.isNaN(parsed) ? dateFormatter.format(parsed) : '\u2014';
-  const dotColor = col.dot === false ? null : getDateDotColor(raw);
-  return { formatted, dotColor };
-}
-
-function createBadgeLabelResolver(locale) {
-  return (raw, fallback) => {
-    if (raw && typeof raw === 'object') return raw[locale] ?? raw.en_US ?? fallback;
-    return raw ?? fallback;
-  };
-}
-
-function renderBooleanBadgeCell(locale, col, ui, val) {
-  const resolveBadgeLabel = createBadgeLabelResolver(locale);
-  const trueLabel = resolveBadgeLabel(col.badgeLabels?.true, ui('statusComplete'));
-  const falseLabel = resolveBadgeLabel(col.badgeLabels?.false, ui('statusInProcess'));
-  if (col.badgeColors) {
-    return renderColoredBooleanBadge(col, val, trueLabel, falseLabel);
-  }
-  return renderBooleanBadge(col, val, trueLabel, falseLabel);
-}
-
-function renderEnumCell(rawValue, tMenu, col) {
-  const raw = rawValue;
-  const label = tMenu(col.enumLabels?.[raw] ?? raw);
-  if (col.display === 'dot') {
-    const dotColor = getStatusDotColor(raw);
-    return (
-      <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-        <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${dotColor}`} />
-        {label}
-      </span>
-    );
-  }
-  if (col.enumVariants) {
-    const variant = col.enumVariants[raw] ?? 'neutral';
-    return <Tag variant={variant} label={label} data-testid="Tag__eb5261" />;
-  }
-  return <span>{label}</span>;
-}
-
-function getPillLabel(pill, row) {
-  return pill?.when(row) ? pill.label : null;
-}
-
-function renderBooleanCell({ rawValue, col, savingToggles, toggleKey, handleInlineToggle, row, locale, t, ui }) {
-  const val = rawValue;
-  // --- boolean-toggle: DE ACA --- (extract: renderBooleanToggle)
-  if (col.toggle) {
-    const checked = isTruthyBoolean(val);
-    const disabled = !!savingToggles[toggleKey] || (!isTruthyBoolean(val) && !isFalsyBoolean(val));
-    return (
-      <div
-        className="flex items-center justify-center"
-        onClick={(e) => e.stopPropagation()}
-        onPointerDown={(e) => e.stopPropagation()}
-      >
-        <Switch
-          checked={checked}
-          disabled={disabled}
-          onCheckedChange={(nextChecked) => {
-            handleInlineToggle(row, col, nextChecked).catch((err) => {
-              // Errors are surfaced to the user via toast inside the request; log for diagnostics.
-              console.error('Failed to toggle inline boolean cell:', err);
-            });
-          }}
-          aria-label={resolveColumnLabel(col, locale, t)}
-          data-testid="Switch__eb5261" />
-      </div>
-    );
-  }
-  // --- boolean-toggle: HASTA ACA ---
-  // --- boolean-badge: DE ACA --- (extract: renderBooleanBadge — colors OR variants)
-  if (col.badge) {
-    const badge = renderBooleanBadgeCell(locale, col, ui, val);
-    if (badge) return badge;
-  }
-  // --- boolean-badge: HASTA ACA ---
-  // --- boolean-fallback: DE ACA --- (extract: renderBooleanFallback — yes / no / em-dash)
-  return renderBooleanFallback(val, ui);
-  // --- boolean-fallback: HASTA ACA ---
-}
-
 /**
  * Generic data table driven by column/filter declarations.
  *
@@ -1389,120 +1236,26 @@ export function DataTable({
   }, [apiBaseUrl, entity, onDataMutated, token]);
 
   const renderCellValue = (row, col) => {
-    // === custom-render: DE ACA ===
-    // Extract to: renderCustomCell(row, col, { entity, token, apiBaseUrl })
-    // Custom render function takes priority
     if (typeof col.render === 'function') return col.render(row, { entity, token, apiBaseUrl });
-    // === custom-render: HASTA ACA ===
 
-    // === resolve-display: DE ACA ===
-    // Extract to helper: resolveCellDisplay(row, col, { optimisticToggles, displayCatalogMaps })
-    // → returns { toggleKey, rawValue, display }
     const { display, rawValue, toggleKey } = resolveCellDisplay(row, col, optimisticToggles, displayCatalogMaps);
-    // === resolve-display: HASTA ACA ===
-
-    // === first-column-pill: DE ACA ===
-    // Extract to: renderFirstColumnWithPill({ display, pill: col.pill, row })
-    // Only applies when col is the first visible column AND type === 'string'.
-    if (isFirstVisibleStringColumn(col, visibleColumns)) {
-      const pill = col.pill;
-      const pillLabel = getPillLabel(pill, row);
-      return (
-        <span className="inline-flex items-center gap-2">
-          <span>{display}</span>
-          {pillLabel && (
-            <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full border ${pill.className || 'bg-gray-50 text-gray-600 border-gray-200'}`} style={{ borderWidth: '0.5px' }}>
-              {pillLabel}
-            </span>
-          )}
-        </span>
-      );
-    }
-    // === first-column-pill: HASTA ACA ===
-
-    // === enum-cell: DE ACA ===
-    // Extract to: renderEnumCell({ rawValue, col, tMenu })
-    // 3 sub-variants: display === 'dot' | enumVariants (Tag) | plain <span>.
-    if (col.type === 'enum') {
-      return renderEnumCell(rawValue, tMenu, col);
-    }
-    // === enum-cell: HASTA ACA ===
-
-    // === status-cell: DE ACA ===
-    // Extract to: renderStatusCell({ row, col, dictionary })
-    // Variants: display === 'dot' | <StatusTag>.
-    if (col.type === 'status') {
-      const raw = row[col.key];
-      const label = statusLabel(raw, dictionary);
-      if (col.display === 'dot') {
-        const dotColor = getStatusDotColor(raw);
-        return (
-          <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
-            <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${dotColor}`} />
-            {label}
-          </span>
-        );
-      }
-      return <StatusTag status={raw} label={label} data-testid="StatusTag__eb5261" />;
-    }
-    // === status-cell: HASTA ACA ===
-
-    // === percent-cell: DE ACA ===
-    // Extract to: renderPercentCell({ value: row[col.key] })
-    // Pure UI — no closure deps beyond the raw numeric value.
-    if (col.type === 'percent') {
-      const { color, pct, textColor } = getPercentCellPalette(row, col);
-      return (
-        <div className="flex items-center gap-2">
-          <div className="w-16 h-1.5 bg-slate-100 rounded-full overflow-hidden">
-            <div className={`h-full rounded-full ${color}`} style={{ width: `${Math.min(pct, 100)}%` }} />
-          </div>
-          <span className={`text-xs tabular-nums ${textColor}`}>{pct}%</span>
-        </div>
-      );
-    }
-    // === percent-cell: HASTA ACA ===
-
-    // === boolean-cell: DE ACA ===
-    // Extract to: renderBooleanCell({ row, col, rawValue, toggleKey, savingToggles,
-    //                                  handleInlineToggle, locale, t, ui })
-    // Has 3 internal blocks (toggle / badge / fallback yes-no-dash) — each can be
-    // its own helper if cognitive complexity is still high after the first split.
-    if (col.type === 'boolean') {
-      return renderBooleanCell({ rawValue, col, savingToggles, toggleKey, handleInlineToggle, row, locale, t, ui });
-    }
-    // === boolean-cell: HASTA ACA ===
-
-    // === date-cell: DE ACA ===
-    // Extract to: renderDateCell({ raw: row[col.key], col, dateFormatter })
-    // Edge cases under test: yyyy-MM-dd (date-only, no TZ shift), full ISO, null/empty.
-    if (col.type === 'date') {
-      const { formatted, dotColor } = formatDateCellDisplay(row, col, dateFormatter);
-      return (
-        <span className="inline-flex items-center gap-1.5">
-          {dotColor && <span className={`inline-block h-2 w-2 rounded-full shrink-0 ${dotColor}`} />}
-          {formatted}
-        </span>
-      );
-    }
-    // === date-cell: HASTA ACA ===
-
-    // === amount-cell: DE ACA ===
-    // Extract to: renderAmountCell({ row, col }) — one-liner, optional but consistent.
-    if (col.type === 'amount') {
-      return <span className="tabular-nums">{formatAmount(row[col.key], row['currency$_identifier'])}</span>;
-    }
-    // === amount-cell: HASTA ACA ===
-
-    // === truncated-fallback: DE ACA ===
-    // Extract to: renderTruncatedText({ display }) — the default branch when no
-    // specialized type matched. Truncates string values longer than 30 chars.
-    const val = display;
-    if (typeof val === 'string' && val.length > 30) {
-      return <span className="block max-w-[200px] truncate" title={val}>{val}</span>;
-    }
-    return val;
-    // === truncated-fallback: HASTA ACA ===
+    const renderer = CELL_RENDERERS[col.type] ?? CELL_RENDERERS.default;
+    return renderer({
+      row,
+      col,
+      display,
+      rawValue,
+      toggleKey,
+      visibleColumns,
+      tMenu,
+      dictionary,
+      savingToggles,
+      handleInlineToggle,
+      locale,
+      t,
+      ui,
+      dateFormatter,
+    });
   };
 
   if (loading) {
@@ -1932,10 +1685,6 @@ export function DataTable({
     </div>
   );
 }
-function isFirstVisibleStringColumn(col, visibleColumns) {
-  return col === visibleColumns[0] && col.type === 'string';
-}
-
 function resolveCellDisplay(row, col, optimisticToggles, displayCatalogMaps) {
   const toggleKey = `${row.id}:${col.key}`;
   const rawValue = Object.hasOwn(optimisticToggles, toggleKey)
@@ -1952,30 +1701,3 @@ function resolveCellDisplay(row, col, optimisticToggles, displayCatalogMaps) {
   }
   return { display, rawValue, toggleKey };
 }
-
-function getPercentCellPalette(row, col) {
-  const val = Number(row[col.key]);
-  const pct = Number.isNaN(val) ? 0 : val;
-  let color;
-  if (pct >= 100) {
-    color = 'bg-emerald-500';
-  } else {
-    if (pct > 0) {
-      color = 'bg-amber-400';
-    } else {
-      color = 'bg-slate-200';
-    }
-  }
-  let textColor;
-  if (pct >= 100) {
-    textColor = 'text-emerald-700';
-  } else {
-    if (pct > 0) {
-      textColor = 'text-amber-700';
-    } else {
-      textColor = 'text-slate-400';
-    }
-  }
-  return { color, pct, textColor };
-}
-

--- a/tools/app-shell/src/components/contract-ui/__tests__/DataTable.cellRenderers.vitest.jsx
+++ b/tools/app-shell/src/components/contract-ui/__tests__/DataTable.cellRenderers.vitest.jsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('@/lib/statusBadge.js', () => ({
+  getStatusDotColor: (raw) => `dot-${raw ?? 'none'}`,
+  statusLabel: (raw) => `status-label-${raw}`,
+}));
+
+vi.mock('@/components/ui/status-tag', () => ({
+  StatusTag: ({ status, label }) => (
+    <span data-testid="status-tag" data-status={status}>{label || status}</span>
+  ),
+}));
+
+vi.mock('@/components/ui/tag', () => ({
+  Tag: ({ label, variant }) => <span data-testid="tag" data-variant={variant}>{label}</span>,
+}));
+
+vi.mock('@/components/ui/switch', () => ({
+  Switch: ({ checked, disabled, onCheckedChange, 'aria-label': ariaLabel }) => (
+    <input
+      type="checkbox"
+      data-testid="switch"
+      role="switch"
+      aria-label={ariaLabel}
+      checked={!!checked}
+      disabled={!!disabled}
+      onChange={(e) => onCheckedChange?.(e.target.checked)}
+    />
+  ),
+}));
+
+vi.mock('@/lib/resolveColumnLabel.js', () => ({
+  resolveColumnLabel: (col) => col.label ?? col.key,
+}));
+
+vi.mock('@/lib/formatAmount.js', () => ({
+  formatAmount: (val, currency) => `${currency ?? ''}${val != null ? String(val) : ''}`.trim(),
+}));
+
+import {
+  CELL_RENDERERS,
+  renderAmountCell,
+  renderBooleanCell,
+  renderDateCell,
+  renderDefaultCell,
+  renderEnumCell,
+  renderPercentCell,
+  renderStatusCell,
+} from '../DataTable.cellRenderers.jsx';
+
+const baseContext = {
+  row: { id: '1' },
+  col: { key: 'value', label: 'Value' },
+  display: 'Display',
+  rawValue: 'Display',
+  toggleKey: '1:value',
+  visibleColumns: [],
+  tMenu: (value) => value,
+  dictionary: {},
+  savingToggles: {},
+  handleInlineToggle: vi.fn(),
+  locale: 'en_US',
+  t: (value) => value,
+  ui: (key) => ({ yes: 'yes', no: 'no', statusComplete: 'Complete', statusInProcess: 'In Process' }[key] ?? key),
+  dateFormatter: new Intl.DateTimeFormat('en-US', { year: 'numeric', month: '2-digit', day: '2-digit' }),
+};
+
+function renderCell(node) {
+  return render(<div data-testid="cell">{node}</div>);
+}
+
+describe('CELL_RENDERERS', () => {
+  it('exposes a renderer for every accepted DataTable cell type', () => {
+    expect(CELL_RENDERERS).toMatchObject({
+      enum: renderEnumCell,
+      status: renderStatusCell,
+      percent: renderPercentCell,
+      boolean: renderBooleanCell,
+      date: renderDateCell,
+      amount: renderAmountCell,
+      default: renderDefaultCell,
+    });
+  });
+});
+
+describe('renderEnumCell', () => {
+  it('maps enumLabels and renders the display label', () => {
+    renderCell(renderEnumCell({
+      ...baseContext,
+      col: { key: 'kind', type: 'enum', enumLabels: { A: 'Alpha' } },
+      rawValue: 'A',
+    }));
+
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+  });
+});
+
+describe('renderStatusCell', () => {
+  it('renders StatusTag by default', () => {
+    renderCell(renderStatusCell({
+      ...baseContext,
+      row: { id: '1', status: 'CO' },
+      col: { key: 'status', type: 'status' },
+    }));
+
+    const tag = screen.getByTestId('status-tag');
+    expect(tag).toHaveAttribute('data-status', 'CO');
+    expect(tag).toHaveTextContent('status-label-CO');
+  });
+});
+
+describe('renderPercentCell', () => {
+  it('renders the percentage with the expected palette', () => {
+    const { container } = renderCell(renderPercentCell({
+      ...baseContext,
+      row: { id: '1', progress: 45 },
+      col: { key: 'progress', type: 'percent' },
+    }));
+
+    expect(screen.getByText('45%')).toBeInTheDocument();
+    expect(container.querySelector('.bg-amber-400')).toBeTruthy();
+  });
+});
+
+describe('renderBooleanCell', () => {
+  it('renders the boolean fallback label and color', () => {
+    const { container } = renderCell(renderBooleanCell({
+      ...baseContext,
+      col: { key: 'active', label: 'Active', type: 'boolean' },
+      rawValue: true,
+    }));
+
+    expect(screen.getByText('yes')).toBeInTheDocument();
+    expect(container.querySelector('.text-emerald-600')).toBeTruthy();
+  });
+});
+
+describe('renderDateCell', () => {
+  it('renders an em dash when the value is empty', () => {
+    renderCell(renderDateCell({
+      ...baseContext,
+      row: { id: '1', date: null },
+      col: { key: 'date', type: 'date' },
+    }));
+
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+});
+
+describe('renderAmountCell', () => {
+  it('renders formatted amount with currency inside a tabular span', () => {
+    const { container } = renderCell(renderAmountCell({
+      ...baseContext,
+      row: { id: '1', total: 1234.5, 'currency$_identifier': 'USD' },
+      col: { key: 'total', type: 'amount' },
+    }));
+
+    expect(screen.getByText('USD1234.5')).toBeInTheDocument();
+    expect(container.querySelector('span.tabular-nums')).toBeTruthy();
+  });
+});
+
+describe('renderDefaultCell', () => {
+  it('truncates long string display values', () => {
+    const long = 'x'.repeat(40);
+    const { container } = renderCell(renderDefaultCell({
+      ...baseContext,
+      display: long,
+      rawValue: long,
+      col: { key: 'note', type: 'string' },
+      visibleColumns: [{ key: 'name', type: 'string' }, { key: 'note', type: 'string' }],
+    }));
+
+    const truncated = container.querySelector('span.truncate');
+    expect(truncated).toBeTruthy();
+    expect(truncated).toHaveAttribute('title', long);
+    expect(truncated).toHaveTextContent(long);
+  });
+});


### PR DESCRIPTION
## Summary
- Refactor DataTable cell rendering into exported CELL_RENDERERS keyed by col.type.
- Keep custom col.render priority and preserve the existing display-resolution path before renderer dispatch.
- Add focused registry tests plus keep existing behavior-lock coverage for visual output.
- Include the Superpowers implementation plan for ETP-4022.

## Delivery repository
- Repository root: /Users/sebastianbarrozo/Documents/work/epic/schema-forge
- Branch: feature/ETP-4022
- Base: epic/ETP-3504
- Changed-file scope: DataTable renderer extraction, registry unit tests, Superpowers plan.

## Tests executed
- cd tools/app-shell && npm run test:vitest -- src/components/contract-ui/__tests__/DataTable.cellRenderers.vitest.jsx -> 8 passed
- cd tools/app-shell && npm run test:vitest -- src/components/contract-ui/__tests__/DataTable.renderCellValue.vitest.jsx -> 30 passed
- cd tools/app-shell && npm run test:vitest -- src/components/contract-ui/__tests__/DataTable*.vitest.jsx -> 121 passed
- cd tools/app-shell && npm run test:vitest -> 6927 passed
- cd tools/app-shell && npm run build -> passed
- git diff --check -> passed
- git push pre-push hooks -> conflicts, data-testid, domain boundary, unit tests/Sonar, and offline regeneration checks passed

## QA
- Pending validation by QA: Matias Bernal / Emilio Polliotti