### PR TITLE
Feature ETP-4249: Onboard Tax Category window into NEO Headless

### DIFF
--- a/artifacts/tax-category/contract.json
+++ b/artifacts/tax-category/contract.json
@@ -1,0 +1,720 @@
+{
+  "version": "0.1.0",
+  "generatedAt": "2026-06-26T17:01:05.650Z",
+  "checksum": "31ebd6536168a8d1",
+  "frontendContract": {
+    "window": {
+      "id": "138",
+      "name": "Tax Category",
+      "primaryEntity": "taxCategory",
+      "category": "configuration",
+      "hidePrint": true,
+      "hideMoreMenu": true,
+      "detailEntity": null,
+      "layoutType": "default"
+    },
+    "entities": {
+      "taxCategory": {
+        "tableName": "C_TaxCategory",
+        "tabId": "176",
+        "tabName": "Tax Category",
+        "uiPattern": "STD",
+        "fields": [
+          {
+            "name": "name",
+            "apiKey": "name",
+            "column": "Name",
+            "label": "Name",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "sourceRequired": true,
+            "section": "principal",
+            "seq": 1
+          },
+          {
+            "name": "description",
+            "apiKey": "description",
+            "column": "Description",
+            "label": "Description",
+            "type": "string",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": false,
+            "form": true,
+            "section": "principal",
+            "seq": 2
+          },
+          {
+            "name": "default",
+            "apiKey": "default",
+            "column": "IsDefault",
+            "label": "Default",
+            "type": "boolean",
+            "tsType": "boolean",
+            "visibility": "editable",
+            "required": true,
+            "grid": true,
+            "form": true,
+            "sourceRequired": true,
+            "section": "principal",
+            "seq": 3
+          },
+          {
+            "name": "asbom",
+            "apiKey": "asbom",
+            "column": "Asbom",
+            "label": "As per BOM",
+            "type": "boolean",
+            "tsType": "boolean",
+            "visibility": "editable",
+            "required": true,
+            "grid": false,
+            "form": true,
+            "sourceRequired": true,
+            "derivation": {
+              "type": "computed",
+              "source": "N"
+            },
+            "defaultValue": "N",
+            "section": "principal",
+            "seq": 4
+          },
+          {
+            "name": "obsptiTaxtype",
+            "apiKey": "obsptiTaxtype",
+            "column": "EM_Obspti_Taxtype",
+            "label": "Tax type",
+            "type": "enum",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": false,
+            "form": true,
+            "enumValues": [
+              {
+                "value": "IGIC",
+                "name": "IGIC"
+              },
+              {
+                "value": "IPSI",
+                "name": "IPSI"
+              },
+              {
+                "value": "IVA",
+                "name": "IVA"
+              },
+              {
+                "value": "VAT",
+                "name": "VAT"
+              }
+            ],
+            "section": "principal",
+            "seq": 5
+          },
+          {
+            "name": "obsptiTransactiontype",
+            "apiKey": "obsptiTransactiontype",
+            "column": "EM_Obspti_Transactiontype",
+            "label": "Transaction type",
+            "type": "enum",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": false,
+            "form": true,
+            "enumValues": [
+              {
+                "value": "BI",
+                "name": "Entrega/Adquisición de bienes"
+              },
+              {
+                "value": "SE",
+                "name": "Prestación de Servicios"
+              },
+              {
+                "value": "IN",
+                "name": "Transmisión/Adquisición B.Inmuebles"
+              }
+            ],
+            "section": "principal",
+            "seq": 6
+          },
+          {
+            "name": "obsptiRatetype",
+            "apiKey": "obsptiRatetype",
+            "column": "EM_Obspti_Ratetype",
+            "label": "Rate type",
+            "type": "enum",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": false,
+            "form": true,
+            "enumValues": [
+              {
+                "value": "CE",
+                "name": "Cero"
+              },
+              {
+                "value": "EX",
+                "name": "Exento"
+              },
+              {
+                "value": "GE",
+                "name": "General"
+              },
+              {
+                "value": "I1",
+                "name": "Incrementado 1"
+              },
+              {
+                "value": "I2",
+                "name": "Incrementado 2"
+              },
+              {
+                "value": "NS",
+                "name": "No sujeto"
+              },
+              {
+                "value": "NO",
+                "name": "Normal"
+              },
+              {
+                "value": "RE",
+                "name": "Reducido"
+              },
+              {
+                "value": "SR",
+                "name": "Super reducido"
+              }
+            ],
+            "section": "principal",
+            "seq": 7
+          },
+          {
+            "name": "aeatsiiDeclarable",
+            "apiKey": "aeatsiiDeclarable",
+            "column": "EM_Aeatsii_Declarable",
+            "label": "SII declarable",
+            "type": "boolean",
+            "tsType": "boolean",
+            "visibility": "editable",
+            "required": true,
+            "grid": false,
+            "form": true,
+            "sourceRequired": true,
+            "derivation": {
+              "type": "computed",
+              "source": "Y"
+            },
+            "defaultValue": "Y",
+            "section": "principal",
+            "seq": 8
+          }
+        ],
+        "searchableFields": [
+          "name"
+        ],
+        "computedFields": [
+          {
+            "name": "asbom",
+            "derivation": {
+              "type": "computed",
+              "source": "N"
+            }
+          },
+          {
+            "name": "aeatsiiDeclarable",
+            "derivation": {
+              "type": "computed",
+              "source": "Y"
+            }
+          }
+        ]
+      }
+    }
+  },
+  "backendContract": {
+    "window": {
+      "id": "138",
+      "name": "Tax Category",
+      "primaryEntity": "taxCategory",
+      "category": "configuration",
+      "hidePrint": true,
+      "hideMoreMenu": true,
+      "detailEntity": null
+    },
+    "entities": {
+      "taxCategory": {
+        "tableName": "C_TaxCategory",
+        "tabId": "176",
+        "tabName": "Tax Category",
+        "fields": [
+          {
+            "name": "organization",
+            "apiKey": "organization",
+            "column": "AD_Org_ID",
+            "type": "foreignKey",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "name",
+            "apiKey": "name",
+            "column": "Name",
+            "type": "string",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "description",
+            "apiKey": "description",
+            "column": "Description",
+            "type": "string",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "default",
+            "apiKey": "default",
+            "column": "IsDefault",
+            "type": "boolean",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "asbom",
+            "apiKey": "asbom",
+            "column": "Asbom",
+            "type": "boolean",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "active",
+            "apiKey": "active",
+            "column": "IsActive",
+            "type": "boolean",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "obsptiTaxtype",
+            "apiKey": "obsptiTaxtype",
+            "column": "EM_Obspti_Taxtype",
+            "type": "enum",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "obsptiTransactiontype",
+            "apiKey": "obsptiTransactiontype",
+            "column": "EM_Obspti_Transactiontype",
+            "type": "enum",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "obsptiRatetype",
+            "apiKey": "obsptiRatetype",
+            "column": "EM_Obspti_Ratetype",
+            "type": "enum",
+            "visibility": "editable",
+            "required": false
+          },
+          {
+            "name": "aeatsiiDeclarable",
+            "apiKey": "aeatsiiDeclarable",
+            "column": "EM_Aeatsii_Declarable",
+            "type": "boolean",
+            "visibility": "editable",
+            "required": true
+          },
+          {
+            "name": "id",
+            "apiKey": "id",
+            "column": "C_TaxCategory_ID",
+            "type": "id",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "client",
+            "apiKey": "client",
+            "column": "AD_Client_ID",
+            "type": "foreignKey",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "creationDate",
+            "apiKey": "creationDate",
+            "column": "Created",
+            "type": "dateTime",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "createdBy",
+            "apiKey": "createdBy",
+            "column": "CreatedBy",
+            "type": "foreignKey",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updated",
+            "apiKey": "updated",
+            "column": "Updated",
+            "type": "dateTime",
+            "visibility": "system",
+            "required": true
+          },
+          {
+            "name": "updatedBy",
+            "apiKey": "updatedBy",
+            "column": "UpdatedBy",
+            "type": "foreignKey",
+            "visibility": "system",
+            "required": true
+          }
+        ]
+      }
+    },
+    "endpoints": [
+      {
+        "method": "GET",
+        "path": "/taxCategory",
+        "entity": "taxCategory",
+        "supportedFilters": [
+          "name"
+        ]
+      },
+      {
+        "method": "GET",
+        "path": "/taxCategory/:id",
+        "entity": "taxCategory",
+        "supportedFilters": []
+      },
+      {
+        "method": "POST",
+        "path": "/taxCategory",
+        "entity": "taxCategory",
+        "supportedFilters": []
+      },
+      {
+        "method": "PUT",
+        "path": "/taxCategory/:id",
+        "entity": "taxCategory",
+        "supportedFilters": []
+      },
+      {
+        "method": "DELETE",
+        "path": "/taxCategory/:id",
+        "entity": "taxCategory",
+        "supportedFilters": []
+      }
+    ],
+    "processEndpoints": []
+  },
+  "apiPrediction": {
+    "specName": "tax-category",
+    "baseUrl": "/sws/neo/tax-category",
+    "crud": {
+      "taxCategory": {
+        "get": true,
+        "getById": true,
+        "post": true,
+        "put": true,
+        "patch": true,
+        "delete": true,
+        "listUrl": "/sws/neo/tax-category/taxCategory",
+        "detailUrl": "/sws/neo/tax-category/taxCategory/{id}",
+        "supportedFilters": [
+          "name"
+        ]
+      }
+    },
+    "selectors": [],
+    "actions": [],
+    "queryParams": {
+      "pagination": {
+        "startRow": "_startRow",
+        "endRow": "_endRow",
+        "default": "0-100"
+      },
+      "sorting": {
+        "param": "_sortBy",
+        "example": "_sortBy=creationDate desc"
+      },
+      "filtering": "Use field name as query param: ?fieldName=value",
+      "parentFilter": "parentId={id} for child entities"
+    },
+    "window": {
+      "category": "configuration"
+    }
+  },
+  "testManifest": {
+    "tests": [
+      {
+        "id": "t-crud-flags-taxCategory",
+        "category": "crud-flags",
+        "entity": "taxCategory",
+        "runner": "node",
+        "description": "CRUD flags for 'taxCategory' should all be booleans"
+      },
+      {
+        "id": "t-default-value-type-taxCategory-aeatsiiDeclarable",
+        "category": "default-value-type",
+        "entity": "taxCategory",
+        "field": "aeatsiiDeclarable",
+        "runner": "node",
+        "description": "Default value for 'aeatsiiDeclarable' in taxCategory should be a string"
+      },
+      {
+        "id": "t-default-value-type-taxCategory-asbom",
+        "category": "default-value-type",
+        "entity": "taxCategory",
+        "field": "asbom",
+        "runner": "node",
+        "description": "Default value for 'asbom' in taxCategory should be a string"
+      },
+      {
+        "id": "t-field-presence-taxCategory-aeatsiiDeclarable",
+        "category": "field-presence",
+        "entity": "taxCategory",
+        "field": "aeatsiiDeclarable",
+        "runner": "node",
+        "description": "Field 'aeatsiiDeclarable' should be present in taxCategory"
+      },
+      {
+        "id": "t-field-presence-taxCategory-asbom",
+        "category": "field-presence",
+        "entity": "taxCategory",
+        "field": "asbom",
+        "runner": "node",
+        "description": "Field 'asbom' should be present in taxCategory"
+      },
+      {
+        "id": "t-field-presence-taxCategory-default",
+        "category": "field-presence",
+        "entity": "taxCategory",
+        "field": "default",
+        "runner": "node",
+        "description": "Field 'default' should be present in taxCategory"
+      },
+      {
+        "id": "t-field-presence-taxCategory-description",
+        "category": "field-presence",
+        "entity": "taxCategory",
+        "field": "description",
+        "runner": "node",
+        "description": "Field 'description' should be present in taxCategory"
+      },
+      {
+        "id": "t-field-presence-taxCategory-name",
+        "category": "field-presence",
+        "entity": "taxCategory",
+        "field": "name",
+        "runner": "node",
+        "description": "Field 'name' should be present in taxCategory"
+      },
+      {
+        "id": "t-field-presence-taxCategory-obsptiRatetype",
+        "category": "field-presence",
+        "entity": "taxCategory",
+        "field": "obsptiRatetype",
+        "runner": "node",
+        "description": "Field 'obsptiRatetype' should be present in taxCategory"
+      },
+      {
+        "id": "t-field-presence-taxCategory-obsptiTaxtype",
+        "category": "field-presence",
+        "entity": "taxCategory",
+        "field": "obsptiTaxtype",
+        "runner": "node",
+        "description": "Field 'obsptiTaxtype' should be present in taxCategory"
+      },
+      {
+        "id": "t-field-presence-taxCategory-obsptiTransactiontype",
+        "category": "field-presence",
+        "entity": "taxCategory",
+        "field": "obsptiTransactiontype",
+        "runner": "node",
+        "description": "Field 'obsptiTransactiontype' should be present in taxCategory"
+      },
+      {
+        "id": "t-field-type-taxCategory-aeatsiiDeclarable",
+        "category": "field-type",
+        "entity": "taxCategory",
+        "field": "aeatsiiDeclarable",
+        "runner": "node",
+        "description": "Field 'aeatsiiDeclarable' should have type 'boolean' in taxCategory"
+      },
+      {
+        "id": "t-field-type-taxCategory-asbom",
+        "category": "field-type",
+        "entity": "taxCategory",
+        "field": "asbom",
+        "runner": "node",
+        "description": "Field 'asbom' should have type 'boolean' in taxCategory"
+      },
+      {
+        "id": "t-field-type-taxCategory-default",
+        "category": "field-type",
+        "entity": "taxCategory",
+        "field": "default",
+        "runner": "node",
+        "description": "Field 'default' should have type 'boolean' in taxCategory"
+      },
+      {
+        "id": "t-field-type-taxCategory-description",
+        "category": "field-type",
+        "entity": "taxCategory",
+        "field": "description",
+        "runner": "node",
+        "description": "Field 'description' should have type 'string' in taxCategory"
+      },
+      {
+        "id": "t-field-type-taxCategory-name",
+        "category": "field-type",
+        "entity": "taxCategory",
+        "field": "name",
+        "runner": "node",
+        "description": "Field 'name' should have type 'string' in taxCategory"
+      },
+      {
+        "id": "t-field-type-taxCategory-obsptiRatetype",
+        "category": "field-type",
+        "entity": "taxCategory",
+        "field": "obsptiRatetype",
+        "runner": "node",
+        "description": "Field 'obsptiRatetype' should have type 'string' in taxCategory"
+      },
+      {
+        "id": "t-field-type-taxCategory-obsptiTaxtype",
+        "category": "field-type",
+        "entity": "taxCategory",
+        "field": "obsptiTaxtype",
+        "runner": "node",
+        "description": "Field 'obsptiTaxtype' should have type 'string' in taxCategory"
+      },
+      {
+        "id": "t-field-type-taxCategory-obsptiTransactiontype",
+        "category": "field-type",
+        "entity": "taxCategory",
+        "field": "obsptiTransactiontype",
+        "runner": "node",
+        "description": "Field 'obsptiTransactiontype' should have type 'string' in taxCategory"
+      },
+      {
+        "id": "t-rule-declared-AD-Client-Security-validation",
+        "category": "rule-declared",
+        "rule": "AD_Client Security validation",
+        "runner": "node",
+        "description": "Rule 'AD_Client Security validation' (validation) should be declared"
+      },
+      {
+        "id": "t-searchable-filters-taxCategory-name",
+        "category": "searchable-filters",
+        "entity": "taxCategory",
+        "field": "name",
+        "runner": "node",
+        "description": "Field 'name' should be a supported filter for taxCategory"
+      },
+      {
+        "id": "t-system-field-taxCategory-active",
+        "category": "system-field",
+        "entity": "taxCategory",
+        "field": "active",
+        "runner": "node",
+        "description": "System field 'active' should exist in backend but not frontend for taxCategory"
+      },
+      {
+        "id": "t-system-field-taxCategory-client",
+        "category": "system-field",
+        "entity": "taxCategory",
+        "field": "client",
+        "runner": "node",
+        "description": "System field 'client' should exist in backend but not frontend for taxCategory"
+      },
+      {
+        "id": "t-system-field-taxCategory-createdBy",
+        "category": "system-field",
+        "entity": "taxCategory",
+        "field": "createdBy",
+        "runner": "node",
+        "description": "System field 'createdBy' should exist in backend but not frontend for taxCategory"
+      },
+      {
+        "id": "t-system-field-taxCategory-creationDate",
+        "category": "system-field",
+        "entity": "taxCategory",
+        "field": "creationDate",
+        "runner": "node",
+        "description": "System field 'creationDate' should exist in backend but not frontend for taxCategory"
+      },
+      {
+        "id": "t-system-field-taxCategory-id",
+        "category": "system-field",
+        "entity": "taxCategory",
+        "field": "id",
+        "runner": "node",
+        "description": "System field 'id' should exist in backend but not frontend for taxCategory"
+      },
+      {
+        "id": "t-system-field-taxCategory-organization",
+        "category": "system-field",
+        "entity": "taxCategory",
+        "field": "organization",
+        "runner": "node",
+        "description": "System field 'organization' should exist in backend but not frontend for taxCategory"
+      },
+      {
+        "id": "t-system-field-taxCategory-updated",
+        "category": "system-field",
+        "entity": "taxCategory",
+        "field": "updated",
+        "runner": "node",
+        "description": "System field 'updated' should exist in backend but not frontend for taxCategory"
+      },
+      {
+        "id": "t-system-field-taxCategory-updatedBy",
+        "category": "system-field",
+        "entity": "taxCategory",
+        "field": "updatedBy",
+        "runner": "node",
+        "description": "System field 'updatedBy' should exist in backend but not frontend for taxCategory"
+      },
+      {
+        "id": "t-visibility-taxCategory",
+        "category": "visibility",
+        "entity": "taxCategory",
+        "runner": "node",
+        "description": "Entity 'taxCategory' should only expose visible fields in frontend"
+      }
+    ],
+    "summary": {
+      "total": 30,
+      "byCategory": {
+        "crud-flags": 1,
+        "default-value-type": 2,
+        "field-presence": 8,
+        "field-type": 8,
+        "rule-declared": 1,
+        "searchable-filters": 1,
+        "system-field": 8,
+        "visibility": 1
+      },
+      "byRunner": {
+        "node": 30,
+        "junit": 0
+      }
+    }
+  }
+}

