### PR TITLE
Feature ETP-4214: Add Observability KPI Foundations

### DIFF
--- a/docs/ops/app-shell-observability.md
+++ b/docs/ops/app-shell-observability.md
@@ -14,12 +14,15 @@ The browser initializer registers these providers:
 | AWS RUM | Hostname has matching RUM IDs | Browser performance, error, and HTTP telemetry |
 | Mixpanel | `VITE_MIXPANEL_ENABLED=true` and `VITE_MIXPANEL_TOKEN` is set | Product analytics events |
 
-Sentry keeps the existing compatibility setting `sendDefaultPii: true`. Treat
-that as an explicit legacy decision; do not add product-event PII to
-observability payloads.
+Sentry defaults to `sendDefaultPii: false`. Only enable it with an explicit
+environment override after reviewing the privacy and legal impact. Release is
+set from `VITE_SENTRY_RELEASE` when present, otherwise from available build
+metadata such as `SENTRY_RELEASE.id` injected at build time.
 
-AWS RUM keeps the current hostname-gated configuration for staging and
-experimental environments. Missing config is a no-op.
+AWS RUM uses hostname-gated configuration for staging, experimental, and
+production (`go.etendo.cloud`). `VITE_RUM_SESSION_SAMPLE_RATE` is parsed as a
+bounded number from `0` to `1`; invalid or missing values fall back to the
+conservative default `0.1`. Missing host config is still a no-op.
 
 Mixpanel is opt-in. If `VITE_MIXPANEL_ENABLED=true` is set without
 `VITE_MIXPANEL_TOKEN`, the provider logs a warning and remains disabled. The SDK
@@ -30,10 +33,15 @@ is lazy-loaded only when the provider is enabled and used.
 | Variable | Description |
 |----------|-------------|
 | `VITE_SENTRY_DSN` | Enables Sentry. |
+| `VITE_SENTRY_RELEASE` | Optional explicit Sentry release. If unset, the app falls back to available build metadata. |
+| `VITE_SENTRY_SEND_DEFAULT_PII` | Optional explicit Sentry PII gate. Defaults to `false`; set to `true` only with approved privacy review. |
 | `VITE_RUM_APP_MONITOR_ID_STAGING` | CloudWatch RUM app monitor for `go.staging.etendo.cloud`. |
 | `VITE_RUM_IDENTITY_POOL_ID_STAGING` | CloudWatch RUM identity pool for staging. |
 | `VITE_RUM_APP_MONITOR_ID_EXPERIMENTAL` | CloudWatch RUM app monitor for `go.experimental.etendo.cloud`. |
 | `VITE_RUM_IDENTITY_POOL_ID_EXPERIMENTAL` | CloudWatch RUM identity pool for experimental. |
+| `VITE_RUM_APP_MONITOR_ID_PROD` | CloudWatch RUM app monitor for `go.etendo.cloud`. |
+| `VITE_RUM_IDENTITY_POOL_ID_PROD` | CloudWatch RUM identity pool for `go.etendo.cloud`. |
+| `VITE_RUM_SESSION_SAMPLE_RATE` | Optional RUM session sample rate. Values are clamped to `0..1`; invalid values fall back to `0.1`. |
 | `VITE_MIXPANEL_ENABLED` | Set to `true` to enable Mixpanel. |
 | `VITE_MIXPANEL_TOKEN` | Mixpanel project token. Required when Mixpanel is enabled. |
 | `VITE_MIXPANEL_DEBUG` | Optional Mixpanel debug flag. |
@@ -41,7 +49,12 @@ is lazy-loaded only when the provider is enabled and used.
 
 ## Events
 
-V1 emits these base lifecycle events:
+Event definitions live in
+`tools/app-shell/src/lib/observability/events.js`. Add new product events there
+first, then use `buildObservabilityEvent()` at call sites so only the
+catalog-approved properties are passed to `track`.
+
+The app currently emits these base lifecycle events:
 
 | Event | When |
 |-------|------|
@@ -50,7 +63,7 @@ V1 emits these base lifecycle events:
 
 Route tracking ignores query-string and hash-only changes.
 
-V1 also includes onboarding product events as the first business-event example:
+The app also emits onboarding product events:
 
 | Event | When |
 |-------|------|
@@ -67,8 +80,32 @@ V1 also includes onboarding product events as the first business-event example:
 | `onboarding_environment_enter_succeeded` | Environment entry succeeds. |
 | `onboarding_environment_enter_failed` | Environment entry fails. |
 
-Broad business events such as CRUD actions, filters, document processing, and
-menu clicks are still out of scope for v1 unless explicitly added and tested.
+Broader business KPI events such as CRUD actions, filters, document processing,
+backend checks, NPS, and timing events are catalogued for ETP-4214, but each
+caller still needs explicit instrumentation and tests before the event is
+considered emitted in production.
+
+## Timing Metrics
+
+Use `startTiming()` or `useTiming()` from `tools/app-shell/src/lib/observability`
+for same-session duration metrics. Timing helpers only emit catalog-backed
+events and add a rounded, non-negative `durationMs` value.
+
+```js
+import { OBSERVABILITY_EVENTS } from '../lib/observability/events.js';
+import { startTiming } from '../lib/observability/timing.js';
+
+const stop = startTiming(OBSERVABILITY_EVENTS.TIME_TO_CREATE, {
+  properties: {
+    category: 'sales',
+    entity: 'sales_order',
+    operation: 'create',
+    specName: 'sales-order',
+  },
+});
+
+await stop({ status: 'success' });
+```
 
 ## Privacy Rules
 
@@ -76,6 +113,12 @@ Payloads are normalized before providers receive them:
 
 - Allowed common fields: `app`, `environment`, `hostname`, `mockMode`, `route`,
   `routePattern`, `timestamp`, and `windowName`.
+- Allowed KPI numeric fields: `accuracy`, `attempt`, `count`, `durationMs`,
+  `position`, `score`, `step`, and `value`. These must be finite numbers within
+  their configured bounds; strings and booleans are dropped for numeric keys.
+- Allowed low-cardinality metadata fields include `action`, `category`,
+  `component`, `enabled`, `entity`, `event`, `locale`, `operation`, `provider`,
+  `source`, `specName`, `status`, `supportRequested`, and `type`.
 - Query strings, hashes, raw URLs, OAuth `code`/`state`, tokens, record IDs,
   document IDs, document numbers, labels, and names are stripped.
 - Record-detail paths such as `/sales-order/ABC123` are emitted as
@@ -101,9 +144,11 @@ names, or UI copy.
 
 Business event payloads are allowlisted. Only these keys are emitted:
 
-`action`, `app`, `component`, `enabled`, `environment`, `event`, `hostname`,
-`locale`, `mockMode`, `provider`, `route`, `routePattern`, `source`, `status`,
-`timestamp`, `type`, and `windowName`.
+`action`, `accuracy`, `app`, `attempt`, `category`, `component`, `count`,
+`durationMs`, `enabled`, `entity`, `environment`, `event`, `hostname`, `locale`,
+`mockMode`, `operation`, `position`, `provider`, `route`, `routePattern`,
+`score`, `source`, `specName`, `status`, `step`, `supportRequested`,
+`timestamp`, `type`, `value`, and `windowName`.
 
 Values must be stable, low-cardinality product metadata. Do not send PII,
 free-form text, raw URLs, OAuth values, tokens, record IDs, document IDs,
@@ -156,5 +201,5 @@ app startup, rendering, routing, or other providers.
 - Observability is scoped to `tools/app-shell`.
 - `packages/apps-sdk` does not receive observability context yet.
 - Broad business-event instrumentation is not included.
-- Sentry PII behavior is preserved for compatibility, but product analytics
-  payloads remain allowlisted and redacted.
+- Product analytics payloads remain allowlisted and redacted even when Sentry is
+  enabled.

--- a/docs/superpowers/plans/2026-06-23-observability-kpi-framework.md
+++ b/docs/superpowers/plans/2026-06-23-observability-kpi-framework.md
@@ -19,7 +19,7 @@ The implementation must preserve the repository rules:
 
 Primary repository:
 
-- `schema-forge` at `/Users/sebastianbarrozo/Documents/work/epic/schema-forge`
+- `schema-forge` repository root
 - Branch observed during planning: `feature/ETP-4214`
 
 Likely secondary repository:

