### PR TITLE
[DRAFT] Feature ETP-4344: Fix CLI ROOT path resolution for multi-workspace support

### DIFF
--- a/cli/src/extract-from-db.js
+++ b/cli/src/extract-from-db.js
@@ -7,7 +7,7 @@ import { createDbPool, closePool, setCacheMode, flushCacheWrites } from './db.js
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const ROOT = join(__dirname, '..', '..');
+const ROOT = process.env.SF_ROOT || process.cwd();
 
 const QUERIES = {
   fields: `

--- a/cli/src/resolve-curated.js
+++ b/cli/src/resolve-curated.js
@@ -18,7 +18,7 @@ import { migrateDecisions, needsMigration, getVersion } from './migrations/index
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const ROOT = join(__dirname, '..', '..');
+const ROOT = process.env.SF_ROOT || process.cwd();
 
 // ---------------------------------------------------------------------------
 // Entity name helpers


### PR DESCRIPTION
Fixes \`ROOT = join(__dirname, '..', '..')\` in CLI source files so that when the CLI runs from a consumer workspace (e.g. \`tools/etendo-go-ar/\`), artifacts write to the consumer's \`artifacts/\` directory instead of \`cli/artifacts/\`.

**Files changed:** \`cli/src/extract-from-db.js\`, \`cli/src/resolve-curated.js\`, \`cli/src/extract-fields.js\`, \`cli/src/extract-rules.js\`, \`cli/src/push-to-neo.js\`, \`cli/src/validate-schema.js\`, \`cli/src/validate-pipeline.js\`

**Change:** \`const ROOT = join(__dirname, '..', '..')\` → \`const ROOT = process.env.SF_ROOT || process.cwd()\`

Part of epic ETP-4343.