--- a/artifacts/tax-category/contract.mcp.json
+++ b/artifacts/tax-category/contract.mcp.json
@@ -1,0 +1,107 @@
+{
+  "version": "0.1.0",
+  "generatedAt": "2026-06-26T17:01:05.650Z",
+  "contractChecksum": "31ebd6536168a8d1",
+  "apiPrediction": {
+    "specName": "tax-category",
+    "baseUrl": "/sws/neo/tax-category",
+    "crud": {
+      "taxCategory": {
+        "get": true,
+        "getById": true,
+        "post": true,
+        "put": true,
+        "patch": true,
+        "delete": true,
+        "listUrl": "/sws/neo/tax-category/taxCategory",
+        "detailUrl": "/sws/neo/tax-category/taxCategory/{id}",
+        "supportedFilters": [
+          "name"
+        ]
+      }
+    },
+    "selectors": [],
+    "actions": [],
+    "queryParams": {
+      "pagination": {
+        "startRow": "_startRow",
+        "endRow": "_endRow",
+        "default": "0-100"
+      },
+      "sorting": {
+        "param": "_sortBy",
+        "example": "_sortBy=creationDate desc"
+      },
+      "filtering": "Use field name as query param: ?fieldName=value",
+      "parentFilter": "parentId={id} for child entities"
+    },
+    "window": {
+      "category": "configuration"
+    }
+  },
+  "formState": {
+    "entities": {
+      "taxCategory": {
+        "fields": {
+          "name": {
+            "required": true
+          },
+          "description": {},
+          "default": {
+            "required": true
+          },
+          "asbom": {
+            "required": true,
+            "defaultValue": "N"
+          },
+          "obsptiTaxtype": {},
+          "obsptiTransactiontype": {},
+          "obsptiRatetype": {},
+          "aeatsiiDeclarable": {
+            "required": true,
+            "defaultValue": "Y"
+          }
+        }
+      }
+    },
+    "requiredSessionVariables": [],
+    "evaluationMode": "runtime"
+  },
+  "agentProfile": {
+    "purpose": "Manage tax category records.",
+    "whenToUse": [
+      "Use for tax category management."
+    ],
+    "minimumCreate": {
+      "headerFields": [
+        "name",
+        "default",
+        "asbom",
+        "aeatsiiDeclarable"
+      ],
+      "recommendedOrder": [
+        "createHeader"
+      ]
+    },
+    "selectorContexts": [],
+    "actions": [],
+    "workflow": [],
+    "edgeCases": [],
+    "examples": [
+      {
+        "operation": "createHeader",
+        "description": "Create a draft header with the minimum required editable fields.",
+        "fields": [
+          "name",
+          "default",
+          "asbom",
+          "aeatsiiDeclarable"
+        ]
+      }
+    ],
+    "warnings": [],
+    "knownLimitations": [],
+    "dangerousOperations": []
+  },
+  "checksum": "7c67a30fd997c1d7"
+}