--- a/docs/superpowers/plans/2026-06-23-observability-kpi-framework.md
+++ b/docs/superpowers/plans/2026-06-23-observability-kpi-framework.md
@@ -1,0 +1,431 @@
+# Observability KPI Framework — Implementation Plan
+
+**Jira:** ETP-4214  
+**Design:** `docs/superpowers/specs/2026-06-10-observability-kpi-framework-design.md`  
+**Status:** Working implementation plan. Frontend foundation items A1-A4 are implemented locally on `feature/ETP-4214`; Phase 0 decisions still block identify, NPS, backend telemetry, SQL jobs, and production rollout.
+
+## Goal
+
+Make every KPI from the SaaS functional-validation document observable through the existing App Shell observability layer plus backend telemetry and SQL integrity checks.
+
+The implementation must preserve the repository rules:
+
+- Do not patch `artifacts/*/generated/`; change generators and shared components.
+- Do not send PII in product analytics payloads.
+- Use NEO-native extension points for backend behavior; window-specific backend hooks belong in `NeoHandler` implementations, not generic services.
+- Behavior-changing changes must update the relevant documentation in the same delivery.
+
+## Delivery Scope
+
+Primary repository:
+
+- `schema-forge` at `/Users/sebastianbarrozo/Documents/work/epic/schema-forge`
+- Branch observed during planning: `feature/ETP-4214`
+
+Likely secondary repository:
+
+- `com.etendoerp.go` inside the Etendo root, for `NeoTelemetryService`, AD model/sourcedata, scheduled SQL checks, and JUnit/OBBaseTest coverage.
+
+Before implementation, confirm the secondary repository root and branch. Do not use tests from one repository as delivery evidence for the other.
+
+## Current State
+
+Frontend observability exists in `tools/app-shell/src/lib/observability/`:
+
+- `createObservability()` supports `track`, `page`, `identify`, `captureException`, `setContext`, and `flush`.
+- Providers: Sentry, AWS RUM, Mixpanel.
+- `RouteTracker.jsx` emits normalized page views.
+- `payload.js` strips denylisted PII keys and only emits allowlisted metadata.
+
+Verified gaps from code and design:
+
+- `tools/app-shell/src/lib/rum.js` has no `go.etendo.cloud` production config and hardcodes `sessionSampleRate: 1`.
+- `tools/app-shell/src/lib/sentry.js` sets `sendDefaultPii: true` and no release.
+- `identify()` exists but no App Shell login/auth bridge calls it.
+- Numeric metric values are supported at value level, but numeric metric keys are not allowlisted.
+- Existing onboarding events in `OnboardingPage.jsx` are ad hoc and need to move into a catalog without renaming.
+- Auth and i18n are re-exported from `@etendosoftware/app-shell-core`; identify wiring and NPS copy require changes in `packages/app-shell-core` before App Shell can safely consume them.
+- The current auth core exposes `token`, `username`, `roleList`, `selectedRole`, and `selectedOrg`, but not a safe opaque user id. `username` is PII-shaped and `token` is a secret, so neither can be used for `identify()`.
+- Runtime i18n copy lives in `packages/app-shell-core/src/locales/en_US.json` and `packages/app-shell-core/src/locales/es_ES.json`; local `tools/app-shell/src/i18n/*` files are wrappers only.
+
+## Phase 0 — Required Decisions
+
+- [ ] Confirm the source-doc owner decision for `★` KPI threshold conflicts. Plan assumes `★` means 0 violations / 100% pass in SQL jobs.
+- [ ] Decide Sentry privacy behavior. Recommended default: `sendDefaultPii: false`; any exception needs documented legal basis.
+- [ ] Choose production RUM env names and sample-rate default:
+  - `VITE_RUM_APP_MONITOR_ID_PROD`
+  - `VITE_RUM_IDENTITY_POOL_ID_PROD`
+  - `VITE_RUM_SESSION_SAMPLE_RATE`
+- [ ] Confirm Mixpanel volume guardrails for frontend and backend events.
+- [ ] Confirm the opaque user identifier source. Do not hash or send email/name; use an existing stable non-PII id or add one server-side.
+- [ ] Confirm where App Shell core auth/i18n changes live, because this repo currently re-exports those modules from `@etendosoftware/app-shell-core`.
+- [ ] Confirm backend repository, branch, module dbprefix, AD model ownership, and required `export.database` flow.
+- [ ] Confirm SQL integrity schedule: Etendo scheduled process vs cron. Recommended: scheduled Etendo process if it needs tenant/session context.
+
+## Phase A — Frontend Observability Foundations
+
+### A1. Harden Sentry and RUM configuration
+
+Status: implemented locally.
+
+Files:
+
+- `tools/app-shell/src/lib/rum.js`
+- `tools/app-shell/src/lib/sentry.js`
+- `tools/app-shell/src/lib/__tests__/observability-adapters.test.js`
+- `docs/ops/app-shell-observability.md`
+
+Work:
+
+- Add production RUM host config for `go.etendo.cloud`.
+- Parse `VITE_RUM_SESSION_SAMPLE_RATE` as a bounded number from `0` to `1`.
+- Set Sentry `release` from env/build metadata.
+- Change or explicitly gate `sendDefaultPii`.
+- Update docs to include production env vars, release, sample rate, and privacy behavior.
+
+Verification:
+
+- `cd tools/app-shell && npm run test -- src/lib/__tests__/observability-adapters.test.js`
+- `cd tools/app-shell && npm run test:vitest -- src/lib/__tests__/observability*.test.js`
+
+### A2. Add canonical event catalog
+
+Status: implemented locally.
+
+Files:
+
+- Add `tools/app-shell/src/lib/observability/events.js`
+- Update `tools/app-shell/src/pages/OnboardingPage.jsx`
+- Add/update observability catalog tests.
+- Update `docs/ops/app-shell-observability.md`
+
+Work:
+
+- Define all event names from the design in one frontend catalog.
+- Include existing IT/environment onboarding events exactly as currently emitted.
+- Export typed helper constants or small builders for stable payload shapes.
+- Add a catalog test that validates snake_case names and disallows unknown channel/property keys.
+
+Verification:
+
+- `cd tools/app-shell && npm run test:vitest -- src/lib/observability/__tests__ src/pages/__tests__/OnboardingPage.vitest.jsx`
+
+### A3. Extend payload allowlist for KPI metrics
+
+Status: implemented locally.
+
+Files:
+
+- `tools/app-shell/src/lib/observability/payload.js`
+- `tools/app-shell/src/lib/__tests__/observability-payload.test.js`
+- `tools/app-shell/src/lib/observability/__tests__/payload.vitest.js`
+
+Work:
+
+- Add safe numeric keys such as `durationMs`, `value`, `count`, `accuracy`, `score`, `step`, `attempt`, and `position`.
+- Add stable low-cardinality metadata keys required by the catalog, such as `specName`, `entity`, `operation`, and `category` if needed.
+- Enforce finite numeric values and sane caps per key. Numeric metric keys must not accept string or boolean values.
+- Keep denylisted fields dominant over allowlisted fields.
+
+Verification:
+
+- `cd tools/app-shell && npm run test -- src/lib/__tests__/observability-payload.test.js`
+- `cd tools/app-shell && npm run test:vitest -- src/lib/observability/__tests__/payload.vitest.js`
+
+### A4. Add timing helpers
+
+Status: implemented locally.
+
+Files:
+
+- Add `tools/app-shell/src/lib/observability/timing.js`
+- Add `tools/app-shell/src/lib/observability/useTiming.js`
+- Add focused Vitest coverage.
+
+Work:
+
+- Implement `startTiming(name) -> stop(extraProps)` with `performance.now()`.
+- Implement `useTiming()` for React flows.
+- Emit events with `durationMs` and catalog-backed names. Unknown timing event names do not emit.
+- Keep this scoped to same-session timings only.
+
+Verification:
+
+- `cd tools/app-shell && npm run test:vitest -- src/lib/observability/__tests__`
+
+### A5. Wire `identify()` after authentication
+
+Files:
+
+- `packages/app-shell-core/src/auth/session.js`
+- `packages/app-shell-core/src/auth/AuthContext.jsx`
+- Existing auth-core tests under `packages/app-shell-core/src/auth/__tests__/`
+- Then `tools/app-shell/src/App.jsx` plus a new small bridge component.
+- `tools/app-shell/src/__tests__/App.vitest.jsx` or a dedicated bridge test.
+
+Work:
+
+- Extend the auth/session contract to carry a backend-provided opaque user id. Do not derive it from `username`.
+- Add an `AuthObservabilityBridge` mounted under `AuthProvider`.
+- Call `identify(opaqueUserId, traits)` once per authenticated user/session.
+- Do not send email, name, token, raw role IDs, org names, or other PII.
+- If `useAuth()` does not expose a safe id, stop here and implement the id source in the auth core/server path first.
+
+Verification:
+
+- `cd tools/app-shell && npm run test:vitest -- src/__tests__/App.vitest.jsx`
+- Add a negative assertion that credentials/tokens/emails are never passed to `identify`.
+
+### A6. Add NPS survey support
+
+Files:
+
+- Add `tools/app-shell/src/lib/observability/nps.js`
+- Add a reusable NPS component under `tools/app-shell/src/components/observability/` or the closest existing shared component location.
+- Add i18n keys in `packages/app-shell-core/src/locales/en_US.json` and `packages/app-shell-core/src/locales/es_ES.json`, not hardcoded local text.
+- Add or extend app-shell-core i18n tests so both locale files carry every NPS key.
+
+Work:
+
+- Implement `trackNps(score, context)` using the catalog.
+- Build a lightweight survey with score validation and localized prompt/scale/submit copy.
+- Support both product-wide NPS and Copilot NPS contexts.
+
+Verification:
+
+- Component test for render, submit, bounds, and no PII.
+- i18n/quality-gate test for all new keys.
+
+## Phase B — Generic Window Auto-Instrumentation
+
+### B1. Thread observability context from the generator
+
+Files:
+
+- `cli/src/generate-frontend.js`
+- `cli/test/generate-frontend.test.js`
+- Generated output fixtures only when tests require fixture updates.
+
+Work:
+
+- Pass explicit observability metadata into `ListView` and `DetailView`, including `specName`, `entity`, `category`, and draft/document-mode flags.
+- Do not derive `specName` from the current route.
+- Keep generated code thin; event behavior lives in shared `contract-ui` components.
+
+Verification:
+
+- `make test` or targeted `node --test cli/test/generate-frontend.test.js`
+
+### B2. Instrument list-level generic events
+
+Files:
+
+- `tools/app-shell/src/components/contract-ui/ListView.jsx`
+- `tools/app-shell/src/components/contract-ui/RowQuickActions.jsx`
+- `tools/app-shell/src/components/contract-ui/ListFilterBar.jsx`
+- Existing nearby ListView/RowQuickActions/ListFilterBar tests.
+
+Events:
+
+- `window_opened`
+- `search_performed`
+- `search_result_selected`
+- `quick_action_used`
+- `record_deleted`
+
+Work:
+
+- Emit once per list mount for `window_opened`.
+- Emit search events from filter/search submission points, with no query text.
+- Emit quick-action events by action key/type only.
+- Emit delete success after the existing delete flow succeeds.
+
+Verification:
+
+- `cd tools/app-shell && npm run test:vitest -- src/components/contract-ui/__tests__/ListView*.jsx src/components/contract-ui/__tests__/RowQuickActions.vitest.jsx src/components/contract-ui/__tests__/ListFilterBar.vitest.jsx`
+
+### B3. Instrument detail/form generic events
+
+Files:
+
+- `tools/app-shell/src/components/contract-ui/DetailView.jsx`
+- Existing DetailView save/action tests.
+
+Events:
+
+- `record_created`
+- `record_updated`
+- `document_completed`
+- `time_to_create`
+
+Work:
+
+- Emit create/update only after `hook.handleSave()` succeeds.
+- Emit `document_completed` only after `handleSaveAndProcess()` succeeds.
+- Use the timing helper for new-record time-to-create from detail mount to first successful save.
+- Do not include record id, document number, labels, names, form values, or backend messages.
+
+Verification:
+
+- `cd tools/app-shell && npm run test:vitest -- src/components/contract-ui/__tests__/DetailView.saveButtons.vitest.jsx src/components/contract-ui/__tests__/DetailView.render.vitest.jsx`
+
+### B4. Add generated-window E2E smoke coverage
+
+Files:
+
+- Existing E2E harness under `e2e/tests/flows/`.
+
+Work:
+
+- Mock/spy the observability provider and assert a generated window emits:
+  - page view
+  - `window_opened`
+  - create/save event
+  - no raw record id in payload
+
+Verification:
+
+- Use the repo-standard E2E command from `docs/e2e-testing-guide.md`.
+
+## Phase C — Specific Frontend KPI Flows
+
+Implement these after the catalog and helpers exist.
+
+- [ ] Dashboard: `pending_tasks_interacted`, quick action events.
+- [ ] Contacts: autocomplete attempted/succeeded, top-3 search result selection.
+- [ ] Purchases/Smart Scan/Copilot OCR: `ocr_invoice_uploaded`, `ocr_extraction_scored`, with `source` set to `purchases`, `smart_scan`, or `copilot`.
+- [ ] Fiscal/business onboarding wizard: `onboarding_step_completed`, `onboarding_finished`, `onboarding_bank_configured`, `time_to_first_invoice`.
+- [ ] Sales: `invoice_emailed`, `quote_created` timing.
+- [ ] Copilot: session started, task resolved, correction needed, Copilot NPS.
+
+Verification:
+
+- Unit tests for each touched caller with mocked `track`.
+- Payload tests for any newly allowlisted properties.
+- E2E only where the KPI depends on a user journey across components.
+
+## Phase D — Backend Telemetry
+
+Repository:
+
+- `com.etendoerp.go` in the Etendo root, to be confirmed before implementation.
+
+Files:
+
+- Add `src/com/etendoerp/go/schemaforge/telemetry/NeoTelemetryService.java`
+- Add mirrored backend event constants.
+- Add targeted `NeoHandler.afterHandle` hooks under `src/com/etendoerp/go/schemaforge/handlers/`
+- Add JUnit tests for emitter payloads, disabled config, failures, and no-secret logging.
+
+Work:
+
+- Read the Mixpanel project token from `AD_SysConfig`; never hardcode it.
+- Emit backend events with `backend_` prefix only for authoritative backend facts.
+- Keep provider failures non-blocking for the business operation.
+- Add a catalog sync check that compares backend event constants with frontend `events.js`.
+
+Backend event candidates:
+
+- `backend_accounting_entry_generated`
+- `backend_ocr_field_accuracy`
+- `backend_bank_match_attempted`
+- `backend_asset_created`
+- `backend_email_invoice_ingested`
+- `backend_monthly_close_started`
+- `backend_monthly_close_completed`
+
+Verification:
+
+- `./gradlew test --tests '*NeoTelemetryService*'`
+- Relevant handler tests once handlers are added.
+
+## Phase E — SQL Integrity Jobs
+
+Repository:
+
+- `com.etendoerp.go` in the Etendo root, to be confirmed.
+
+Work:
+
+- Add `ETGO_KPI_CHECK` with full AD model and sourcedata registration.
+- Generate UUIDs with `make uuid`; do not hand-type IDs.
+- Run `./gradlew generate.entities` after AD model changes.
+- Add invariant query implementations for all `★` KPIs.
+- Add a scheduled Etendo process to run checks and write `{kpi, total, violations, pass}`.
+- Run `./gradlew export.database` after DB metadata is changed/exported.
+
+Initial invariant groups:
+
+- Collections correctly linked to invoice.
+- Creditor invoices without critical data error.
+- Stock movements with traceable origin.
+- Purchase receipts update stock.
+- Outbound delivery notes reduce stock.
+- Invoices with correct accounting entry.
+- Contacts available in Sales and Purchases.
+- Product card stock equals Inventory stock.
+- Onboarding users with correct roles.
+- Fixed-asset amortization/disposal invariants.
+
+Verification:
+
+- OBBaseTest fixtures with pass and violation rows for each query group.
+- XML well-formed checks for AD model/sourcedata.
+- `./gradlew test` or targeted module tests from the confirmed backend repository.
+
+## Phase F — Consumption and Reporting
+
+Files:
+
+- Add a monthly report script under an agreed tools location.
+- Add report docs under `docs/ops/` or `docs/superpowers/` as appropriate.
+
+Work:
+
+- Pull Mixpanel, RUM/Sentry, and `ETGO_KPI_CHECK` data.
+- Produce month-1 and month-2 green/red threshold reports.
+- Keep token-cost KPI as a documented placeholder.
+- Do not build a new in-app KPI dashboard for this task.
+
+Verification:
+
+- Unit tests with mocked provider responses.
+- Golden sample output for a mixed pass/fail month.
+
+## Delivery Evidence Required
+
+Each PR/delivery must include:
+
+- Delivery repository root and branch.
+- Changed-file scope.
+- Requirement covered.
+- Tests added or changed.
+- Exact commands executed and results.
+- Functional validation data and expected result.
+- QA status: validated by Matías Bernal / Emilio Polliotti, or explicitly pending.
+
+Recommended command set by scope:
+
+- Schema Forge CLI: `make test`
+- App Shell focused frontend: `cd tools/app-shell && npm run test:all`
+- Targeted App Shell during iteration: `cd tools/app-shell && npm run test:vitest -- <paths>`
+- Backend Java: `./gradlew test` or targeted `./gradlew test --tests '<ClassName>'` from the confirmed Etendo root.
+
+## Suggested PR Split
+
+1. Frontend provider hardening + docs (`A1`).
+2. Event catalog + payload numeric support + timing helper (`A2-A4`).
+3. Identify bridge + NPS support (`A5-A6`).
+4. Generator and generic `contract-ui` instrumentation (`B1-B4`).
+5. Specific frontend KPI flows (`C`), split by module if review size grows.
+6. Backend telemetry service and event sync lint (`D`).
+7. `ETGO_KPI_CHECK` AD model + SQL integrity process (`E`).
+8. Monthly report script and operational docs (`F`).
+
+## Open Risks
+
+- App Shell core dependency may require a coordinated branch/release for auth and i18n.
+- RUM and Mixpanel event volume can create cost surprises if sample/rate controls are not enforced before production.
+- Backend event taxonomy can drift from frontend catalog without CI enforcement.
+- SQL invariant checks may need indexes or nightly scheduling to avoid large-tenant load.
+- Some KPI thresholds conflict in the source document; implementation should not encode disputed thresholds until Phase 0 closes.

