### PR TITLE
Feature ETP-4298: Add accounting status badge to grid views

### DIFF
--- a/artifacts/physical-inventory/contract.json
+++ b/artifacts/physical-inventory/contract.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.28.0",
+  "version": "0.29.0",
   "generatedAt": "2026-06-29T12:25:17.116Z",
-  "updatedAt": "2026-06-29T17:06:06.204Z",
-  "checksum": "df22c8e80ad8cb12",
+  "updatedAt": "2026-06-29T19:54:37.453Z",
+  "checksum": "a4d30902f2aa3a7f",
   "frontendContract": {
     "window": {
       "id": "168",
@@ -57,7 +57,15 @@
       },
       "noHeaderBorder": true,
       "layoutType": "default",
-      "linesLayout": "inlineEditable"
+      "linesLayout": "inlineEditable",
+      "statusPills": [
+        {
+          "field": "posted",
+          "trueKey": "postedStatus",
+          "falseKey": "notPostedStatus",
+          "_note": "Accounting status pill — visible to financial+admin roles only (permissions enforcement pending)"
+        }
+      ]
     },
     "entities": {
       "inventory": {
@@ -83,6 +91,7 @@
               "source": "@#Date@"
             },
             "defaultValue": "@#Date@",
+            "gridOrder": 1,
             "readOnlyLogic": {
               "raw": "@Processed@='Y'",
               "evaluable": true,
@@ -106,6 +115,7 @@
               "source": "@#Date@"
             },
             "defaultValue": "@#Date@",
+            "gridOrder": 2,
             "readOnlyLogic": {
               "raw": "@Processed@='Y'",
               "evaluable": true,
@@ -126,6 +136,7 @@
             "sourceRequired": true,
             "reference": "Warehouse",
             "inputMode": "search",
+            "gridOrder": 3,
             "readOnlyLogic": {
               "raw": "@Processed@='Y'",
               "evaluable": true,
@@ -177,6 +188,7 @@
               "true": "green",
               "false": "orange"
             },
+            "gridOrder": 5,
             "displayLogic": {
               "raw": "@Processed@='Y' & @#ShowAcct@='Y'",
               "evaluable": false,
@@ -276,7 +288,8 @@
                 "value": "false",
                 "name": "statusDraft"
               }
-            ]
+            ],
+            "gridOrder": 4
           }
         ],
         "searchableFields": [
@@ -613,7 +626,15 @@
         "navigateTo": "/physical-inventory/new"
       },
       "noHeaderBorder": true,