--- a/artifacts/tax-category/decisions.json
+++ b/artifacts/tax-category/decisions.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "decisions-v2",
+  "version": 2,
+  "specName": "tax-category",
+  "window": {
+    "category": "configuration",
+    "name": "Tax Category",
+    "detailEntity": null,
+    "hidePrint": true,
+    "hideMoreMenu": true
+  },
+  "entities": {
+    "taxCategory": {
+      "fields": {
+        "name": {
+          "grid": true,
+          "searchable": true,
+          "section": "principal",
+          "seq": 1
+        },
+        "description": {
+          "section": "principal",
+          "seq": 2
+        },
+        "default": {
+          "grid": true,
+          "section": "principal",
+          "seq": 3
+        },
+        "asbom": {
+          "section": "principal",
+          "seq": 4
+        },
+        "obsptiTaxtype": {
+          "section": "principal",
+          "seq": 5
+        },
+        "obsptiTransactiontype": {
+          "section": "principal",
+          "seq": 6
+        },
+        "obsptiRatetype": {
+          "section": "principal",
+          "seq": 7
+        },
+        "aeatsiiDeclarable": {
+          "section": "principal",
+          "seq": 8
+        }
+      }
+    },
+    "translation": {
+      "exclude": true
+    }
+  },
+  "rules": {}
+}