--- a/docs/superpowers/specs/2026-06-10-observability-kpi-framework-design.md
+++ b/docs/superpowers/specs/2026-06-10-observability-kpi-framework-design.md
@@ -1,0 +1,271 @@
+# Observability KPI Framework — Design
+
+- **Date:** 2026-06-10
+- **Source:** `Etendo-SaaS-KPIs-Validacion-Funcional-v1.0` (functional validation KPIs, 10 modules)
+- **Status:** Approved design — pending implementation plan
+- **Scope:** End-to-end instrumentation plan that makes every KPI in the source document observable using the existing observability framework, plus the framework extensions, backend telemetry, and SQL validation jobs required to close the gaps.
+
+## 1. Context & Problem
+
+The KPI document defines ~60 KPIs across 10 first-iteration modules plus 7 cross-cutting KPIs, organized in 6 dimensions: **Rendimiento** (performance), **Adopción** (adoption), **Precisión** (precision), **Integridad** (integrity), **UX**, **Negocio** (business). It also defines acceptance criteria (a module is validated at ≥80% of its KPIs; Integrity-100% KPIs are blocking) and a 3-phase measurement plan (Alpha weeks 1-2, Beta weeks 3-6, Post-launch months 1-2).
+
+A privacy-conscious observability framework **already exists** in `tools/app-shell/src/lib/observability/`:
+
+- Provider-agnostic core (`createObservability`) with `track / page / identify / captureException / setContext / flush`.
+- Three wired providers: **Sentry** (errors/exceptions), **AWS CloudWatch RUM** (performance: web vitals, http, errors), **Mixpanel** (product analytics).
+- `RouteTracker.jsx` auto-emits normalized page-views.
+- `payload.js` enforces a strict PII allowlist/denylist (privacy-by-design).
+
+**Gaps:**
+
+1. Actual product instrumentation is concentrated in onboarding. `OnboardingPage.jsx` already emits ~12 distinct events (`onboarding_auth_*`, `onboarding_setup_step_*`, `onboarding_run_*`, `onboarding_environment_enter_*`) plus `app_started`. These are the IT/environment-setup flow, **not** the 4-step business wizard (`windows/custom/fiscal-config/OnboardingWizard.jsx`). The 10 product modules are otherwise uninstrumented, and the existing onboarding events must be folded into the catalog (Section 4), not duplicated.
+2. `payload.js`'s `SAFE_EVENT_PROPERTY_KEYS` allows **no numeric metric keys** — yet nearly all Rendimiento/Precisión KPIs and UX timings need numeric measurements. Note: `sanitizeEventProperties` already accepts `typeof value === 'number'` at the value level (payload.js:132); numeric values are dropped only because their *key names* are absent from the allowlist. The fix is key-name additions, not value-type support.
+3. **Integridad 100%** KPIs are data-consistency invariants (stock = inventory, linked accounting entries, correct roles) — backend/data truth, not frontend telemetry.
+4. `identify()` exists but is never called, so all retention/cohort KPIs cannot be computed (30-day retention, 3-day abandonment, "Accounting board ≥1/week", "Copilot weekly in month 1").
+5. No NPS mechanism for the two NPS KPIs.
+6. **RUM has no production config.** `rum.js` (`getRumConfigs`) only defines `go.staging.etendo.cloud` and `go.experimental.etendo.cloud`; on any other host `createRumProvider` returns `enabled: false` and silently no-ops. **Every Channel-1 (performance) KPI is currently blind in production.**
+7. **Sentry sends PII by default.** `sentry.js:32` sets `sendDefaultPii: true` (IP, cookies, headers) and sets no `release`. The first is a GDPR concern for an EU financial SaaS; the second means Sentry Release Health (the actual crash-free-session metric) cannot be computed.
+8. **Provider method coverage is asymmetric.** RUM implements only `init()` (captures performance/http/errors independently via the AWS SDK); Sentry implements `init/captureException/setContext`. Only Mixpanel implements `track/page/identify`. So `track()`/`page()` are Mixpanel-only — this is correct by design but means the framework is not symmetrically provider-agnostic across all methods.
+
+## 2. Architecture
+
+Three data origins, three consumption tools, one shared event taxonomy so a KPI is coherent regardless of where it is emitted.
+
+```
+┌─ CONSUMPTION ──────────────────────────────────────────────────┐
+│  Mixpanel (Adoption/UX/Business) · CloudWatch RUM (Performance) │
+│  Sentry (Stability) · Monthly consolidated report (script)      │
+└────────────────────────────────────────────────────────────────┘
+        ▲                    ▲                      ▲
+┌─ FRONTEND (app-shell) ─┐ ┌─ BACKEND (Etendo Go) ┐ ┌─ DATA (SQL) ─┐
+│ A) Generator-driven    │ │ NeoTelemetryService   │ │ Integrity    │
+│    auto-instrumentation│ │ (NeoHandler hooks →   │ │ validation   │
+│    + contract-ui       │ │  Mixpanel server-side)│ │ jobs (100%)  │
+│ B) Event catalog +     │ │ for backend Precision/│ │ + data-      │
+│    hooks (specific      │ │ Adoption truth        │ │ quality      │
+│    flows)               │ └───────────────────────┘ └──────────────┘
+│  ─────────────────────  │
+│  Existing framework:    │
+│  track/page/identify/   │
+│  captureException       │
+└─────────────────────────┘
+```
+
+**Instrumentation strategy = Hybrid (Enfoque C):**
+
+- **A) Generator-driven (generic, covers all 10 modules at once):** instrument once in the generator (`cli/src/generate-frontend.js`) and the shared `contract-ui/` components. Generated windows auto-emit the standard event set, reading category/draftMode/completion-flow from the contract. Lives in the generator/shared components — **never patched into `generated/`** (repo policy).
+- **B) Event catalog + hooks (specific flows):** a central `events.js` taxonomy plus hooks (`useTrackEvent`, `useTiming`) called explicitly in module-specific flows (OCR, onboarding wizard, Copilot, NPS).
+
+## 3. Framework Extensions (Foundations)
+
+1. **Numeric metrics in `payload.js`** — add a controlled set of numeric keys to the allowlist: `durationMs`, `value`, `count`, `accuracy`, `score`, `step`, `attempt`. Validate type `number`, finite, and apply sanity caps. PII denylist remains intact. (Value-level numeric support already exists — see Gap 2.)
+2. **Timing helper** — `startTiming(name) → stop(extraProps)` and a React `useTiming()` hook; emits an event with `durationMs`. Backed by `performance.now()`. **Limitation:** session-scoped — cannot span users/sessions/hours, so cross-session durations (e.g. monthly close) must use backend start/stop events instead (Channel 6).
+3. **NPS mechanism** — a lightweight in-app survey component + `trackNps(score, context)`. **i18n required:** all user-visible strings (prompt, scale labels, submit) must have keys in both `en_US.json` and `es_ES.json` per CLAUDE.md — hardcoded English is a bug.
+4. **Event catalog** — `events.js`: the **canonical reference** for event names and valid properties. Java cannot import it, so the backend keeps mirrored string constants; add a CI lint check that validates backend event names against the catalog. The existing `OnboardingPage.jsx` events (Gap 1) must be migrated into the catalog rather than left ad-hoc.
+5. **Identify wiring** — call `identify(opaqueUserId)` on login with a hashed/opaque id (PII-safe). **Prerequisite for all cohort/retention KPIs**, not just the two cross-cutting ones (also gates "Accounting board ≥1/week" and "Copilot weekly in month 1").
+6. **RUM production config** — add a production host entry to `getRumConfigs` (`VITE_RUM_APP_MONITOR_ID_PROD`, `VITE_RUM_IDENTITY_POOL_ID_PROD`) and set `sessionSampleRate` from env (not hardcoded `1`). Without this, no performance KPI is measured in production (Gap 6).
+7. **Sentry hardening** — set `release` (enables crash-free session rate) and resolve `sendDefaultPii` (Gap 7): default to `false`, or document the GDPR legal basis if kept.
+
+## 4. Event Taxonomy
+
+**Generic (Enfoque A — auto-emitted from generator / `contract-ui`):**
+
+`window_opened` · `record_created` · `record_updated` · `record_deleted` · `document_completed` · `quick_action_used` · `search_performed` · `search_result_selected` · `time_to_create` (timing form-open → save)
+
+**Specific (Enfoque B — catalog + hooks):**
+
+- Onboarding (4-step business wizard, `OnboardingWizard.jsx`): `onboarding_step_completed` (with `step`, `supportRequested`), `onboarding_finished`, `onboarding_bank_configured`, `time_to_first_invoice`. **Distinct from** the existing IT/environment events in `OnboardingPage.jsx` (`onboarding_auth_*`, `onboarding_setup_step_*`, `onboarding_run_*`) — those are migrated into the catalog as-is under their own namespace, not renamed.
+- Dashboard: `pending_tasks_interacted`
+- Contactos: `contact_autocomplete_attempted`, `contact_autocomplete_succeeded`
+- Compras: `ocr_invoice_uploaded`, `ocr_extraction_scored`, `email_invoice_ingested`
+- Copilot: `copilot_session_started`, `copilot_task_resolved`, `copilot_correction_needed`, `copilot_nps`. **Smart Scan** (OCR via Copilot) reuses the OCR events with `source: 'copilot'` so the OCR-accuracy KPI is captured on both the Compras and Copilot paths.
+- Ventas: `invoice_emailed`, `quote_created` (timing)
+- Backend (server-side, mirrored names, `backend_` prefix): `accounting_entry_generated`, `ocr_field_accuracy`, `bank_match_attempted`, `asset_created`, `email_invoice_ingested`, `monthly_close_started` / `monthly_close_completed`
+
+## 5. Measurement Channels
+
+The ~60 KPIs collapse into 7 channels:
+
+| # | Channel | Mechanism |
+|---|---|---|
+| 1 | RUM (auto) | Web vitals / automatic timing |
+| 2 | Sentry | Crash-free sessions |
+| 3 | Mixpanel events/funnels/cohorts | `track()` + funnels + retention |
+| 4 | Timing helper | `durationMs` events |
+| 5 | NPS survey | `trackNps()` |
+| 6 | Backend telemetry (Etendo Go) | Server-side events, same taxonomy |
+| 7 | SQL validation jobs | Scheduled invariant queries, pass/fail |
+
+## 6. Full KPI → Channel Mapping
+
+Channels: **1** RUM · **2** Sentry · **3** Mixpanel · **4** Timing · **5** NPS · **6** Backend · **7** SQL job. `★` = Integrity-100% blocking KPI.
+
+> **Threshold note (source-doc contradiction):** the source KPI tables and the §4 acceptance table disagree on some `★` KPIs (e.g. "% invoices with correct accounting entry" is `>98%` in §2.5 but a 100% blocking invariant in §4). For every `★` KPI the SQL job enforces **0 violations (100%)** per the acceptance table's blocking intent; the looser table threshold is treated as a soft warning band only. This must be confirmed with the doc owner before implementation.
+
+### Dashboard
+| KPI | Target | Channel |
+|---|---|---|
+| Dashboard load time | <2s | 1 |
+| % users using quick actions in first 7d | >60% | 3 (`quick_action_used`) |
+| % users interacting with Pending Tasks panel | >50% | 3 (`pending_tasks_interacted`) |
+| % sessions navigating Dashboard → document | >30% | 3 (page funnel) |
+
+### Ventas
+| KPI | Target | Channel |
+|---|---|---|
+| Avg time to create a quote | <3min | 4 (`quote_created`) |
+| % invoices emailed from system | >70% | 3 (`invoice_emailed` / total) |
+| ★ % collections correctly linked to invoice | 100% | 7 |
+
+### Compras
+| KPI | Target | Channel |
+|---|---|---|
+| % supplier invoices via OCR vs manual | >50% | 3 + 6 (`ocr_invoice_uploaded` vs manual `record_created`) |
+| OCR field accuracy | >85% | 6 (`ocr_field_accuracy`) |
+| Tokens used (FUTURE) | — | placeholder |
+| % invoices via dedicated email | >30% / 60d | 6 (`email_invoice_ingested`) |
+| Avg OCR invoice registration time | <1min | 4 |
+| Avg manual invoice registration time | <5min | 4 |
+| ★ % creditor invoices processed without critical data error | 100% | 7 |
+
+### Inventario
+| KPI | Target | Channel |
+|---|---|---|
+| Stock accuracy (system vs physical count) | >98% | 7 (+ count input) |
+| ★ % stock movements with traceable origin | 100% | 7 |
+| Avg inventory adjustment time | <5min | 4 |
+| ★ % purchase receipts correctly updating stock | 100% | 7 |
+| ★ % outbound delivery notes correctly reducing stock | 100% | 7 |
+
+### Contabilidad y Finanzas
+| KPI | Target | Channel |
+|---|---|---|
+| % accounting entries generated automatically | >90% | 6 (`accounting_entry_generated`) |
+| Bank reconciliation auto-match rate | >70% | 6 (`bank_match_attempted`) |
+| Avg monthly close time | <2h | 6 (backend start/stop events — not session-scoped timing) |
+| ★ % invoices with correct accounting entry | 100% (see note) | 7 |
+| % users accessing Accounting board ≥1/week | >60% | 3 (`window_opened` cohort) |
+| Time to view aging reports | <3s | 1 |
+
+### Contactos
+| KPI | Target | Channel |
+|---|---|---|
+| Autocomplete success rate (name/CIF) | >80% | 3 (`contact_autocomplete_attempted` + `contact_autocomplete_succeeded`) |
+| Avg time to create a contact | <2min | 4 (`time_to_create`) |
+| % contacts with minimum data (email+phone+address) | >75% | 7 (data-quality) |
+| % searches with correct result in top 3 | >90% | 3 (`search_result_selected` position) |
+| ★ % contacts available in Ventas & Compras | 100% | 7 |
+
+### Productos
+| KPI | Target | Channel |
+|---|---|---|
+| Avg time to create a product | <2min | 4 |
+| % products with photo at 30d | >40% | 7 (data-quality) |
+| % catalog searches correct in top 3 | >95% | 3 |
+| % products with sale & purchase price | >90% | 7 (data-quality) |
+| ★ % products whose card stock = Inventory stock | 100% | 7 |
+
+### Copilot IA
+| KPI | Target | Channel |
+|---|---|---|
+| % users using Copilot in first 7d | >50% | 3 (`copilot_session_started` cohort) |
+| % users using Copilot weekly in month 1 | >35% | 3 (retention) |
+| Full task resolution rate via Copilot | >60% | 3 (`copilot_task_resolved`) |
+| % conversations needing manual correction | <20% | 3 (`copilot_correction_needed`) |
+| Copilot NPS | >40 | 5 |
+| Agent response time for simple tasks | <5s | 4 |
+
+### Configuración y Administración (Onboarding)
+| KPI | Target | Channel |
+|---|---|---|
+| % users completing the 4-step wizard | >85% | 3 (funnel) |
+| Time from signup to first invoice | <10min | 4 (`time_to_first_invoice`) |
+| % wizard steps completed without external support | >90% | 3 (`onboarding_step_completed` with `supportRequested` flag) |
+| % companies with a bank account at finish | >40% | 7 (authoritative DB state; Ch3 `onboarding_bank_configured` optional) |
+| ★ % users with correctly assigned roles | >95% (100% critical) | 7 |
+| System abandonment rate in first 3 days | <20% | 3 (retention cohort) |
+
+### Activos Fijos
+| KPI | Target | Channel |
+|---|---|---|
+| Avg time to create an asset (manual) | <3min | 4 |
+| % assets created from purchase invoice | >40% | 6 (`asset_created` source) |
+| % assets with complete card | >90% | 7 (data-quality) |
+| ★ Monthly amortization entry generation rate | 100% | 7 |
+| ★ % amortization installments correct (linear) | 100% | 7 |
+| ★ % amortization entries linked to source asset | 100% | 7 |
+| Avg time to process asset disposal | <5min | 4 |
+| ★ % disposals with correct P&L entry | 100% | 7 |
+| ★ % assets correct in amortization schedule | 100% | 7 |
+| ★ % fully-amortized assets correct in report | 100% | 7 |
+
+### Cross-cutting (Transversales)
+| KPI | Target | Channel |
+|---|---|---|
+| Load time of any screen/report | <2s | 1 |
+| % sessions without critical errors (500, data loss, inconsistent states) | >99.5% | 1 (RUM HTTP 5xx rate) + 2 (Sentry crash-free, needs `release`) |
+| 30-day user retention | >70% | 3 (needs `identify`) |
+| Overall product NPS | >35 | 5 |
+| Abandonment in first 3 days | <20% | 3 |
+| Write-operation response time (save/confirm) | <3s | 1 / 4 |
+| Functionality coverage: 100% features have a success metric | 100% | meta-check (taxonomy) |
+
+## 7. Backend & SQL Integrity Jobs
+
+**Telemetry emitter** — `NeoTelemetryService` (CDI bean) invoked from `NeoHandler.afterHandle` hooks, pushing server-side events to Mixpanel via HTTP (same project, `backend_` prefix). No per-window logic in generic services — follows the repo's NeoHandler pattern. Covers what the frontend cannot assert: whether an entry was auto-generated, real OCR accuracy, bank-match outcome, asset source, email ingestion, monthly-close duration. The Mixpanel **project token lives in `AD_SysConfig`** (never hardcoded), read at runtime by the service.
+
+**SQL validation jobs (Integrity 100%)** — a set of invariant queries, one per critical KPI, run as a scheduled Etendo Process (or cron). Each returns `{kpi, total, violations, pass}` and writes to an `ETGO_KPI_CHECK` table (timestamp + result). **Note:** this is not a trivial DDL — it requires full Etendo AD registration (`AD_TABLE`, `AD_COLUMN`, `AD_ELEMENT`, dbprefix, `export.database`), budgeted in Sprint 0. UUIDs via `make uuid`, never hand-typed. Each `★` job enforces 0 violations (see Section 6 threshold note). Examples:
+
+- `stock_trazabilidad` — movements without reference document → must be 0
+- `stock_vs_inventario` — product-card stock ≠ inventory stock → must be 0
+- `amortizacion_vinculada` — amortization entries without source asset → must be 0
+- `roles_onboarding` — post-onboarding users without correct role → must be 0
+
+`ETGO_KPI_CHECK` feeds the monthly consolidated report's green/red status.
+
+## 8. Consumption
+
+- **Mixpanel** — Adoption / UX / Business: funnels, retention, cohorts, numeric-property charts.
+- **CloudWatch RUM** — Performance: load times, web vitals (mostly automatic + a few custom report timings).
+- **Sentry** — Stability: crash-free session rate.
+- **Monthly consolidated report** — a script that pulls from the three tools + `ETGO_KPI_CHECK` and produces a green/red vs-threshold table for month-1 and month-2 close (Fase 3 of the source doc). No new in-app UI.
+
+## 9. Work Plan (Phasing)
+
+Quick wins + foundations first, then aligned to the document's 3 phases.
+
+- **Sprint 0 — Foundations + Quick wins (parallel)**
+  - *Config prerequisites (must land first):* add RUM **production** host config + env-driven `sessionSampleRate` (Gap 6); set Sentry `release` and resolve `sendDefaultPii` (Gap 7); register `ETGO_KPI_CHECK` in AD + store backend Mixpanel token in `AD_SysConfig`.
+  - *Quick wins:* validate RUM + Sentry dashboards; wire `identify()` on login (opaque id); validate route taxonomy; migrate existing `OnboardingPage.jsx` events into the catalog.
+  - *Foundations:* extend `payload.js` (numeric keys); timing helper + `useTiming`; NPS component (with i18n keys); `events.js` catalog + backend name-sync CI lint; generator auto-instrumentation scaffolding (pass spec name explicitly as a property — do not rely on route derivation).
+- **Fase 1 — Alpha (Integrity + Performance)**
+  - Roll generic auto-instrumentation to all 10 windows (channel A).
+  - SQL integrity jobs + `ETGO_KPI_CHECK` table.
+  - Validate all Performance KPIs via RUM.
+- **Fase 2 — Beta (Adoption + UX, real users)**
+  - Module-specific instrumentation (Compras OCR, Onboarding funnel, Copilot, quick actions, searches).
+  - Copilot NPS. Mixpanel funnels and cohorts.
+- **Fase 3 — Post-launch (Business)**
+  - 30-day retention, 3-day abandonment, overall NPS.
+  - Monthly consolidated report script (KPIs vs threshold, green/red) for month-1 and month-2 close.
+  - Threshold review.
+
+## 10. Testing
+
+- **Frontend:** Vitest with mocked `track()` (existing `observability.test.js` pattern) — assert each flow emits the correct event with valid props. Contract test over the `events.js` catalog. Playwright E2E capturing `track` calls via a mocked provider.
+- **Backend:** JUnit for `NeoTelemetryService`; OBBaseTest for SQL jobs (fixtures with/without violations).
+
+## 11. Risks & Mitigations
+
+- **PII (existing + new)** — beyond new event props, the existing `sendDefaultPii: true` in `sentry.js` already ships IP/cookies/headers and must be resolved (Gap 7). New numeric props and `identify()` must respect the denylist; opaque/hashed user id; mandatory review of every new event's props.
+- **Volume/cost (Sprint 0 decision, not deferred)** — `rum.js` hardcodes `sessionSampleRate: 1` (100% of sessions) with no env guard; shipping that to production is a per-session cost time-bomb. Must be env-driven before any prod rollout. Same for Mixpanel event volume.
+- **Generated-files policy** — auto-instrumentation lives in generator/`contract-ui`, never patched into `generated/`. The generator must pass the spec name explicitly into the event payload; route-derived `windowName` can be empty if `window_opened` fires before navigation settles.
+- **SQL job performance** on large datasets — indexes + nightly execution window.
+- **Frontend↔backend name drift** — `events.js` is not importable by Java; the CI lint check is the only guard against silent divergence of mirrored constants.
+- **Out of scope / placeholders** — "tokens used (FUTURE)" stays a placeholder. "Inconsistent states" within the crash-free KPI is acknowledged but not operationally instrumented this iteration (would require a state-invariant definition); covered partially by the SQL integrity jobs.
+
+## 12. Out of Scope
+
+- New in-app KPI dashboard UI (consumption is via existing tools + report script).
+- Second-iteration modules and KPIs.
+- Token-cost KPI (marked FUTURE in the source).