-      "linesLayout": "inlineEditable"
+      "linesLayout": "inlineEditable",
+      "statusPills": [
+        {
+          "field": "posted",
+          "trueKey": "postedStatus",
+          "falseKey": "notPostedStatus",
+          "_note": "Accounting status pill — visible to financial+admin roles only (permissions enforcement pending)"
+        }
+      ]
     },
     "entities": {
       "inventory": {

--- a/artifacts/physical-inventory/contract.mcp.json
+++ b/artifacts/physical-inventory/contract.mcp.json
@@ -1,7 +1,7 @@
 {
   "version": "0.28.0",
   "generatedAt": "2026-06-29T12:25:17.116Z",
-  "contractChecksum": "df22c8e80ad8cb12",
+  "contractChecksum": "a4d30902f2aa3a7f",
   "apiPrediction": {
     "specName": "physical-inventory",
     "baseUrl": "/sws/neo/physical-inventory",

--- a/artifacts/physical-inventory/contract.mcp.json
+++ b/artifacts/physical-inventory/contract.mcp.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.28.0",
+  "version": "0.29.0",
   "generatedAt": "2026-06-29T12:25:17.116Z",
   "contractChecksum": "a4d30902f2aa3a7f",
   "apiPrediction": {

--- a/artifacts/physical-inventory/decisions.json
+++ b/artifacts/physical-inventory/decisions.json
@@ -57,6 +57,14 @@
         "successKey": "documentPosted",
         "visibleWhenFieldTrue": "processed"
       }
+    ],
+    "statusPills": [
+      {
+        "field": "posted",
+        "trueKey": "postedStatus",
+        "falseKey": "notPostedStatus",
+        "_note": "Accounting status pill — visible to financial+admin roles only (permissions enforcement pending)"
+      }
     ]
   },
   "entities": {
@@ -65,11 +73,13 @@
       "fields": {
         "warehouse": {
           "grid": true,
+          "gridOrder": 3,
           "searchable": true,
           "readOnlyLogic": null
         },
         "movementDate": {
           "grid": true,
+          "gridOrder": 1,
           "searchable": true,
           "readOnlyLogic": null
         },
@@ -81,6 +91,7 @@
         },
         "name": {
           "grid": true,
+          "gridOrder": 2,
           "readOnlyLogic": "@Processed@='Y'"
         },
         "description": {
@@ -91,6 +102,7 @@
           "visibility": "readOnly",
           "label": "Status",
           "grid": true,
+          "gridOrder": 4,
           "form": false,
           "columnType": "status",
           "enumValues": [
@@ -121,6 +133,7 @@
           "type": "boolean",
           "form": false,
           "grid": true,
+          "gridOrder": 5,
           "badge": true,
           "badgeLabels": {
             "true":  { "en_US": "Posted",     "es_ES": "Contabilizado"   },

--- a/artifacts/physical-inventory/generated/web/physical-inventory/InventoryPage.jsx
+++ b/artifacts/physical-inventory/generated/web/physical-inventory/InventoryPage.jsx
@@ -24,7 +24,7 @@ const statusField = 'processed';
 
 // @sf-generated-start extraBadges:inventory
 const extraBadges = [
-
+  { key: 'posted', type: 'statusPill', trueKey: 'postedStatus', falseKey: 'notPostedStatus' },
 ];
 // @sf-generated-end extraBadges:inventory
 

--- a/artifacts/physical-inventory/generated/web/physical-inventory/InventoryTable.jsx
+++ b/artifacts/physical-inventory/generated/web/physical-inventory/InventoryTable.jsx
@@ -6,8 +6,8 @@ const columns = [
   { key: 'movementDate', column: 'MovementDate', type: 'date', label: 'Movement Date', required: true },
   { key: 'name', column: 'Name', type: 'string', label: 'Name', required: true },
   { key: 'warehouse', column: 'M_Warehouse_ID', type: 'selector', label: 'Warehouse', required: true },
-  { key: 'posted', column: 'Posted', type: 'boolean', label: 'Posted', badge: true, badgeLabels: {"true":{"en_US":"Posted","es_ES":"Contabilizado"},"false":{"en_US":"Not posted","es_ES":"Sin contabilizar"}}, badgeVariants: {"true":"green","false":"orange"}, required: true },
   { key: 'processed', column: 'Processed', type: 'status', label: 'Status', enumLabels: { 'true': 'statusProcessed', 'false': 'statusDraft' }, required: true },
+  { key: 'posted', column: 'Posted', type: 'boolean', label: 'Posted', badge: true, badgeLabels: {"true":{"en_US":"Posted","es_ES":"Contabilizado"},"false":{"en_US":"Not posted","es_ES":"Sin contabilizar"}}, badgeVariants: {"true":"green","false":"orange"}, required: true },
 ];
 // @sf-generated-end columns:inventory
 

--- a/artifacts/purchase-invoice/contract.json
+++ b/artifacts/purchase-invoice/contract.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.59.0",
+  "version": "0.60.0",
   "generatedAt": "2026-04-30T15:42:46.722Z",
-  "updatedAt": "2026-06-29T12:09:16.568Z",
-  "checksum": "f9f0a1390a47943c",
+  "updatedAt": "2026-06-29T19:54:37.694Z",
+  "checksum": "b370f896543f140f",
   "frontendContract": {
     "window": {
       "id": "183",
@@ -527,7 +527,7 @@
             "grid": true,
             "form": false,
             "sourceRequired": true,
-            "gridOrder": 5
+            "gridOrder": 6
           },
           {
             "name": "summedLineAmount",
@@ -643,6 +643,7 @@
               "source": "0"
             },
             "defaultValue": "0",
+            "gridOrder": 7,
             "displayLogic": {
               "raw": "@Processed@='Y' & @Ispaid@='N'",
               "evaluable": true
@@ -761,6 +762,7 @@
               "true": "green",
               "false": "orange"
             },
+            "gridOrder": 5,
             "displayLogic": {
               "raw": "@Processed@='Y' & @#ShowAcct@='Y'",
               "evaluable": false,
@@ -1343,7 +1345,7 @@
             "required": false,
             "grid": true,
             "form": false,
-            "gridOrder": 7
+            "gridOrder": 8
           },
           {
             "name": "eTGODeliveryStatus",
@@ -1356,7 +1358,7 @@
             "required": false,
             "grid": true,
             "form": false,
-            "gridOrder": 8
+            "gridOrder": 9
           }
         ],
         "searchableFields": [

--- a/artifacts/purchase-invoice/contract.mcp.json
+++ b/artifacts/purchase-invoice/contract.mcp.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.59.0",
+  "version": "0.60.0",
   "generatedAt": "2026-04-30T15:42:46.722Z",
   "updatedAt": "2026-06-25T19:58:30.549Z",
   "contractChecksum": "b370f896543f140f",

--- a/artifacts/purchase-invoice/contract.mcp.json
+++ b/artifacts/purchase-invoice/contract.mcp.json
@@ -2,7 +2,7 @@
   "version": "0.59.0",
   "generatedAt": "2026-04-30T15:42:46.722Z",
   "updatedAt": "2026-06-25T19:58:30.549Z",
-  "contractChecksum": "f9f0a1390a47943c",
+  "contractChecksum": "b370f896543f140f",
   "apiPrediction": {
     "specName": "purchase-invoice",
     "baseUrl": "/sws/neo/purchase-invoice",

--- a/artifacts/purchase-invoice/contract.prev.json
+++ b/artifacts/purchase-invoice/contract.prev.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.59.0",
+  "version": "0.60.0",
   "generatedAt": "2026-04-30T15:42:46.722Z",
-  "updatedAt": "2026-06-29T12:09:16.568Z",
-  "checksum": "f9f0a1390a47943c",
+  "updatedAt": "2026-06-29T19:54:37.694Z",
+  "checksum": "b370f896543f140f",
   "frontendContract": {
     "window": {
       "id": "183",
@@ -527,7 +527,7 @@
             "grid": true,
             "form": false,
             "sourceRequired": true,
-            "gridOrder": 5
+            "gridOrder": 6
           },
           {
             "name": "summedLineAmount",
@@ -643,6 +643,7 @@
               "source": "0"
             },
             "defaultValue": "0",
+            "gridOrder": 7,
             "displayLogic": {
               "raw": "@Processed@='Y' & @Ispaid@='N'",
               "evaluable": true
@@ -761,6 +762,7 @@
               "true": "green",
               "false": "orange"
             },
+            "gridOrder": 5,
             "displayLogic": {
               "raw": "@Processed@='Y' & @#ShowAcct@='Y'",
               "evaluable": false,
@@ -1343,7 +1345,7 @@
             "required": false,
             "grid": true,
             "form": false,
-            "gridOrder": 7
+            "gridOrder": 8
           },
           {
             "name": "eTGODeliveryStatus",
@@ -1356,7 +1358,7 @@
             "required": false,
             "grid": true,
             "form": false,
-            "gridOrder": 8
+            "gridOrder": 9
           }
         ],
         "searchableFields": [

--- a/artifacts/purchase-invoice/decisions.json
+++ b/artifacts/purchase-invoice/decisions.json
@@ -278,7 +278,7 @@
           "visibility": "readOnly",
           "form": false,
           "grid": true,
-          "gridOrder": 5
+          "gridOrder": 6
         },
         "summedLineAmount": {
           "visibility": "readOnly",
@@ -308,19 +308,20 @@
         "outstandingAmount": {
           "visibility": "readOnly",
           "grid": true,
+          "gridOrder": 7,
           "form": false
         },
         "eTGODueDate": {
           "visibility": "readOnly",
           "grid": true,
-          "gridOrder": 7,
+          "gridOrder": 8,
           "form": false,
           "searchable": true
         },
         "eTGODeliveryStatus": {
           "visibility": "readOnly",
           "grid": true,
-          "gridOrder": 8,
+          "gridOrder": 9,
           "form": false
         },
         "dueAmount": {
@@ -361,6 +362,7 @@
           "visibility": "readOnly",
           "form": false,
           "grid": true,
+          "gridOrder": 5,
           "badge": true,
           "badgeLabels": {
             "true": {

--- a/artifacts/purchase-invoice/generated/web/purchase-invoice/HeaderTable.jsx
+++ b/artifacts/purchase-invoice/generated/web/purchase-invoice/HeaderTable.jsx
@@ -7,11 +7,11 @@ const columns = [
   { key: 'orderReference', column: 'POReference', type: 'string', label: 'Supplier Reference' },
   { key: 'businessPartner', column: 'C_BPartner_ID', type: 'selector', label: 'Business Partner', required: true },
   { key: 'documentStatus', column: 'DocStatus', type: 'status', label: 'Document Status', enumLabels: { 'CL': 'Closed', 'CO': 'Completed', 'DR': 'Draft', 'NA': 'Not Accepted', 'WP': 'Not Paid', 'RE': 'Re-Opened', 'TEMP': 'Temporal', 'IP': 'Under Way', '??': 'Unknown', 'VO': 'Voided' }, required: true },
+  { key: 'posted', column: 'Posted', type: 'boolean', label: 'Posted', badge: true, badgeLabels: {"true":{"en_US":"Posted","es_ES":"Contabilizado"},"false":{"en_US":"Not posted","es_ES":"Sin contabilizar"}}, badgeVariants: {"true":"green","false":"orange"}, required: true },
   { key: 'grandTotalAmount', column: 'GrandTotal', type: 'amount', label: 'Total Gross Amount', required: true },
   { key: 'outstandingAmount', column: 'OutstandingAmt', type: 'amount', label: 'Total Outstanding', required: true },
   { key: 'eTGODueDate', column: 'em_etgo_due_date', type: 'date', label: 'em_etgo_due_date' },
   { key: 'eTGODeliveryStatus', column: 'em_etgo_delivery_status', type: 'number', label: 'em_etgo_delivery_status' },
-  { key: 'posted', column: 'Posted', type: 'boolean', label: 'Posted', badge: true, badgeLabels: {"true":{"en_US":"Posted","es_ES":"Contabilizado"},"false":{"en_US":"Not posted","es_ES":"Sin contabilizar"}}, badgeVariants: {"true":"green","false":"orange"}, required: true },
   { key: 'aeatsiiEstado', column: 'EM_Aeatsii_Estado', type: 'enum', label: 'SII Registration Status', enumLabels: { 'AE': 'Accepted with errors', 'AN': 'Annulled', 'IN': 'Incorrect', 'NR': 'Not Registrable to SII', 'PE': 'Pending to send to SII', 'CO': 'Right', 'EE': 'Sending error', 'BA': 'Unsubscribed' } },
 ];
 // @sf-generated-end columns:header

--- a/artifacts/sales-invoice/contract.json
+++ b/artifacts/sales-invoice/contract.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.40.0",
+  "version": "0.41.0",
   "generatedAt": "2026-04-30T15:42:46.582Z",
-  "updatedAt": "2026-06-29T17:06:06.473Z",
-  "checksum": "c8dc4e4ab20ae380",
+  "updatedAt": "2026-06-29T19:54:37.986Z",
+  "checksum": "361ed75db4f720a4",
   "frontendContract": {
     "window": {
       "id": "167",
@@ -442,7 +442,7 @@
             "form": true,
             "sourceRequired": true,
             "section": "summary",
-            "gridOrder": 5
+            "gridOrder": 6
           },
           {
             "name": "summedLineAmount",
@@ -534,6 +534,7 @@
               "true": "green",
               "false": "orange"
             },
+            "gridOrder": 5,
             "displayLogic": {
               "raw": "@Processed@='Y' & @#ShowAcct@='Y'",
               "evaluable": false,
@@ -559,7 +560,7 @@
             },
             "defaultValue": "0",
             "section": "summary",
-            "gridOrder": 6,
+            "gridOrder": 7,
             "displayLogic": {
               "raw": "@Processed@='Y' & @Ispaid@='N'",
               "evaluable": true
@@ -1078,7 +1079,7 @@
             "required": false,
             "grid": true,
             "form": false,
-            "gridOrder": 7
+            "gridOrder": 8
           },
           {
             "name": "eTGODeliveryStatus",
@@ -1091,7 +1092,7 @@
             "required": false,
             "grid": true,
             "form": false,
-            "gridOrder": 8
+            "gridOrder": 9
           },
           {
             "name": "transactionDocument",

--- a/artifacts/sales-invoice/contract.mcp.json
+++ b/artifacts/sales-invoice/contract.mcp.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.40.0",
+  "version": "0.41.0",
   "generatedAt": "2026-04-30T15:42:46.582Z",
   "updatedAt": "2026-06-28T15:29:27.060Z",
   "contractChecksum": "361ed75db4f720a4",

--- a/artifacts/sales-invoice/contract.mcp.json
+++ b/artifacts/sales-invoice/contract.mcp.json
@@ -2,7 +2,7 @@
   "version": "0.40.0",
   "generatedAt": "2026-04-30T15:42:46.582Z",
   "updatedAt": "2026-06-28T15:29:27.060Z",
-  "contractChecksum": "c8dc4e4ab20ae380",
+  "contractChecksum": "361ed75db4f720a4",
   "apiPrediction": {
     "specName": "sales-invoice",
     "baseUrl": "/sws/neo/sales-invoice",

--- a/artifacts/sales-invoice/custom/InvoiceHeaderTable.jsx
+++ b/artifacts/sales-invoice/custom/InvoiceHeaderTable.jsx
@@ -109,6 +109,7 @@ export default function InvoiceHeaderTable(props) {
       },
       { key: 'businessPartner', column: 'C_BPartner_ID', type: 'string' },
       { key: 'documentStatus', column: 'DocStatus', type: 'status', label: t('statusColumn') },
+      { key: 'posted', column: 'Posted', type: 'boolean', badge: true, badgeLabels: { true: { en_US: 'Posted', es_ES: 'Contabilizado' }, false: { en_US: 'Not posted', es_ES: 'Sin contabilizar' } }, badgeVariants: { true: 'green', false: 'orange' } },
       ...fiscalCols,
       { key: 'grandTotalAmount', column: 'GrandTotal', type: 'amount' },
       { key: 'outstandingAmount', column: 'OutstandingAmt', type: 'amount' },

--- a/artifacts/sales-invoice/custom/__tests__/InvoiceHeaderTable.test.js
+++ b/artifacts/sales-invoice/custom/__tests__/InvoiceHeaderTable.test.js
@@ -20,6 +20,7 @@ const expectedKeysInOrder = [
   'eTGODueDate',
   'businessPartner',
   'documentStatus',
+  'posted',
   'grandTotalAmount',
   'outstandingAmount',
   'eTGODeliveryStatus',
@@ -30,7 +31,7 @@ describe('Sales InvoiceHeaderTable — columns', () => {
     assert.ok(columnsBlock, 'expected `const columns = useMemo(() => [...], [])` block');
   });
 
-  it('renders the nine expected columns in order', () => {
+  it('renders the ten expected columns in order', () => {
     const block = columnsBlock[1];
     const keys = [...block.matchAll(/key:\s*'([^']+)'/g)].map(m => m[1]);
     assert.deepEqual(keys, expectedKeysInOrder);

--- a/artifacts/sales-invoice/decisions.json
+++ b/artifacts/sales-invoice/decisions.json
@@ -225,6 +225,7 @@
           "visibility": "readOnly",
           "form": false,
           "grid": true,
+          "gridOrder": 5,
           "badge": true,
           "badgeLabels": {
             "true": {
@@ -245,7 +246,7 @@
         "grandTotalAmount": {
           "visibility": "readOnly",
           "grid": true,
-          "gridOrder": 5,
+          "gridOrder": 6,
           "section": "summary"
         },
         "summedLineAmount": {
@@ -255,21 +256,21 @@
         "outstandingAmount": {
           "visibility": "readOnly",
           "grid": true,
-          "gridOrder": 6,
+          "gridOrder": 7,
           "form": false,
           "section": "summary"
         },
         "eTGODueDate": {
           "visibility": "readOnly",
           "grid": true,
-          "gridOrder": 7,
+          "gridOrder": 8,
           "form": false,
           "searchable": true
         },
         "eTGODeliveryStatus": {
           "visibility": "readOnly",
           "grid": true,
-          "gridOrder": 8,
+          "gridOrder": 9,
           "form": false
         },
         "isPaid": {

--- a/artifacts/sales-invoice/generated/web/sales-invoice/HeaderTable.jsx
+++ b/artifacts/sales-invoice/generated/web/sales-invoice/HeaderTable.jsx
@@ -7,11 +7,11 @@ const columns = [
   { key: 'documentNo', column: 'DocumentNo', type: 'string', label: 'Document No.', required: true },
   { key: 'businessPartner', column: 'C_BPartner_ID', type: 'selector', label: 'Business Partner', required: true },
   { key: 'documentStatus', column: 'DocStatus', type: 'status', label: 'Document Status', enumLabels: { 'CL': 'Closed', 'CO': 'Completed', 'DR': 'Draft', 'NA': 'Not Accepted', 'WP': 'Not Paid', 'RE': 'Re-Opened', 'TEMP': 'Temporal', 'IP': 'Under Way', '??': 'Unknown', 'VO': 'Voided' }, required: true },
+  { key: 'posted', column: 'Posted', type: 'boolean', label: 'Posted', badge: true, badgeLabels: {"true":{"en_US":"Posted","es_ES":"Contabilizado"},"false":{"en_US":"Not posted","es_ES":"Sin contabilizar"}}, badgeVariants: {"true":"green","false":"orange"}, required: true },
   { key: 'grandTotalAmount', column: 'GrandTotal', type: 'amount', label: 'Total Gross Amount', required: true },
   { key: 'outstandingAmount', column: 'OutstandingAmt', type: 'amount', label: 'Total Outstanding', required: true },
   { key: 'eTGODueDate', column: 'em_etgo_due_date', type: 'date', label: 'em_etgo_due_date' },
   { key: 'eTGODeliveryStatus', column: 'em_etgo_delivery_status', type: 'number', label: 'em_etgo_delivery_status' },
-  { key: 'posted', column: 'Posted', type: 'boolean', label: 'Posted', badge: true, badgeLabels: {"true":{"en_US":"Posted","es_ES":"Contabilizado"},"false":{"en_US":"Not posted","es_ES":"Sin contabilizar"}}, badgeVariants: {"true":"green","false":"orange"}, required: true },
   { key: 'etvfacInvoiceStatus', column: 'EM_Etvfac_Invoice_Status', type: 'status', label: 'Estado de Envío a Verifactu', enumLabels: { 'AC': 'Aceptada', 'AE': 'Aceptada con Errores', 'IN': 'Inválida', 'PE': 'Pendiente', 'ER': 'Rechazada' } },
   { key: 'aeatsiiEstado', column: 'EM_Aeatsii_Estado', type: 'enum', label: 'SII Registration Status', enumLabels: { 'AE': 'Accepted with errors', 'AN': 'Annulled', 'IN': 'Incorrect', 'NR': 'Not Registrable to SII', 'PE': 'Pending to send to SII', 'CO': 'Right', 'EE': 'Sending error', 'BA': 'Unsubscribed' } },
 ];

--- a/cli/test/invoice-delivery-status.test.js
+++ b/cli/test/invoice-delivery-status.test.js
@@ -51,7 +51,7 @@ for (const { tag, artifactDir, labelEs, labelEn } of SCOPES) {
       assert.ok(cfg, 'expected entities.header.fields.eTGODeliveryStatus');
       assert.equal(cfg.visibility, 'readOnly');
       assert.equal(cfg.grid, true);
-      assert.equal(cfg.gridOrder, 8);
+      assert.equal(cfg.gridOrder, 9);
       assert.equal(cfg.form, false);
     });
 
@@ -69,7 +69,7 @@ for (const { tag, artifactDir, labelEs, labelEn } of SCOPES) {
       assert.ok(field, 'expected header.fields entry for apiKey "eTGODeliveryStatus"');
       assert.equal(field.column, 'em_etgo_delivery_status');
       assert.equal(field.grid, true);
-      assert.equal(field.gridOrder, 8);
+      assert.equal(field.gridOrder, 9);
     });
 
     it('contract.json carries the labelOverrides forward', () => {

--- a/docs/plans/ETP-4298-cross-domain.md
+++ b/docs/plans/ETP-4298-cross-domain.md
@@ -16,10 +16,11 @@ that intentionally spans the generator, platform, multiple windows, and i18n.
 | `app-shell-core` | `packages/app-shell-core/src/locales/en_US.json`, `packages/app-shell-core/src/locales/es_ES.json` | i18n keys for accounting status (`accountingStatus`, `postedStatus`, `notPostedStatus`) added to both locales. |
 | `window:amortization` | `artifacts/amortization/**` | Post/Unpost/Bulk Post actions + accounting status pill + `posted` boolean column. |
 | `window:goods-movements` | `artifacts/goods-movements/**` | Same as amortization. |
-| `window:goods-receipt` | `artifacts/goods-receipt/**` | Same as amortization. |
-| `window:goods-shipment` | `artifacts/goods-shipment/**` | Same as amortization. |
-| `window:purchase-invoice` | `artifacts/purchase-invoice/**` | Same as amortization. |
-| `window:sales-invoice` | `artifacts/sales-invoice/**` | Same as amortization. |
+| `window:goods-receipt` | `artifacts/goods-receipt/**`, `tools/app-shell/src/windows/custom/goods-receipt/index.jsx` | Same as amortization. Grid badge added to custom HEADER_COLUMNS array (custom loader overrides generated table). |
+| `window:goods-shipment` | `artifacts/goods-shipment/**`, `tools/app-shell/src/windows/custom/goods-shipment/index.jsx` | Same as amortization. Grid badge added to custom COLUMNS array. |
+| `window:physical-inventory` | `artifacts/physical-inventory/**`, `tools/app-shell/src/windows/custom/physical-inventory/index.jsx` | statusPills added to decisions.json for detail view pill; posted badge column added to custom COLUMNS array for grid view; gridOrder set on all 5 header fields. |
+| `window:purchase-invoice` | `artifacts/purchase-invoice/**`, `tools/app-shell/src/windows/custom/purchase-invoice/PurchaseInvoiceHeaderTable.jsx` | Same as amortization. Grid badge added to custom columns useMemo array. |
+| `window:sales-invoice` | `artifacts/sales-invoice/**`, `artifacts/sales-invoice/custom/InvoiceHeaderTable.jsx` | Same as amortization. Grid badge added to custom InvoiceHeaderTable columns useMemo array. |
 | `window:sales-order` | `artifacts/sales-order/**` | Same as amortization. |
 | `window:simple-g-l-journal` | `artifacts/simple-g-l-journal/**` | Same as amortization. |
 | `window:not-posted-documents` | `artifacts/not-posted-documents/**`, `tools/app-shell/src/windows/custom/not-posted-documents/**` | New fully-custom window aggregating unposted documents with single and bulk Post actions. |

--- a/tools/app-shell/src/windows/custom/goods-receipt/index.jsx
+++ b/tools/app-shell/src/windows/custom/goods-receipt/index.jsx
@@ -20,6 +20,7 @@ const HEADER_COLUMNS = [
   { key: 'orderReference', column: 'POReference', type: 'string' },
   { key: 'businessPartner', column: 'C_BPartner_ID', type: 'selector' },
   { key: 'documentStatus', column: 'DocStatus', type: 'status' },
+  { key: 'posted', column: 'Posted', type: 'boolean', badge: true, badgeLabels: { true: { en_US: 'Posted', es_ES: 'Contabilizado' }, false: { en_US: 'Not posted', es_ES: 'Sin contabilizar' } }, badgeVariants: { true: 'green', false: 'orange' } },
   { key: 'warehouse', column: 'M_Warehouse_ID', type: 'selector' },
   { key: 'invoiceStatus', column: 'InvoiceStatus', type: 'percent' },
 ];

--- a/tools/app-shell/src/windows/custom/goods-shipment/index.jsx
+++ b/tools/app-shell/src/windows/custom/goods-shipment/index.jsx
@@ -22,6 +22,7 @@ const COLUMNS = [
   { key: 'documentNo', column: 'DocumentNo', type: 'string' },
   { key: 'businessPartner', column: 'C_BPartner_ID', type: 'string' },
   { key: 'documentStatus', column: 'DocStatus', type: 'status' },
+  { key: 'posted', column: 'Posted', type: 'boolean', badge: true, badgeLabels: { true: { en_US: 'Posted', es_ES: 'Contabilizado' }, false: { en_US: 'Not posted', es_ES: 'Sin contabilizar' } }, badgeVariants: { true: 'green', false: 'orange' } },
   { key: 'warehouse', column: 'M_Warehouse_ID', type: 'string' },
   { key: 'invoiceStatus', column: 'InvoiceStatus', type: 'percent' },
 ];

--- a/tools/app-shell/src/windows/custom/physical-inventory/index.jsx
+++ b/tools/app-shell/src/windows/custom/physical-inventory/index.jsx
@@ -21,6 +21,7 @@ const COLUMNS = [
     },
   },
   { key: 'processed', column: 'Processed', type: 'status', enumLabels: { 'true': 'statusProcessed', 'false': 'statusDraft' } },
+  { key: 'posted', column: 'Posted', type: 'boolean', badge: true, badgeLabels: { true: { en_US: 'Posted', es_ES: 'Contabilizado' }, false: { en_US: 'Not posted', es_ES: 'Sin contabilizar' } }, badgeVariants: { true: 'green', false: 'orange' } },
 ];
 
 function CustomInventoryTable(props) {

--- a/tools/app-shell/src/windows/custom/purchase-invoice/PurchaseInvoiceHeaderTable.jsx
+++ b/tools/app-shell/src/windows/custom/purchase-invoice/PurchaseInvoiceHeaderTable.jsx
@@ -101,6 +101,7 @@ export default function PurchaseInvoiceHeaderTable(props) {
       },
       { key: 'businessPartner', column: 'C_BPartner_ID', type: 'selector' },
       { key: 'documentStatus', column: 'DocStatus', type: 'status' },
+      { key: 'posted', column: 'Posted', type: 'boolean', badge: true, badgeLabels: { true: { en_US: 'Posted', es_ES: 'Contabilizado' }, false: { en_US: 'Not posted', es_ES: 'Sin contabilizar' } }, badgeVariants: { true: 'green', false: 'orange' } },
       ...fiscalCols,
       {
         key: 'grandTotalAmount', column: 'GrandTotal', type: 'custom',

--- a/tools/app-shell/src/windows/custom/purchase-invoice/__tests__/PurchaseInvoiceHeaderTable.test.js
+++ b/tools/app-shell/src/windows/custom/purchase-invoice/__tests__/PurchaseInvoiceHeaderTable.test.js
@@ -20,6 +20,7 @@ const expectedKeysInOrder = [
   'eTGODueDate',
   'businessPartner',
   'documentStatus',
+  'posted',
   'grandTotalAmount',
   'outstandingAmount',
   'eTGODeliveryStatus',
@@ -34,7 +35,7 @@ describe('PurchaseInvoiceHeaderTable — columns', () => {
     assert.ok(columnsBlock, 'expected `const columns = useMemo(() => [...], [])` block');
   });
 
-  it('renders the nine expected columns in order (transactionDocument is visible badge + type filter)', () => {
+  it('renders the ten expected columns in order (transactionDocument is visible badge + type filter)', () => {
     const block = columnsBlock[1];
     const keys = [...block.matchAll(/key:\s*'([^']+)'/g)].map(m => m[1]);
     assert.deepEqual(keys, expectedKeysInOrder);


### PR DESCRIPTION
## Summary

- Adds the **Contabilizado / Sin contabilizar** badge to the list/grid view for: Sales Invoice, Purchase Invoice, Physical Inventory, Goods Shipment, and Goods Receipt
- Inserts a `posted` column (`type: boolean, badge: true`) in each window's custom column array — bypassing generated `*Table.jsx` files since `customLoaders` takes precedence in `registry.js`
- Adds `statusPills` config for Physical Inventory detail view
- Updates `decisions.json` gridOrder for the 3 windows that went through `make regen`, and regenerates their contracts + MCP snapshots

## Test plan

- [ ] Run `make test` — all unit tests pass (invoice-delivery-status, InvoiceHeaderTable, PurchaseInvoiceHeaderTable)
- [ ] Verify badge renders in Sales Invoice grid (green = Contabilizado, orange = Sin contabilizar)
- [ ] Verify same in Purchase Invoice, Physical Inventory, Goods Shipment, Goods Receipt
- [ ] Confirm Physical Inventory detail view shows the accounting status pill
- [ ] Run `node cli/src/validate-pipeline.js --scope=sales-invoice,purchase-invoice,physical-inventory` — 0 violations