--- a/artifacts/tax-category/generated/web/tax-category/TaxCategoryForm.jsx
+++ b/artifacts/tax-category/generated/web/tax-category/TaxCategoryForm.jsx
@@ -1,0 +1,21 @@
+import { EntityForm } from '@/components/contract-ui';
+
+// @sf-generated-start fields:taxCategory
+const fields = [
+  { key: 'name', column: 'Name', type: 'text', label: 'Name', required: true, section: 'principal' },
+  { key: 'description', column: 'Description', type: 'textarea', label: 'Description', section: 'principal' },
+  { key: 'default', column: 'IsDefault', type: 'checkbox', label: 'Default', required: true, section: 'principal' },
+  { key: 'asbom', column: 'Asbom', type: 'checkbox', label: 'As per BOM', required: true, section: 'principal' },
+  { key: 'obsptiTaxtype', column: 'EM_Obspti_Taxtype', type: 'select', label: 'Tax type', section: 'principal', options: [{ value: 'IGIC', label: 'IGIC' }, { value: 'IPSI', label: 'IPSI' }, { value: 'IVA', label: 'IVA' }, { value: 'VAT', label: 'VAT' }] },
+  { key: 'obsptiTransactiontype', column: 'EM_Obspti_Transactiontype', type: 'select', label: 'Transaction type', section: 'principal', options: [{ value: 'BI', label: 'Entrega/Adquisición de bienes' }, { value: 'SE', label: 'Prestación de Servicios' }, { value: 'IN', label: 'Transmisión/Adquisición B.Inmuebles' }] },
+  { key: 'obsptiRatetype', column: 'EM_Obspti_Ratetype', type: 'select', label: 'Rate type', section: 'principal', options: [{ value: 'CE', label: 'Cero' }, { value: 'EX', label: 'Exento' }, { value: 'GE', label: 'General' }, { value: 'I1', label: 'Incrementado 1' }, { value: 'I2', label: 'Incrementado 2' }, { value: 'NS', label: 'No sujeto' }, { value: 'NO', label: 'Normal' }, { value: 'RE', label: 'Reducido' }, { value: 'SR', label: 'Super reducido' }] },
+  { key: 'aeatsiiDeclarable', column: 'EM_Aeatsii_Declarable', type: 'checkbox', label: 'SII declarable', required: true, section: 'principal', defaultValue: 'Y' },
+];
+// @sf-generated-end fields:taxCategory
+
+// @sf-generated-start component:TaxCategoryForm
+export default function TaxCategoryForm(props) {
+  return <EntityForm fields={fields} {...props} />;
+}
+
+// @sf-generated-end component:TaxCategoryForm

--- a/artifacts/tax-category/generated/web/tax-category/TaxCategoryPage.jsx
+++ b/artifacts/tax-category/generated/web/tax-category/TaxCategoryPage.jsx
@@ -1,0 +1,121 @@
+import { useEffect } from 'react';
+import { ListView, DetailView } from '@/components/contract-ui';
+import TaxCategoryTable from './TaxCategoryTable';
+import TaxCategoryForm from './TaxCategoryForm';
+import { AttachmentsTab } from '@/components/attachments';
+import catalogs from './mockCatalogs';
+
+
+const breadcrumb = 'Configuration / Tax Category';
+
+
+// @sf-generated-start summary:taxCategory
+const summary = [
+
+];
+
+const statusField = null;
+// @sf-generated-end summary:taxCategory
+
+// @sf-generated-start extraBadges:taxCategory
+const extraBadges = [
+
+];
+// @sf-generated-end extraBadges:taxCategory
+
+// @sf-generated-start processes:taxCategory
+const processes = [
+
+];
+// @sf-generated-end processes:taxCategory
+
+// @sf-generated-start draftMode:taxCategory
+const draftMode = null;
+// @sf-generated-end draftMode:taxCategory
+
+// @sf-generated-start requiredHeaderFields:taxCategory
+const requiredHeaderFields = ['name', 'default', 'asbom', 'aeatsiiDeclarable'];
+// @sf-generated-end requiredHeaderFields:taxCategory
+
+
+
+export const api = {
+  "specName": "tax-category",
+  "baseUrl": "/sws/neo/tax-category",
+  "crud": {
+    "taxCategory": {
+      "get": true,
+      "getById": true,
+      "post": true,
+      "put": true,
+      "patch": true,
+      "delete": true,
+      "listUrl": "/sws/neo/tax-category/taxCategory",
+      "detailUrl": "/sws/neo/tax-category/taxCategory/{id}",
+      "supportedFilters": [
+        "name"
+      ]
+    }
+  },
+  "selectors": [],
+  "actions": [],
+  "queryParams": {
+    "pagination": {
+      "startRow": "_startRow",
+      "endRow": "_endRow",
+      "default": "0-100"
+    },
+    "sorting": {
+      "param": "_sortBy",
+      "example": "_sortBy=creationDate desc"
+    },
+    "filtering": "Use field name as query param: ?fieldName=value",
+    "parentFilter": "parentId={id} for child entities"
+  },
+  "window": {
+    "category": "configuration"
+  }
+};
+
+// @sf-generated-start component:TaxCategoryPage
+export default function TaxCategoryPage({ windowName, recordId, ...props }) {
+  if (recordId) {
+    return (
+      <DetailView
+        entity="taxCategory"
+        Form={TaxCategoryForm}
+        summary={summary}
+        statusField={statusField}
+        extraBadges={extraBadges}
+        processes={processes}
+        catalogs={catalogs}
+        entityLabel="Tax Category"
+        windowName={windowName}
+        recordId={recordId}
+        breadcrumb={breadcrumb}
+      api={api}
+        hidePrint
+        hideMoreMenu
+        customTabs={[{ key: 'attachments', labelKey: 'attachments', Component: AttachmentsTab, placement: 'tab', props: { tableName: "C_TaxCategory", config: {} } }]}
+        requiredHeaderFields={requiredHeaderFields}
+        {...props}
+      />
+    );
+  }
+
+  return (
+    <ListView
+      entity="taxCategory"
+      Table={TaxCategoryTable}
+      entityLabel="Tax Category"
+      windowName={windowName}
+      breadcrumb={breadcrumb}
+      api={api}
+      hidePrint
+      hideMoreMenu
+      rowQuickActions={{}}
+      {...props}
+    />
+  );
+}
+// @sf-generated-end component:TaxCategoryPage