--- a/docs/superpowers/specs/2026-06-10-observability-kpi-framework-design.md
+++ b/docs/superpowers/specs/2026-06-10-observability-kpi-framework-design.md
@@ -7,7 +7,7 @@
 
 ## 1. Context & Problem
 
-The KPI document defines ~60 KPIs across 10 first-iteration modules plus 7 cross-cutting KPIs, organized in 6 dimensions: **Rendimiento** (performance), **Adopción** (adoption), **Precisión** (precision), **Integridad** (integrity), **UX**, **Negocio** (business). It also defines acceptance criteria (a module is validated at ≥80% of its KPIs; Integrity-100% KPIs are blocking) and a 3-phase measurement plan (Alpha weeks 1-2, Beta weeks 3-6, Post-launch months 1-2).
+The KPI document defines ~60 KPIs across 10 first-iteration modules plus 7 cross-cutting KPIs, organized in 6 dimensions: **Performance**, **Adoption**, **Precision**, **Integrity**, **UX**, and **Business**. It also defines acceptance criteria (a module is validated at ≥80% of its KPIs; Integrity-100% KPIs are blocking) and a 3-phase measurement plan (Alpha weeks 1-2, Beta weeks 3-6, Post-launch months 1-2).
 
 A privacy-conscious observability framework **already exists** in `tools/app-shell/src/lib/observability/`:
 
@@ -19,8 +19,8 @@ A privacy-conscious observability framework **already exists** in `tools/app-she
 **Gaps:**
 
 1. Actual product instrumentation is concentrated in onboarding. `OnboardingPage.jsx` already emits ~12 distinct events (`onboarding_auth_*`, `onboarding_setup_step_*`, `onboarding_run_*`, `onboarding_environment_enter_*`) plus `app_started`. These are the IT/environment-setup flow, **not** the 4-step business wizard (`windows/custom/fiscal-config/OnboardingWizard.jsx`). The 10 product modules are otherwise uninstrumented, and the existing onboarding events must be folded into the catalog (Section 4), not duplicated.
-2. `payload.js`'s `SAFE_EVENT_PROPERTY_KEYS` allows **no numeric metric keys** — yet nearly all Rendimiento/Precisión KPIs and UX timings need numeric measurements. Note: `sanitizeEventProperties` already accepts `typeof value === 'number'` at the value level (payload.js:132); numeric values are dropped only because their *key names* are absent from the allowlist. The fix is key-name additions, not value-type support.
-3. **Integridad 100%** KPIs are data-consistency invariants (stock = inventory, linked accounting entries, correct roles) — backend/data truth, not frontend telemetry.
+2. `payload.js`'s `SAFE_EVENT_PROPERTY_KEYS` allows **no numeric metric keys** — yet nearly all Performance/Precision KPIs and UX timings need numeric measurements. Note: `sanitizeEventProperties` already accepts `typeof value === 'number'` at the value level (payload.js:132); numeric values are dropped only because their *key names* are absent from the allowlist. The fix is key-name additions, not value-type support.
+3. **Integrity 100%** KPIs are data-consistency invariants (stock = inventory, linked accounting entries, correct roles) — backend/data truth, not frontend telemetry.
 4. `identify()` exists but is never called, so all retention/cohort KPIs cannot be computed (30-day retention, 3-day abandonment, "Accounting board ≥1/week", "Copilot weekly in month 1").
 5. No NPS mechanism for the two NPS KPIs.
 6. **RUM has no production config.** `rum.js` (`getRumConfigs`) only defines `go.staging.etendo.cloud` and `go.experimental.etendo.cloud`; on any other host `createRumProvider` returns `enabled: false` and silently no-ops. **Every Channel-1 (performance) KPI is currently blind in production.**
@@ -51,7 +51,7 @@ Three data origins, three consumption tools, one shared event taxonomy so a KPI 
 └─────────────────────────┘
 ```
 
-**Instrumentation strategy = Hybrid (Enfoque C):**
+**Instrumentation strategy = Hybrid (Approach C):**
 
 - **A) Generator-driven (generic, covers all 10 modules at once):** instrument once in the generator (`cli/src/generate-frontend.js`) and the shared `contract-ui/` components. Generated windows auto-emit the standard event set, reading category/draftMode/completion-flow from the contract. Lives in the generator/shared components — **never patched into `generated/`** (repo policy).
 - **B) Event catalog + hooks (specific flows):** a central `events.js` taxonomy plus hooks (`useTrackEvent`, `useTiming`) called explicitly in module-specific flows (OCR, onboarding wizard, Copilot, NPS).
@@ -68,18 +68,18 @@ Three data origins, three consumption tools, one shared event taxonomy so a KPI 
 
 ## 4. Event Taxonomy
 
-**Generic (Enfoque A — auto-emitted from generator / `contract-ui`):**
+**Generic (Approach A — auto-emitted from generator / `contract-ui`):**
 
 `window_opened` · `record_created` · `record_updated` · `record_deleted` · `document_completed` · `quick_action_used` · `search_performed` · `search_result_selected` · `time_to_create` (timing form-open → save)
 
-**Specific (Enfoque B — catalog + hooks):**
+**Specific (Approach B — catalog + hooks):**
 
 - Onboarding (4-step business wizard, `OnboardingWizard.jsx`): `onboarding_step_completed` (with `step`, `supportRequested`), `onboarding_finished`, `onboarding_bank_configured`, `time_to_first_invoice`. **Distinct from** the existing IT/environment events in `OnboardingPage.jsx` (`onboarding_auth_*`, `onboarding_setup_step_*`, `onboarding_run_*`) — those are migrated into the catalog as-is under their own namespace, not renamed.
 - Dashboard: `pending_tasks_interacted`
-- Contactos: `contact_autocomplete_attempted`, `contact_autocomplete_succeeded`
-- Compras: `ocr_invoice_uploaded`, `ocr_extraction_scored`, `email_invoice_ingested`
-- Copilot: `copilot_session_started`, `copilot_task_resolved`, `copilot_correction_needed`, `copilot_nps`. **Smart Scan** (OCR via Copilot) reuses the OCR events with `source: 'copilot'` so the OCR-accuracy KPI is captured on both the Compras and Copilot paths.
-- Ventas: `invoice_emailed`, `quote_created` (timing)
+- Contacts: `contact_autocomplete_attempted`, `contact_autocomplete_succeeded`
+- Purchasing: `ocr_invoice_uploaded`, `ocr_extraction_scored`, `email_invoice_ingested`
+- Copilot: `copilot_session_started`, `copilot_task_resolved`, `copilot_correction_needed`, `copilot_nps`. **Smart Scan** (OCR via Copilot) reuses the OCR events with `source: 'copilot'` so the OCR-accuracy KPI is captured on both the Purchasing and Copilot paths.
+- Sales: `invoice_emailed`, `quote_created` (timing)
 - Backend (server-side, mirrored names, `backend_` prefix): `accounting_entry_generated`, `ocr_field_accuracy`, `bank_match_attempted`, `asset_created`, `email_invoice_ingested`, `monthly_close_started` / `monthly_close_completed`
 
 ## 5. Measurement Channels
@@ -110,14 +110,14 @@ Channels: **1** RUM · **2** Sentry · **3** Mixpanel · **4** Timing · **5** N
 | % users interacting with Pending Tasks panel | >50% | 3 (`pending_tasks_interacted`) |
 | % sessions navigating Dashboard → document | >30% | 3 (page funnel) |
 
-### Ventas
+### Sales
 | KPI | Target | Channel |
 |---|---|---|
 | Avg time to create a quote | <3min | 4 (`quote_created`) |
 | % invoices emailed from system | >70% | 3 (`invoice_emailed` / total) |
 | ★ % collections correctly linked to invoice | 100% | 7 |
 
-### Compras
+### Purchasing
 | KPI | Target | Channel |
 |---|---|---|
 | % supplier invoices via OCR vs manual | >50% | 3 + 6 (`ocr_invoice_uploaded` vs manual `record_created`) |
@@ -128,7 +128,7 @@ Channels: **1** RUM · **2** Sentry · **3** Mixpanel · **4** Timing · **5** N
 | Avg manual invoice registration time | <5min | 4 |
 | ★ % creditor invoices processed without critical data error | 100% | 7 |
 
-### Inventario
+### Inventory
 | KPI | Target | Channel |
 |---|---|---|
 | Stock accuracy (system vs physical count) | >98% | 7 (+ count input) |
@@ -137,7 +137,7 @@ Channels: **1** RUM · **2** Sentry · **3** Mixpanel · **4** Timing · **5** N
 | ★ % purchase receipts correctly updating stock | 100% | 7 |
 | ★ % outbound delivery notes correctly reducing stock | 100% | 7 |
 
-### Contabilidad y Finanzas
+### Accounting and Finance
 | KPI | Target | Channel |
 |---|---|---|
 | % accounting entries generated automatically | >90% | 6 (`accounting_entry_generated`) |
@@ -147,16 +147,16 @@ Channels: **1** RUM · **2** Sentry · **3** Mixpanel · **4** Timing · **5** N
 | % users accessing Accounting board ≥1/week | >60% | 3 (`window_opened` cohort) |
 | Time to view aging reports | <3s | 1 |
 
-### Contactos
+### Contacts
 | KPI | Target | Channel |
 |---|---|---|
 | Autocomplete success rate (name/CIF) | >80% | 3 (`contact_autocomplete_attempted` + `contact_autocomplete_succeeded`) |
 | Avg time to create a contact | <2min | 4 (`time_to_create`) |
 | % contacts with minimum data (email+phone+address) | >75% | 7 (data-quality) |
 | % searches with correct result in top 3 | >90% | 3 (`search_result_selected` position) |
-| ★ % contacts available in Ventas & Compras | 100% | 7 |
+| ★ % contacts available in Sales & Purchasing | 100% | 7 |
 
-### Productos
+### Products
 | KPI | Target | Channel |
 |---|---|---|
 | Avg time to create a product | <2min | 4 |
@@ -165,7 +165,7 @@ Channels: **1** RUM · **2** Sentry · **3** Mixpanel · **4** Timing · **5** N
 | % products with sale & purchase price | >90% | 7 (data-quality) |
 | ★ % products whose card stock = Inventory stock | 100% | 7 |
 
-### Copilot IA
+### Copilot AI
 | KPI | Target | Channel |
 |---|---|---|
 | % users using Copilot in first 7d | >50% | 3 (`copilot_session_started` cohort) |
@@ -175,7 +175,7 @@ Channels: **1** RUM · **2** Sentry · **3** Mixpanel · **4** Timing · **5** N
 | Copilot NPS | >40 | 5 |
 | Agent response time for simple tasks | <5s | 4 |
 
-### Configuración y Administración (Onboarding)
+### Configuration and Administration (Onboarding)
 | KPI | Target | Channel |
 |---|---|---|
 | % users completing the 4-step wizard | >85% | 3 (funnel) |
@@ -185,7 +185,7 @@ Channels: **1** RUM · **2** Sentry · **3** Mixpanel · **4** Timing · **5** N
 | ★ % users with correctly assigned roles | >95% (100% critical) | 7 |
 | System abandonment rate in first 3 days | <20% | 3 (retention cohort) |
 
-### Activos Fijos
+### Fixed Assets
 | KPI | Target | Channel |
 |---|---|---|
 | Avg time to create an asset (manual) | <3min | 4 |
@@ -199,7 +199,7 @@ Channels: **1** RUM · **2** Sentry · **3** Mixpanel · **4** Timing · **5** N
 | ★ % assets correct in amortization schedule | 100% | 7 |
 | ★ % fully-amortized assets correct in report | 100% | 7 |
 
-### Cross-cutting (Transversales)
+### Cross-cutting
 | KPI | Target | Channel |
 |---|---|---|
 | Load time of any screen/report | <2s | 1 |
@@ -216,9 +216,9 @@ Channels: **1** RUM · **2** Sentry · **3** Mixpanel · **4** Timing · **5** N
 
 **SQL validation jobs (Integrity 100%)** — a set of invariant queries, one per critical KPI, run as a scheduled Etendo Process (or cron). Each returns `{kpi, total, violations, pass}` and writes to an `ETGO_KPI_CHECK` table (timestamp + result). **Note:** this is not a trivial DDL — it requires full Etendo AD registration (`AD_TABLE`, `AD_COLUMN`, `AD_ELEMENT`, dbprefix, `export.database`), budgeted in Sprint 0. UUIDs via `make uuid`, never hand-typed. Each `★` job enforces 0 violations (see Section 6 threshold note). Examples:
 
-- `stock_trazabilidad` — movements without reference document → must be 0
-- `stock_vs_inventario` — product-card stock ≠ inventory stock → must be 0
-- `amortizacion_vinculada` — amortization entries without source asset → must be 0
+- `stock_traceability` — movements without reference document → must be 0
+- `stock_vs_inventory` — product-card stock ≠ inventory stock → must be 0
+- `linked_amortization` — amortization entries without source asset → must be 0
 - `roles_onboarding` — post-onboarding users without correct role → must be 0
 
 `ETGO_KPI_CHECK` feeds the monthly consolidated report's green/red status.
@@ -228,7 +228,7 @@ Channels: **1** RUM · **2** Sentry · **3** Mixpanel · **4** Timing · **5** N
 - **Mixpanel** — Adoption / UX / Business: funnels, retention, cohorts, numeric-property charts.
 - **CloudWatch RUM** — Performance: load times, web vitals (mostly automatic + a few custom report timings).
 - **Sentry** — Stability: crash-free session rate.
-- **Monthly consolidated report** — a script that pulls from the three tools + `ETGO_KPI_CHECK` and produces a green/red vs-threshold table for month-1 and month-2 close (Fase 3 of the source doc). No new in-app UI.
+- **Monthly consolidated report** — a script that pulls from the three tools + `ETGO_KPI_CHECK` and produces a green/red vs-threshold table for month-1 and month-2 close (Phase 3 of the source doc). No new in-app UI.
 
 ## 9. Work Plan (Phasing)
 
@@ -238,14 +238,14 @@ Quick wins + foundations first, then aligned to the document's 3 phases.
   - *Config prerequisites (must land first):* add RUM **production** host config + env-driven `sessionSampleRate` (Gap 6); set Sentry `release` and resolve `sendDefaultPii` (Gap 7); register `ETGO_KPI_CHECK` in AD + store backend Mixpanel token in `AD_SysConfig`.
   - *Quick wins:* validate RUM + Sentry dashboards; wire `identify()` on login (opaque id); validate route taxonomy; migrate existing `OnboardingPage.jsx` events into the catalog.
   - *Foundations:* extend `payload.js` (numeric keys); timing helper + `useTiming`; NPS component (with i18n keys); `events.js` catalog + backend name-sync CI lint; generator auto-instrumentation scaffolding (pass spec name explicitly as a property — do not rely on route derivation).
-- **Fase 1 — Alpha (Integrity + Performance)**
+- **Phase 1 — Alpha (Integrity + Performance)**
   - Roll generic auto-instrumentation to all 10 windows (channel A).
   - SQL integrity jobs + `ETGO_KPI_CHECK` table.
   - Validate all Performance KPIs via RUM.
