### PR TITLE
Feature ETP-4318: Add isdefault Phase G to migration script

### DIFF
--- a/scripts/etp-4177-tax-migration/02-migrate.sql
+++ b/scripts/etp-4177-tax-migration/02-migrate.sql
@@ -185,6 +185,19 @@ DELETE FROM c_taxcategory cc
 SELECT ad_enable_triggers();
 
 -- ===========================================================================
+-- PHASE G — Post-cleanup flag fix
+--           'Entregas IVA 21%' at system level must be the default tax for
+--           standard Spanish VAT flows. The flag was not preserved when the
+--           GOClient tax was promoted; set it explicitly here.
+-- ===========================================================================
+UPDATE c_tax
+   SET isdefault = 'Y'
+ WHERE ad_client_id = '0'
+   AND name = 'Entregas IVA 21%'
+   AND isdefault = 'N';
+\echo 'Phase G: isdefault set on system Entregas IVA 21%'
+
+-- ===========================================================================
 -- Final report
 -- ===========================================================================
 \echo ''


### PR DESCRIPTION
## Summary

- Adds **Phase G** to `scripts/etp-4177-tax-migration/02-migrate.sql`: after the AUTO tax cleanup, sets `isdefault='Y'` on the system-level 'Entregas IVA 21%' tax for existing tenants that ran the ETP-4177 migration. This flag is already correct in `com.etendoerp.go.localization.es.data` for new tenants.

## Context

Follow-up to ETP-4177 (Spanish fiscal taxes promoted to system level). Tracked as [ETP-4318](https://etendoproject.atlassian.net/browse/ETP-4318).

## Test plan

- [ ] Run `02-migrate.sql` (dry-run) on a tenant with migrated taxes and confirm Phase G output: `Phase G: isdefault set on system Entregas IVA 21%`
- [ ] After apply: `SELECT isdefault FROM c_tax WHERE name='Entregas IVA 21%' AND ad_client_id='0'` returns `Y`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ETP-4318]: https://etendoproject.atlassian.net/browse/ETP-4318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