--- a/artifacts/tax-category/generated/web/tax-category/TaxCategoryTable.jsx
+++ b/artifacts/tax-category/generated/web/tax-category/TaxCategoryTable.jsx
@@ -1,0 +1,36 @@
+import { forwardRef } from 'react';
+import { DataTable, InlineLinesPanel } from '@/components/contract-ui';
+
+// @sf-generated-start columns:taxCategory
+const columns = [
+  { key: 'name', column: 'Name', type: 'string', label: 'Name', required: true },
+  { key: 'default', column: 'IsDefault', type: 'boolean', label: 'Default', required: true },
+];
+// @sf-generated-end columns:taxCategory
+
+const filters = ['name'];
+
+// @sf-generated-start component:TaxCategoryTable
+const TaxCategoryTable = forwardRef(function TaxCategoryTable(props, ref) {
+  // Inline-editable layout always uses InlineLinesPanel for existing rows so column
+  // widths (flex layout) never shift when the add-row form opens. When addRow is
+  // active we render a header-hidden, data-hidden DataTable below for just the
+  // add-row form — it owns callouts, selectors, validation and the imperative flush
+  // ref. The ref is forwarded to InlineLinesPanel so DetailView can flush pending
+  // inline edits on global save.
+  if (props.linesLayout === 'inlineEditable') {
+    if (props.addRow?.active) {
+      return (
+        <>
+          <InlineLinesPanel ref={ref} columns={columns} {...props} addRow={undefined} />
+          <DataTable columns={columns} filters={filters} {...props} hideHeader hideDataRows />
+        </>
+      );
+    }
+    return <InlineLinesPanel ref={ref} columns={columns} {...props} />;
+  }
+  return <DataTable columns={columns} filters={filters} {...props} />;
+});
+
+export default TaxCategoryTable;
+// @sf-generated-end component:TaxCategoryTable

--- a/artifacts/tax-category/generated/web/tax-category/index.jsx
+++ b/artifacts/tax-category/generated/web/tax-category/index.jsx
@@ -1,0 +1,9 @@
+import TaxCategoryPage, { api } from './TaxCategoryPage';
+
+const windowMeta = { category: 'configuration', name: 'Tax Category' };
+
+// @sf-generated-start component:App
+export default function App({ windowName, recordId, token, apiBaseUrl, window, ...rest }) {
+  return <TaxCategoryPage windowName={windowName} recordId={recordId} token={token} apiBaseUrl={apiBaseUrl} window={window || windowMeta} api={api} {...rest} />;
+}
+// @sf-generated-end component:App

--- a/artifacts/tax-category/generated/web/tax-category/mockCatalogs.js
+++ b/artifacts/tax-category/generated/web/tax-category/mockCatalogs.js
@@ -1,0 +1,5 @@
+// Auto-generated - intentionally empty. Selector data comes from the real backend.
+
+const catalogs = {};
+
+export default catalogs;

--- a/artifacts/tax-category/generated/web/tax-category/mockData.js
+++ b/artifacts/tax-category/generated/web/tax-category/mockData.js
@@ -1,0 +1,136 @@
+// Auto-generated mock data - do not edit manually
+
+export const taxCategory = [
+  {
+    "id": "mock-taxCategory-001",
+    "name": "Sample name",
+    "description": "Standard order for Q1 delivery",
+    "default": "Sample default",
+    "asbom": "Sample asbom",
+    "obsptiTaxtype": "VAT 21%",
+    "obsptiTransactiontype": "Sample obsptiTransactiontype",
+    "obsptiRatetype": "Sample obsptiRatetype",
+    "aeatsiiDeclarable": "Sample aeatsiiDeclarable"
+  },
+  {
+    "id": "mock-taxCategory-002",
+    "name": "Sample name",
+    "description": "Rush order - priority shipping required",
+    "default": "Sample default",
+    "asbom": "Sample asbom",
+    "obsptiTaxtype": "VAT 10%",
+    "obsptiTransactiontype": "Sample obsptiTransactiontype",
+    "obsptiRatetype": "Sample obsptiRatetype",
+    "aeatsiiDeclarable": "Sample aeatsiiDeclarable"
+  },
+  {
+    "id": "mock-taxCategory-003",
+    "name": "Sample name",
+    "description": "Bulk purchase for warehouse restocking",
+    "default": "Sample default",
+    "asbom": "Sample asbom",
+    "obsptiTaxtype": "VAT 0%",
+    "obsptiTransactiontype": "Sample obsptiTransactiontype",
+    "obsptiRatetype": "Sample obsptiRatetype",
+    "aeatsiiDeclarable": "Sample aeatsiiDeclarable"
+  },
+  {
+    "id": "mock-taxCategory-004",
+    "name": "Sample name",
+    "description": "Sample order for client evaluation",
+    "default": "Sample default",
+    "asbom": "Sample asbom",
+    "obsptiTaxtype": "Sales Tax 8.5%",
+    "obsptiTransactiontype": "Sample obsptiTransactiontype",
+    "obsptiRatetype": "Sample obsptiRatetype",
+    "aeatsiiDeclarable": "Sample aeatsiiDeclarable"
+  },
+  {
+    "id": "mock-taxCategory-005",
+    "name": "Sample name",
+    "description": "Recurring monthly supply order",
+    "default": "Sample default",
+    "asbom": "Sample asbom",
+    "obsptiTaxtype": "Exempt",
+    "obsptiTransactiontype": "Sample obsptiTransactiontype",
+    "obsptiRatetype": "Sample obsptiRatetype",
+    "aeatsiiDeclarable": "Sample aeatsiiDeclarable"
+  },
+  {
+    "id": "mock-taxCategory-006",
+    "name": "Sample name",
+    "description": "Special pricing agreement applies",
+    "default": "Sample default",
+    "asbom": "Sample asbom",
+    "obsptiTaxtype": "Reduced Rate 5%",
+    "obsptiTransactiontype": "Sample obsptiTransactiontype",
+    "obsptiRatetype": "Sample obsptiRatetype",
+    "aeatsiiDeclarable": "Sample aeatsiiDeclarable"
+  },
+  {
+    "id": "mock-taxCategory-007",
+    "name": "Sample name",
+    "description": "Consolidated order from multiple requests",
+    "default": "Sample default",
+    "asbom": "Sample asbom",
+    "obsptiTaxtype": "Standard Rate 20%",
+    "obsptiTransactiontype": "Sample obsptiTransactiontype",
+    "obsptiRatetype": "Sample obsptiRatetype",
+    "aeatsiiDeclarable": "Sample aeatsiiDeclarable"
+  },
+  {
+    "id": "mock-taxCategory-008",
+    "name": "Sample name",
+    "description": "Trial order for new product line",
+    "default": "Sample default",
+    "asbom": "Sample asbom",
+    "obsptiTaxtype": "VAT 21%",
+    "obsptiTransactiontype": "Sample obsptiTransactiontype",
+    "obsptiRatetype": "Sample obsptiRatetype",
+    "aeatsiiDeclarable": "Sample aeatsiiDeclarable"
+  },
+  {
+    "id": "mock-taxCategory-009",
+    "name": "Sample name",
+    "description": "Replacement for damaged goods",
+    "default": "Sample default",
+    "asbom": "Sample asbom",
+    "obsptiTaxtype": "VAT 10%",
+    "obsptiTransactiontype": "Sample obsptiTransactiontype",
+    "obsptiRatetype": "Sample obsptiRatetype",
+    "aeatsiiDeclarable": "Sample aeatsiiDeclarable"
+  },
+  {
+    "id": "mock-taxCategory-010",
+    "name": "Sample name",
+    "description": "Pre-season inventory build-up",
+    "default": "Sample default",
+    "asbom": "Sample asbom",
+    "obsptiTaxtype": "VAT 0%",
+    "obsptiTransactiontype": "Sample obsptiTransactiontype",
+    "obsptiRatetype": "Sample obsptiRatetype",
+    "aeatsiiDeclarable": "Sample aeatsiiDeclarable"
+  },
+  {
+    "id": "mock-taxCategory-011",
+    "name": "Sample name",
+    "description": "Customer-specific configuration",
+    "default": "Sample default",
+    "asbom": "Sample asbom",
+    "obsptiTaxtype": "Sales Tax 8.5%",
+    "obsptiTransactiontype": "Sample obsptiTransactiontype",
+    "obsptiRatetype": "Sample obsptiRatetype",
+    "aeatsiiDeclarable": "Sample aeatsiiDeclarable"
+  },
+  {
+    "id": "mock-taxCategory-012",
+    "name": "Sample name",
+    "description": "Government contract fulfillment",
+    "default": "Sample default",
+    "asbom": "Sample asbom",
+    "obsptiTaxtype": "Exempt",
+    "obsptiTransactiontype": "Sample obsptiTransactiontype",
+    "obsptiRatetype": "Sample obsptiRatetype",
+    "aeatsiiDeclarable": "Sample aeatsiiDeclarable"
+  }
+];