-- **Fase 2 — Beta (Adoption + UX, real users)**
-  - Module-specific instrumentation (Compras OCR, Onboarding funnel, Copilot, quick actions, searches).
+- **Phase 2 — Beta (Adoption + UX, real users)**
+  - Module-specific instrumentation (Purchasing OCR, Onboarding funnel, Copilot, quick actions, searches).
   - Copilot NPS. Mixpanel funnels and cohorts.
-- **Fase 3 — Post-launch (Business)**
+- **Phase 3 — Post-launch (Business)**
   - 30-day retention, 3-day abandonment, overall NPS.
   - Monthly consolidated report script (KPIs vs threshold, green/red) for month-1 and month-2 close.
   - Threshold review.

--- a/tools/app-shell/src/lib/__tests__/observability-adapters.test.js
+++ b/tools/app-shell/src/lib/__tests__/observability-adapters.test.js
@@ -2,8 +2,19 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
 import { buildBrowserObservabilityConfig } from '../observability/browser.js';
-import { createRumProvider, resolveRumConfig } from '../rum.js';
-import { createSentryProvider, resolveSentryEnvironment } from '../sentry.js';
+import {
+  createRumProvider,
+  DEFAULT_RUM_SESSION_SAMPLE_RATE,
+  resolveRumConfig,
+  resolveRumSessionSampleRate,
+} from '../rum.js';
+import {
+  createSentryProvider,
+  DEFAULT_SENTRY_SEND_DEFAULT_PII,
+  resolveSentryEnvironment,
+  resolveSentryRelease,
+  resolveSentrySendDefaultPii,
+} from '../sentry.js';
 
 describe('sentry observability adapter', () => {
   it('preserves hostname to environment mapping', () => {
@@ -13,7 +24,7 @@ describe('sentry observability adapter', () => {
     assert.equal(resolveSentryEnvironment('localhost'), 'development');
   });
 
-  it('initializes Sentry with the existing tracing and PII config', () => {
+  it('initializes Sentry with tracing, release metadata, and privacy-safe PII defaults', () => {
     const calls = [];
     const fakeSentry = {
       browserTracingIntegration() {
@@ -28,6 +39,9 @@ describe('sentry observability adapter', () => {
       dsn: 'dsn-123',
       hostname: 'go.staging.etendo.cloud',
       sentry: fakeSentry,
+      env: {
+        VITE_SENTRY_RELEASE: 'release-from-env',
+      },
     });
     provider.init();
 
@@ -35,9 +49,10 @@ describe('sentry observability adapter', () => {
     assert.equal(provider.enabled, true);
     assert.equal(calls[0].dsn, 'dsn-123');
     assert.equal(calls[0].environment, 'staging');
+    assert.equal(calls[0].release, 'release-from-env');
     assert.deepEqual(calls[0].integrations, ['browser-tracing']);
     assert.equal(calls[0].tracesSampleRate, 0.1);
-    assert.equal(calls[0].sendDefaultPii, true);
+    assert.equal(calls[0].sendDefaultPii, false);
     assert.deepEqual(calls[0].tracePropagationTargets, [/core\..+\.etendo\.cloud/, 'core.etendo.cloud']);
   });
 
@@ -45,6 +60,32 @@ describe('sentry observability adapter', () => {
     const provider = createSentryProvider({ dsn: '' });
 
     assert.equal(provider.enabled, false);
+  });
+
+  it('enables Sentry PII only when explicitly requested via env', () => {
+    assert.equal(resolveSentrySendDefaultPii(undefined), DEFAULT_SENTRY_SEND_DEFAULT_PII);
+    assert.equal(resolveSentrySendDefaultPii('true'), true);
+    assert.equal(resolveSentrySendDefaultPii('1'), true);
+    assert.equal(resolveSentrySendDefaultPii('false'), false);
+    assert.equal(resolveSentrySendDefaultPii('unexpected'), DEFAULT_SENTRY_SEND_DEFAULT_PII);
+  });
+
+  it('resolves Sentry release from env first and then build metadata', () => {
+    assert.equal(
+      resolveSentryRelease(
+        { VITE_SENTRY_RELEASE: 'env-release' },
+        { SENTRY_RELEASE: { id: 'build-release' } }
+      ),
+      'env-release'
+    );
+    assert.equal(
+      resolveSentryRelease({}, { SENTRY_RELEASE: { id: 'build-release' } }),
+      'build-release'
+    );
+    assert.equal(
+      resolveSentryRelease({}, { __APP_VERSION__: '0.1.0+sha.abc123' }),
+      '0.1.0+sha.abc123'
+    );
   });
 });
 
@@ -55,6 +96,8 @@ describe('AWS RUM observability adapter', () => {
       VITE_RUM_IDENTITY_POOL_ID_STAGING: 'staging-pool',
       VITE_RUM_APP_MONITOR_ID_EXPERIMENTAL: 'experimental-monitor',
       VITE_RUM_IDENTITY_POOL_ID_EXPERIMENTAL: 'experimental-pool',
+      VITE_RUM_APP_MONITOR_ID_PROD: 'prod-monitor',
+      VITE_RUM_IDENTITY_POOL_ID_PROD: 'prod-pool',
     };
 
     assert.deepEqual(resolveRumConfig('go.staging.etendo.cloud', env), {
@@ -65,10 +108,13 @@ describe('AWS RUM observability adapter', () => {
       appMonitorId: 'experimental-monitor',
       identityPoolId: 'experimental-pool',
     });
-    assert.equal(resolveRumConfig('go.etendo.cloud', env), undefined);
+    assert.deepEqual(resolveRumConfig('go.etendo.cloud', env), {
+      appMonitorId: 'prod-monitor',
+      identityPoolId: 'prod-pool',
+    });
   });
 
-  it('initializes AWS RUM with the existing region, endpoint, and telemetries', () => {
+  it('initializes AWS RUM with the existing region, endpoint, telemetries, and bounded sample rate', () => {
     const calls = [];
     class FakeAwsRum {
       constructor(...args) {
@@ -81,6 +127,7 @@ describe('AWS RUM observability adapter', () => {
       env: {
         VITE_RUM_APP_MONITOR_ID_EXPERIMENTAL: 'monitor-id',
         VITE_RUM_IDENTITY_POOL_ID_EXPERIMENTAL: 'pool-id',
+        VITE_RUM_SESSION_SAMPLE_RATE: '0.25',
       },
       AwsRumCtor: FakeAwsRum,
       logger: { warn() {} },
@@ -94,7 +141,7 @@ describe('AWS RUM observability adapter', () => {
       '1.0.0',
       'eu-west-3',
       {
-        sessionSampleRate: 1,
+        sessionSampleRate: 0.25,
         identityPoolId: 'pool-id',
         endpoint: 'https://dataplane.rum.eu-west-3.amazonaws.com',
         telemetries: ['performance', 'errors', 'http'],
@@ -148,6 +195,31 @@ describe('AWS RUM observability adapter', () => {
     assert.equal(provider.enabled, false);
     assert.doesNotThrow(() => provider.init());
     assert.deepEqual(calls, []);
+
+    const nullEnvProvider = createRumProvider({
+      hostname: 'localhost',
+      env: null,
+      AwsRumCtor: FakeAwsRum,
+      logger: { warn() {} },
+    });
+
+    assert.equal(nullEnvProvider.enabled, false);
+    assert.doesNotThrow(() => nullEnvProvider.init());
+    assert.deepEqual(calls, []);
+  });
+
+  it('bounds the RUM session sample rate and falls back conservatively', () => {
+    assert.equal(
+      resolveRumSessionSampleRate(undefined),
+      DEFAULT_RUM_SESSION_SAMPLE_RATE
+    );
+    assert.equal(resolveRumSessionSampleRate('0.5'), 0.5);
+    assert.equal(resolveRumSessionSampleRate('2'), 1);
+    assert.equal(resolveRumSessionSampleRate('-1'), 0);
+    assert.equal(
+      resolveRumSessionSampleRate('not-a-number'),
+      DEFAULT_RUM_SESSION_SAMPLE_RATE
+    );
   });
 });
 

--- a/tools/app-shell/src/lib/__tests__/observability-adapters.test.js
+++ b/tools/app-shell/src/lib/__tests__/observability-adapters.test.js
@@ -213,6 +213,14 @@ describe('AWS RUM observability adapter', () => {
       resolveRumSessionSampleRate(undefined),
       DEFAULT_RUM_SESSION_SAMPLE_RATE
     );
+    assert.equal(
+      resolveRumSessionSampleRate(''),
+      DEFAULT_RUM_SESSION_SAMPLE_RATE
+    );
+    assert.equal(
+      resolveRumSessionSampleRate('   '),
+      DEFAULT_RUM_SESSION_SAMPLE_RATE
+    );
     assert.equal(resolveRumSessionSampleRate('0.5'), 0.5);
     assert.equal(resolveRumSessionSampleRate('2'), 1);
     assert.equal(resolveRumSessionSampleRate('-1'), 0);

--- a/tools/app-shell/src/lib/__tests__/observability-payload.test.js
+++ b/tools/app-shell/src/lib/__tests__/observability-payload.test.js
@@ -45,6 +45,9 @@ describe('observability payload normalization', () => {
     assert.deepEqual(
       sanitizeEventProperties({
         action: 'open',
+        durationMs: 125,
+        specName: 'sales-order',
+        entity: 'sales_order',
         component: 'menu',
         documentId: 'secret-doc-id',
         label: 'Customer Name',
@@ -54,7 +57,89 @@ describe('observability payload normalization', () => {
       }),
       {
         action: 'open',
+        durationMs: 125,
+        specName: 'sales-order',
+        entity: 'sales_order',
         component: 'menu',
+      }
+    );
+  });
+
+  it('keeps bounded numeric metrics and low-cardinality metadata', () => {
+    assert.deepEqual(
+      sanitizeEventProperties({
+        accuracy: 98.4,
+        attempt: 2,
+        category: 'sales',
+        count: 3,
+        durationMs: 2500,
+        operation: 'create',
+        position: 1,
+        score: 9,
+        source: 'copilot',
+        specName: 'sales-order',
+        step: 4,
+        supportRequested: false,
+        value: 1,
+      }),
+      {
+        accuracy: 98.4,
+        attempt: 2,
+        category: 'sales',
+        count: 3,
+        durationMs: 2500,
+        operation: 'create',
+        position: 1,
+        score: 9,
+        source: 'copilot',
+        specName: 'sales-order',
+        step: 4,
+        supportRequested: false,
+        value: 1,
+      }
+    );
+  });
+
+  it('drops out-of-bounds numeric metrics even when the key is allowlisted', () => {
+    assert.deepEqual(
+      sanitizeEventProperties({
+        accuracy: 120,
+        durationMs: Number.POSITIVE_INFINITY,
+        position: -1,
+        score: 11,
+        step: 101,
+        value: 1000001,
+      }),
+      {}
+    );
+  });
+
+  it('drops non-numeric values for numeric metric keys', () => {
+    assert.deepEqual(
+      sanitizeEventProperties({
+        accuracy: '98',
+        attempt: true,
+        count: '3',
+        durationMs: '2500',
+        position: false,
+        score: '9',
+        step: '4',
+        value: '1',
+      }),
+      {}
+    );
+  });
+
+  it('gives the denylist priority over the allowlist', () => {
+    assert.deepEqual(
+      sanitizeEventProperties({
+        id: 42,
+        name: 'private',
+        rawUrl: '/sales-order/ABC123',
+        specName: 'sales-order',
+      }),
+      {
+        specName: 'sales-order',
       }
     );
   });

--- a/tools/app-shell/src/lib/observability/__tests__/events.vitest.js
+++ b/tools/app-shell/src/lib/observability/__tests__/events.vitest.js
@@ -1,0 +1,111 @@
+import {
+  OBSERVABILITY_CHANNELS,
+  OBSERVABILITY_EVENT_LIST,
+  OBSERVABILITY_EVENTS,
+  OBSERVABILITY_PROPERTY_KEYS,
+  buildObservabilityEvent,
+  getObservabilityEvent,
+} from '../events.js';
+
+const ALLOWED_CHANNELS = new Set(Object.values(OBSERVABILITY_CHANNELS));
+const ALLOWED_PROPERTIES = new Set(Object.values(OBSERVABILITY_PROPERTY_KEYS));
+const SNAKE_CASE_EVENT_NAME = /^[a-z0-9]+(?:_[a-z0-9]+)*$/;
+
+describe('observability event catalog', () => {
+  it('uses snake_case names for every event', () => {
+    for (const event of OBSERVABILITY_EVENT_LIST) {
+      expect(event.name).toMatch(SNAKE_CASE_EVENT_NAME);
+    }
+  });
+
+  it('keeps event names unique', () => {
+    const names = OBSERVABILITY_EVENT_LIST.map(event => event.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  it('uses only known channels and property keys', () => {
+    for (const event of OBSERVABILITY_EVENT_LIST) {
+      for (const channel of event.channels) {
+        expect(ALLOWED_CHANNELS.has(channel)).toBe(true);
+      }
+
+      for (const property of event.properties) {
+        expect(ALLOWED_PROPERTIES.has(property)).toBe(true);
+      }
+    }
+  });
+
+  it('preserves the current onboarding event strings exactly', () => {
+    expect(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_SUBMITTED.name).toBe('onboarding_auth_submitted');
+    expect(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_SUCCEEDED.name).toBe('onboarding_auth_succeeded');
+    expect(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_FAILED.name).toBe('onboarding_auth_failed');
+    expect(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_LOGOUT.name).toBe('onboarding_auth_logout');
+    expect(OBSERVABILITY_EVENTS.ONBOARDING_ENVIRONMENT_ENTER_SUBMITTED.name).toBe('onboarding_environment_enter_submitted');
+    expect(OBSERVABILITY_EVENTS.ONBOARDING_ENVIRONMENT_ENTER_SUCCEEDED.name).toBe('onboarding_environment_enter_succeeded');
+    expect(OBSERVABILITY_EVENTS.ONBOARDING_ENVIRONMENT_ENTER_FAILED.name).toBe('onboarding_environment_enter_failed');
+    expect(OBSERVABILITY_EVENTS.ONBOARDING_RUN_STARTED.name).toBe('onboarding_run_started');
+    expect(OBSERVABILITY_EVENTS.ONBOARDING_RUN_SUCCEEDED.name).toBe('onboarding_run_succeeded');
+    expect(OBSERVABILITY_EVENTS.ONBOARDING_RUN_FAILED.name).toBe('onboarding_run_failed');
+    expect(OBSERVABILITY_EVENTS.ONBOARDING_SETUP_STEP_COMPLETED.name).toBe('onboarding_setup_step_completed');
+    expect(OBSERVABILITY_EVENTS.ONBOARDING_SETUP_STEP_BACK.name).toBe('onboarding_setup_step_back');
+  });
+
+  it('builds stable payloads from the catalog and drops unknown keys', () => {
+    expect(buildObservabilityEvent(OBSERVABILITY_EVENTS.TIME_TO_CREATE, {
+      category: 'contacts',
+      durationMs: 1200,
+      entity: 'business_partner',
+      operation: 'create',
+      specName: 'business-partner',
+      label: 'Private label',
+      recordId: 'secret',
+    })).toEqual({
+      name: 'time_to_create',
+      properties: {
+        category: 'contacts',
+        durationMs: 1200,
+        entity: 'business_partner',
+        operation: 'create',
+        specName: 'business-partner',
+      },
+    });
+  });
+
+  it('normalizes catalog event properties before returning them', () => {
+    expect(buildObservabilityEvent(OBSERVABILITY_EVENTS.TIME_TO_CREATE, {
+      category: 'contacts',
+      durationMs: '1200',
+      value: true,
+    })).toEqual({
+      name: 'time_to_create',
+      properties: {
+        category: 'contacts',
+      },
+    });
+  });
+
+  it('normalizes fallback event properties for ad hoc callers', () => {
+    expect(buildObservabilityEvent('custom_event', {
+      action: 'open',
+      rawUrl: '/private/123',
+      randomKey: 'ignored',
+    })).toEqual({
+      name: 'custom_event',
+      properties: {
+        action: 'open',
+      },
+    });
+  });
+
+  it('resolves events by name', () => {
+    expect(getObservabilityEvent('time_to_create')).toBe(OBSERVABILITY_EVENTS.TIME_TO_CREATE);
+  });
+
+  it('rejects malformed event definition objects', () => {
+    expect(getObservabilityEvent({ name: 'time_to_create' })).toBeUndefined();
+    expect(buildObservabilityEvent({ name: 'time_to_create' }, { durationMs: 10 })).toEqual({
+      name: undefined,
+      properties: {},
+    });
+  });
+});

--- a/tools/app-shell/src/lib/observability/__tests__/events.vitest.js
+++ b/tools/app-shell/src/lib/observability/__tests__/events.vitest.js
@@ -101,6 +101,20 @@ describe('observability event catalog', () => {
     expect(getObservabilityEvent('time_to_create')).toBe(OBSERVABILITY_EVENTS.TIME_TO_CREATE);
   });
 
+  it('resolves event-like objects through the canonical catalog', () => {
+    expect(getObservabilityEvent({
+      name: 'time_to_create',
+      channels: ['custom-channel'],
+      properties: ['unsafeProperty'],
+    })).toBe(OBSERVABILITY_EVENTS.TIME_TO_CREATE);
+
+    expect(getObservabilityEvent({
+      name: 'uncataloged_event',
+      channels: ['mixpanel'],
+      properties: ['action'],
+    })).toBeUndefined();
+  });
+
   it('rejects malformed event definition objects', () => {
     expect(getObservabilityEvent({ name: 'time_to_create' })).toBeUndefined();
     expect(buildObservabilityEvent({ name: 'time_to_create' }, { durationMs: 10 })).toEqual({

--- a/tools/app-shell/src/lib/observability/__tests__/payload.vitest.js
+++ b/tools/app-shell/src/lib/observability/__tests__/payload.vitest.js
@@ -110,6 +110,28 @@ describe('sanitizeEventProperties', () => {
     expect(sanitizeEventProperties({ status: 200 })).toEqual({ status: 200 });
   });
 
+  it('keeps bounded KPI metric keys', () => {
+    expect(sanitizeEventProperties({
+      accuracy: 98.2,
+      attempt: 2,
+      count: 4,
+      durationMs: 1234,
+      position: 1,
+      score: 10,
+      step: 3,
+      value: 1,
+    })).toEqual({
+      accuracy: 98.2,
+      attempt: 2,
+      count: 4,
+      durationMs: 1234,
+      position: 1,
+      score: 10,
+      step: 3,
+      value: 1,
+    });
+  });
+
   it('keeps safe keys with boolean values', () => {
     expect(sanitizeEventProperties({ enabled: true })).toEqual({ enabled: true });
   });
@@ -132,6 +154,48 @@ describe('sanitizeEventProperties', () => {
 
   it('removes object values (not string/number/boolean)', () => {
     expect(sanitizeEventProperties({ action: { nested: true } })).toEqual({});
+  });
+
+  it('removes out-of-range KPI metric values', () => {
+    expect(sanitizeEventProperties({
+      accuracy: 101,
+      attempt: 101,
+      count: 100001,
+      durationMs: -1,
+      position: 101,
+      score: 11,
+      step: 1000,
+      value: 1000001,
+    })).toEqual({});
+  });
+
+  it('removes non-numeric values for KPI metric keys', () => {
+    expect(sanitizeEventProperties({
+      accuracy: '98',
+      attempt: true,
+      count: '4',
+      durationMs: '1234',
+      position: false,
+      score: '10',
+      step: '3',
+      value: '1',
+    })).toEqual({});
+  });
+
+  it('keeps low-cardinality metadata keys', () => {
+    expect(sanitizeEventProperties({
+      category: 'sales',
+      entity: 'sales_order',
+      operation: 'create',
+      specName: 'sales-order',
+      supportRequested: false,
+    })).toEqual({
+      category: 'sales',
+      entity: 'sales_order',
+      operation: 'create',
+      specName: 'sales-order',
+      supportRequested: false,
+    });
   });
 
   it('returns empty object for empty input', () => {

--- a/tools/app-shell/src/lib/observability/__tests__/timing.vitest.jsx
+++ b/tools/app-shell/src/lib/observability/__tests__/timing.vitest.jsx
@@ -1,0 +1,127 @@
+import { renderHook } from '@testing-library/react';
+
+const observabilityMock = vi.hoisted(() => ({
+  track: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../observability.js', () => ({
+  track: observabilityMock.track,
+}));
+
+import { OBSERVABILITY_EVENTS } from '../events.js';
+import { startTiming } from '../timing.js';
+import { useTiming } from '../useTiming.js';
+
+describe('startTiming', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('tracks a catalog-backed timing event with durationMs', async () => {
+    const now = vi.fn()
+      .mockReturnValueOnce(100)
+      .mockReturnValueOnce(432.2);
+
+    const stop = startTiming(OBSERVABILITY_EVENTS.TIME_TO_CREATE, { now });
+    const event = await stop({
+      category: 'contacts',
+      entity: 'business_partner',
+      operation: 'create',
+      specName: 'business-partner',
+      label: 'should-be-dropped',
+    });
+
+    expect(observabilityMock.track).toHaveBeenCalledWith('time_to_create', {
+      category: 'contacts',
+      durationMs: 332,
+      entity: 'business_partner',
+      operation: 'create',
+      specName: 'business-partner',
+    });
+    expect(event).toEqual({
+      name: 'time_to_create',
+      properties: {
+        category: 'contacts',
+        durationMs: 332,
+        entity: 'business_partner',
+        operation: 'create',
+        specName: 'business-partner',
+      },
+    });
+  });
+
+  it('tracks only once even if stop is called twice', async () => {
+    const now = vi.fn()
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(20);
+
+    const stop = startTiming(OBSERVABILITY_EVENTS.TIME_TO_CREATE, { now });
+    await stop({ category: 'contacts' });
+    await stop({ category: 'contacts' });
+
+    expect(observabilityMock.track).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns without tracking when no valid clock is available', async () => {
+    const stop = startTiming(OBSERVABILITY_EVENTS.TIME_TO_CREATE, {
+      now: () => undefined,
+    });
+
+    await expect(stop({ category: 'contacts' })).resolves.toBeUndefined();
+    expect(observabilityMock.track).not.toHaveBeenCalled();
+  });
+
+  it('returns without tracking unknown timing event names', async () => {
+    const stop = startTiming('ad_hoc_timing_event', {
+      now: () => 10,
+    });
+
+    await expect(stop({ durationMs: 20, rawUrl: '/private/123' })).resolves.toBeUndefined();
+    expect(observabilityMock.track).not.toHaveBeenCalled();
+  });
+});
+
+describe('useTiming', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts and stops a timing session for React flows', async () => {
+    const now = vi.fn()
+      .mockReturnValueOnce(50)
+      .mockReturnValueOnce(140);
+    const { result } = renderHook(() =>
+      useTiming(OBSERVABILITY_EVENTS.TIME_TO_CREATE, { now })
+    );
+
+    result.current.start({ category: 'contacts', specName: 'business-partner' });
+    await result.current.stop({
+      entity: 'business_partner',
+      operation: 'create',
+      rawUrl: '/business-partner/123',
+    });
+
+    expect(observabilityMock.track).toHaveBeenCalledWith('time_to_create', {
+      category: 'contacts',
+      durationMs: 90,
+      entity: 'business_partner',
+      operation: 'create',
+      specName: 'business-partner',
+    });
+  });
+
+  it('cancels an active timer without emitting an event', async () => {
+    const now = vi.fn()
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(40);
+    const { result } = renderHook(() =>
+      useTiming(OBSERVABILITY_EVENTS.TIME_TO_CREATE, { now })
+    );
+
+    result.current.start({ category: 'contacts' });
+    result.current.cancel();
+    await result.current.stop({ entity: 'business_partner' });
+
+    expect(observabilityMock.track).not.toHaveBeenCalled();
+  });
+});

--- a/tools/app-shell/src/lib/observability/__tests__/timing.vitest.jsx
+++ b/tools/app-shell/src/lib/observability/__tests__/timing.vitest.jsx
@@ -79,6 +79,16 @@ describe('startTiming', () => {
     await expect(stop({ durationMs: 20, rawUrl: '/private/123' })).resolves.toBeUndefined();
     expect(observabilityMock.track).not.toHaveBeenCalled();
   });
+
+  it('returns without tracking catalog events that are not timing events', async () => {
+    const now = vi.fn()
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(40);
+    const stop = startTiming(OBSERVABILITY_EVENTS.APP_STARTED, { now });
+
+    await expect(stop({ category: 'startup' })).resolves.toBeUndefined();
+    expect(observabilityMock.track).not.toHaveBeenCalled();
+  });
 });
 
 describe('useTiming', () => {

--- a/tools/app-shell/src/lib/observability/browser.js
+++ b/tools/app-shell/src/lib/observability/browser.js
@@ -28,6 +28,7 @@ export function buildBrowserObservabilityConfig({
     providers: [
       createSentryProvider({
         dsn: env.VITE_SENTRY_DSN,
+        env,
         hostname,
       }),
       createRumProvider({

--- a/tools/app-shell/src/lib/observability/browser.js
+++ b/tools/app-shell/src/lib/observability/browser.js
@@ -1,4 +1,5 @@
 import { initObservability, track } from '../observability.js';
+import { OBSERVABILITY_EVENTS } from './events.js';
 import { createMixpanelProvider } from './providers/mixpanel.js';
 import { createRumProvider } from '../rum.js';
 import { createSentryProvider } from '../sentry.js';
@@ -50,5 +51,5 @@ export async function initBrowserObservability(
   client = { initObservability, track }
 ) {
   await client.initObservability(buildBrowserObservabilityConfig(options));
-  await client.track('app_started');
+  await client.track(OBSERVABILITY_EVENTS.APP_STARTED.name);
 }

--- a/tools/app-shell/src/lib/observability/events.js
+++ b/tools/app-shell/src/lib/observability/events.js
@@ -1,0 +1,525 @@
+import { sanitizeEventProperties } from './payload.js';
+
+const OBSERVABILITY_CHANNEL_VALUES = Object.freeze({
+  MIXPANEL: 'mixpanel',
+  TIMING: 'timing',
+  NPS: 'nps',
+  BACKEND: 'backend',
+  RUM: 'rum',
+  SENTRY: 'sentry',
+  SQL: 'sql',
+});
+
+const OBSERVABILITY_PROPERTY_VALUES = Object.freeze({
+  ACTION: 'action',
+  ACCURACY: 'accuracy',
+  ATTEMPT: 'attempt',
+  CATEGORY: 'category',
+  COUNT: 'count',
+  DURATION_MS: 'durationMs',
+  ENTITY: 'entity',
+  OPERATION: 'operation',
+  POSITION: 'position',
+  PROVIDER: 'provider',
+  SCORE: 'score',
+  SOURCE: 'source',
+  SPEC_NAME: 'specName',
+  STATUS: 'status',
+  STEP: 'step',
+  SUPPORT_REQUESTED: 'supportRequested',
+  TYPE: 'type',
+  VALUE: 'value',
+});
+
+function defineEvent(name, { channels = [], properties = [] } = {}) {
+  return Object.freeze({
+    name,
+    channels: Object.freeze([...channels]),
+    properties: Object.freeze([...properties]),
+  });
+}
+
+function buildEventMap(events) {
+  return new Map(events.map(event => [event.name, event]));
+}
+
+function pickEventProperties(event, properties = {}) {
+  const sanitized = {};
+
+  for (const key of event.properties) {
+    const value = properties[key];
+    if (value != null) {
+      sanitized[key] = value;
+    }
+  }
+
+  return sanitized;
+}
+
+export const OBSERVABILITY_CHANNELS = OBSERVABILITY_CHANNEL_VALUES;
+export const OBSERVABILITY_PROPERTY_KEYS = OBSERVABILITY_PROPERTY_VALUES;
+
+export const OBSERVABILITY_EVENTS = Object.freeze({
+  APP_STARTED: defineEvent('app_started', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+  }),
+  WINDOW_OPENED: defineEvent('window_opened', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.ENTITY,
+      OBSERVABILITY_PROPERTY_KEYS.SPEC_NAME,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+    ],
+  }),
+  RECORD_CREATED: defineEvent('record_created', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.ENTITY,
+      OBSERVABILITY_PROPERTY_KEYS.OPERATION,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.SPEC_NAME,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  RECORD_UPDATED: defineEvent('record_updated', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.ENTITY,
+      OBSERVABILITY_PROPERTY_KEYS.OPERATION,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.SPEC_NAME,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  RECORD_DELETED: defineEvent('record_deleted', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.ENTITY,
+      OBSERVABILITY_PROPERTY_KEYS.OPERATION,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.SPEC_NAME,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  DOCUMENT_COMPLETED: defineEvent('document_completed', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.ENTITY,
+      OBSERVABILITY_PROPERTY_KEYS.OPERATION,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.SPEC_NAME,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  QUICK_ACTION_USED: defineEvent('quick_action_used', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ACTION,
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.ENTITY,
+      OBSERVABILITY_PROPERTY_KEYS.OPERATION,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.SPEC_NAME,
+      OBSERVABILITY_PROPERTY_KEYS.TYPE,
+    ],
+  }),
+  SEARCH_PERFORMED: defineEvent('search_performed', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ATTEMPT,
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.COUNT,
+      OBSERVABILITY_PROPERTY_KEYS.ENTITY,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.SPEC_NAME,
+      OBSERVABILITY_PROPERTY_KEYS.TYPE,
+    ],
+  }),
+  SEARCH_RESULT_SELECTED: defineEvent('search_result_selected', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.ENTITY,
+      OBSERVABILITY_PROPERTY_KEYS.POSITION,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.SPEC_NAME,
+      OBSERVABILITY_PROPERTY_KEYS.TYPE,
+    ],
+  }),
+  TIME_TO_CREATE: defineEvent('time_to_create', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL, OBSERVABILITY_CHANNELS.TIMING],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.DURATION_MS,
+      OBSERVABILITY_PROPERTY_KEYS.ENTITY,
+      OBSERVABILITY_PROPERTY_KEYS.OPERATION,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.SPEC_NAME,
+      OBSERVABILITY_PROPERTY_KEYS.STEP,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  ONBOARDING_STEP_COMPLETED: defineEvent('onboarding_step_completed', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.STEP,
+      OBSERVABILITY_PROPERTY_KEYS.SUPPORT_REQUESTED,
+    ],
+  }),
+  ONBOARDING_FINISHED: defineEvent('onboarding_finished', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.STEP,
+    ],
+  }),
+  ONBOARDING_BANK_CONFIGURED: defineEvent('onboarding_bank_configured', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL, OBSERVABILITY_CHANNELS.SQL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.STEP,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  TIME_TO_FIRST_INVOICE: defineEvent('time_to_first_invoice', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL, OBSERVABILITY_CHANNELS.TIMING],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.DURATION_MS,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.STEP,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  PENDING_TASKS_INTERACTED: defineEvent('pending_tasks_interacted', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ACTION,
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.POSITION,
+      OBSERVABILITY_PROPERTY_KEYS.TYPE,
+    ],
+  }),
+  CONTACT_AUTOCOMPLETE_ATTEMPTED: defineEvent('contact_autocomplete_attempted', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ATTEMPT,
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+    ],
+  }),
+  CONTACT_AUTOCOMPLETE_SUCCEEDED: defineEvent('contact_autocomplete_succeeded', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ATTEMPT,
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  OCR_INVOICE_UPLOADED: defineEvent('ocr_invoice_uploaded', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ATTEMPT,
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.TYPE,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  OCR_EXTRACTION_SCORED: defineEvent('ocr_extraction_scored', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ACCURACY,
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.SCORE,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  EMAIL_INVOICE_INGESTED: defineEvent('email_invoice_ingested', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL, OBSERVABILITY_CHANNELS.BACKEND],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ATTEMPT,
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.COUNT,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  COPILOT_SESSION_STARTED: defineEvent('copilot_session_started', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.TYPE,
+    ],
+  }),
+  COPILOT_TASK_RESOLVED: defineEvent('copilot_task_resolved', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.COUNT,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.TYPE,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  COPILOT_CORRECTION_NEEDED: defineEvent('copilot_correction_needed', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ATTEMPT,
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.COUNT,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.TYPE,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  COPILOT_NPS: defineEvent('copilot_nps', {
+    channels: [OBSERVABILITY_CHANNELS.NPS],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.SCORE,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.TYPE,
+    ],
+  }),
+  INVOICE_EMAILED: defineEvent('invoice_emailed', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ATTEMPT,
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.COUNT,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  QUOTE_CREATED: defineEvent('quote_created', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL, OBSERVABILITY_CHANNELS.TIMING],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.DURATION_MS,
+      OBSERVABILITY_PROPERTY_KEYS.ENTITY,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.SPEC_NAME,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  BACKEND_ACCOUNTING_ENTRY_GENERATED: defineEvent('backend_accounting_entry_generated', {
+    channels: [OBSERVABILITY_CHANNELS.BACKEND],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.COUNT,
+      OBSERVABILITY_PROPERTY_KEYS.ENTITY,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.SPEC_NAME,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  BACKEND_OCR_FIELD_ACCURACY: defineEvent('backend_ocr_field_accuracy', {
+    channels: [OBSERVABILITY_CHANNELS.BACKEND],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ACCURACY,
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.COUNT,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  BACKEND_BANK_MATCH_ATTEMPTED: defineEvent('backend_bank_match_attempted', {
+    channels: [OBSERVABILITY_CHANNELS.BACKEND],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ATTEMPT,
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.COUNT,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  BACKEND_ASSET_CREATED: defineEvent('backend_asset_created', {
+    channels: [OBSERVABILITY_CHANNELS.BACKEND],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.COUNT,
+      OBSERVABILITY_PROPERTY_KEYS.ENTITY,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.SPEC_NAME,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  BACKEND_EMAIL_INVOICE_INGESTED: defineEvent('backend_email_invoice_ingested', {
+    channels: [OBSERVABILITY_CHANNELS.BACKEND],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ATTEMPT,
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.COUNT,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  BACKEND_MONTHLY_CLOSE_STARTED: defineEvent('backend_monthly_close_started', {
+    channels: [OBSERVABILITY_CHANNELS.BACKEND],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.COUNT,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.STEP,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  BACKEND_MONTHLY_CLOSE_COMPLETED: defineEvent('backend_monthly_close_completed', {
+    channels: [OBSERVABILITY_CHANNELS.BACKEND],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.CATEGORY,
+      OBSERVABILITY_PROPERTY_KEYS.COUNT,
+      OBSERVABILITY_PROPERTY_KEYS.DURATION_MS,
+      OBSERVABILITY_PROPERTY_KEYS.SOURCE,
+      OBSERVABILITY_PROPERTY_KEYS.STEP,
+      OBSERVABILITY_PROPERTY_KEYS.VALUE,
+    ],
+  }),
+  ONBOARDING_AUTH_LOGOUT: defineEvent('onboarding_auth_logout', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ACTION,
+      OBSERVABILITY_PROPERTY_KEYS.PROVIDER,
+      OBSERVABILITY_PROPERTY_KEYS.STATUS,
+    ],
+  }),
+  ONBOARDING_AUTH_SUBMITTED: defineEvent('onboarding_auth_submitted', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ACTION,
+      OBSERVABILITY_PROPERTY_KEYS.PROVIDER,
+      OBSERVABILITY_PROPERTY_KEYS.STATUS,
+    ],
+  }),
+  ONBOARDING_AUTH_SUCCEEDED: defineEvent('onboarding_auth_succeeded', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ACTION,
+      OBSERVABILITY_PROPERTY_KEYS.PROVIDER,
+      OBSERVABILITY_PROPERTY_KEYS.STATUS,
+    ],
+  }),
+  ONBOARDING_AUTH_FAILED: defineEvent('onboarding_auth_failed', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ACTION,
+      OBSERVABILITY_PROPERTY_KEYS.PROVIDER,
+      OBSERVABILITY_PROPERTY_KEYS.STATUS,
+    ],
+  }),
+  ONBOARDING_ENVIRONMENT_ENTER_SUBMITTED: defineEvent('onboarding_environment_enter_submitted', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ACTION,
+      OBSERVABILITY_PROPERTY_KEYS.STATUS,
+    ],
+  }),
+  ONBOARDING_ENVIRONMENT_ENTER_SUCCEEDED: defineEvent('onboarding_environment_enter_succeeded', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ACTION,
+      OBSERVABILITY_PROPERTY_KEYS.STATUS,
+    ],
+  }),
+  ONBOARDING_ENVIRONMENT_ENTER_FAILED: defineEvent('onboarding_environment_enter_failed', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ACTION,
+      OBSERVABILITY_PROPERTY_KEYS.STATUS,
+    ],
+  }),
+  ONBOARDING_RUN_STARTED: defineEvent('onboarding_run_started', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ACTION,
+      OBSERVABILITY_PROPERTY_KEYS.STATUS,
+    ],
+  }),
+  ONBOARDING_RUN_SUCCEEDED: defineEvent('onboarding_run_succeeded', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ACTION,
+      OBSERVABILITY_PROPERTY_KEYS.STATUS,
+    ],
+  }),
+  ONBOARDING_RUN_FAILED: defineEvent('onboarding_run_failed', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ACTION,
+      OBSERVABILITY_PROPERTY_KEYS.STATUS,
+    ],
+  }),
+  ONBOARDING_SETUP_STEP_COMPLETED: defineEvent('onboarding_setup_step_completed', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ACTION,
+      OBSERVABILITY_PROPERTY_KEYS.STATUS,
+      OBSERVABILITY_PROPERTY_KEYS.TYPE,
+    ],
+  }),
+  ONBOARDING_SETUP_STEP_BACK: defineEvent('onboarding_setup_step_back', {
+    channels: [OBSERVABILITY_CHANNELS.MIXPANEL],
+    properties: [
+      OBSERVABILITY_PROPERTY_KEYS.ACTION,
+      OBSERVABILITY_PROPERTY_KEYS.STATUS,
+      OBSERVABILITY_PROPERTY_KEYS.TYPE,
+    ],
+  }),
+});
+
+export const OBSERVABILITY_EVENT_LIST = Object.freeze(Object.values(OBSERVABILITY_EVENTS));
+
+const EVENT_MAP = buildEventMap(OBSERVABILITY_EVENT_LIST);
+
+function isEventDefinition(value) {
+  return (
+    value &&
+    typeof value === 'object' &&
+    typeof value.name === 'string' &&
+    Array.isArray(value.channels) &&
+    Array.isArray(value.properties)
+  );
+}
+
+export function getObservabilityEvent(nameOrEvent) {
+  if (!nameOrEvent) return undefined;
+
+  if (isEventDefinition(nameOrEvent)) {
+    return nameOrEvent;
+  }
+
+  if (typeof nameOrEvent === 'string') {
+    return EVENT_MAP.get(nameOrEvent);
+  }
+
+  return undefined;
+}
+
+export function buildObservabilityEvent(nameOrEvent, properties = {}) {
+  const event = getObservabilityEvent(nameOrEvent);
+  const name = event?.name ?? (typeof nameOrEvent === 'string' ? nameOrEvent : undefined);
+
+  if (!name) {
+    return { name: undefined, properties: {} };
+  }
+
+  if (!event) {
+    return { name, properties: sanitizeEventProperties(properties) };
+  }
+
+  return {
+    name,
+    properties: sanitizeEventProperties(pickEventProperties(event, properties)),
+  };
+}

--- a/tools/app-shell/src/lib/observability/events.js
+++ b/tools/app-shell/src/lib/observability/events.js
@@ -496,7 +496,7 @@ export function getObservabilityEvent(nameOrEvent) {
   if (!nameOrEvent) return undefined;
 
   if (isEventDefinition(nameOrEvent)) {
-    return nameOrEvent;
+    return EVENT_MAP.get(nameOrEvent.name);
   }
 
   if (typeof nameOrEvent === 'string') {

--- a/tools/app-shell/src/lib/observability/payload.js
+++ b/tools/app-shell/src/lib/observability/payload.js
@@ -22,23 +22,50 @@ const DENYLISTED_PROPERTY_KEYS = new Set([
 
 const SAFE_EVENT_PROPERTY_KEYS = new Set([
   'action',
+  'accuracy',
   'app',
+  'attempt',
+  'category',
   'component',
+  'count',
+  'durationMs',
   'enabled',
+  'entity',
   'environment',
   'event',
   'hostname',
   'locale',
   'mockMode',
+  'operation',
+  'position',
   'provider',
   'route',
   'routePattern',
+  'score',
+  'specName',
   'source',
   'status',
+  'step',
+  'supportRequested',
   'timestamp',
   'type',
+  'value',
   'windowName',
 ]);
+
+const NUMERIC_PROPERTY_BOUNDS = {
+  accuracy: { min: 0, max: 100 },
+  attempt: { min: 0, max: 100 },
+  count: { min: 0, max: 100000 },
+  durationMs: { min: 0, max: 86400000 },
+  position: { min: 0, max: 100 },
+  score: { min: 0, max: 10 },
+  step: { min: 0, max: 100 },
+  value: { min: 0, max: 1000000 },
+};
+
+const NUMERIC_PROPERTY_KEYS = new Set(Object.keys(NUMERIC_PROPERTY_BOUNDS));
+const SKIP_PROPERTY = Symbol('skip-property');
 
 function toPathname(value = '/') {
   const raw = String(value || '/');
@@ -127,14 +154,35 @@ export function sanitizeEventProperties(properties = {}) {
   const sanitized = {};
 
   for (const [key, value] of Object.entries(properties ?? {})) {
-    if (DENYLISTED_PROPERTY_KEYS.has(key) || !SAFE_EVENT_PROPERTY_KEYS.has(key)) continue;
-    if (value == null) continue;
-    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-      sanitized[key] = value;
-    }
+    const safeValue = sanitizeEventProperty(key, value);
+    if (safeValue !== SKIP_PROPERTY) sanitized[key] = safeValue;
   }
 
   return sanitized;
+}
+
+function sanitizeEventProperty(key, value) {
+  if (DENYLISTED_PROPERTY_KEYS.has(key) || !SAFE_EVENT_PROPERTY_KEYS.has(key)) return SKIP_PROPERTY;
+  if (value == null) return SKIP_PROPERTY;
+
+  if (NUMERIC_PROPERTY_KEYS.has(key)) {
+    return isSafeNumber(key, value) ? value : SKIP_PROPERTY;
+  }
+
+  if (typeof value === 'number') {
+    return isSafeNumber(key, value) ? value : SKIP_PROPERTY;
+  }
+
+  return typeof value === 'string' || typeof value === 'boolean' ? value : SKIP_PROPERTY;
+}
+
+function isSafeNumber(key, value) {
+  if (!Number.isFinite(value)) return false;
+
+  const bounds = NUMERIC_PROPERTY_BOUNDS[key];
+  if (!bounds) return true;
+
+  return value >= bounds.min && value <= bounds.max;
 }
 
 export function buildEventPayload({

--- a/tools/app-shell/src/lib/observability/timing.js
+++ b/tools/app-shell/src/lib/observability/timing.js
@@ -1,0 +1,46 @@
+import { track } from '../observability.js';
+import { buildObservabilityEvent, getObservabilityEvent } from './events.js';
+
+function getPerformanceNow() {
+  if (typeof globalThis.performance?.now === 'function') {
+    return globalThis.performance.now();
+  }
+
+  return undefined;
+}
+
+function toDurationMs(startedAt, endedAt) {
+  if (!Number.isFinite(startedAt) || !Number.isFinite(endedAt)) {
+    return undefined;
+  }
+
+  return Math.max(0, Math.round(endedAt - startedAt));
+}
+
+export function startTiming(name, options = {}) {
+  const eventDefinition = getObservabilityEvent(name);
+  const startedAt = (options.now ?? getPerformanceNow)();
+  const baseProperties = { ...(options.properties ?? {}) };
+  const client = options.client ?? { track };
+  let stopped = false;
+
+  return async function stop(extraProps = {}) {
+    if (stopped) return undefined;
+    stopped = true;
+    if (!eventDefinition) return undefined;
+
+    const durationMs = toDurationMs(startedAt, (options.now ?? getPerformanceNow)());
+    if (durationMs == null) return undefined;
+
+    const event = buildObservabilityEvent(eventDefinition, {
+      ...baseProperties,
+      ...extraProps,
+      durationMs,
+    });
+
+    if (!event.name) return undefined;
+
+    await client.track(event.name, event.properties);
+    return event;
+  };
+}

--- a/tools/app-shell/src/lib/observability/timing.js
+++ b/tools/app-shell/src/lib/observability/timing.js
@@ -1,5 +1,10 @@
 import { track } from '../observability.js';
-import { buildObservabilityEvent, getObservabilityEvent } from './events.js';
+import {
+  OBSERVABILITY_CHANNELS,
+  OBSERVABILITY_PROPERTY_KEYS,
+  buildObservabilityEvent,
+  getObservabilityEvent,
+} from './events.js';
 
 function getPerformanceNow() {
   if (typeof globalThis.performance?.now === 'function') {
@@ -17,6 +22,13 @@ function toDurationMs(startedAt, endedAt) {
   return Math.max(0, Math.round(endedAt - startedAt));
 }
 
+function isTimingEvent(eventDefinition) {
+  return Boolean(
+    eventDefinition?.channels?.includes(OBSERVABILITY_CHANNELS.TIMING) &&
+    eventDefinition?.properties?.includes(OBSERVABILITY_PROPERTY_KEYS.DURATION_MS)
+  );
+}
+
 export function startTiming(name, options = {}) {
   const eventDefinition = getObservabilityEvent(name);
   const startedAt = (options.now ?? getPerformanceNow)();
@@ -27,7 +39,7 @@ export function startTiming(name, options = {}) {
   return async function stop(extraProps = {}) {
     if (stopped) return undefined;
     stopped = true;
-    if (!eventDefinition) return undefined;
+    if (!isTimingEvent(eventDefinition)) return undefined;
 
     const durationMs = toDurationMs(startedAt, (options.now ?? getPerformanceNow)());
     if (durationMs == null) return undefined;

--- a/tools/app-shell/src/lib/observability/useTiming.js
+++ b/tools/app-shell/src/lib/observability/useTiming.js
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { startTiming } from './timing.js';
+
+export function useTiming(name, options = {}) {
+  const stopRef = useRef(null);
+  const client = options.client;
+  const now = options.now;
+
+  const start = useCallback((properties = {}) => {
+    const stop = startTiming(name, { client, now, properties });
+    stopRef.current = stop;
+    return stop;
+  }, [client, name, now]);
+
+  const stop = useCallback((extraProps = {}) => {
+    const activeStop = stopRef.current;
+    stopRef.current = null;
+
+    return activeStop ? activeStop(extraProps) : undefined;
+  }, []);
+
+  const cancel = useCallback(() => {
+    stopRef.current = null;
+  }, []);
+
+  useEffect(() => cancel, [cancel]);
+
+  return {
+    start,
+    stop,
+    cancel,
+  };
+}

--- a/tools/app-shell/src/lib/rum.js
+++ b/tools/app-shell/src/lib/rum.js
@@ -6,6 +6,14 @@ export function resolveRumSessionSampleRate(
   value,
   fallback = DEFAULT_RUM_SESSION_SAMPLE_RATE
 ) {
+  if (value == null) {
+    return fallback;
+  }
+
+  if (typeof value === 'string' && value.trim().length === 0) {
+    return fallback;
+  }
+
   const parsed = Number(value);
 
   if (!Number.isFinite(parsed)) {

--- a/tools/app-shell/src/lib/rum.js
+++ b/tools/app-shell/src/lib/rum.js
@@ -1,16 +1,35 @@
 import { AwsRum } from 'aws-rum-web';
 
+export const DEFAULT_RUM_SESSION_SAMPLE_RATE = 0.1;
+
+export function resolveRumSessionSampleRate(
+  value,
+  fallback = DEFAULT_RUM_SESSION_SAMPLE_RATE
+) {
+  const parsed = Number(value);
+
+  if (!Number.isFinite(parsed)) {
+    return fallback;
+  }
+
+  return Math.min(1, Math.max(0, parsed));
+}
+
 export function getRumConfigs(env = import.meta.env) {
   return {
-  'go.staging.etendo.cloud': {
-    appMonitorId: env.VITE_RUM_APP_MONITOR_ID_STAGING,
-    identityPoolId: env.VITE_RUM_IDENTITY_POOL_ID_STAGING,
-  },
-  'go.experimental.etendo.cloud': {
-    appMonitorId: env.VITE_RUM_APP_MONITOR_ID_EXPERIMENTAL,
-    identityPoolId: env.VITE_RUM_IDENTITY_POOL_ID_EXPERIMENTAL,
-  },
-};
+    'go.staging.etendo.cloud': {
+      appMonitorId: env.VITE_RUM_APP_MONITOR_ID_STAGING,
+      identityPoolId: env.VITE_RUM_IDENTITY_POOL_ID_STAGING,
+    },
+    'go.experimental.etendo.cloud': {
+      appMonitorId: env.VITE_RUM_APP_MONITOR_ID_EXPERIMENTAL,
+      identityPoolId: env.VITE_RUM_IDENTITY_POOL_ID_EXPERIMENTAL,
+    },
+    'go.etendo.cloud': {
+      appMonitorId: env.VITE_RUM_APP_MONITOR_ID_PROD,
+      identityPoolId: env.VITE_RUM_IDENTITY_POOL_ID_PROD,
+    },
+  };
 }
 
 export function resolveRumConfig(hostname, env = import.meta.env) {
@@ -24,7 +43,11 @@ export function createRumProvider({
   logger = console,
   enabled = true,
 } = {}) {
-  const config = resolveRumConfig(hostname, env);
+  const resolvedEnv = env ?? {};
+  const config = resolveRumConfig(hostname, resolvedEnv);
+  const sessionSampleRate = resolveRumSessionSampleRate(
+    resolvedEnv.VITE_RUM_SESSION_SAMPLE_RATE
+  );
 
   return {
     name: 'aws-rum',
@@ -35,7 +58,7 @@ export function createRumProvider({
 
       try {
         new AwsRumCtor(config.appMonitorId, '1.0.0', 'eu-west-3', {
-          sessionSampleRate: 1,
+          sessionSampleRate,
           identityPoolId: config.identityPoolId,
           endpoint: 'https://dataplane.rum.eu-west-3.amazonaws.com',
           telemetries: ['performance', 'errors', 'http'],

--- a/tools/app-shell/src/lib/sentry.js
+++ b/tools/app-shell/src/lib/sentry.js
@@ -6,8 +6,52 @@ export const SENTRY_ENV_MAP = {
   'go.etendo.cloud': 'production',
 };
 
+export const DEFAULT_SENTRY_SEND_DEFAULT_PII = false;
+
 export function resolveSentryEnvironment(hostname) {
   return SENTRY_ENV_MAP[hostname] ?? 'development';
+}
+
+export function resolveSentrySendDefaultPii(
+  value,
+  fallback = DEFAULT_SENTRY_SEND_DEFAULT_PII
+) {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
+  const normalized = value.trim().toLowerCase();
+
+  if (['true', '1', 'yes', 'on'].includes(normalized)) {
+    return true;
+  }
+
+  if (['false', '0', 'no', 'off'].includes(normalized)) {
+    return false;
+  }
+
+  return fallback;
+}
+
+export function resolveSentryRelease(
+  env = import.meta.env,
+  buildMetadata = globalThis
+) {
+  const candidates = [
+    env?.VITE_SENTRY_RELEASE,
+    env?.VITE_APP_VERSION,
+    buildMetadata?.SENTRY_RELEASE?.id,
+    buildMetadata?.__SENTRY_RELEASE__,
+    buildMetadata?.__APP_VERSION__,
+  ];
+
+  return candidates.find(
+    (candidate) => typeof candidate === 'string' && candidate.trim().length > 0
+  );
 }
 
 export function createSentryProvider({
@@ -15,7 +59,15 @@ export function createSentryProvider({
   hostname = globalThis.window?.location?.hostname,
   enabled = Boolean(dsn),
   sentry = Sentry,
+  env = import.meta.env,
+  buildMetadata = globalThis,
 } = {}) {
+  const resolvedEnv = env ?? {};
+  const release = resolveSentryRelease(resolvedEnv, buildMetadata);
+  const sendDefaultPii = resolveSentrySendDefaultPii(
+    resolvedEnv.VITE_SENTRY_SEND_DEFAULT_PII
+  );
+
   return {
     name: 'sentry',
     enabled,
@@ -26,10 +78,11 @@ export function createSentryProvider({
       sentry.init({
         dsn,
         environment: resolveSentryEnvironment(hostname),
+        release,
         integrations: [sentry.browserTracingIntegration()],
         tracesSampleRate: 0.1,
         tracePropagationTargets: [/core\..+\.etendo\.cloud/, 'core.etendo.cloud'],
-        sendDefaultPii: true,
+        sendDefaultPii,
       });
     },
 

--- a/tools/app-shell/src/pages/OnboardingPage.jsx
+++ b/tools/app-shell/src/pages/OnboardingPage.jsx
@@ -32,6 +32,7 @@ import { getPasswordChecks, isStrongPassword, PASSWORD_RULES } from './onboardin
 import { useLocaleSwitch, useUI } from '../i18n/index.js';
 import { buildAppReturnToHref, getSafeReturnTo } from '../lib/oauthReturnTo.js';
 import { track } from '../lib/observability.js';
+import { OBSERVABILITY_EVENTS, buildObservabilityEvent } from '../lib/observability/events.js';
 import {
   applyProgressMessage,
   buildEnvironmentSessionStorage,
@@ -72,14 +73,16 @@ const DEFAULT_ONBOARDING_FORM = {
 };
 const SSO_PROVIDERS = getConfiguredSsoProviders();
 
-function trackOnboarding(eventName, properties = {}) {
+function trackOnboarding(eventDefinition, properties = {}) {
+  const event = buildObservabilityEvent(eventDefinition, properties);
+
   // Fire-and-forget telemetry: swallow rejections so a failed track() never
   // surfaces as an unhandled promise rejection in the onboarding flow.
   // Promise.resolve(...) tolerates a non-thenable return (e.g. a stubbed track()).
   Promise.resolve(
-    track(eventName, {
+    track(event.name, {
       ...ONBOARDING_EVENT_CONTEXT,
-      ...properties,
+      ...event.properties,
     }),
   ).catch(() => {});
 }
@@ -701,7 +704,7 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
 
   /* c8 ignore start -- Logout is only reachable from the legacy list view, which current routing bypasses. */
   const handleLogout = () => {
-    trackOnboarding('onboarding_auth_logout', {
+    trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_LOGOUT, {
       action: 'logout',
       status: 'success',
     });
@@ -731,7 +734,7 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
   /* c8 ignore stop */
 
   const handleSsoProviderLogin = useCallback(async (provider, payload) => {
-    trackOnboarding('onboarding_auth_submitted', {
+    trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_SUBMITTED, {
       action: 'sso',
       provider,
       status: 'started',
@@ -743,14 +746,14 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
     try {
       const data = await loginWithSsoProvider(fetch, BASE_URL, provider, payload);
       if (data.token) {
-        trackOnboarding('onboarding_auth_succeeded', {
+        trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_SUCCEEDED, {
           action: 'sso',
           provider,
           status: 'success',
         });
         handleAuthSuccess(data.token, data.account, { authMethod: 'sso' });
       } else {
-        trackOnboarding('onboarding_auth_failed', {
+        trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_FAILED, {
           action: 'sso',
           provider,
           status: 'failed',
@@ -758,7 +761,7 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
         setSsoError(ui('onboardingSsoFailed'));
       }
     } catch (err) {
-      trackOnboarding('onboarding_auth_failed', {
+      trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_FAILED, {
         action: 'sso',
         provider,
         status: 'failed',
@@ -812,7 +815,7 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
   // Register
   const handleRegister = async (e) => {
     e.preventDefault();
-    trackOnboarding('onboarding_auth_submitted', {
+    trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_SUBMITTED, {
       action: 'register',
       status: 'started',
     });
@@ -824,20 +827,20 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
         language: locale || form.language,
       });
       if (data.token) {
-        trackOnboarding('onboarding_auth_succeeded', {
+        trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_SUCCEEDED, {
           action: 'register',
           status: 'success',
         });
         handleRegisterSuccess(data.token, data.account);
       } else {
-        trackOnboarding('onboarding_auth_failed', {
+        trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_FAILED, {
           action: 'register',
           status: 'failed',
         });
         setRegisterError(ui('onboardingRegisterFailed'));
       }
     } catch (err) {
-      trackOnboarding('onboarding_auth_failed', {
+      trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_FAILED, {
         action: 'register',
         status: 'failed',
       });
@@ -852,7 +855,7 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
   // Login
   const handleLogin = async (e) => {
     e.preventDefault();
-    trackOnboarding('onboarding_auth_submitted', {
+    trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_SUBMITTED, {
       action: 'login',
       status: 'started',
     });
@@ -862,20 +865,20 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
     try {
       const data = await loginAccount(fetch, BASE_URL, loginForm);
       if (data.token) {
-        trackOnboarding('onboarding_auth_succeeded', {
+        trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_SUCCEEDED, {
           action: 'login',
           status: 'success',
         });
         handleAuthSuccess(data.token, data.account);
       } else {
-        trackOnboarding('onboarding_auth_failed', {
+        trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_FAILED, {
           action: 'login',
           status: 'failed',
         });
         setLoginError(ui('onboardingInvalidCredentials'));
       }
     } catch (err) {
-      trackOnboarding('onboarding_auth_failed', {
+      trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_AUTH_FAILED, {
         action: 'login',
         status: 'failed',
       });
@@ -923,7 +926,7 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
 
   const loginToEnvironment = async (env, { requireReadiness = false } = {}) => {
     const token = getPlatformToken();
-    trackOnboarding('onboarding_environment_enter_submitted', {
+    trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_ENVIRONMENT_ENTER_SUBMITTED, {
       action: 'enter_environment',
       status: 'started',
     });
@@ -947,7 +950,7 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
         if (requireReadiness) {
           const readiness = await checkSalesInvoiceReadiness(fetch, BASE_URL, data.token);
           if (!readiness.ready) {
-            trackOnboarding('onboarding_environment_enter_failed', {
+            trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_ENVIRONMENT_ENTER_FAILED, {
               action: 'enter_environment',
               status: 'failed',
             });
@@ -959,7 +962,7 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
             return;
           }
         }
-        trackOnboarding('onboarding_environment_enter_succeeded', {
+        trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_ENVIRONMENT_ENTER_SUCCEEDED, {
           action: 'enter_environment',
           status: 'success',
         });
@@ -969,13 +972,13 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
         );
         return;
       }
-      trackOnboarding('onboarding_environment_enter_failed', {
+      trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_ENVIRONMENT_ENTER_FAILED, {
         action: 'enter_environment',
         status: 'failed',
       });
       alert(ui('onboardingEnvironmentLoginFailed'));
     } catch (err) {
-      trackOnboarding('onboarding_environment_enter_failed', {
+      trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_ENVIRONMENT_ENTER_FAILED, {
         action: 'enter_environment',
         status: 'failed',
       });
@@ -991,7 +994,7 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
 
   const runOnboarding = useCallback(async () => {
     const token = getPlatformToken();
-    trackOnboarding('onboarding_run_started', {
+    trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_RUN_STARTED, {
       action: 'create_environment',
       status: 'started',
     });
@@ -1011,13 +1014,13 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
           };
           setResult(resultObj);
           if (msg.success) {
-            trackOnboarding('onboarding_run_succeeded', {
+            trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_RUN_SUCCEEDED, {
               action: 'create_environment',
               status: 'success',
             });
             succeeded = true;
           } else {
-            trackOnboarding('onboarding_run_failed', {
+            trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_RUN_FAILED, {
               action: 'create_environment',
               status: 'failed',
             });
@@ -1027,7 +1030,7 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
         }
       });
     } catch (err) {
-      trackOnboarding('onboarding_run_failed', {
+      trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_RUN_FAILED, {
         action: 'create_environment',
         status: 'failed',
       });
@@ -1819,7 +1822,7 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
             <Button
               type="button"
               onClick={() => {
-                trackOnboarding('onboarding_setup_step_completed', {
+                trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_SETUP_STEP_COMPLETED, {
                   action: 'continue',
                   status: 'success',
                   type: 'profile',
@@ -1908,7 +1911,7 @@ export default function OnboardingPage() { // NOSONAR: route component coordinat
               type="button"
               onClick={() => {
                 if (running) return;
-                trackOnboarding('onboarding_setup_step_back', {
+                trackOnboarding(OBSERVABILITY_EVENTS.ONBOARDING_SETUP_STEP_BACK, {
                   action: 'back',
                   status: 'success',
                   type: 'company',


### PR DESCRIPTION
## Delivery repository
- repository root: `/Users/sebastianbarrozo/Documents/work/epic/schema-forge`
- branch: `feature/ETP-4214`
- base branch: `epic/ETP-3504`
- changed-file scope: App Shell observability docs, planning/spec docs, Sentry/RUM adapters, observability event catalog, KPI payload sanitization, timing helpers, onboarding telemetry migration, and focused observability tests.
- repo-specific validation required: repository pre-push hook plus focused App Shell Node/Vitest coverage.

## What changed
- Added the ETP-4214 implementation plan and included the existing KPI framework spec in the PR branch.
- Hardened Sentry and AWS RUM defaults with production RUM config, bounded sample rate, release metadata, and privacy-safe Sentry PII default.
- Added a canonical frontend observability event catalog and catalog-backed builders.
- Extended payload sanitization for bounded KPI numeric metrics and low-cardinality metadata while preserving denylist priority.
- Added `startTiming()` and `useTiming()` helpers for same-session KPI duration events.
- Migrated onboarding telemetry to catalog definitions without renaming emitted event strings.

## Added or modified tests
- `tools/app-shell/src/lib/__tests__/observability-adapters.test.js`
- `tools/app-shell/src/lib/__tests__/observability-payload.test.js`
- `tools/app-shell/src/lib/observability/__tests__/payload.vitest.js`
- `tools/app-shell/src/lib/observability/__tests__/events.vitest.js`
- `tools/app-shell/src/lib/observability/__tests__/timing.vitest.jsx`

## Tests executed
- `git push --dry-run origin feature/ETP-4214`: passed pre-push checks after the Sonar cognitive-complexity refactor.
- `git push origin feature/ETP-4214`: passed conflict check, data-testid check, domain boundary check, unit tests and SonarQube analysis, and offline regeneration check.
- `node --test src/lib/__tests__/observability-payload.test.js`: 10 tests passed.
- `npm run test:vitest -- src/lib/observability/__tests__/payload.vitest.js src/lib/observability/__tests__/events.vitest.js src/lib/observability/__tests__/timing.vitest.jsx`: 59 tests passed.

## Functional validation
- Validated that observability payloads strip sensitive fields, keep bounded numeric KPI metrics, reject non-numeric metric values, and keep denylisted fields dominant.
- Validated that catalog-backed event builders normalize payload properties before dispatch.
- Validated that timing helpers emit only catalog-backed timing events and only once per timing session.
- Validated that the existing onboarding telemetry event names are preserved.

## QA
- Pending validation by QA: Matías Bernal / Emilio Polliotti

## Remaining scope
- ETP-4214 remains in progress for identify wiring, NPS survey support, backend telemetry, SQL integrity checks, and production rollout decisions.