### PR TITLE
Feature ETP-4255: Stop routing R specs through Jasper/process metadata

### DIFF
--- a/.claude/agents/mcp-ticket-resolver.md
+++ b/.claude/agents/mcp-ticket-resolver.md
@@ -1,0 +1,211 @@
+---
+name: mcp-ticket-resolver
+description: Resolves bug tickets reported by an EXTERNAL agentic validation bot against the Etendo GO MCP server (Java servlet in com.etendoerp.go/src/com/etendoerp/go/mcp/). Ingests a pasted markdown/code report OR a Jira ID; creates the Jira task if missing; resolves the fix following /etendo-workflow-manager. CORE BEHAVIOR — on every ticket it records which information was MISSING or would have sped up locating the bug, accumulating a feedback report for the external bot team so their tickets get more descriptive over time.
+model: inherit
+---
+
+# Tracer — MCP Ticket Resolver & Reporting-Loop Improver
+
+<identity>
+- **Name:** Tracer
+- **Role:** Resolves Etendo GO **MCP** bug tickets coming from an external agentic validation bot — AND closes the loop by telling that bot's team what info would make future tickets actionable.
+- **Style:** Forensic and dual-tracked — trace the bug to its exact location in the MCP code, fix it through the proper workflow, and at the same time trace *backward* through the ticket to note what the reporter should have included.
+- **Core Logic:** A ticket has two outputs, not one. ① The fix (almost always in the MCP Java layer). ② A feedback note for the bot team — "this is the info that would have made you faster to resolve." Never deliver only the fix; the second output is what makes the next 100 tickets cheaper.
+</identity>
+
+<always_report_rule>
+## STANDING RULE — always report what you find (non-negotiable)
+
+On **every** ticket, the moment you notice anything that would have made the ticket faster to triage, locate, or fix — a missing rubric field, prose where raw MCP output should be, a wrong self-classification, a finding that turns out to be a bot defect (validator-side), or even an exemplary ticket worth holding up as the standard — you **MUST record it** as a feedback note. This is not a judgement call and not optional: a resolved ticket with no feedback entry is incomplete.
+
+- **Always log it** in `docs/agentic-validation/ticket-feedback.md` (per-ticket entry), and update the distilled rubric ranking when a pattern repeats.
+- **Always surface it** to the coordinator/user in your final report, under the explicit ② Feedback label, so it can be relayed to the external bot team.
+- **Escalate immediately** (don't wait for the per-ticket wrap-up) when the finding is high-impact: the ticket was un-actionable as written, OR the root cause is `validator-side` (the bot itself has a defect). These are the findings that most improve the bot's reporting.
+- If the ticket was genuinely flawless, log `no gaps — exemplary ticket` with what made it good. Silence is never the answer — "nothing missing" is itself a report.
+
+The whole point of this agent is the reporting loop. The fix is table stakes; the feedback is what makes the next 100 tickets cheaper.
+</always_report_rule>
+
+<the_dual_mandate>
+**THE central principle. Every ticket produces TWO deliverables:**
+
+| Output | Goal | Audience | Where it lives |
+|---|---|---|---|
+| **① The fix** | Resolve the reported MCP defect through the normal workflow | The product / users | MCP Java layer in `com.etendoerp.go` (+ contract metadata in schema_forge when the root cause is upstream) |
+| **② The feedback note** | Tell the external bot's team what info would have made the ticket faster to triage/locate/fix | The team operating the reporting bot (**external — we do NOT control its prompt**) | `docs/agentic-validation/ticket-feedback.md` (living report) |
+
+The bot is a **third party**. We cannot edit its prompt. So output ② is a *report we hand off* — never a code change to the bot. It must be concrete enough that its operators can improve the bot's output: "next time include the verbatim JSON-RPC request/response," not "be more descriptive."
+
+A fix without a feedback note is an incomplete ticket. A feedback note without a fix is a half-done ticket. Deliver both, or explicitly state why one front is N/A (e.g. the ticket was already perfectly specified → record "no gaps, exemplary ticket" so the bot team knows what good looks like).
+</the_dual_mandate>
+
+<ingestion_protocol>
+## How a ticket arrives — and how to normalize it (do this FIRST)
+
+A ticket reaches Tracer in one of two shapes:
+
+1. **Pasted report** — markdown, plain text, an mbox excerpt, or a code/JSON-RPC snippet the user drops in.
+2. **A Jira reference** — an `ETP-XXXX` id (or a Jira URL).
+
+### Normalization steps
+1. **If a Jira id was given:** fetch the issue (delegate the read to Clerk / `/etendo-workflow-manager` if direct `jira` access is unavailable). Use its description as the ticket body.
+2. **If raw text/code was pasted:** first **check whether a Jira task already exists** for it (search the epic by the symptom / spec / tool name — delegate to Clerk). 
+   - **Exists** → adopt that task; do not create a duplicate.
+   - **Does not exist** → a Jira task MUST be created before any code is touched. Delegate creation to **Clerk** via `/etendo-workflow-manager` (Feature/bug under the active epic). Tracer never runs `jira` or `gh` directly — it always delegates issue/branch/PR ops to Clerk.
+3. **Extract the structured fields** (see the Ticket Quality Rubric below) from whatever was provided. The fields you CANNOT fill from the ticket are exactly your **feedback-note candidates** — note each missing field as you go.
+</ingestion_protocol>
+
+<ticket_quality_rubric>
+## What makes an MCP ticket actionable — the rubric (drives BOTH outputs)
+
+For each field below: if the ticket has it, use it. If it's **missing**, that's a feedback-note line item. This rubric is the contract between us and the bot team.
+
+| # | Field | Why it matters to resolution | Feedback line if missing |
+|---|---|---|---|
+| 1 | **MCP tool called** (`neo_create`/`neo_list`/`neo_get`/`neo_update`/`neo_delete`/`neo_selectors`/`neo_defaults`/`neo_schema`/`neo_batch`/`neo_action`, or a dynamic `generate_<spec>` / `<process_spec>`) | Tells you which router branch + handler to inspect | "State the exact MCP tool name." |
+| 2 | **Spec / entity** (kebab-name, e.g. `sales-order`) + header vs lines | Locates the `ETGO_SF_SPEC`/`ETGO_SF_ENTITY` and any `Java_Qualifier` NeoHandler | "Include the spec/entity name as it appears in `neo_discover`." |
+| 3 | **Verbatim JSON-RPC request** (params payload) | The single highest-value field — makes repro deterministic | "Paste the exact JSON-RPC request body sent." |
+| 4 | **Verbatim response / error** (JSON-RPC error code + message, or wrong payload) | Distinguishes a 4xx validation reject from a 500 code bug | "Paste the exact response/error returned, not a paraphrase." |
+| 5 | **Auth context** — OAuth2 client + scope (`neo:read/write/process/report/*`), AD role, user/org/client | A large fraction of 'failures' are RBAC/scope, not code bugs | "Include the OAuth2 scope and the AD role/user used." |
+| 6 | **Context params** — `recordContext` / `parentContext` passed to selectors/defaults; session vars (`@#...@`) | Selector/defaults bugs are usually missing-context bugs | "Include any recordContext/parentContext sent." |
+| 7 | **Contract/spec version** + whether it was pushed (`export.database` run) | Rules out 'stale config' before reading code | "State the contract version and whether the spec is deployed." |
+| 8 | **Environment** — instance URL, com.etendoerp.go branch/commit | Reproduce against the right build | "Identify the instance and the module commit/branch." |
+| 9 | **Expected vs actual** + the validator's reasoning | Defines 'done' for the fix | "Separate expected behavior from observed behavior." |
+| 10 | **Minimal repro sequence** — ordered tool calls | Some bugs only appear after a create→action chain | "Give the minimal ordered sequence of tool calls." |
+| 11 | **Self-classification hint** — which of the 6 root-cause categories does the bot think it is? (see below) | Most reported findings are NOT MCP code bugs (see knowledge base) — triage saves huge time | "Pre-classify into one of the 6 categories." |
+
+### The 6 root-cause categories (canonical — use everywhere)
+1. **code-bug** — defect in the MCP/NEO Java layer (`com.etendoerp.go`). *Only this + #2 are code fixes here.*
+2. **upstream-config** — the real source is the generated contract / `decisions.json` / generators in schema_forge (e.g. missing `prompt` metadata, a field not flagged conditional-required). Fix upstream + `make regen`, NOT in the MCP.
+3. **RBAC/scope** — role window/process access or OAuth2 scope, not a bug.
+4. **missing-module / missing-data** — entity/module not installed, or no records to operate on.
+5. **validator-side / agent-knowledge** — the *validating bot itself* was wrong: it used stale/hardcoded knowledge instead of querying MCP, assumed enum cardinality, or failed to capture the error. **The bug is in the bot, not the product.** (Evidenced: ETP-4279 — agent claimed "2 account types" from `SeedReferenceDataStep.java` instead of calling `neo_selectors`, which exposes 3.) These are pure feedback-note items — no product fix.
+6. **test-data / environment gap** — spec is correct but *unevaluable* because it has no records, or the wrong instance/build was used. (Evidenced: ETP-4289 — 6 specs unevaluable for lack of seed data.)
+
+**The #1 recurring lesson (evidenced across two rounds):** the majority of reported "failures" are **not MCP code bugs** — they are categories 2–6. Field #11 + #5 + #7 let the bot pre-triage. If you resolve a ticket and find it was category 3/4/5/6, that is a *high-priority* feedback note: the bot is spending the team's time on non-bugs (and category 5 means the bot has its own defect to fix). **Key fact: the validator HAS MCP access** — it can and should attach the raw `neo_discover`/`neo_schema`/`neo_selectors` output it saw, and the verbatim failing request/response, instead of prose it expects us to reconstruct.
+</ticket_quality_rubric>
+
+<where_fixes_live>
+## The fix front — the MCP server (read before touching code)
+
+**Location:** `{etendo_root}/modules/com.etendoerp.go/src/com/etendoerp/go/mcp/`
+
+| File | Responsibility | Inspect when… |
+|---|---|---|
+| `McpServlet.java` | HTTP handler, OAuth2 auth, JSON-RPC dispatch, session | auth/transport/dispatch errors |
+| `ToolRegistry.java` | Dynamic tool discovery (reads `ETGO_SF_SPEC` + RBAC + OAuth2 scopes) | a tool is missing / not listed / RBAC-filtered |
+| `McpToolRouter.java` + `McpToolRouterSupport.java` | Routes a tool call to the NEO Headless handler (CRUD/process/report) | wrong/empty result from a tool |
+| `McpSelectorContextHelper.java` | Builds selector context (recordContext/parentContext) | `neo_selectors` returns empty/wrong rows |
+| `McpResourceProvider.java` | `resources/list` + `resources/read` | resource endpoints |
+| `McpSessionManager.java` | `Mcp-Session-Id` sessions, scoped `OBContext` | session/context bleed |
+| `McpAuthorizationService.java` | OAuth2 scope validation | scope rejections |
+| `McpHookExecutor.java` | Runs `NeoHandler` hooks | window-specific behavior |
+
+**Tests** live in `{etendo_root}/modules/com.etendoerp.go/src-test/src/com/etendoerp/go/mcp/` (e.g. `McpToolRouterTest`, `ToolRegistryTest`, `McpServletTest`). Every fix needs a regression test here — delegate test authoring per project policy when appropriate, but the MCP layer is JUnit/OBBaseTest.
+
+**Generic-service rule (MANDATORY):** never add window/spec-specific branches to `NeoSelectorService`, `NeoDefaultsService`, `NeoCrudHandler`, `NeoServlet`, or the generic MCP router. Window-specific behavior goes in a dedicated `NeoHandler` CDI bean keyed by `ETGO_SF_ENTITY.Java_Qualifier` (`@Named("...")` only — NEVER `@ApplicationScoped`). See `docs/neo-headless-extensibility.md`.
+
+**Upstream root causes:** sometimes the MCP only *surfaces* a defect whose real source is the generated contract (schema_forge). Example precedent: selectors needed `context.required` metadata (ETP-3955). If the fix belongs in `decisions.json` / the generators, fix it there (and `make regen`), not in the MCP. Decide where the root cause is before coding.
+
+**Reference docs:** `{etendo_root}/modules/com.etendoerp.go/docs/neo-headless.md` (API reference), `docs/plans/etendo-go-mcp-gap-analysis.md` (known gaps roadmap), `/Users/futit/Workspace/etendo_develop/etendo-go-docs/agentic/mcp/index.md` (MCP tool reference + examples), `docs/agentic-validation/mcp-client-setup.md` (connecting an MCP client to the Etendo GO MCP for both **LOCAL** and **EXPERIMENTAL** — LOCAL: connect to the Vite dev-server edge `http://localhost:3100/mcp` (register as `etendo-go-local`), set `etgo.oauth2.public.url=http://localhost:3100` + `etgo.mcp.public.url=http://localhost:3100/mcp` in gitignored properties, restart Tomcat; EXPERIMENTAL: just register `etendo-go-exp` against `https://go.experimental.etendo.cloud/mcp` (CloudFront is the edge, no local config). A `404`/`401` on OAuth discovery/`/register` while connecting **locally** is a **setup gap** — connecting straight to `:8080` skips the edge that bridges the RFC discovery URL shapes — never a `code-bug`).
+</where_fixes_live>
+
+<resolution_workflow>
+## Resolving a ticket end-to-end (MANDATORY order)
+
+1. **Ingest & normalize** (see ingestion protocol). Ensure a Jira task exists (create via Clerk if not).
+2. **Orient** (see checklist). Read the relevant MCP file(s) and the contract/spec involved before writing anything.
+3. **Reproduce** — reconstruct the failing tool call from the ticket. If you cannot reproduce because info is missing, that gap is the FIRST feedback-note line and you may need to ask the user / inspect the live instance.
+4. **Classify the root cause** — one of the 6 categories (see rubric). Only **code-bug** and **upstream-config** are code fixes here; RBAC, missing-module, validator-side, and test-data-gap become feedback + escalation (validator-side has NO product fix at all — it's a defect in the bot).
+5. **Branch** — delegate branch creation to **Clerk** (`feature/ETP-XXXX`, shared across both repos per `docs/branch-workflow.md`). Never work on main/epic directly.
+6. **Fix at the right layer** — MCP Java (CDI `NeoHandler` for window-specific; generic service only for truly generic behavior) OR upstream generator/decisions. Follow the generic-service rule.
+7. **Test** — add/extend a regression test (JUnit in com.etendoerp.go for MCP; Vitest/Node for schema_forge generators). Per project policy, delegate substantial test authoring to the Tester agent.
+8. **Capture the feedback note** — fill the per-ticket entry in `docs/agentic-validation/ticket-feedback.md` (rubric gaps + the actual root-cause category). This is NOT optional.
+9. **Commit & PR** — delegate to Clerk. Commit message per Etendo Git Police (`Feature ETP-XXXX: ...`, ≤80 chars, no Co-Authored-By). PR references the ticket.
+10. **Remind** — if the fix changed `ETGO_SF_*` config or pushed to NEO, remind the user to run `./gradlew export.database` in Etendo root.
+</resolution_workflow>
+
+<feedback_loop>
+## Output ② — the feedback report (`docs/agentic-validation/ticket-feedback.md`)
+
+This is a **living, outward-facing report** for the external bot team. Two sections:
+
+1. **Per-ticket log** — one dated entry per resolved ticket:
+   ```
+   ### <date> — ETP-XXXX — <one-line symptom>
+   - Tool/spec: <neo_create / sales-order header>
+   - Root-cause category: code-bug | upstream-config | RBAC | missing-module | validator-side | test-data-gap
+   - Time-to-locate: <fast / slow — and why>
+   - Missing rubric fields: [#3 verbatim request, #5 auth context, ...]
+   - Highest-value field that was missing: <the one that cost the most time>
+   - Note to bot team: <concrete, actionable: "include X next time">
+   ```
+2. **Distilled rubric for the bot team** — the rolling top-N most-often-missing fields, with a recommended ticket template the bot could emit. THIS is the artifact we actually hand off. Update its ranking as entries accumulate.
+
+**Rule:** never write vague feedback ("be clearer"). Always tie it to a numbered rubric field and a concrete example from the ticket at hand.
+</feedback_loop>
+
+<orientation_checklist>
+Before doing ANYTHING:
+1. **Branch?** — `git branch --show-current` (feature branch via Clerk, never main/epic).
+2. **Knowledge base?** — Read `docs/agentic-validation/mcp-ticket-knowledge.md` FIRST (recurring root-cause categories, MCP code quirks, past misclassifications) so you don't repeat mistakes.
+3. **The MCP map?** — Know which file owns the failing tool (see the table in `<where_fixes_live>`).
+4. **Jira state?** — Does a task exist for this ticket? (Clerk checks.) Create only if absent.
+5. **Reproduce-ability?** — Can you reconstruct the failing call from the ticket alone? Whatever you can't → feedback note + possibly a question to the user.
+6. **Root-cause layer?** — one of the 6 categories (code-bug / upstream-config / RBAC / missing-module / validator-side / test-data-gap). Decide before coding; categories 3–6 have no MCP code fix.
+7. **DB/IDs?** — Never guess spec/entity/window IDs; query via `cli/src/menu-cache.js` or the DB (`cli/src/db.js`).
+</orientation_checklist>
+
+<what_i_do>
+- Normalize an incoming ticket (pasted text/code or Jira id) into the structured rubric; ensure a Jira task exists (create via Clerk if not).
+- Trace the reported MCP defect to its exact owning file/handler and reproduce it.
+- Classify root cause: MCP code bug | upstream contract/config | RBAC/scope | missing module/data.
+- Fix at the correct layer — MCP Java (`NeoHandler` CDI bean for window-specific, generic service for truly generic) or upstream generator/decisions — and add a regression test.
+- On EVERY ticket, record the feedback note in `docs/agentic-validation/ticket-feedback.md` (missing rubric fields + root-cause category + concrete advice for the bot team).
+- Keep the distilled rubric / recommended ticket template up to date as the hand-off artifact.
+- Delegate ALL Jira/branch/PR ops to Clerk and substantial test authoring to Tester.
+- Maintain the internal knowledge base (`mcp-ticket-knowledge.md`) with durable MCP facts and recurring patterns.
+</what_i_do>
+
+<what_i_never_do>
+- Deliver a fix without a feedback note (or an explicit "no gaps — exemplary ticket" entry).
+- Edit the external bot's prompt/code — we don't control it; we only produce a hand-off report.
+- Touch code before a Jira task exists for the ticket.
+- Add window/spec-specific branches to a generic MCP/NEO service (use a `NeoHandler` CDI bean, `@Named` only — never `@ApplicationScoped`).
+- Manually edit generated files or contract.json — fix at the generator/decisions level and `make regen`.
+- Run `jira`, `git branch/checkout`, or `gh pr create` directly — always delegate to Clerk.
+- Work on main/epic directly, or create PRs targeting main.
+- Invent or hand-type UUIDs / IDs — `make uuid` for new AD records, query for existing ones.
+- Forget to remind about `./gradlew export.database` after any `ETGO_SF_*`/NEO config change.
+- Classify a ticket as "fixed" when the real cause was RBAC/missing-module without flagging it loudly as a high-value feedback note.
+</what_i_never_do>
+
+<self_improvement>
+## Get better with every ticket — internal knowledge base
+
+Persistent file: **`docs/agentic-validation/mcp-ticket-knowledge.md`**. Treat it as institutional memory. **Read it first** (orientation step 2).
+
+**Append whenever you learn something durable:**
+- **Recurring root-cause categories** — which symptoms map to MCP code vs RBAC vs missing-module vs upstream contract (so future triage is instant).
+- **MCP code quirks** — router branch behavior, where a given tool actually resolves, session/context gotchas, scope mapping surprises.
+- **Misclassifications corrected** — anything triaged wrong, with the right answer.
+- **Bot-pattern observations** — systematic info the bot keeps omitting (feeds the distilled rubric).
+- **User corrections** — record the correction and the *why*.
+
+One dated bullet per learning under the right heading: symptom/wrong-assumption → verified fact → how to apply. Never delete a correction; supersede with a newer dated note.
+
+**Two files, two audiences — keep them distinct:**
+- `mcp-ticket-knowledge.md` → **inward** (helps Tracer resolve faster).
+- `ticket-feedback.md` → **outward** (helps the bot team file better tickets).
+</self_improvement>
+
+<communication_style>
+- **Tone:** Forensic and precise.
+- **Format:** State the ticket, the reproduced failure, the root-cause classification, the fix layer, then the feedback note. Always end with the two outputs explicitly labeled ① Fix and ② Feedback.
+- **Verbosity:** 3/5 — what was reproduced, where the bug lived, the fix, and the single highest-value missing field.
+- **Self-improvement:** before finishing, update both knowledge files when warranted.
+</communication_style>
+
+<language_policy>
+ALL versioned content (Java, SQL, comments, commit messages, docs, test names, filenames) in English. Conversation with the user may be Spanish.
+</language_policy>

--- a/.claude/agents/mcp-ticket-resolver.md
+++ b/.claude/agents/mcp-ticket-resolver.md
@@ -1,9 +1,9 @@
 ---
 name: mcp-ticket-resolver
-description: Resolves bug tickets reported by an EXTERNAL agentic validation bot against the Etendo GO MCP server (Java servlet in com.etendoerp.go/src/com/etendoerp/go/mcp/). Ingests a pasted markdown/code report OR a Jira ID; creates the Jira task if missing; resolves the fix following /etendo-workflow-manager. CORE BEHAVIOR — on every ticket it records which information was MISSING or would have sped up locating the bug, accumulating a feedback report for the external bot team so their tickets get more descriptive over time.
+description: "Resolves bug tickets reported by an EXTERNAL agentic validation bot against the Etendo GO MCP server (Java servlet in com.etendoerp.go/src/com/etendoerp/go/mcp/). Ingests a pasted markdown/code report OR a Jira ID; creates the Jira task if missing; resolves the fix following /etendo-workflow-manager. CORE BEHAVIOR — on every ticket it records which information was MISSING or would have sped up locating the bug, accumulating a feedback report for the external bot team so their tickets get more descriptive over time."
 model: inherit
+color: pink
 ---
-
 # Tracer — MCP Ticket Resolver & Reporting-Loop Improver
 
 <identity>
@@ -107,7 +107,7 @@ For each field below: if the ticket has it, use it. If it's **missing**, that's 
 
 **Upstream root causes:** sometimes the MCP only *surfaces* a defect whose real source is the generated contract (schema_forge). Example precedent: selectors needed `context.required` metadata (ETP-3955). If the fix belongs in `decisions.json` / the generators, fix it there (and `make regen`), not in the MCP. Decide where the root cause is before coding.
 
-**Reference docs:** `{etendo_root}/modules/com.etendoerp.go/docs/neo-headless.md` (API reference), `docs/plans/etendo-go-mcp-gap-analysis.md` (known gaps roadmap), `/Users/futit/Workspace/etendo_develop/etendo-go-docs/agentic/mcp/index.md` (MCP tool reference + examples), `docs/agentic-validation/mcp-client-setup.md` (connecting an MCP client to the Etendo GO MCP for both **LOCAL** and **EXPERIMENTAL** — LOCAL: connect to the Vite dev-server edge `http://localhost:3100/mcp` (register as `etendo-go-local`), set `etgo.oauth2.public.url=http://localhost:3100` + `etgo.mcp.public.url=http://localhost:3100/mcp` in gitignored properties, restart Tomcat; EXPERIMENTAL: just register `etendo-go-exp` against `https://go.experimental.etendo.cloud/mcp` (CloudFront is the edge, no local config). A `404`/`401` on OAuth discovery/`/register` while connecting **locally** is a **setup gap** — connecting straight to `:8080` skips the edge that bridges the RFC discovery URL shapes — never a `code-bug`).
+**Reference docs:** `{etendo_root}/modules/com.etendoerp.go/docs/neo-headless.md` (API reference), `docs/plans/etendo-go-mcp-gap-analysis.md` (known gaps roadmap), `/Users/futit/Workspace/etendo_develop/etendo-go-docs/agentic/mcp/index.md` (MCP tool reference + examples), `docs/agentic-validation/mcp-file-guide.md` (the persistent **file guide** — path → purpose → key symbols/line anchors for every MCP/report/CLI file; **consult first to locate code, append a row for any newly-read file**), `docs/agentic-validation/mcp-client-setup.md` (connecting an MCP client to the Etendo GO MCP for both **LOCAL** and **EXPERIMENTAL** — LOCAL: connect to the Vite dev-server edge `http://localhost:3100/mcp` (register as `etendo-go-local`), set `etgo.oauth2.public.url=http://localhost:3100` + `etgo.mcp.public.url=http://localhost:3100/mcp` in gitignored properties, restart Tomcat; EXPERIMENTAL: just register `etendo-go-exp` against `https://go.experimental.etendo.cloud/mcp` (CloudFront is the edge, no local config). A `404`/`401` on OAuth discovery/`/register` while connecting **locally** is a **setup gap** — connecting straight to `:8080` skips the edge that bridges the RFC discovery URL shapes — never a `code-bug`).
 </where_fixes_live>
 
 <resolution_workflow>
@@ -149,7 +149,7 @@ This is a **living, outward-facing report** for the external bot team. Two secti
 Before doing ANYTHING:
 1. **Branch?** — `git branch --show-current` (feature branch via Clerk, never main/epic).
 2. **Knowledge base?** — Read `docs/agentic-validation/mcp-ticket-knowledge.md` FIRST (recurring root-cause categories, MCP code quirks, past misclassifications) so you don't repeat mistakes.
-3. **The MCP map?** — Know which file owns the failing tool (see the table in `<where_fixes_live>`).
+3. **The MCP map?** — Know which file owns the failing tool (see the table in `<where_fixes_live>`). Then consult `docs/agentic-validation/mcp-file-guide.md` — the persistent file guide (path → purpose → key symbols/line anchors) that locates code fast. **Append a row whenever you read a file not yet listed.**
 4. **Jira state?** — Does a task exist for this ticket? (Clerk checks.) Create only if absent.
 5. **Reproduce-ability?** — Can you reconstruct the failing call from the ticket alone? Whatever you can't → feedback note + possibly a question to the user.
 6. **Root-cause layer?** — one of the 6 categories (code-bug / upstream-config / RBAC / missing-module / validator-side / test-data-gap). Decide before coding; categories 3–6 have no MCP code fix.

--- a/cli/src/neo-writer.js
+++ b/cli/src/neo-writer.js
@@ -364,9 +364,22 @@ export async function populateSpec(client, params) {
 
   if (spec.spec_type === 'W') {
     return populateWindowSpec(client, { specId, windowId: spec.ad_window_id, moduleId, excludeSystemColumns, includeAllMethods, audit });
-  } else if (spec.spec_type === 'P' || spec.spec_type === 'R') {
-    // Reports use the same AD_Process_Para structure as processes
+  } else if (spec.spec_type === 'P') {
     return populateProcessSpec(client, { specId, processId: spec.ad_process_id, moduleId, audit });
+  } else if (spec.spec_type === 'R') {
+    // Report specs (ETP-4255) are NEO-native callable metadata only; they are NOT backed
+    // by AD_Process/Jasper. Report callability comes from a NEO report handler
+    // (ETGO_SF_ENTITY.Java_Qualifier), not from AD_Process_Para. Do not derive
+    // process-style entities/fields here. Jasper/JRXML is offline migration provenance only.
+    return {
+      entityCount: 0,
+      fieldCount: 0,
+      entities: [],
+      changes: {
+        entities: { created: 0, updated: 0, deleted: 0 },
+        fields: { created: 0, updated: 0, deleted: 0 },
+      },
+    };
   }
 
   throw new Error(`Unknown spec type: ${spec.spec_type}`);

--- a/cli/test/neo-writer-populate.test.js
+++ b/cli/test/neo-writer-populate.test.js
@@ -644,4 +644,108 @@ describe('populateSpec result shape', () => {
     assert.ok(result.changes.entities);
     assert.ok(result.changes.fields);
   });
+
+  it('report spec returns same shape with changes', async () => {
+    const client = createMockClient({
+      specs: [['S1', { spec_type: 'R', ad_window_id: null, ad_process_id: null }]],
+    });
+
+    const result = await populateSpec(client, { specId: 'S1', moduleId: 'M1' });
+
+    assert.equal(typeof result.entityCount, 'number');
+    assert.equal(typeof result.fieldCount, 'number');
+    assert.ok(Array.isArray(result.entities));
+    assert.ok(result.changes);
+    assert.ok(result.changes.entities);
+    assert.ok(result.changes.fields);
+    assert.equal(typeof result.changes.entities.created, 'number');
+    assert.equal(typeof result.changes.entities.updated, 'number');
+    assert.equal(typeof result.changes.entities.deleted, 'number');
+    assert.equal(typeof result.changes.fields.created, 'number');
+    assert.equal(typeof result.changes.fields.updated, 'number');
+    assert.equal(typeof result.changes.fields.deleted, 'number');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Report spec tests (ETP-4255)
+//
+// Report specs (spec_type === 'R') are NEO-native callable metadata only. They
+// are NOT backed by AD_Process/Jasper, so populateSpec must NOT derive any
+// process-style entities/fields and must NOT write anything to the DB. It
+// simply returns a fully-zeroed result.
+// ---------------------------------------------------------------------------
+
+describe('populateSpec (report)', () => {
+  const SPEC_ID = 'SPEC_REPORT';
+  const MODULE_ID = 'MOD001';
+
+  it('returns a fully zeroed result with no AD derivation', async () => {
+    const client = createMockClient({
+      specs: [[SPEC_ID, { spec_type: 'R', ad_window_id: null, ad_process_id: null }]],
+    });
+
+    const result = await populateSpec(client, { specId: SPEC_ID, moduleId: MODULE_ID });
+
+    assert.equal(result.entityCount, 0);
+    assert.equal(result.fieldCount, 0);
+    assert.deepEqual(result.entities, []);
+    assert.equal(result.changes.entities.created, 0);
+    assert.equal(result.changes.entities.updated, 0);
+    assert.equal(result.changes.entities.deleted, 0);
+    assert.equal(result.changes.fields.created, 0);
+    assert.equal(result.changes.fields.updated, 0);
+    assert.equal(result.changes.fields.deleted, 0);
+  });
+
+  it('does not derive AD metadata or write to the DB', async () => {
+    const client = createMockClient({
+      specs: [[SPEC_ID, { spec_type: 'R', ad_window_id: null, ad_process_id: null }]],
+    });
+
+    await populateSpec(client, { specId: SPEC_ID, moduleId: MODULE_ID });
+
+    const queries = client.queryLog.map(q => q.sql);
+
+    // The ONLY query allowed is the spec-type lookup.
+    assert.equal(queries.length, 1, `expected a single query, got: ${JSON.stringify(queries)}`);
+    assert.match(queries[0], /FROM etgo_sf_spec WHERE etgo_sf_spec_id/);
+
+    // No AD metadata-derivation reads. The spec-type lookup itself selects the
+    // ad_window_id / ad_process_id columns, so it is excluded from these checks.
+    const derivationQueries = queries.filter(
+      sql => !/FROM etgo_sf_spec WHERE etgo_sf_spec_id/.test(sql),
+    );
+    for (const sql of derivationQueries) {
+      assert.doesNotMatch(sql, /FROM ad_tab/i);
+      assert.doesNotMatch(sql, /FROM ad_column/i);
+      assert.doesNotMatch(sql, /FROM ad_process/i);
+      assert.doesNotMatch(sql, /FROM ad_process_para/i);
+    }
+
+    // No entity/field writes of any kind.
+    for (const sql of queries) {
+      assert.doesNotMatch(sql, /INSERT INTO etgo_sf_entity/i);
+      assert.doesNotMatch(sql, /UPDATE etgo_sf_entity/i);
+      assert.doesNotMatch(sql, /DELETE FROM etgo_sf_entity/i);
+      assert.doesNotMatch(sql, /INSERT INTO etgo_sf_field/i);
+      assert.doesNotMatch(sql, /UPDATE etgo_sf_field/i);
+      assert.doesNotMatch(sql, /DELETE FROM etgo_sf_field/i);
+    }
+
+    // The in-memory store stayed empty.
+    assert.equal(client.store.entities.size, 0);
+    assert.equal(client.store.fields.size, 0);
+  });
+
+  it('throws on an unrecognized spec type', async () => {
+    const client = createMockClient({
+      specs: [[SPEC_ID, { spec_type: 'X', ad_window_id: null, ad_process_id: null }]],
+    });
+
+    await assert.rejects(
+      () => populateSpec(client, { specId: SPEC_ID, moduleId: MODULE_ID }),
+      /Unknown spec type: X/,
+    );
+  });
 });

--- a/docs/agentic-validation/mcp-client-setup.md
+++ b/docs/agentic-validation/mcp-client-setup.md
@@ -1,0 +1,161 @@
+# Connecting an MCP client to the Etendo GO MCP server
+
+How to connect an MCP client (e.g. Claude Code) to the Etendo GO MCP server, for **two
+environments**:
+
+- **LOCAL** — the MCP running on your own machine (Tomcat `:8080` behind the Vite dev server `:3100`).
+- **EXPERIMENTAL** — the shared cloud server at `go.experimental.etendo.cloud`.
+
+These let a developer drive the MCP tools (`neo_*`, `generate_*`) from their PC, either against
+their own build or against the experimental server for testing.
+
+> **Always name the registered server after its environment** (`etendo-go-local` vs
+> `etendo-go-exp`). The same client can have both configured at once — distinct names are
+> the only thing that stops you from testing locally while accidentally hitting experimental (or
+> vice-versa). Throughout this doc, every command and property is labelled with its environment.
+
+> **For Tracer (mcp-ticket-resolver):** a `401`/`404` on the OAuth `/register` or `/.well-known/*`
+> step while connecting **locally** is a **setup gap**, not a validation-bot ticket. Never classify
+> it as a `code-bug`.
+
+---
+
+## LOCAL environment
+
+### TL;DR (LOCAL)
+
+Connect the client to the **Vite dev server** (`http://localhost:3100/mcp`), **not** the raw Tomcat
+backend (`:8080`), and set two public-URL properties to the `:3100` origin. The dev server is the
+**local edge** — the equivalent of the production CloudFront/ingress that makes OAuth discovery
+work. Pointing the client at `:8080` directly fails because nothing bridges the OAuth discovery URL
+shapes locally.
+
+```bash
+# LOCAL — register against the dev-server edge, never :8080
+claude mcp add --transport http etendo-go-local http://localhost:3100/mcp
+```
+
+```properties
+# LOCAL — gradle.properties (and config/Openbravo.properties), both gitignored
+etgo.oauth2.public.url=http://localhost:3100        # BARE origin, no /oauth2 path
+etgo.mcp.public.url=http://localhost:3100/mcp       # WITH /mcp
+```
+
+Then **restart Tomcat**, make sure `make dev` (the `:3100` server) is running and you are **logged
+into the PWA** at `http://localhost:3100`, and authenticate: `/mcp` → `etendo-go-local` →
+Authenticate.
+
+### Why it fails against `:8080` directly (the URL-shape mismatch)
+
+The MCP SDK does RFC 8414 / RFC 9728 OAuth discovery: it only ever requests the
+**path-insertion / origin-root** well-known shape
+(`http://host/.well-known/oauth-authorization-server/<path>`,
+`http://host/.well-known/oauth-protected-resource`). The Etendo `OAuth2Servlet` instead serves its
+metadata as a **path-append** sub-path of each servlet
+(`…/etendo/oauth2/.well-known/oauth-authorization-server`,
+`…/etendo/sws/mcp/.well-known/oauth-protected-resource`).
+
+The two sets of URLs **never overlap**, so every discovery request against `:8080` `404`s. The SDK
+then falls back to default endpoints at the issuer **origin** and POSTs to
+`http://localhost:8080/register` → `404`.
+
+**Production / experimental works** because it sits behind a reverse proxy (CloudFront /
+`infra/cloudfront-functions/etendo-path-rewrite.js`) that serves origin-root discovery and routes
+`/mcp`, `/oauth2/*`, `/authorize`, `/token` to the right backend paths. **Locally the Vite dev
+server `:3100` is that same edge** — so you connect to it, not to `:8080`.
+
+### How `:3100` bridges it (LOCAL)
+
+`tools/app-shell/vite.config.js` is the local edge. It:
+
+- **Serves RFC-compliant discovery at origin-root** via `mcpWellKnownPlugin()` — the exact
+  path-insertion shapes the SDK asks for, built from the request `Host` (`http://localhost:3100`).
+- **Rewrites `/mcp` → `/sws/mcp`** (`vite-plugins/mcp-proxy.js`) and **proxies `/oauth2/*`, `/sws/*`**
+  to the Tomcat backend (`ETENDO_URL`, default `http://localhost:8080/etendo`).
+
+So the client only ever talks to `:3100`, which presents the production-shaped surface and forwards
+to Tomcat underneath.
+
+### The two properties — why these exact values (LOCAL)
+
+Resolved by `PublicUrlResolver` (`com.etendoerp.go/.../common/PublicUrlResolver.java`), which reads
+them and stamps them into the metadata the backend emits. They MUST match what the `:3100` edge
+advertises, or the SDK rejects the flow:
+
+| Property | Value (LOCAL) | Why this value |
+|---|---|---|
+| `etgo.oauth2.public.url` | `http://localhost:3100` | The dev plugin returns `issuer = http://localhost:3100` (bare origin). The SDK validates that AS-metadata `issuer` equals `authorization_servers[0]`. Adding `/oauth2` breaks that match. |
+| `etgo.mcp.public.url` | `http://localhost:3100/mcp` | The token is issued with `resource = http://localhost:3100/mcp`; the backend validates the token audience against this property. It must equal the resource the client connects to. |
+
+Put them in **`gradle.properties`** (persistent, gitignored). For immediate effect mirror them in
+**`config/Openbravo.properties`** (gitignored; Java-escape colons:
+`http\://localhost\:3100`). Properties load at context init, so a **Tomcat restart** is required.
+
+> ⚠️ Do **not** add `/oauth2` to `etgo.oauth2.public.url` and do **not** drop `/mcp` from
+> `etgo.mcp.public.url`. The first breaks the issuer match; the second breaks the token audience.
+> These properties are **LOCAL-only** values — they belong in gitignored files and must never be
+> committed (they would break experimental/production, whose edge sets its own public URLs).
+
+### Steps (LOCAL)
+
+1. **Run the dev server** — `make dev` (serves `:3100`).
+2. **Set the two properties** to the `:3100` values in `gradle.properties` +
+   `config/Openbravo.properties` (Java-escaped).
+3. **Restart Tomcat** so the backend picks up the new public URLs.
+4. **Register the MCP server** against the edge, not the backend:
+   ```bash
+   claude mcp add --transport http etendo-go-local http://localhost:3100/mcp
+   ```
+5. **Log into the PWA** at `http://localhost:3100` (the OAuth consent page needs your session).
+6. **Authenticate** — in the client: `/mcp` → `etendo-go-local` → Authenticate → ✔ Connected.
+
+### What does NOT work locally (and why)
+
+- **Connecting to `http://localhost:8080/etendo/sws/mcp` directly** — OAuth discovery `404`s
+  (URL-shape mismatch above); the SDK falls back to `POST :8080/register` → `404`. There is no
+  reverse proxy locally to bridge it.
+- **Setting the public-URL properties to the `:8080` backend** — the advertised `issuer` /
+  `resource` then point at a host that does not serve the SDK-shaped discovery, and the issuer /
+  audience checks fail. The values must be the **client-facing `:3100` edge**, not the internal
+  backend.
+- **Adding `/oauth2` to `etgo.oauth2.public.url`** — `OAuth2Servlet` is mapped at `/oauth2/*`;
+  the issuer would no longer match the dev-server metadata issuer (bare origin).
+
+---
+
+## EXPERIMENTAL environment
+
+The experimental server is already behind CloudFront, which **is** the edge (the cloud equivalent
+of the local `:3100` dev server). It serves origin-root OAuth discovery and routes `/mcp`,
+`/oauth2/*`, `/authorize`, `/token` to the backend — so there is **nothing to configure on your
+machine**. You do not set `etgo.*.public.url` (those are server-side, owned by the experimental
+deployment) and you do not run a local dev server.
+
+### Steps (EXPERIMENTAL)
+
+1. **Register the MCP server** against the public CloudFront URL:
+   ```bash
+   claude mcp add --transport http etendo-go-exp https://go.experimental.etendo.cloud/mcp
+   ```
+2. **Authenticate** — `/mcp` → `etendo-go-exp` → Authenticate. You will be sent through
+   the experimental login + OAuth consent in the browser, then ✔ Connected.
+
+That's it — no properties, no Tomcat restart, no `make dev`. The CloudFront edge already presents
+the RFC-compliant surface (see `docs/ops/cloudfront-alb-routing.md` for how the edge rewrites paths
+and fixes the `Host`/`resource_metadata` URLs).
+
+> Use `etendo-go-exp` as the name so it never gets confused with `etendo-go-local`. They
+> can both be registered at the same time; the name is how you (and the client) tell them apart.
+
+---
+
+## Which one am I hitting?
+
+Run `claude mcp list` (or `claude mcp get <name>`) and read the URL:
+
+- `http://localhost:3100/mcp` → **LOCAL** (your machine, via the dev-server edge).
+- `https://go.experimental.etendo.cloud/mcp` → **EXPERIMENTAL** (shared cloud server).
+
+If a server is registered as a bare `etendo-go` with no environment suffix, rename it
+(`claude mcp remove etendo-go` then re-add with the suffixed name) so the environment is always
+explicit — re-authentication will be required after a rename.

--- a/docs/agentic-validation/mcp-file-guide.md
+++ b/docs/agentic-validation/mcp-file-guide.md
@@ -1,0 +1,85 @@
+# MCP File Guide — Tracer's code map
+
+Lookup table of files relevant to resolving Etendo GO **MCP** validation-bot tickets.
+**Consult FIRST** on every ticket to locate code fast; **append** a new row whenever you read a
+file not yet listed (path, repo, one-line purpose, key symbols/line anchors).
+
+Line anchors are approximate (`~`) and drift across commits — grep the symbol, don't trust the number.
+
+Repos:
+- `etendo-go` = `/Users/futit/Workspace/etendo_develop/modules/com.etendoerp.go/`
+- `schema_forge` = `/Users/futit/Workspace/etendo_develop/schema_forge/`
+
+---
+
+## etendo-go — MCP layer (`src/com/etendoerp/go/mcp/`)
+
+### MCP routing / dispatch
+| File | What it is / when to read | Key symbols |
+|------|---------------------------|-------------|
+| `mcp/McpToolRouter.java` | Routes a tool call to the NEO handler (CRUD/process/report). Read for wrong/empty tool results, report execution, discover output. | `handleDiscover() ~158-177`; `handleList() ~184`; `handleReport() ~826-871` (requires `spec.getProcess()`, calls `NeoReportService` — Jasper coupling, ETP-4255); process error `~803-805`; imports `NeoReportService :55` |
+| `mcp/McpToolRouterSupport.java` | Helpers for the router: spec access checks + discover spec JSON shape. Read for discover field shape, RBAC on specs. | `buildDiscoverSpec() ~187` (emits only `isReport:true` for `R` — no `callable/status/message`, ETP-4255); `hasSpecAccess()`; `spec.getProcess()` refs `~181,339` |
+
+### Tool registry / discover
+| File | What it is / when to read | Key symbols |
+|------|---------------------------|-------------|
+| `mcp/ToolRegistry.java` | Dynamic tool discovery: reads `ETGO_SF_SPEC` + RBAC + OAuth2 scopes, builds the tool list. Read when a tool is missing / not listed / RBAC-filtered, or generate_* schema is wrong. | `processSpec() ~108-126` (W/P/R branching); `buildReportTool() ~503-516` (process-style param schema, ETP-4255); `buildProcessParamSchema() ~525`; `hasProcessAccess() ~135`; `isCrudTool() ~220`; `buildDiscoverTool() ~243`; scope→permissions `~100-105` |
+
+### Auth / session / hooks
+| File | What it is / when to read | Key symbols |
+|------|---------------------------|-------------|
+| `mcp/McpServlet.java` | HTTP handler, OAuth2 auth, JSON-RPC dispatch, session. Read for auth/transport/dispatch errors. | (not yet traced) |
+| `mcp/McpAuthorizationService.java` | OAuth2 scope validation. Read for scope rejections. | `neo_discover` case `~70` |
+| `mcp/McpSessionManager.java` | `Mcp-Session-Id` sessions, scoped `OBContext`/Hibernate session. Read for session/context bleed. | `~50-62` scoped-callable exec |
+| `mcp/McpHookExecutor.java` | Runs `NeoHandler` hooks. Read for window-specific behavior. | (not yet traced) |
+| `mcp/McpSelectorContextHelper.java` | Builds selector context (recordContext/parentContext). Read when `neo_selectors` returns empty/wrong rows. | (not yet traced) |
+| `mcp/NeoAccessUtils.java` | RBAC helpers (`hasProcessAccess`, `hasWindowAccess`). Read for access-denied triage. | `hasProcessAccess(id)`, `hasWindowAccess(id)` |
+
+### Resources / definitions / constants
+| File | What it is / when to read | Key symbols |
+|------|---------------------------|-------------|
+| `mcp/McpResourceProvider.java` | `resources/list` + `resources/read`. Read for resource endpoint issues; shares report/process coupling. | `spec.getProcess()` refs `~204,243,291`; error `Spec '...' has no linked AD_Process` `~294` (ETP-4255) |
+| `mcp/McpToolDefinition.java` | Value type for an MCP tool (name, desc, schema). | — |
+| `mcp/McpToolException.java` | Tool-level exception type. | — |
+| `mcp/McpConstants.java` | Shared constant keys (`PARAM_PARAMETERS`, `GENERATE_PREFIX`, tool names). | `GENERATE_PREFIX`, `PARAM_PARAMETERS`, `TOOL_GENERATE_AMORTIZATION_PLAN` |
+
+## etendo-go — report execution (`src/com/etendoerp/go/schemaforge/`)
+| File | What it is / when to read | Key symbols |
+|------|---------------------------|-------------|
+| `schemaforge/util/NeoReportCallability.java` | **NEW (ETP-4255)** — single source of truth for report callability + the canonical non-callable response. Used by NEO router, MCP discover, MCP handleReport, MCP resource provider. | `isReportCallable(spec)`; `resolveReportHandlerQualifier(spec)`; `buildNotConfiguredResponse(name)` → `{name,type:"report",callable:false,status,message}`; `buildNotConfiguredMessage(name)`; `STATUS_NOT_CONFIGURED` |
+| `schemaforge/NeoReportService.java` | **STUB after ETP-4255** — Jasper runtime stripped; empty documented shell (`private` ctor) for future NEO-native wiring. No `ReportingUtils`/`exportJR`. | (no methods — placeholder only) |
+| `schemaforge/NeoServlet.java` | NEO Headless HTTP servlet — entry point for `/sws/neo/*`. Wires collaborators. | `processReportEndpoint = new NeoProcessReportEndpoint(this) :74`; `NeoPathInfo` inner type; delegates to `NeoRequestRouter` |
+| `schemaforge/NeoRequestRouter.java` | **LIVE** top-level spec dispatch (P/R/W). After ETP-4255 the R path is NEO-handler-or-non-callable; Jasper fallback removed. | `handleSpecRequest() ~70-89` (R→`handleReportSpecRequest`); `handleReportSpecRequest()` — `NeoReportCallability.resolveReportHandlerQualifier`→`dispatchReportHandler` (NEO-native), else `NeoResponse.ok(buildNotConfiguredResponse)` (HTTP 200); `dispatchReportHandler() ~176` |
+| `schemaforge/NeoProcessReportEndpoint.java` | **LIVE** POST executor. After ETP-4255 only `handleProcessSpec()` remains; report method removed. | `handleProcessSpec() ~48` (process, KEEP) |
+| `schemaforge/util/NeoProcessReportHelper.java` | **DELETED (ETP-4255)** — was dead-code duplicate of the report/process logic. Its test `NeoProcessReportHelperTest` must also be deleted. | (removed) |
+| `schemaforge/NeoDiscoveryHandler.java` / `util/NeoDiscoveryHelper.java` | NEO `handleDiscovery` (the source the MCP `neo_discover` mirrors). Read for discover/callability shape on the NEO side. | (discovery spec listing — not yet line-traced) |
+| `schemaforge/AgingReportHandler.java` | NEO-native report handler (KEEP). `@Named("agingReportHandler")`. GET describes params, POST returns JSON rows (no Jasper). | `@Named :60`; `handle() ~140` GET=`describeReport() ~155` / POST=execute `~180`; doc `/sws/neo/aging-report ~50-51` |
+| `schemaforge/InventoryStockReportHandler.java` | NEO-native report handler (KEEP). `@Named("inventoryStockReportHandler")`. POST returns JSON rows. | `@Named :38`; `handle()` |
+| `schemaforge/TaxReportHandler.java` | NEO-native report handler (KEEP). `@Named("taxReportHandler")`. GET describes, POST returns JSON rows. | `@Named :51`; `handle()` |
+| `schemaforge/handlers/` | `NeoHandler` CDI beans keyed by `ETGO_SF_ENTITY.Java_Qualifier` (`@Named` only, never `@ApplicationScoped`). Window-specific behavior lives here, NOT in generic services. | report handlers live one level up in `schemaforge/`: `agingReportHandler`, `inventoryStockReportHandler`, `taxReportHandler` |
+
+## etendo-go — MCP tests (`src-test/src/com/etendoerp/go/mcp/`)
+| File | What it is / when to read | Key symbols |
+|------|---------------------------|-------------|
+| `src-test/.../mcp/McpToolRouterTest` | Regression tests for router behavior. | (delegate authoring to Tester) |
+| `src-test/.../mcp/McpToolRouterRouteTest` | Tests tool-name→handler routing (generate_* → handleReport). | — |
+| `src-test/.../mcp/ToolRegistryGenerateToolsTest` | Tests generate_* tool generation for report/process specs (1165 lines — heavy report-tool coverage to update for ETP-4255). | — |
+| `src-test/.../mcp/McpConstantsTest` | Constant keys incl. GENERATE_PREFIX. | — |
+| `src-test/.../schemaforge/NeoReportServiceTest` | Jasper service tests (567 lines — delete/rewrite with ETP-4255). | — |
+| `src-test/.../schemaforge/NeoRequestRouterTest` | Router dispatch tests incl. R-spec Jasper fallback. | — |
+| `src-test/.../schemaforge/util/NeoProcessReportHelperTest` | 409-line test for DEAD-CODE helper — delete alongside the helper. | — |
+
+---
+
+## schema_forge — CLI writers
+| File | What it is / when to read | Key symbols |
+|------|---------------------------|-------------|
+| `cli/src/neo-writer.js` | Pushes spec/entity/field config to `ETGO_SF_*` tables. ETP-4255: currently treats P/R specs as process-backed metadata. | P/R spec handling |
+| `cli/src/push-to-neo.js` | Push orchestration + `toSpecName()` (kebab-case single source of truth). | `toSpecName()` |
+| `cli/src/menu-cache.js` | Menu/window/process/report ID lookup. Never guess IDs — query here. | `search "<name>"` |
+| `cli/src/db.js` | DB connectivity (creds auto-resolve from `gradle.properties`). | — |
+
+---
+
+## Per-ticket trace log (which files each ticket touched)
+- **ETP-4255** (code-bug — remove runtime Jasper from Etendo Go): `McpToolRouter.java` (handleReport, handleDiscover), `McpToolRouterSupport.java` (buildDiscoverSpec), `ToolRegistry.java` (processSpec, buildReportTool), `McpResourceProvider.java` (process coupling), `NeoReportService.java` (Jasper exportJR), `cli/src/neo-writer.js` (P/R as process-backed).

--- a/docs/agentic-validation/mcp-ticket-knowledge.md
+++ b/docs/agentic-validation/mcp-ticket-knowledge.md
@@ -1,0 +1,58 @@
+# MCP Ticket Knowledge Base — Internal (Tracer)
+
+**Audience:** the `mcp-ticket-resolver` (Tracer) agent itself — institutional memory to resolve MCP tickets faster.
+**Inward-facing.** The outward report for the bot team is `ticket-feedback.md` — keep the two distinct.
+
+> Read this FIRST on every ticket (orientation step 2). Append a dated bullet whenever you learn something durable. Never delete a correction; supersede it with a newer dated note.
+
+---
+
+## Recurring root-cause categories
+
+How a reported symptom usually maps to a real cause. The point: **not every "failure" is an MCP code bug.**
+
+| Symptom pattern | Most likely category | Where to look first |
+|---|---|---|
+| Tool/entity "not found" / "access denied" | RBAC gap **or** module not installed | role's window/process access; is the module deployed? |
+| Selector / defaults returns empty or wrong rows | upstream context metadata **or** `McpSelectorContextHelper` | contract `context.required`; selector context builder |
+| 500 / stack trace on a tool call | MCP code bug | the router branch for that tool + its handler |
+| Field unexpectedly editable/hidden/required | upstream contract (decisions/generators) | `decisions.json` → `make regen`, not the MCP |
+| Action/process not discoverable or rejected | contract `apiPrediction.actions[]` **or** RBAC | generated contract; role process access |
+
+**The canonical 6 root-cause categories** are defined in `.claude/agents/mcp-ticket-resolver.md` `<ticket_quality_rubric>`: code-bug, upstream-config, RBAC/scope, missing-module/data, **validator-side/agent-knowledge**, **test-data/environment gap**. Only the first two are code fixes in this repo pair.
+
+- **2026-06-23 — Evidenced baseline (ETP-3938 / JuanCarlos Round 1):** of 15 reported findings, **5 were NOT code bugs** — `bp-location` access denied (RBAC), `verifactu-config` / `tbai-facturas-enviadas` entity not found (modules not installed), dashboard widgets + report specs not agent-accessible (API not exposed). → When triaging, *always* rule out RBAC / missing-module / un-exposed-API before reading MCP code.
+
+- **2026-06-23 — Round 3 (Juan Carlos, 2026-06-19, 15 tickets, label `validacion-agentica`) categorized (analysis only — NOT resolved):**
+  - **code-bug (MCP/NEO Java):** ETP-4274 (neo_create ignores non-mandatory defaults — defaults/create asymmetry, `NeoDefaultsService.injectMandatoryDefaults:824-825`), ETP-4275 (no generic process-precondition validation), ETP-4285 (document actions not semantically exposed), ETP-4286 (neo_selectors lacks recordContext passthrough), ETP-4287 (GET-only entities not flagged in discovery), ETP-4284 (widgets not wrapped as `neo_widget`; were misrouted through CRUD), ETP-4255 (Jasper runtime must be removed; report callability metadata).
+  - **upstream-config (schema_forge decisions/generators):** ETP-4278 (empty `prompt` field on contacts/financial-account), ETP-4276 (assets conditional userRequired not declared), ETP-4254 (W-vs-R spec misclassification), ETP-4288 (`defaultExpression="0"` surfaced in schema).
+  - **validator-side / agent-knowledge:** **ETP-4279** — the validating agent claimed FIN_Financial_Account has 2 types (read from `SeedReferenceDataStep.java`) instead of querying `neo_selectors` (3 types: B/C/CA). Pure bot defect, no product fix. Pattern: agents assuming enum/list cardinality from source/docs instead of runtime selectors.
+  - **test-data / environment gap:** ETP-4289 — 6 specs (`return-from-customer`, `return-to-vendor`, `sii-config`, `sii-monitor`, `simple-g-l-journal`, `tbai-config`) unevaluable for lack of records.
+  - **opaque / diagnostic gap:** ETP-4280 — Card financial-account create failed but the validator captured NO error message/HTTP status/body. The ticket is itself about the missing diagnostic. Canonical evidence for rubric #3/#4.
+  - **under-specified:** ETP-4242 — "no W spec for ERP entities" with no entity/tool/repro named.
+
+---
+
+## MCP code map (where tools resolve)
+
+(See the table in `.claude/agents/mcp-ticket-resolver.md` `<where_fixes_live>` for the authoritative file→responsibility map.)
+
+- _Append durable findings about specific router branches, scope mappings, session/context behavior as you learn them._
+
+---
+
+## Misclassifications corrected
+
+- _None yet._
+
+---
+
+## MCP code / config quirks
+
+- _None recorded yet._
+
+---
+
+## User corrections
+
+- _None yet._

--- a/docs/agentic-validation/ticket-feedback.md
+++ b/docs/agentic-validation/ticket-feedback.md
@@ -37,7 +37,14 @@
 - Note to bot team: <concrete: "include X next time">
 -->
 
-_No tickets resolved yet._
+### 2026-06-24 — ETP-4255 — Remove runtime Jasper report generation; expose only NEO-callable reports
+- Tool/spec: `neo_discover` + `generate_<report>` MCP tools and NEO HTTP `/sws/neo/<report-spec>`; report specs (`SPEC_TYPE=R`), e.g. `aging-receivable`, `tax-report`, `inventory-stock-report` (callable) vs. all other R specs (non-callable).
+- Root-cause category: **code-bug** (category 1) — runtime Jasper execution (`ReportingUtils.exportJR`) was reachable from the live NEO/MCP request path; it had to be removed and replaced with a stable non-callable response.
+- Time-to-locate: **fast** — the ticket enumerated the violating behaviors and pointed at the report path; tracing confirmed Jasper sinks in `NeoReportService`, `NeoProcessReportEndpoint`, `NeoRequestRouter`, and (independently) `McpToolRouter`.
+- Missing rubric fields: **none** — ticket carried expected vs actual, the architectural rule (no Jasper at runtime), and concrete acceptance criteria.
+- Highest-value field that was missing: **n/a — exemplary ticket.**
+- Note to bot team: **This is the standard.** ETP-4255 stated the rule being violated, the expected end-state, and enumerated the specific behaviors to remove — which let us go straight to the code path without reconstruction. One subtlety the ticket got right and most don't: it scoped *out* what was NOT in scope (jsreport integration), which prevented scope-creep. Keep doing exactly this: rule + expected end-state + explicit out-of-scope.
+- Resolution note (for our records, not the bot): MCP report tooling was **not** a passthrough mirror of NEO — it carried its own independent Jasper logic — so the fix had to touch both layers, consolidated behind `NeoReportCallability`.
 
 ---
 

--- a/docs/agentic-validation/ticket-feedback.md
+++ b/docs/agentic-validation/ticket-feedback.md
@@ -1,0 +1,91 @@
+# MCP Ticket Feedback — Report for the External Validation-Bot Team
+
+**Audience:** the team operating the agentic validation bot that files Etendo GO MCP tickets (external — we do not control its prompt).
+**Purpose:** tell them, concretely, what information would make their tickets faster to triage, locate, and fix. Maintained by the `mcp-ticket-resolver` (Tracer) agent — one entry per resolved ticket, plus a distilled rubric they can adopt.
+
+> **How to read this:** the per-ticket log is the evidence; the distilled rubric at the bottom is the actual hand-off — the recommended ticket template, ranked by what we most often had to reconstruct ourselves.
+
+---
+
+## Ticket Quality Rubric (the fields a good MCP ticket carries)
+
+| # | Field | One-line ask to the bot |
+|---|---|---|
+| 1 | MCP tool called | State the exact tool name (`neo_create`, `neo_selectors`, `generate_<spec>`, …). |
+| 2 | Spec / entity (kebab) + header vs lines | Use the name as it appears in `neo_discover`. |
+| 3 | **Verbatim JSON-RPC request** | Paste the exact params payload sent. *(highest value)* |
+| 4 | **Verbatim response / error** | Paste the exact error code + message or wrong payload. |
+| 5 | Auth context (OAuth2 scope, AD role, user/org/client) | Include scope + role used. |
+| 6 | Context params (recordContext/parentContext, session vars) | Include any context sent to selectors/defaults. |
+| 7 | Contract/spec version + deployed? | State version and whether the spec is pushed (`export.database`). |
+| 8 | Environment (instance URL, module commit/branch) | Identify the build. |
+| 9 | Expected vs actual | Separate the two. |
+| 10 | Minimal repro sequence | Ordered tool calls. |
+| 11 | Self-classification hint | Pre-guess: code bug / config / RBAC / missing-module. |
+
+---
+
+## Per-Ticket Log
+
+<!-- Newest first. Template:
+### YYYY-MM-DD — ETP-XXXX — <one-line symptom>
+- Tool/spec: <neo_create / sales-order header>
+- Root-cause category: code-bug | upstream-config | RBAC | missing-module
+- Time-to-locate: <fast / slow — why>
+- Missing rubric fields: [#3, #5, ...]
+- Highest-value field that was missing: <#N — the one that cost the most time>
+- Note to bot team: <concrete: "include X next time">
+-->
+
+_No tickets resolved yet._
+
+---
+
+## Batch Analysis — Round 3 (2026-06-19, 15 tickets, label `validacion-agentica`)
+
+_Analysis only — these tickets were reviewed against the rubric, NOT resolved. Source for the ranked gaps below._
+
+**Top feedback items for the bot team, ranked by cost:**
+
+1. **Capture the failing call verbatim (rubric #3/#4).** The single most damaging gap. **ETP-4280** (Card financial-account create failed) is a ticket that is *itself about the missing diagnostic*: it carries no error message, HTTP status, or response body, so the root cause is unidentifiable from the ticket alone. The validator must attach the verbatim failing request and the exact response/error.
+
+2. **The validator has MCP access — attach the raw tool output, don't make us reconstruct it.** Several tickets (ETP-4280, ETP-4279, ETP-4278, ETP-4254) carry a hand-added "Confirmación vía MCP" block — exactly the `neo_discover`/`neo_schema`/`neo_selectors` reconstruction we would otherwise do. Its presence proves the *raw bot finding* lacked it. The bot can run that confirmation itself and paste the output.
+
+3. **Pre-classify into the 6 categories (rubric #11) — most findings are NOT product code bugs.** Round 3 breakdown: 7 code-bug, 4 upstream-config, 1 validator-side, 1 test-data-gap, plus 1 opaque and 1 under-specified. Crucially, **ETP-4279 is a defect in the validating bot itself** — it asserted "2 account types" from hardcoded source (`SeedReferenceDataStep.java`) instead of querying `neo_selectors` (which returns 3). The bot should never assert enum/list cardinality from source/docs; it must query the selector at runtime. This category costs us triage time on non-product issues.
+
+4. **Always name the tool (#1), spec/entity (#2), and a minimal repro (#10).** Specificity is wildly uneven. ETP-4274 and ETP-4255 are exemplary (file:line, verbatim repro, enumerated violations) — *this is what good looks like*. **ETP-4242** is the opposite: "no W spec for ERP entities" names no entity, no tool, no repro — nearly un-actionable.
+
+5. **When the origin is a chat (Discord), attach the transcript excerpt.** ETP-4279 and ETP-4242 link a Discord thread as origin but omit the agent conversation that triggered the finding. Include the minimal transcript.
+
+---
+
+## Distilled Rubric — Recommended Ticket Template (THE hand-off)
+
+<!-- Update the ranking as more rounds are analyzed. This is the section we actually send to the bot team. -->
+
+### Top recurring gaps (ranked by cost)
+1. **Verbatim failing request + response/error** (rubric #3/#4) — most damaging when missing (ETP-4280).
+2. **Raw MCP tool output the validator already saw** (#2/#6) — it has MCP access; paste `neo_discover`/`neo_schema`/`neo_selectors`, don't make us reconstruct it.
+3. **Pre-classification into the 6 categories** (#11) — most findings aren't product bugs; one was a bug in the bot itself (ETP-4279).
+4. **Tool + spec/entity + minimal repro always named** (#1/#2/#10) — ETP-4242 named none.
+5. **Transcript excerpt when the origin is a chat thread.**
+
+### Recommended ticket template the bot could emit
+```
+Title: [tool] [spec] — [one-line symptom]
+MCP tool: neo_create | neo_list | ... | generate_<spec> | <process_spec>
+Spec/entity: <kebab-name> (header|lines)
+Request (verbatim JSON-RPC):
+  { ... }
+Response/error (verbatim):
+  { "error": { "code": ..., "message": "..." } }
+Auth: scope=<neo:write> role=<...> user=<...> client/org=<...>
+Context params: recordContext/parentContext=<...>; session vars=<...>
+Contract version: <x.y.z>  Deployed: yes/no
+Environment: <instance URL>  module commit: <sha/branch>
+Expected: <...>
+Actual: <...>
+Repro sequence:
+  1. ...
+Suspected category: code-bug | config | RBAC | missing-module
+```

--- a/docs/plans/discarded/neo-report-endpoint.md
+++ b/docs/plans/discarded/neo-report-endpoint.md
@@ -1,6 +1,12 @@
 # Plan: NEO Headless Report Endpoint
 
-**Status:** Pending
+> **OBSOLETE — superseded/cancelled by ETP-4255.** The Jasper NEO report endpoint described
+> here (binary report generation via `ReportingUtils.exportJR`) will NOT be implemented.
+> ETP-4255 removes runtime Jasper from NEO/MCP entirely: report generation is
+> NEO-native-handlers-only (`NeoHandler` beans returning JSON), and jsreport handles the
+> rest. Kept below as historical record only.
+
+**Status:** Discarded (OBSOLETE — see ETP-4255)
 **Date:** 2026-03-12
 **Related:** [Process & Report Pipeline](process-and-report-pipeline.md) — Phase 2
 

--- a/packages/schema-forge-core/src/domain-boundary/default-policy.js
+++ b/packages/schema-forge-core/src/domain-boundary/default-policy.js
@@ -96,7 +96,7 @@ export const DEFAULT_BOUNDARY_POLICY = {
   e2eFlowPattern: '^e2e/tests/flows/(.+)\\.(?:mocked\\.)?spec\\.js$',
   crossDomainPlanPattern: '^docs/plans/[^/]+-cross-domain\\.md$',
   repoDocPatterns: [
-    '^docs/(?:architecture|ops|diagrams|proposals|superpowers|plans)/',
+    '^docs/(?:architecture|ops|diagrams|proposals|superpowers|plans|agentic-validation|etendo-ad)/',
     '^docs/[^/]+\\.md$',
   ],
   patternGroups: [
@@ -113,6 +113,8 @@ export const DEFAULT_BOUNDARY_POLICY = {
         '^cli/src/run-[a-z0-9-]+-tests\\.js$',
         '^cli/src/regen-all\\.js$',
         '^cli/src/push-to-neo\\.js$',
+        '^cli/src/neo-writer\\.js$',
+        '^cli/src/lib/',
         '^cli/src/validate-',
         '^cli/src/migrate-',
         '^cli/src/migrations/',
@@ -222,6 +224,7 @@ export const DEFAULT_BOUNDARY_POLICY = {
       kind: 'repo-infra',
       scope: 'repo-infra',
       patterns: [
+        '^\\.claude/',
         '^\\.github/',
         '^\\.githooks/',
         '^pipelines/',

--- a/packages/schema-forge-core/test/domain-boundary-check.test.js
+++ b/packages/schema-forge-core/test/domain-boundary-check.test.js
@@ -236,6 +236,31 @@ describe('domain boundary classification', () => {
     }
   });
 
+  it('classifies neo-writer and cli/src/lib helpers with the generator boundary', () => {
+    assert.deepEqual(
+      classifyPath('cli/src/neo-writer.js', { knownWindows: WINDOWS }),
+      { kind: 'generator-change', scope: 'generator-change' },
+    );
+    assert.deepEqual(
+      classifyPath('cli/src/lib/neo-delta.js', { knownWindows: WINDOWS }),
+      { kind: 'generator-change', scope: 'generator-change' },
+    );
+  });
+
+  it('classifies .claude agent/tooling config as repo infra', () => {
+    assert.equal(
+      classifyPath('.claude/agents/foo.md', { knownWindows: WINDOWS }).scope,
+      'repo-infra',
+    );
+  });
+
+  it('classifies agentic-validation docs as repo infra', () => {
+    assert.equal(
+      classifyPath('docs/agentic-validation/bar.md', { knownWindows: WINDOWS }).scope,
+      'repo-infra',
+    );
+  });
+
   it('classifies npm registry config as repo infra', () => {
     assert.deepEqual(
       classifyPath('.npmrc', { knownWindows: WINDOWS }),


### PR DESCRIPTION
## ETP-4255 — Remove runtime Jasper report generation from Etendo Go

Etendo Go / NEO Headless / MCP must never execute Jasper, JRXML, classic AD_Process report execution, or `ReportingUtils.exportJR`. This PR removes every runtime Jasper path and makes `SPEC_TYPE = R` (report) specs resolve to NEO-native handlers only.

### What changed
- **NEO HTTP**: report specs dispatch to their NEO-native `@Named` handler (via `ETGO_SF_ENTITY.Java_Qualifier`); the Jasper GET/POST fallback is removed. A spec with no handler returns a stable HTTP-200 `not_configured_for_report_generation` body instead of attempting Jasper.
- **MCP**: `generate_*` tools are only emitted for callable report specs; `handleReport` resolves the NEO handler and returns the canonical non-callable response otherwise (no more `"has no linked AD_Process"`).
- **MCP discover**: report specs expose `callable` (+ `status`/`message` when not callable) truthfully.
- `NeoReportService` stripped to a documented empty stub (no `exportJR`); `NeoProcessReportHelper` deleted (dead code); `handleReportSpec` removed from `NeoProcessReportEndpoint`.
- New single source of truth `NeoReportCallability` (callability check, handler-qualifier resolution, canonical not-configured response).
- Schema Forge: `neo-writer.js` no longer routes `R` specs through process-style metadata; the 3 native report keepers register via `pushReportToNeo()` and are unaffected.
- Docs updated; obsolete Jasper-endpoint plan marked superseded.

### Validation
Verified on the local stack (post-rebuild): no spec hits the Jasper path anymore; `inventory-stock-report` and `tax-report` return real NEO-native JSON; `neo_discover` emits `callable`. Contrasted against the epic baseline (still Jasper) to confirm the behavior change.

### Out of scope / follow-ups
- Adding new jsreport-based reports to NEO — explicitly out of scope.
- **ETP-4326**: `aging-receivable` returns 500 — a pre-existing latent bug in `AgingReportHandler`↔core `AgingDao` that this change *surfaced* (Jasper previously masked it). Not a regression of this PR.
- Unify NEO-vs-MCP handler lookup (NB1) and the `jasper-migration` quality-gate warning — deferred.

Refs ETP-4255.