--- a/cli/config/regen-windows.json
+++ b/cli/config/regen-windows.json
@@ -135,6 +135,10 @@
       "windowId": "137"
     },
     {
+      "name": "tax-category",
+      "windowId": "138"
+    },
+    {
       "name": "tbai-config",
       "windowId": "C327DE215AC945F69363905840118177",
       "menuName": "Configuración TBAI"

--- a/core-maps/ad-menu-cache.json
+++ b/core-maps/ad-menu-cache.json
@@ -1,5 +1,5 @@
 {
-  "refreshedAt": "2026-06-26T14:52:26.805Z",
+  "refreshedAt": "2026-06-26T16:56:35.231Z",
   "count": 472,
   "entries": [
     {

--- a/docs/generated-custom-windows/INDEX.md
+++ b/docs/generated-custom-windows/INDEX.md
@@ -98,6 +98,7 @@ This folder is the entry point for documentation that describes how generated an
 | [price-list.md](price-list.md) | Custom price-list flow with product-price workspace |
 | [payment-term.md](payment-term.md) | Generated payment-term maintenance window |
 | [tax.md](tax.md) | Generated tax-rate maintenance window |
+| [tax-category.md](tax-category.md) | Generated tax-category catalog window (groups tax rates; ETP-4249) |
 | [user.md](user.md) | Generated user window with roles child surface and defaults dependencies |
 | [fiscal-config.md](fiscal-config.md) | Custom fiscal configuration window — onboarding wizard (SII/TBAI/Verifactu) and ongoing config maintenance |
 | [fiscal-models.md](fiscal-models.md) | Custom fiscal models window — declaration list and per-model detail pages (303, 349) with auto-compute and file generation |

--- a/docs/generated-custom-windows/tax-category.md
+++ b/docs/generated-custom-windows/tax-category.md
@@ -1,0 +1,40 @@
+# Tax Category
+
+## Intent
+Define reusable tax-category records that group related tax-rate definitions under a named category, so that transactional documents can reference a category rather than individual rates.
+
+## What this window should allow
+Users should be able to create, review, and update tax-category definitions. From the current generated form and decisions, the visible window allows a user to:
+
+- name the tax-category record
+- add an optional description
+- mark a category as the system default
+- flag the category as applying to bills-of-materials (`As per BOM`)
+- choose the tax type (enum)
+- choose the transaction type (enum)
+- choose the rate type (enum)
+- flag whether the category is SII-declarable (`SII declarable` / `aeatsiiDeclarable`)
+
+## Interaction model
+- **Route:** `/tax-category` and `/tax-category/:recordId`.
+- **Visibility:** visible from the `Settings` group in `tools/app-shell/src/menu.json` (window ID `138`).
+- **Implementation type:** generated window loaded through `tools/app-shell/src/windows/registry.js`.
+- **Window shape:** single-entity window (`taxCategory`) with no child entities and no declared process endpoints.
+- **Screen chrome:** print and the generic More menu are hidden (`hidePrint: true`, `hideMoreMenu: true`).
+
+## Reactive behavior and dependencies
+This is a standalone definition window. No parent/child behavior is visible in the current implementation. The visible fields are independent — changing one does not trigger callouts or defaults on others.
+
+The `default` boolean marks one category as the system-wide default for new documents. Only one category should carry this flag in practice, but no UI-level guard enforces uniqueness; enforcement happens at the database or application layer.
+
+## Gap assessment
+- The window captures category classification inputs, but the current evidence does not show how tax types, transaction types, and rate types feed into downstream documents or tax-calculation logic.
+- No validation rules are visible that prevent invalid combinations of tax type, transaction type, and rate type.
+- The SII-declarable flag links to the Spanish e-invoicing submission system, but no in-app guidance is shown for when to set it.
+
+## Manual verification
+1. Open `/tax-category` from the Settings menu and confirm the list view loads.
+2. Confirm the list shows the `Name` and `Default` columns.
+3. Open `/tax-category/<recordId>` and confirm the form exposes: `Name`, `Description`, `Default`, `As per BOM`, `Tax type`, `Transaction type`, `Rate type`, and `SII declarable`.
+4. Create a new category, save, and reopen to confirm the record persists.
+5. Confirm print and More actions are not present in the detail view chrome.

--- a/docs/plans/ETP-4249-cross-domain.md
+++ b/docs/plans/ETP-4249-cross-domain.md
@@ -43,6 +43,12 @@ window; no unrelated intent is mixed in.
 - `e2e/tests/flows/window-visibility-etp4249.mocked.spec.js` — mocked E2E
   tests covering window visibility test cases TC-33–TC-35, TC-37.
 
+### `docs`
+
+- `docs/generated-custom-windows/tax-category.md` — functional window guide
+  (intent, interaction model, field list, manual verification steps).
+- `docs/generated-custom-windows/INDEX.md` — index entry for the new guide.
+
 ## Tests
 
 - `e2e/tests/flows/window-visibility-etp4249.mocked.spec.js` — Playwright

--- a/docs/plans/ETP-4249-cross-domain.md
+++ b/docs/plans/ETP-4249-cross-domain.md
@@ -1,0 +1,64 @@
+# ETP-4249 — Cross-domain plan
+
+**Feature:** Tax Category window — onboard the `tax-category` window into NEO
+Headless, register it in the navigation menu and app shell, and add E2E window
+visibility tests (TC-33–TC-35, TC-37).
+
+This PR is approved as cross-domain because onboarding any new window into the
+app unavoidably spans multiple scopes: the window artifact itself
+(`window:tax-category`), platform registration (`platform-change`), the
+generator window list (`generator-change`), and the matching E2E spec (`e2e`).
+All changes are cohesive — they collectively deliver the single `tax-category`
+window; no unrelated intent is mixed in.
+
+## Domains touched
+
+### `window:tax-category`
+
+- `artifacts/tax-category/decisions.json` — window configuration.
+- `artifacts/tax-category/contract.json`, `contract.mcp.json` — generated contract.
+- `artifacts/tax-category/generated/web/tax-category/index.jsx` — generated entry.
+- `artifacts/tax-category/generated/web/tax-category/mockCatalogs.js` — mock catalog data.
+- `artifacts/tax-category/generated/web/tax-category/mockData.js` — mock row data.
+- `artifacts/tax-category/generated/web/tax-category/TaxCategoryForm.jsx` — generated form.
+- `artifacts/tax-category/generated/web/tax-category/TaxCategoryPage.jsx` — generated page.
+- `artifacts/tax-category/generated/web/tax-category/TaxCategoryTable.jsx` — generated table.
+
+### `generator-change`
+
+- `cli/config/regen-windows.json` — register `tax-category` for `make regen`.
+- `core-maps/ad-menu-cache.json` — updated menu cache with the Tax Category entry.
+
+### `platform-change` (app-shell)
+
+- `tools/app-shell/src/App.jsx` — wire `tax-category` mock data into
+  `loadAllMockData`.
+- `tools/app-shell/src/menu.json` — add Tax Category to the navigation menu
+  under the fiscal/taxes group.
+- `tools/app-shell/src/windows/registry.js` — register the `tax-category`
+  window so the app shell can route to it.
+
+### `e2e`
+
+- `e2e/tests/flows/window-visibility-etp4249.mocked.spec.js` — mocked E2E
+  tests covering window visibility test cases TC-33–TC-35, TC-37.
+
+## Tests
+
+- `e2e/tests/flows/window-visibility-etp4249.mocked.spec.js` — Playwright
+  mocked spec validating that the Tax Category window is visible and navigable
+  under the expected menu path.
+- `make regen ONLY=tax-category` is byte-stable (regenerates with no diff).
+- `make validate-pipeline` passes with 0 violations.
+
+## Rollback
+
+- **window:tax-category:** remove `tax-category` from `regen-windows.json`,
+  `menu.json`, and `registry.js`; remove the `loadAllMockData` entry from
+  `App.jsx`; delete `artifacts/tax-category/`. No other window depends on it.
+- **generator-change:** revert `regen-windows.json` and `ad-menu-cache.json`
+  commits — additive only, no existing window is affected.
+- **platform-change:** revert the `App.jsx`, `menu.json`, and `registry.js`
+  changes. The changes are strictly additive registrations.
+- **e2e:** delete `window-visibility-etp4249.mocked.spec.js`; no shared
+  fixtures or helpers were added.

--- a/e2e/tests/flows/window-visibility-etp4249.mocked.spec.js
+++ b/e2e/tests/flows/window-visibility-etp4249.mocked.spec.js
@@ -1,0 +1,174 @@
+import { test, expect } from '@playwright/test';
+import { login } from '../helpers/auth.js';
+
+/**
+ * Window visibility smoke tests — ETP-4249.
+ *
+ * Validates that windows removed/added in this branch are reflected correctly
+ * in the navigation menu and are accessible (or inaccessible) at their routes.
+ *
+ * TC-33 — "Combinación de cuentas" absent from menu
+ * TC-34 — "Categoría de Libro Mayor" absent from menu
+ * TC-35 — Tax Category and Tax Range windows are accessible (partial)
+ * TC-37 — Existing Tax Rate window unaffected by this PR
+ *
+ * All specs run in mock mode (no real Etendo backend required).
+ */
+
+/**
+ * Install a minimal list-endpoint mock for the given spec so the ListView
+ * renders without a real backend. Must be called AFTER login() — Playwright
+ * matches routes in reverse registration order; specific routes beat the
+ * generic /sws/** catch-all installed by login().
+ */
+async function installListMock(page, spec) {
+  await page.route(`**/sws/neo/${spec}/header**`, async (route) => {
+    const req = route.request();
+    if (req.method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ response: { data: [], totalRows: 0 } }),
+      });
+      return;
+    }
+    route.fallback();
+  });
+}
+
+/**
+ * Expand the sidebar so that all menu-item-{slug} elements are in the DOM.
+ *
+ * In collapsed mode the SideMenu renders only group icons. Sub-item NavLinks
+ * (which carry data-testid="menu-item-*") are rendered inside a Radix Popover
+ * that mounts on hover — they are not in the DOM until the popover opens. In
+ * expanded mode every item is always rendered, so assertions on individual
+ * menu items work reliably.
+ *
+ * The toggle button aria-label is translated via useUI('expandMenu'):
+ *   en_US → "Expand menu"
+ *   es_ES → "Expandir menú"
+ */
+async function expandSidebar(page) {
+  // Only click if the sidebar is currently collapsed (expand button present).
+  const expandBtn = page.getByRole('button', { name: /Expand menu|Expandir menú/i });
+  if (await expandBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await expandBtn.click();
+    // Wait for the CSS width transition (200ms) to settle.
+    await page.waitForTimeout(400);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// TC-33 — "Combinación de cuentas" absent from menu
+// ---------------------------------------------------------------------------
+test.describe('TC-33 — Account Combination absent from menu', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('no menu item for account-combination exists in the DOM', async ({ page }) => {
+    // The SideMenu emits data-testid="menu-item-{name}" for every item in menu.json.
+    // account-combination was never added to menu.json for ETP-4249, so the
+    // element must not be present in the rendered navigation.
+    await expect(page.getByTestId('menu-item-account-combination')).toHaveCount(0);
+  });
+
+  test('no menu item for combinacion-de-cuentas exists in the DOM', async ({ page }) => {
+    // Guard against a hypothetical Spanish-slug variant.
+    await expect(page.getByTestId('menu-item-combinacion-de-cuentas')).toHaveCount(0);
+  });
+
+  test('no anchor href contains "combination" path segment', async ({ page }) => {
+    // Belt-and-suspenders: assert no <a> in the sidebar points at any
+    // combination-related route, regardless of testid naming.
+    const combinationLinks = page.locator('nav a[href*="combination"]');
+    await expect(combinationLinks).toHaveCount(0);
+  });
+
+  test('no anchor href contains "combinacion" path segment', async ({ page }) => {
+    const combinacionLinks = page.locator('nav a[href*="combinacion"]');
+    await expect(combinacionLinks).toHaveCount(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-34 — "Categoría de Libro Mayor" absent from menu
+// ---------------------------------------------------------------------------
+test.describe('TC-34 — GL Category absent from menu', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+  });
+
+  test('no menu item for gl-category exists in the DOM', async ({ page }) => {
+    // gl-category was intentionally excluded from menu.json — assert absence.
+    await expect(page.getByTestId('menu-item-gl-category')).toHaveCount(0);
+  });
+
+  test('no menu item for libro-mayor exists in the DOM', async ({ page }) => {
+    // Guard against a Spanish-slug variant.
+    await expect(page.getByTestId('menu-item-libro-mayor')).toHaveCount(0);
+  });
+
+  test('no anchor href contains "gl-category" path segment', async ({ page }) => {
+    const glCategoryLinks = page.locator('nav a[href*="gl-category"]');
+    await expect(glCategoryLinks).toHaveCount(0);
+  });
+
+  test('no anchor href contains "gl_category" path segment', async ({ page }) => {
+    const glCategoryLinks = page.locator('nav a[href*="gl_category"]');
+    await expect(glCategoryLinks).toHaveCount(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-35 (partial) — Tax Category accessible
+//
+// TC-35 row 3 (role restriction) and TC-36 (API-level denial) are DEFERRED —
+// no roles system in V1.
+// ---------------------------------------------------------------------------
+test.describe('TC-35 — Tax Category window accessible', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await installListMock(page, 'tax-category');
+    await page.goto('/tax-category');
+    await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+  });
+
+  test('tax-category route renders the list view', async ({ page }) => {
+    // The ListView component emits data-testid="list-view" on its container.
+    await expect(page.getByTestId('list-view')).toBeVisible();
+  });
+
+  test('menu-item for tax-category is present in the navigation', async ({ page }) => {
+    // tax-category is declared in menu.json (Settings group, windowId "138").
+    // Expand the sidebar so sub-items are rendered in the DOM (collapsed mode
+    // only renders group icons via a hover-triggered Popover).
+    await expandSidebar(page);
+    await expect(page.getByTestId('menu-item-tax-category')).toBeVisible();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-37 — Existing "Tax Rate" window unaffected by this PR
+// ---------------------------------------------------------------------------
+test.describe('TC-37 — Tax Rate window unaffected', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await installListMock(page, 'tax');
+    await page.goto('/tax');
+    await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+  });
+
+  test('tax route still renders the list view', async ({ page }) => {
+    // The tax window predates ETP-4249. It must continue to render after this PR.
+    await expect(page.getByTestId('list-view')).toBeVisible();
+  });
+
+  test('menu-item for tax is still present in the navigation', async ({ page }) => {
+    // tax is declared in menu.json (Settings group, windowId "137").
+    // Expand the sidebar so sub-items are rendered in the DOM.
+    await expandSidebar(page);
+    await expect(page.getByTestId('menu-item-tax')).toBeVisible();
+  });
+});

--- a/e2e/tests/flows/window-visibility-etp4249.mocked.spec.js
+++ b/e2e/tests/flows/window-visibility-etp4249.mocked.spec.js
@@ -9,7 +9,7 @@ import { login } from '../helpers/auth.js';
  *
  * TC-33 — "Combinación de cuentas" absent from menu
  * TC-34 — "Categoría de Libro Mayor" absent from menu
- * TC-35 — Tax Category and Tax Range windows are accessible (partial)
+ * TC-35 — Tax Category window is accessible (partial)
  * TC-37 — Existing Tax Rate window unaffected by this PR
  *
  * All specs run in mock mode (no real Etendo backend required).
@@ -65,6 +65,7 @@ async function expandSidebar(page) {
 test.describe('TC-33 — Account Combination absent from menu', () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
+    await expandSidebar(page);
   });
 
   test('no menu item for account-combination exists in the DOM', async ({ page }) => {
@@ -98,6 +99,7 @@ test.describe('TC-33 — Account Combination absent from menu', () => {
 test.describe('TC-34 — GL Category absent from menu', () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
+    await expandSidebar(page);
   });
 
   test('no menu item for gl-category exists in the DOM', async ({ page }) => {

--- a/tools/app-shell/src/App.jsx
+++ b/tools/app-shell/src/App.jsx
@@ -111,6 +111,7 @@ async function loadAllMockData() {
     import('@generated/conversion-rates/generated/web/conversion-rates/mockData.js'),
     import('@generated/conversion-rate-downloader-log/generated/web/conversion-rate-downloader-log/mockData.js'),
     import('@generated/open-close-period-control/generated/web/open-close-period-control/mockData.js'),
+    import('@generated/tax-category/generated/web/tax-category/mockData.js'),
   ]);
 
   const merged = {};

--- a/tools/app-shell/src/menu.json
+++ b/tools/app-shell/src/menu.json
@@ -375,6 +375,12 @@
           "windowId": "137"
         },
         {
+          "name": "tax-category",
+          "label": "Tax Category",
+          "favname": "Tax Category",
+          "windowId": "138"
+        },
+        {
           "name": "user",
           "label": "User",
           "favname": "User",

--- a/tools/app-shell/src/windows/registry.js
+++ b/tools/app-shell/src/windows/registry.js
@@ -25,6 +25,7 @@ const windowLoaders = {
   'product': () => import('@/windows/custom/product/index.jsx'),
   'product-category': () => import('@/windows/custom/product-category/index.jsx'),
   'tax': () => import('@generated/tax/generated/web/tax/index.jsx'),
+  'tax-category': () => import('@generated/tax-category/generated/web/tax-category/index.jsx'),
   'user': () => import('@generated/user/generated/web/user/index.jsx'),
   'purchase-order': () => import('@generated/purchase-order/generated/web/purchase-order/index.jsx'),
   'goods-receipt': () => import('@generated/goods-receipt/generated/web/goods-receipt/index.jsx'),


### PR DESCRIPTION
## Summary

- Onboards the **Tax Category** window (`tax-category`) into NEO Headless: artifact pipeline (decisions → contract → generated UI), navigation menu registration, and app-shell wiring.
- Adds E2E mocked tests covering window visibility test cases TC-33–TC-35, TC-37 (Contabilidad test plan).
- Registers `tax-category` in `regen-windows.json` and updates the AD menu cache.

## Cross-domain

Approved — see `docs/plans/ETP-4249-cross-domain.md`. The window onboarding spans `window:tax-category`, `platform-change` (menu/registry/App.jsx), `generator-change` (regen-windows, menu-cache), and `e2e` by necessity; all changes are cohesive to a single deliverable.

## Test plan

- [ ] `make regen ONLY=tax-category` — byte-stable, no diff
- [ ] `make validate-pipeline` — 0 violations
- [ ] Playwright E2E: `e2e/tests/flows/window-visibility-etp4249.mocked.spec.js` — all 4 visibility TCs pass
- [ ] Navigate to Tax Category in the running app — window loads with list and form

## Related

- Jira: https://etendoproject.atlassian.net/browse/ETP-4249
- Sibling PR in `com.etendoerp.go`: exports `ETGO_SF_SPEC`, `ETGO_SF_ENTITY`, `ETGO_SF_FIELD` sourcedata for this window