### PR TITLE
Feature ETP-4355: Fix Not Posted Documents window

### DIFF
--- a/cli/src/push-to-neo.js
+++ b/cli/src/push-to-neo.js
@@ -1051,7 +1051,7 @@ export async function pushCustomWindowToNeo(windowName, options = {}) {
       const entityId = existingEntity.rows[0].etgo_sf_entity_id;
       await client.query(
         `UPDATE etgo_sf_entity
-         SET java_qualifier = $1, updated = now()
+         SET java_qualifier = $1, isget = 'Y', ispost = 'Y', updated = now()
          WHERE etgo_sf_entity_id = $2`,
         [javaQualifier, entityId],
       );

--- a/cli/src/push-to-neo.js
+++ b/cli/src/push-to-neo.js
@@ -894,7 +894,9 @@ export async function pushReportToNeo(reportName, options = {}) {
         // Update handler qualifier on existing entity
         const entityId = existingEntity.rows[0].etgo_sf_entity_id;
         await client.query(
-          `UPDATE etgo_sf_entity SET java_qualifier = $1, name = $2, updated = now() WHERE etgo_sf_entity_id = $3`,
+          `UPDATE etgo_sf_entity
+           SET java_qualifier = $1, name = $2, isget = 'Y', ispost = 'Y', updated = now()
+           WHERE etgo_sf_entity_id = $3`,
           [handler, specName, entityId],
         );
         console.log(`[2/2] Updated entity handler: ${handler} (entity ${entityId})`);

--- a/docs/generated-custom-windows/not-posted-documents.md
+++ b/docs/generated-custom-windows/not-posted-documents.md
@@ -2,18 +2,120 @@
 
 ## Intent
 
-Use this window to find and mass-post all accounting documents that are still pending posting across the organization. It aggregates unposted documents of every supported type into a single cross-document list, lets the user filter by type, accounting status, and date range, and exposes a **Post** action per row as well as a **Post selected** bulk action.
+Use this window to find and mass-post all accounting documents that are still pending posting across the organization. It aggregates unposted documents of every **supported** type into a single cross-document list, lets the user filter by type, accounting status, and date range, and exposes a **Post** action per row as well as a **Post selected** bulk action.
 
-The window has no backing AD window — it is 100 % custom. Data is served by `NotPostedDocumentsHandler` (`@Named("not-posted-documents")`), which delegates to `NoPostedDocumentDS` from `bulk.posting-3.0.0.jar`.
+The window has no backing AD window — it is 100% custom. Data is served by `NotPostedDocumentsHandler` (`@Named("not-posted-documents")`), which delegates to `NoPostedDocumentDS` from `bulk.posting-3.0.0.jar`.
 
-## What this window should allow
+---
 
-- Display all unposted documents for the current organization in a flat list.
-- Filter by document type (Sales Invoice, Purchase Invoice, Goods Shipment, etc.), accounting status, and date range (from / to).
-- Post a single document directly from the row action button.
-- Select multiple rows (including a select-all with indeterminate state) and post them all in one bulk operation.
-- Show a success / partial / failure toast after every post attempt.
-- Refresh the list automatically after a successful post without resetting active filters.
+## Document type accounting support
+
+Not every document type in `ETBLKP_Documents` (`AD_Reference_ID = DE94535164E741AB9B1A560EF3F72854`) can actually be posted in a standard Etendo + APRM installation. The table below is the authoritative reference.
+
+The **enabled** column reflects the `ENABLED_DOCUMENT_TYPE_CODES` set in `NotPostedDocumentsHandler.java`. Changing that set is the only place you need to edit to add or remove a type from the dropdown.
+
+| Code | Name | AD_Table | AD_Table_ID | In c_acctschema_table? | Posting status | **Enabled** | Reason |
+|------|------|----------|-------------|------------------------|----------------|:-----------:|--------|
+| `A`   | Amortization             | `A_Amortization`          | `800060` | ✅ isactive=Y | ✅ Working (N+Y records) | ✅ | — |
+| `BMP` | Bill of Materials Prod.  | `M_Production`            | `325` | ✅ isactive=Y | ✅ Working | ✅ | — |
+| `BS`  | Bank Statements          | `FIN_BankStatement`       | `D4C23A17190649E7B78F55A05AF3438C` | ✅ isactive=Y | ❌ All D (100%) | ❌ | APRM posts via Transaction, not BankStatement |
+| `CA`  | Cost Adjustment          | `M_CostAdjustment`        | `D022B92163074E5E82449C8E0B5AFDF6` | ✅ isactive=Y | ⚠️ 0 documents | ❌ | No documents in this installation; enable when activated |
+| `DD`  | Doubtful Debt            | `FIN_Doubtful_Debt`       | `30721072789F410E9606D2235CB2A226` | ✅ isactive=Y | ⚠️ 0 documents | ❌ | No documents in this installation; enable when activated |
+| `GLJ` | G/L Journal              | `GL_Journal`              | `224` | ✅ isactive=Y | ✅ Working (N+Y records) | ✅ | — |
+| `GR`  | Goods Receipt            | `M_InOut`                 | `319` | ✅ isactive=Y | ✅ Working (N+Y records) | ✅ | — |
+| `GS`  | Goods Shipment           | `M_InOut`                 | `319` | ✅ isactive=Y | ✅ Working (N+Y records) | ✅ | — |
+| `IC`  | Internal Consumption     | `M_Internal_Consumption`  | `800168` | ❌ Not present | ❌ N/A | ❌ | No accounting schema entry |
+| `INV` | Inventory                | `M_Inventory`             | `321` | ✅ isactive=Y | ✅ Working (N+Y records) | ✅ | — |
+| `LC`  | Landed Cost              | `M_LandedCost`            | `082F967CDF7245EB9A150941F326C45C` | ✅ isactive=Y | ✅ Working (N records) | ✅ | — |
+| `LCC` | Landed Cost Cost         | `M_LC_Cost`               | `55A984C314FD4C4FB5E7C32DE36BB07B` | ✅ isactive=Y | ✅ Working (N records) | ✅ | — |
+| `MI`  | Matched Invoices         | `M_MatchInv`              | `472` | ✅ isactive=Y | ✅ Working (E+i+p+Y) | ✅ | — |
+| `M`   | Movements                | `M_Movement`              | `323` | ✅ isactive=Y | ✅ Working (Y records) | ✅ | — |
+| `PIN` | Payment In               | `FIN_Payment`             | `D1A97202E832470285C9B1EB026D54E2` | ✅ isactive=Y | ❌ 99.9% D | ❌ | APRM: payment accounting via Transaction |
+| `POT` | Payment Out              | `FIN_Payment`             | `D1A97202E832470285C9B1EB026D54E2` | ✅ isactive=Y | ❌ 99.9% D | ❌ | APRM: payment accounting via Transaction |
+| `PI`  | Purchase Invoice         | `C_Invoice`               | `318` | ✅ isactive=Y | ✅ Working (N+Y records) | ✅ | — |
+| `R`   | Reconciliation           | `FIN_Reconciliation`      | `B1B7075C46934F0A9FD4C4D0F1457B42` | ✅ isactive=Y | ❌ 89% D | ❌ | APRM: reconciliation accounting via Transaction |
+| `RMR` | Return Material Receipt  | `M_InOut`                 | `319` | ✅ isactive=Y | ✅ Working (N+Y records) | ✅ | — |
+| `RVS` | Return to Vendor Ship.   | `M_InOut`                 | `319` | ✅ isactive=Y | ✅ Working (N+Y records) | ✅ | — |
+| `SI`  | Sales Invoice            | `C_Invoice`               | `318` | ✅ isactive=Y | ✅ Working (N+Y records) | ✅ | — |
+| `T`   | Transaction              | `FIN_Finacc_Transaction`  | `4D8C3B3C31D1410DA046140C9F024D17` | ✅ isactive=Y | ✅ Working (N+E+Y records) | ✅ | APRM primary posting table |
+| `WE`  | Work Effort              | `S_TimeExpense`           | `486` | ❌ Not present | ❌ N/A | ❌ | No accounting schema entry |
+
+### Why APRM disables BS, PIN, POT, R
+
+Etendo's Advanced Payables & Receivables Management (APRM) module routes all financial accounting through `FIN_Finacc_Transaction` (code `T`). When a payment, bank statement, or reconciliation document is created via APRM, the system immediately sets `POSTED = 'D'` on those records — signalling that direct bulk-posting is disabled for them. The `FIN_Finacc_Transaction` records are what actually carry the accounting entries.
+
+Verification queries:
+```sql
+-- See the actual posted distribution per table
+SELECT 'FIN_Payment'      , posted, count(*) FROM fin_payment      GROUP BY posted
+UNION ALL
+SELECT 'FIN_BankStatement', posted, count(*) FROM fin_bankstatement GROUP BY posted
+UNION ALL
+SELECT 'FIN_Reconciliation',posted, count(*) FROM fin_reconciliation GROUP BY posted
+UNION ALL
+SELECT 'FIN_Finacc_Transaction', posted, count(*) FROM fin_finacc_transaction GROUP BY posted
+ORDER BY 1, 2;
+```
+
+### How to enable or disable a document type
+
+**In `NotPostedDocumentsHandler.java`** (the only file you need to edit):
+
+```java
+// File: modules/com.etendoerp.go/src/com/etendoerp/go/schemaforge/handlers/NotPostedDocumentsHandler.java
+
+static final Set<String> ENABLED_DOCUMENT_TYPE_CODES = new LinkedHashSet<>(Arrays.asList(
+    "A",    // Amortization             → A_Amortization
+    "BMP",  // Bill of Mat. Production  → M_Production
+    // ... add or remove codes here
+));
+```
+
+**Before enabling a new code, verify:**
+1. The code appears in `AD_Ref_List` for reference `DE94535164E741AB9B1A560EF3F72854`
+2. Its backing table exists in `c_acctschema_table` with `isactive = 'Y'`:
+   ```sql
+   SELECT ast.isactive, count(*)
+   FROM c_acctschema_table ast
+   JOIN ad_table t ON ast.ad_table_id = t.ad_table_id
+   WHERE t.tablename = 'YOUR_TABLE_NAME'
+   GROUP BY ast.isactive;
+   ```
+3. Documents of that type have records with `posted` values other than `'D'`:
+   ```sql
+   SELECT posted, count(*) FROM your_table GROUP BY posted;
+   ```
+4. Add the table → `AD_Table_ID` mapping to `DOCUMENT_TYPE_TO_TABLE_ID` if not already present (needed for the post action to resolve the correct table).
+
+**To enable `DD` (Doubtful Debt) or `CA` (Cost Adjustment)** when those modules go live: simply add `"DD"` or `"CA"` to the set — no other change needed.
+
+**To re-enable payments (PIN/POT)** if APRM accounting is ever reconfigured: add `"PIN"` and `"POT"` back. You will also need to verify that `FIN_Payment` records are no longer initialized with `posted = 'D'`.
+
+---
+
+## Accounting status filter
+
+The "Estado contable" multi-select shows 4 curated options. The values in the dropdown are search keys (`N`, `E,C`, `i`, `p`), but `NoPostedDocumentDS` requires `ad_ref_list_id` UUIDs internally — `getValues()` queries `AD_Ref_List` by primary key, not by search key. The handler translates via `ACCOUNTING_STATUS_KEY_TO_ID`.
+
+| Option label | Search key(s) | `ad_ref_list_id` | Notes |
+|--------------|---------------|-----------------|-------|
+| Unposted | `N` | `D16B6411F4CB4708AE05E7F6E109920E` | |
+| Error | `E`, `C` | `420D49CD77304D32BE49582002C315BE`, `4AE29BF062D4484E976B1BEEF34A7913` | Unified: Error + Error-No-Cost |
+| Invalid Account | `i` | `A12420CC6D4144768EEC57143859EFD6` | |
+| Period Closed | `p` | `D1EAA8BCC3E649C398D4E544282E5292` | |
+
+When no filter is selected (initial load), the handler defaults to all four options — `["N","E","C","i","p"]` — because passing an empty list to `searchAllDocuments(org, emptyList)` returns zero results (the datasource short-circuits on empty status list).
+
+Full reference for all 18 accounting statuses (excluded from UI):
+```sql
+SELECT ad_ref_list_id, value, name
+FROM ad_ref_list
+WHERE ad_reference_id = 'D431058F6B7345598D1E0709DFF3B5DD'
+  AND isactive = 'Y'
+ORDER BY value;
+```
+
+---
 
 ## Data architecture
 
@@ -22,14 +124,15 @@ NotPostedDocumentsPage (React)
   │
   ├── GET /header?_mode=filter-options
   │     → NotPostedDocumentsHandler.buildFilterOptions()
-  │           → refListOptions(DOCUMENT_TYPE_REF_ID)     ← AD_Ref_List "ETBLKP_Documents"
-  │           → refListOptions(ACCOUNTING_STATUS_REF_ID) ← AD_Ref_List accounting status
+  │           → refListDocumentTypes()          ← AD_Ref_List filtered by ENABLED_DOCUMENT_TYPE_CODES
+  │           → buildAccountingStatusOptions()  ← curated 4-option subset from AD_Ref_List
   │           returns { documentTypes: [{value,label}], accountingStatuses: [{value,label}] }
   │
   ├── GET /header?document=X&accountingStatus=Y&dateFrom=Z&dateTo=W
   │     → NotPostedDocumentsHandler.buildDocumentGrid(params)
-  │           → AccessibleDS.fetchAll(dsParams)  (subclass exposing NoPostedDocumentDS.getData)
-  │           → enriches each row with tableId from DOCUMENT_TYPE_TO_TABLE_ID
+  │           → buildDsParams()  translates search keys → ad_ref_list_id UUIDs
+  │           → AccessibleDS.fetchAll(dsParams)
+  │           → enriches rows with tableId from DOCUMENT_TYPE_TO_TABLE_ID
   │           returns { rows: [...], total: N }
   │
   ├── POST /header/{recordId}/action/post          body: { tableId, recordId }
@@ -42,6 +145,10 @@ NotPostedDocumentsPage (React)
               returns { ok, total, results: [{recordId, tableId, success, message}] }
 ```
 
+All responses are **unwrapped** — `NeoResponse.ok(body)` writes the body directly with no `{response:{data:[...]}}` envelope. The frontend reads `json.documentTypes`, `json.rows`, etc. directly.
+
+---
+
 ## Backend — `NotPostedDocumentsHandler`
 
 File: `modules/com.etendoerp.go/src/com/etendoerp/go/schemaforge/handlers/NotPostedDocumentsHandler.java`
@@ -50,7 +157,7 @@ CDI qualifier: `@Named("not-posted-documents")` — **`@Named` only, no normal s
 
 ### `NoPostedDocumentDS` access pattern
 
-`getData()` is declared `protected` in the JAR. The handler bridges this via a private static inner subclass:
+`getData()` is `protected` in the JAR. The handler bridges this via a private static inner subclass:
 
 ```java
 private static class AccessibleDS extends NoPostedDocumentDS {
@@ -60,68 +167,34 @@ private static class AccessibleDS extends NoPostedDocumentDS {
 }
 ```
 
+The no-arg constructor of `NoPostedDocumentDS` instantiates `DocumentSearchService` directly (`new DocumentSearchService()`) — CDI injection is not involved.
+
+### `buildDsParams` — UUID translation
+
+`NoPostedDocumentDS.getGridData` calls `getValues(jsonArray, referenceId)` which queries `AD_Ref_List` **by primary key** (`ad_ref_list_id IN (...)`). Passing search keys like `"N"` silently returns an empty list, causing `searchAllDocuments(org, emptyList)` to return zero rows.
+
+The handler maintains `ACCOUNTING_STATUS_KEY_TO_ID` (search key → UUID) and translates before building the datasource param map. When no `accountingStatus` filter is provided (initial load), it defaults to the curated 5 keys `[N, E, C, i, p]`.
+
 ### `tableId` enrichment
 
-`NoPostedDocumentDS` returns a `documentType` string (e.g. `"Sales Invoice"`) but not the `AD_Table_ID`. The handler maintains a static `DOCUMENT_TYPE_TO_TABLE_ID` map populated from `NoPostedConstants` string constants and an AD_Table lookup:
+`NoPostedDocumentDS` returns a `documentType` string (e.g. `"Goods Shipment"`) but not `AD_Table_ID`. The handler's `DOCUMENT_TYPE_TO_TABLE_ID` map resolves it at response time so the frontend can call POST /action/post without extra lookups.
 
-| Document type string | AD_Table_ID | Table |
-|---------------------|-------------|-------|
-| `Sales Invoice` / `Purchase Invoice` / `Invoice` | `318` | `C_Invoice` |
-| `Goods Shipment` / `Goods Receipt` / `ShipmentInOut` / `Return to Vendor Shipment` / `Return Material Receipt` | `319` | `M_InOut` |
-| `Movement` | `323` | `M_Movement` |
-| `Amortization` | `800060` | `A_Amortization` |
-| `GL Journal` | `224` | `GL_Journal` |
-| `Inventory` | `321` | `M_Inventory` |
-
-### Filter criteria mapping
-
-Frontend query params are translated to SmartClient `AdvancedCriteria` JSON before being passed to `getData`:
-
-| Frontend param | Criteria field | Operator |
-|----------------|---------------|----------|
-| `document` | `document` | `iEquals` |
-| `accountingStatus` (single) | `accountingStatus` | `iEquals` |
-| `accountingStatus` (comma-separated) | `accountingStatus` | `inSet` |
-| `dateFrom` | `accountingDate` | `greaterOrEqual` |
-| `dateTo` | `accountingDate` | `lessOrEqual` |
+Source for table IDs:
+```sql
+SELECT tablename, ad_table_id FROM ad_table
+WHERE tablename IN ('C_Invoice','M_InOut','M_Movement','A_Amortization',
+                    'GL_Journal','M_Inventory','M_Production','M_MatchInv',
+                    'M_Movement','M_LandedCost','M_LC_Cost','FIN_Finacc_Transaction');
+```
 
 ### AD_Ref_List constants
 
-| Constant | AD_Reference_ID |
-|---------|-----------------|
-| `DOCUMENT_TYPE_REF_ID` | `DE94535164E741AB9B1A560EF3F72854` (`ETBLKP_Documents`) |
-| `ACCOUNTING_STATUS_REF_ID` | `D674E22A40DE4CEE931AB96F4CD914F9` |
+| Constant | AD_Reference_ID | Purpose |
+|---------|-----------------|---------|
+| `DOCUMENT_TYPE_REF_ID` | `DE94535164E741AB9B1A560EF3F72854` | `ETBLKP_Documents` — all document types |
+| `ACCOUNTING_STATUS_REF_ID` | `D431058F6B7345598D1E0709DFF3B5DD` | `ETBLKP_All_Accounting Status` |
 
-Filter option labels are returned in the user's session language via `ListTrl.getADListTrlList()`, falling back to the base `List.getName()` when no translation is found.
-
-### API responses
-
-**`GET /header?_mode=filter-options`**
-```json
-{
-  "response": {
-    "data": [{ "documentTypes": [{"value":"X","label":"Y"}], "accountingStatuses": [...] }]
-  }
-}
-```
-
-**`GET /header?...`**
-```json
-{ "response": { "data": [{ "rows": [...], "total": N }] } }
-```
-Each row includes: `documentType`, `documentId`, `description`, `accountingDate`, `organization`, `tableId` (enriched by handler).
-
-**`POST /header/{id}/action/post`**
-```json
-{ "response": { "data": [{ "success": true|false, "message": "..." }] } }
-```
-Returns HTTP 422 on failure (non-ok `PostResult`).
-
-**`POST /header/0/action/bulk-post`**
-```json
-{ "response": { "data": [{ "ok": N, "total": M, "success": true|false, "results": [...] }] } }
-```
-Always returns HTTP 200; per-row `success` fields indicate individual outcomes.
+---
 
 ## NEO spec / entity DB records
 
@@ -131,69 +204,50 @@ Pushed by the generic custom-window path in `push-to-neo.js` (idempotent — ups
 node cli/src/push-to-neo.js not-posted-documents --type custom [--dry-run]
 ```
 
-Spec name: `not-posted-documents` (kebab-case, matches `toSpecName()` convention).
-Entity name: `header`. Java_Qualifier: `not-posted-documents` (read from `decisions.json → entities.header.javaQualifier`).
-No backing AD window — `AD_Window_ID` is null. IDs are generated dynamically on first insert.
+Spec name: `not-posted-documents`. Entity: `header`. Java_Qualifier: `not-posted-documents`.  
+`isget = 'Y'`, `ispost = 'Y'` on the entity — both GET (grid + filter-options) and POST (actions) are enabled.
+
+---
 
 ## Frontend component — `NotPostedDocumentsPage`
 
 File: `tools/app-shell/src/windows/custom/not-posted-documents/NotPostedDocumentsPage.jsx`
 
-Props: `{ token, apiBaseUrl }` — `apiBaseUrl` is already spec-scoped (e.g. `.../swebsf/not-posted-documents`), used directly as `neoUrl`.
+Props: `{ token, apiBaseUrl }` — `apiBaseUrl` is already spec-scoped.
+
+### Accounting status multi-select
+
+State: `accountingStatuses: Set<string>` of selected search keys.  
+Empty set = "all curated statuses" — the backend defaults when nothing is selected.  
+The `MultiSelect` component (inline in the same file) closes on outside-click via `useRef` + `mousedown` listener.
 
 ### Lifecycle
 
-1. **Mount** — fetches filter options (`GET /header?_mode=filter-options`); fetches initial row list with no filters.
-2. **Apply filters** — calls `fetchRows(filters)` with the current filter state; clears the selection set.
-3. **Post row** — fires `POST /header/{recordId}/action/post`; on success shows a toast and re-fetches the list without resetting filters.
-4. **Post selected** — fires `POST /header/0/action/bulk-post` with all selected rows that have a resolved `tableId`; on success shows a partial/complete/failure toast and re-fetches.
+1. **Mount** — fetches filter options; fetches initial rows with empty filters (backend defaults to N+E+C+i+p).
+2. **Apply** — `fetchRows(filters)` with current state; clears selection.
+3. **Post row** — `POST /header/{id}/action/post`; refreshes on success.
+4. **Post selected** — `POST /header/0/action/bulk-post`; refreshes on any result.
 
-### Selection model
-
-- Per-row checkboxes managed by a `Set<documentId>` state.
-- Select-all checkbox uses `ref` to set `indeterminate` when some (not all) rows are checked.
-- Selection is cleared on filter apply and on successful bulk post.
-
-### Toast keys
-
-| Scenario | i18n key |
-|----------|----------|
-| Single post success | `documentPosted` |
-| Bulk post — all ok | `postingComplete` |
-| Bulk post — partial | `postingPartial` (substitutes `{ok}` and `{total}`) |
-| Any failure | `postingFailed` |
-
-## Interaction model
-
-- Route: `/not-posted-documents` (custom window).
-- Implementation type: `layoutType: "custom"` — loaded from `customLoaders` in `tools/app-shell/src/windows/registry.js`.
-- Entry point: `NotPostedDocumentsPage.jsx`.
-- Requests carry AbortController signals — switching filters or unmounting cancels in-flight fetches.
+---
 
 ## Manual verification
 
-1. Open `/not-posted-documents` — confirm the filter bar renders with Document type and Accounting status dropdowns populated from the real AD_Ref_List data.
-2. Confirm the table loads with unposted documents for the current org on first render (no Apply needed).
-3. Select a document type filter and click Apply — confirm the table refreshes with only that document type.
-4. Click **Post** on a single row — confirm a success (or error) toast appears and the row disappears from the list after refresh.
-5. Select several rows using the row checkboxes — confirm the **Post selected (N)** button appears in the toolbar.
-6. Click **Post selected** — confirm a toast with the `postingComplete` or `postingPartial` message appears and the table refreshes.
-7. Select all rows via the header checkbox — confirm the indeterminate state transitions to checked. Deselect one row — confirm it goes back to indeterminate.
-8. With no rows matching the filters, confirm the empty-state illustration renders instead of an empty table.
-9. Confirm the page title and record count in the topbar update to reflect the number of rows in the table.
+1. Open `/not-posted-documents` — filter dropdowns populate; document type list has exactly 15 entries (no payments, no bank statements, no reconciliation, no work effort, no internal consumption, no doubtful debt, no cost adjustment).
+2. Initial table loads with rows (defaults to N+E+C+i+p statuses — no Apply needed).
+3. Filter by document type → only that type appears.
+4. Filter by accounting status → only selected statuses appear.
+5. Post a single row → success toast + row disappears.
+6. Post selected → partial/complete toast + table refreshes.
+7. Menu title shows "Documentos no contabilizados" in Spanish.
+
+---
 
 ## Automated evidence
 
 - `artifacts/not-posted-documents/decisions.json` — `layoutType: "custom"`, `javaQualifier: "not-posted-documents"`, Finance category.
-- `cli/src/push-to-neo.js --type custom` — generic custom-window push; reads `javaQualifier` from `decisions.json`; queries `MODULE_ID` from DB; `--dry-run` flag supported.
-- `cli/src/validate-pipeline.js` — `not-posted-documents` listed in `CUSTOM_ONLY_ARTIFACTS`; pipeline contract validation skipped.
 - `tools/app-shell/src/windows/registry.js` — `not-posted-documents` in `customLoaders`.
-- `tools/app-shell/src/menu.json` — entry in the Finance group (after `amortization`).
-- `tools/app-shell/src/windows/custom/not-posted-documents/NotPostedDocumentsPage.jsx` — main component; AbortController fetch cancellation; select-all indeterminate via ref.
-- `tools/app-shell/src/windows/custom/not-posted-documents/not-posted-documents.css` — scoped `npd-*` CSS; design-system custom properties.
-- `tools/app-shell/src/windows/custom/not-posted-documents/index.jsx` — re-export barrel.
-- `modules/com.etendoerp.go/src/com/etendoerp/go/schemaforge/handlers/NotPostedDocumentsHandler.java` — `@Named("not-posted-documents")`; `AccessibleDS` inner subclass; `DOCUMENT_TYPE_TO_TABLE_ID` static map; `refListOptions` + `getTranslatedName` AD_Ref_List helpers; package-private `setPostingService` seam for unit tests.
-- `modules/com.etendoerp.go/src-db/database/sourcedata/ETGO_SF_SPEC.xml` — persisted spec record.
-- `modules/com.etendoerp.go/src-db/database/sourcedata/ETGO_SF_ENTITY.xml` — persisted entity record.
+- `tools/app-shell/src/windows/custom/not-posted-documents/NotPostedDocumentsPage.jsx` — main component.
+- `tools/app-shell/src/windows/custom/not-posted-documents/not-posted-documents.css` — scoped `npd-*` CSS.
+- `modules/com.etendoerp.go/src/com/etendoerp/go/schemaforge/handlers/NotPostedDocumentsHandler.java` — `@Named("not-posted-documents")`; `ENABLED_DOCUMENT_TYPE_CODES` set; `ACCOUNTING_STATUS_KEY_TO_ID` UUID map; `DEFAULT_ACCOUNTING_STATUS_KEYS`; `AccessibleDS` inner subclass.
+- `modules/com.etendoerp.go/src-db/database/sourcedata/ETGO_SF_ENTITY.xml` — `isget=Y, ispost=Y`.
 - i18n keys: `notPostedDocuments`, `postSelected`, `postingComplete`, `postingPartial`, `postingFailed`, `filterDocumentType`, `filterAccountingStatus`, `accountingDate` in `en_US.json` / `es_ES.json`.
-- `e2e/tests/flows/not-posted-documents.mocked.spec.js` — Playwright mocked E2E: filter options load, row table render, single-row Post action, bulk Post selected action, empty state.

--- a/docs/generated-custom-windows/not-posted-documents.md
+++ b/docs/generated-custom-windows/not-posted-documents.md
@@ -57,39 +57,46 @@ SELECT 'FIN_Finacc_Transaction', posted, count(*) FROM fin_finacc_transaction GR
 ORDER BY 1, 2;
 ```
 
-### How to enable or disable a document type
+### How the dynamic filter works
 
-**In `NotPostedDocumentsHandler.java`** (the only file you need to edit):
+`refListDocumentTypes()` runs this query at request time and compares each code's backing table:
 
-```java
-// File: modules/com.etendoerp.go/src/com/etendoerp/go/schemaforge/handlers/NotPostedDocumentsHandler.java
-
-static final Set<String> ENABLED_DOCUMENT_TYPE_CODES = new LinkedHashSet<>(Arrays.asList(
-    "A",    // Amortization             → A_Amortization
-    "BMP",  // Bill of Mat. Production  → M_Production
-    // ... add or remove codes here
-));
+```sql
+SELECT DISTINCT ad_table_id FROM c_acctschema_table WHERE isactive = 'Y'
 ```
 
-**Before enabling a new code, verify:**
-1. The code appears in `AD_Ref_List` for reference `DE94535164E741AB9B1A560EF3F72854`
-2. Its backing table exists in `c_acctschema_table` with `isactive = 'Y'`:
-   ```sql
-   SELECT ast.isactive, count(*)
-   FROM c_acctschema_table ast
-   JOIN ad_table t ON ast.ad_table_id = t.ad_table_id
-   WHERE t.tablename = 'YOUR_TABLE_NAME'
-   GROUP BY ast.isactive;
-   ```
-3. Documents of that type have records with `posted` values other than `'D'`:
-   ```sql
-   SELECT posted, count(*) FROM your_table GROUP BY posted;
-   ```
-4. Add the table → `AD_Table_ID` mapping to `DOCUMENT_TYPE_TO_TABLE_ID` if not already present (needed for the post action to resolve the correct table).
+A document type is shown if and only if:
+1. Its code is in `DOCUMENT_TYPE_CODE_TO_TABLE_ID` (the static code → `AD_Table_ID` map in the handler)
+2. That `AD_Table_ID` is returned by the query above
+3. Its code is NOT in `APRM_DISABLED_TYPES`
 
-**To enable `DD` (Doubtful Debt) or `CA` (Cost Adjustment)** when those modules go live: simply add `"DD"` or `"CA"` to the set — no other change needed.
+**Consequence:** any new Etendo module that registers its document table in `c_acctschema_table` with `isactive = 'Y'` will automatically appear in the dropdown — no code change needed.
 
-**To re-enable payments (PIN/POT)** if APRM accounting is ever reconfigured: add `"PIN"` and `"POT"` back. You will also need to verify that `FIN_Payment` records are no longer initialized with `posted = 'D'`.
+### How to enable a new document type
+
+**Case A — new module adds a new table:**
+1. The module inserts a row into `c_acctschema_table` with `isactive = 'Y'` for the new table.
+2. Add the code → `AD_Table_ID` entry to `DOCUMENT_TYPE_CODE_TO_TABLE_ID` in the handler. That's the only code change needed.
+3. If the code is also new in `AD_Ref_List` (reference `DE94535164E741AB9B1A560EF3F72854`), `NoPostedDocumentDS` must handle that document type in its `searchStrategies` too — that's inside the `bulk.posting` JAR and out of scope here.
+
+**Case B — existing excluded code (DD, CA) has its module activated:**
+Add its `AD_Table_ID` entry to `DOCUMENT_TYPE_CODE_TO_TABLE_ID` if missing. Since DD and CA already have `c_acctschema_table` rows with `isactive = 'Y'`, they will appear automatically — no further change needed.
+
+**Case C — APRM type (BS/PIN/POT/R) is re-enabled:**
+Remove its code from `APRM_DISABLED_TYPES`. Also verify that new documents of that type are no longer initialized with `posted = 'D'`.
+
+### How to disable a document type
+
+Remove its code from `DOCUMENT_TYPE_CODE_TO_TABLE_ID`, or add it to `APRM_DISABLED_TYPES` (if it should be permanently suppressed regardless of accounting schema state).
+
+To verify accounting schema state at any time:
+```sql
+SELECT t.tablename, count(*) FILTER (WHERE ast.isactive = 'Y') as active_schemas
+FROM c_acctschema_table ast
+JOIN ad_table t ON ast.ad_table_id = t.ad_table_id
+GROUP BY t.tablename
+ORDER BY t.tablename;
+```
 
 ---
 

--- a/docs/generated-custom-windows/not-posted-documents.md
+++ b/docs/generated-custom-windows/not-posted-documents.md
@@ -111,7 +111,7 @@ The "Estado contable" multi-select shows 4 curated options. The values in the dr
 | Invalid Account | `i` | `A12420CC6D4144768EEC57143859EFD6` | |
 | Period Closed | `p` | `D1EAA8BCC3E649C398D4E544282E5292` | |
 
-When no filter is selected (initial load), the handler defaults to all four options — `["N","E","C","i","p"]` — because passing an empty list to `searchAllDocuments(org, emptyList)` returns zero results (the datasource short-circuits on empty status list).
+When no filter is selected (initial load), the handler defaults to all curated keys — `["N","E","C","i","p"]` (the 4 UI options, with "Error" expanded to its 2 underlying keys) — because passing an empty list to `searchAllDocuments(org, emptyList)` returns zero results (the datasource short-circuits on empty status list).
 
 Full reference for all 18 accounting statuses (excluded from UI):
 ```sql

--- a/docs/plans/ETP-4355-cross-domain.md
+++ b/docs/plans/ETP-4355-cross-domain.md
@@ -1,0 +1,20 @@
+# ETP-4355 Cross-Domain Plan
+
+## Domains changed
+
+| Domain | Files | Reason |
+|--------|-------|--------|
+| `window:not-posted-documents` | `NotPostedDocumentsPage.jsx`, `not-posted-documents.css`, `docs/generated-custom-windows/not-posted-documents.md` | New custom window: Not Posted Documents |
+| `app-shell-core` | `en_US.json`, `es_ES.json` | i18n keys for the new window UI |
+| `generator-change` | `cli/src/push-to-neo.js` | Set `isget='Y'`, `ispost='Y'` on entity update so the NEO endpoint registers both HTTP methods |
+
+## Tests
+
+- Manual: search grid returns only postable document types; APRM payments excluded
+- Manual: bulk-post and single-post show correct success/error toasts
+- Manual: document type dropdown populated dynamically from `c_acctschema_table`
+- i18n: all new keys present in both `en_US.json` and `es_ES.json`
+
+## Rollback
+
+Revert `feature/ETP-4355` in both repos. No DB schema changes — only `ETGO_SF_SPEC`/`ETGO_SF_ENTITY` rows which are managed by `push-to-neo.js` and can be re-applied or removed via the same script.

--- a/packages/app-shell-core/src/locales/en_US.json
+++ b/packages/app-shell-core/src/locales/en_US.json
@@ -21103,6 +21103,9 @@
     "Balance sheet and P&L structure Setup": {
       "label": "Balance sheet and P&L structure Setup"
     },
+    "Not Posted Documents": {
+      "label": "Not Posted Documents"
+    },
     "Not Posted Transaction Report": {
       "label": "Not Posted Transaction Report"
     },

--- a/packages/app-shell-core/src/locales/es_ES.json
+++ b/packages/app-shell-core/src/locales/es_ES.json
@@ -21351,6 +21351,9 @@
     "Sales Order Report": {
       "label": "Pedidos "
     },
+    "Not Posted Documents": {
+      "label": "Documentos no contabilizados"
+    },
     "Not Posted Transaction Report": {
       "label": "Documentos no contabilizados"
     },

--- a/tools/app-shell/src/components/contract-ui/__tests__/CurrencyRatePicker.vitest.jsx
+++ b/tools/app-shell/src/components/contract-ui/__tests__/CurrencyRatePicker.vitest.jsx
@@ -1,0 +1,455 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, act, waitFor, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/auth/AuthContext.jsx', () => ({
+  useAuth: () => ({ token: 'ctx-token' }),
+}));
+
+vi.mock('@/hooks/useNeoResource.js', () => ({
+  getApiBase: () => '',
+}));
+
+import { CurrencyRatePicker } from '../CurrencyRatePicker.jsx';
+
+const FIELD = { key: 'cCurrencyId', column: 'C_Currency_ID', id: 'fld-1', required: false };
+const BASE_URL = 'http://localhost/sws/neo/sales-order';
+const TOKEN = 'test-token';
+
+const CURRENCIES = [
+  { id: 'usd-id', isoCode: 'USD', rate: 1.2345 },
+  { id: 'eur-id', isoCode: 'EUR', rate: 1 },
+];
+
+function mkFetch(currencies = CURRENCIES, sessionPrecision) {
+  return vi.fn((url) => {
+    if (String(url).includes('/sws/neo/session')) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => (sessionPrecision != null ? { currencyStandardPrecision: sessionPrecision } : {}),
+      });
+    }
+    if (String(url).includes('/action/currencyOptions')) {
+      return Promise.resolve({ ok: true, json: async () => currencies });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({}) });
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('CurrencyRatePicker', () => {
+  it('renders a read-only display with iso code and formatted rate', () => {
+    globalThis.fetch = mkFetch();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value="usd-id"
+        displayValue="USD"
+        formData={{ id: 'new', eTGOCurrencyRate: '1.5' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        isReadOnly
+        onChange={() => {}}
+      />,
+    );
+    const container = screen.getByTestId(`field-${FIELD.key}`);
+    expect(within(container).getByText('USD')).toBeInTheDocument();
+    // orgPrecision defaults to 2 (useCurrencyPrecision's initial state) before its fetch resolves.
+    expect(within(container).getByText('— 1.50')).toBeInTheDocument();
+  });
+
+  it('renders the placeholder when no value is selected', () => {
+    globalThis.fetch = mkFetch();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value=""
+        formData={{ id: 'new' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText(/Seleccionar Currency/)).toBeInTheDocument();
+    expect(screen.queryByTestId('currency-rate-pencil')).not.toBeInTheDocument();
+  });
+
+  it('opens the dropdown, fetches options, and lists them', async () => {
+    globalThis.fetch = mkFetch();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value=""
+        formData={{ id: 'new' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('currency-rate-trigger'));
+    await waitFor(() => expect(screen.getByText('USD')).toBeInTheDocument());
+    expect(screen.getByText('EUR')).toBeInTheDocument();
+  });
+
+  it('shows "Sin resultados" when the search filter matches nothing', async () => {
+    globalThis.fetch = mkFetch();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value=""
+        formData={{ id: 'new' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('currency-rate-trigger'));
+    await waitFor(() => expect(screen.getByText('USD')).toBeInTheDocument());
+
+    const searchInput = screen.getByPlaceholderText('Buscar moneda...');
+    fireEvent.change(searchInput, { target: { value: 'zzz' } });
+
+    expect(screen.getByText('Sin resultados')).toBeInTheDocument();
+  });
+
+  it('filters options by iso code as the user types', async () => {
+    globalThis.fetch = mkFetch();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value=""
+        formData={{ id: 'new' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('currency-rate-trigger'));
+    await waitFor(() => expect(screen.getByText('USD')).toBeInTheDocument());
+
+    fireEvent.change(screen.getByPlaceholderText('Buscar moneda...'), { target: { value: 'eur' } });
+
+    expect(screen.queryByText('USD')).not.toBeInTheDocument();
+    expect(screen.getByText('EUR')).toBeInTheDocument();
+  });
+
+  it('selecting an option stages the currency, identifier, and system rate', async () => {
+    globalThis.fetch = mkFetch();
+    const onChange = vi.fn();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value=""
+        formData={{ id: 'new' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('currency-rate-trigger'));
+    await waitFor(() => expect(screen.getByText('USD')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText('USD'));
+
+    expect(onChange).toHaveBeenCalledWith('cCurrencyId', 'usd-id', 'C_Currency_ID');
+    expect(onChange).toHaveBeenCalledWith('cCurrencyId$_identifier', 'USD');
+    expect(onChange).toHaveBeenCalledWith('eTGOCurrencyRate', 1.2345, 'EM_ETGO_Currency_Rate');
+    expect(screen.queryByText('Buscar moneda...')).not.toBeInTheDocument();
+  });
+
+  it('does not stage a rate when the selected option has no rate', async () => {
+    globalThis.fetch = mkFetch([{ id: 'no-rate-id', isoCode: 'XYZ', rate: null }]);
+    const onChange = vi.fn();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value=""
+        formData={{ id: 'new' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('currency-rate-trigger'));
+    await waitFor(() => expect(screen.getByText('XYZ')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('XYZ'));
+
+    expect(onChange).not.toHaveBeenCalledWith('eTGOCurrencyRate', expect.anything(), expect.anything());
+  });
+
+  it('shows the pencil icon once a currency is selected on a saved record', () => {
+    globalThis.fetch = mkFetch();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value="usd-id"
+        displayValue="USD"
+        formData={{ id: 'rec-1', eTGOCurrencyRate: '1.2345' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByTestId('currency-rate-pencil')).toBeInTheDocument();
+  });
+
+  it('clicking the pencil opens rate editing pre-filled with the current rate', () => {
+    globalThis.fetch = mkFetch();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value="usd-id"
+        displayValue="USD"
+        formData={{ id: 'rec-1', eTGOCurrencyRate: '1.2345' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('currency-rate-pencil'));
+    expect(screen.getByTestId('currency-rate-input')).toHaveValue(1.2345);
+  });
+
+  it('confirming a valid rate override calls onChange and exits edit mode', () => {
+    globalThis.fetch = mkFetch();
+    const onChange = vi.fn();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value="usd-id"
+        displayValue="USD"
+        formData={{ id: 'rec-1', eTGOCurrencyRate: '1.2345' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('currency-rate-pencil'));
+    fireEvent.change(screen.getByTestId('currency-rate-input'), { target: { value: '2.5' } });
+    fireEvent.click(screen.getByTestId('currency-rate-confirm'));
+
+    expect(onChange).toHaveBeenCalledWith('eTGOCurrencyRate', 2.5, 'EM_ETGO_Currency_Rate');
+    expect(screen.queryByTestId('currency-rate-input')).not.toBeInTheDocument();
+  });
+
+  it('confirming an invalid (non-numeric) rate does not call onChange', () => {
+    globalThis.fetch = mkFetch();
+    const onChange = vi.fn();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value="usd-id"
+        displayValue="USD"
+        formData={{ id: 'rec-1', eTGOCurrencyRate: '1.2345' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('currency-rate-pencil'));
+    fireEvent.change(screen.getByTestId('currency-rate-input'), { target: { value: 'not-a-number' } });
+    fireEvent.click(screen.getByTestId('currency-rate-confirm'));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('currency-rate-input')).not.toBeInTheDocument();
+  });
+
+  it('confirming a zero or negative rate does not call onChange', () => {
+    globalThis.fetch = mkFetch();
+    const onChange = vi.fn();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value="usd-id"
+        displayValue="USD"
+        formData={{ id: 'rec-1', eTGOCurrencyRate: '1.2345' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('currency-rate-pencil'));
+    fireEvent.change(screen.getByTestId('currency-rate-input'), { target: { value: '-1' } });
+    fireEvent.click(screen.getByTestId('currency-rate-confirm'));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('cancelling rate edit discards the input without calling onChange', () => {
+    globalThis.fetch = mkFetch();
+    const onChange = vi.fn();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value="usd-id"
+        displayValue="USD"
+        formData={{ id: 'rec-1', eTGOCurrencyRate: '1.2345' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('currency-rate-pencil'));
+    fireEvent.change(screen.getByTestId('currency-rate-input'), { target: { value: '9.9' } });
+    fireEvent.click(screen.getByTestId('currency-rate-cancel'));
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('currency-rate-input')).not.toBeInTheDocument();
+  });
+
+  it('pressing Enter in the rate input confirms the override', () => {
+    globalThis.fetch = mkFetch();
+    const onChange = vi.fn();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value="usd-id"
+        displayValue="USD"
+        formData={{ id: 'rec-1', eTGOCurrencyRate: '1.2345' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('currency-rate-pencil'));
+    fireEvent.change(screen.getByTestId('currency-rate-input'), { target: { value: '3.3' } });
+    fireEvent.keyDown(screen.getByTestId('currency-rate-input'), { key: 'Enter' });
+
+    expect(onChange).toHaveBeenCalledWith('eTGOCurrencyRate', 3.3, 'EM_ETGO_Currency_Rate');
+  });
+
+  it('pressing Escape in the rate input cancels the override', () => {
+    globalThis.fetch = mkFetch();
+    const onChange = vi.fn();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value="usd-id"
+        displayValue="USD"
+        formData={{ id: 'rec-1', eTGOCurrencyRate: '1.2345' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('currency-rate-pencil'));
+    fireEvent.keyDown(screen.getByTestId('currency-rate-input'), { key: 'Escape' });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('currency-rate-input')).not.toBeInTheDocument();
+  });
+
+  it('closes the dropdown when clicking outside of it', async () => {
+    globalThis.fetch = mkFetch();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value=""
+        formData={{ id: 'new' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('currency-rate-trigger'));
+    await waitFor(() => expect(screen.getByText('USD')).toBeInTheDocument());
+
+    fireEvent.mouseDown(document.body);
+
+    expect(screen.queryByText('Buscar moneda...')).not.toBeInTheDocument();
+  });
+
+  it('pressing Escape in the search box closes the dropdown', async () => {
+    globalThis.fetch = mkFetch();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value=""
+        formData={{ id: 'new' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('currency-rate-trigger'));
+    await waitFor(() => expect(screen.getByText('USD')).toBeInTheDocument());
+
+    fireEvent.keyDown(screen.getByPlaceholderText('Buscar moneda...'), { key: 'Escape' });
+
+    expect(screen.queryByText('Buscar moneda...')).not.toBeInTheDocument();
+  });
+
+  it('does not fetch options when the component token prop is missing', () => {
+    globalThis.fetch = mkFetch();
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value=""
+        formData={{ id: 'new' }}
+        resolvedLabel="Currency"
+        token=""
+        apiBaseUrl={BASE_URL}
+        onChange={() => {}}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('currency-rate-trigger'));
+    // useCurrencyPrecision reads its own token from the (mocked) AuthContext, so a
+    // /sws/neo/session call still fires — only the component's own currencyOptions
+    // fetch must be gated on the token PROP.
+    const calledUrls = globalThis.fetch.mock.calls.map((c) => String(c[0]));
+    expect(calledUrls.some((u) => u.includes('currencyOptions'))).toBe(false);
+  });
+
+  it('shows a required marker when the field is required', () => {
+    globalThis.fetch = mkFetch();
+    render(
+      <CurrencyRatePicker
+        field={{ ...FIELD, required: true }}
+        value=""
+        formData={{ id: 'new' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText('*')).toBeInTheDocument();
+  });
+
+  it('applies the fetched org precision when formatting the trigger rate', async () => {
+    globalThis.fetch = mkFetch(CURRENCIES, 2);
+    render(
+      <CurrencyRatePicker
+        field={FIELD}
+        value="usd-id"
+        displayValue="USD"
+        formData={{ id: 'rec-1', eTGOCurrencyRate: '1.2345' }}
+        resolvedLabel="Currency"
+        token={TOKEN}
+        apiBaseUrl={BASE_URL}
+        onChange={() => {}}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('— 1.23')).toBeInTheDocument());
+  });
+});

--- a/tools/app-shell/src/windows/custom/chart-of-accounts/__tests__/AccountTreeView.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/chart-of-accounts/__tests__/AccountTreeView.vitest.jsx
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@/i18n', () => ({ useUI: () => (key) => key }));
+
+// Stub NewAccountModal — AccountTreeView.jsx's own tree logic is what this
+// suite targets; NewAccountModal has its own dedicated test file.
+vi.mock('../NewAccountModal', () => ({
+  default: ({ isOpen, onClose, onSaved, currentRecord }) =>
+    isOpen ? (
+      <div data-testid="new-account-modal-stub">
+        <span data-testid="modal-current-record-id">{currentRecord?.id ?? 'none'}</span>
+        <button type="button" data-testid="modal-close" onClick={onClose}>close</button>
+        <button type="button" data-testid="modal-save" onClick={onSaved}>save</button>
+      </div>
+    ) : null,
+}));
+
+import AccountTreeView from '../AccountTreeView.jsx';
+
+const DATA = [
+  { id: 'acc-40000001', searchKey: '40000002', name: 'Sales EU', ytdDebit: 100, ytdCredit: 50, ytdBalance: 50, parentCode4: '4000', parentCode4Name: 'Sales', hasChildren: false, summaryLevel: 'N' },
+  { id: 'acc-40000000', searchKey: '40000001', name: 'Sales US', ytdDebit: 10, ytdCredit: 5, ytdBalance: -5, parentCode4: '4000', parentCode4Name: 'Sales', hasChildren: false, summaryLevel: 'N' },
+  { id: 'acc-50000001', searchKey: '50000001', name: 'Purchases US', ytdDebit: 0, ytdCredit: 0, ytdBalance: null, parentCode4: '5000', parentCode4Name: 'Purchases', hasChildren: false, summaryLevel: 'N' },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('AccountTreeView', () => {
+  it('shows the empty state when there are no accounts', () => {
+    render(<AccountTreeView data={[]} />);
+    expect(screen.getByText('accountTreeNoAccounts')).toBeInTheDocument();
+  });
+
+  it('groups accounts by parentCode4 and auto-expands the group headers', () => {
+    render(<AccountTreeView data={DATA} />);
+    // Group headers are visible…
+    expect(screen.getByTestId('account-tree-row-group-4000')).toBeInTheDocument();
+    expect(screen.getByTestId('account-tree-row-group-5000')).toBeInTheDocument();
+    // …and their children too, since groups auto-expand on load.
+    expect(screen.getByTestId('account-tree-row-acc-40000001')).toBeInTheDocument();
+    expect(screen.getByTestId('account-tree-row-acc-40000000')).toBeInTheDocument();
+  });
+
+  it('sorts children within a group by searchKey', () => {
+    render(<AccountTreeView data={DATA} />);
+    const rows = screen.getAllByRole('row').map((r) => r.getAttribute('data-testid'));
+    const idxUS = rows.indexOf('account-tree-row-acc-40000000'); // 40000001
+    const idxEU = rows.indexOf('account-tree-row-acc-40000001'); // 40000002
+    expect(idxUS).toBeLessThan(idxEU);
+  });
+
+  it('collapsing a group hides its children without affecting other groups', () => {
+    render(<AccountTreeView data={DATA} />);
+    fireEvent.click(screen.getByTestId('account-tree-toggle-group-4000'));
+
+    expect(screen.queryByTestId('account-tree-row-acc-40000000')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('account-tree-row-acc-40000001')).not.toBeInTheDocument();
+    expect(screen.getByTestId('account-tree-row-acc-50000001')).toBeInTheDocument();
+  });
+
+  it('toggling a group chevron does not select the row or call onNavigate', () => {
+    const onNavigate = vi.fn();
+    render(<AccountTreeView data={DATA} onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByTestId('account-tree-toggle-group-4000'));
+
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(screen.getByTestId('account-tree-row-group-4000')).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('clicking a leaf row selects it and calls onNavigate with the item', () => {
+    const onNavigate = vi.fn();
+    render(<AccountTreeView data={DATA} onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByTestId('account-tree-row-acc-40000000'));
+
+    expect(onNavigate).toHaveBeenCalledWith(expect.objectContaining({ id: 'acc-40000000' }));
+    expect(screen.getByTestId('account-tree-row-acc-40000000')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('clicking a virtual group row selects it but does not call onNavigate', () => {
+    const onNavigate = vi.fn();
+    render(<AccountTreeView data={DATA} onNavigate={onNavigate} />);
+    fireEvent.click(screen.getByTestId('account-tree-row-group-4000'));
+
+    expect(onNavigate).not.toHaveBeenCalled();
+    expect(screen.getByTestId('account-tree-row-group-4000')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('"Contraer" (collapse all) hides every group\'s children', () => {
+    render(<AccountTreeView data={DATA} />);
+    fireEvent.click(screen.getByText('collapse'));
+
+    expect(screen.queryByTestId('account-tree-row-acc-40000000')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('account-tree-row-acc-50000001')).not.toBeInTheDocument();
+    expect(screen.getByTestId('account-tree-row-group-4000')).toBeInTheDocument();
+  });
+
+  it('"Expandir" (expand all) re-reveals every group\'s children', () => {
+    render(<AccountTreeView data={DATA} />);
+    fireEvent.click(screen.getByText('collapse'));
+    fireEvent.click(screen.getByText('expand'));
+
+    expect(screen.getByTestId('account-tree-row-acc-40000000')).toBeInTheDocument();
+    expect(screen.getByTestId('account-tree-row-acc-50000001')).toBeInTheDocument();
+  });
+
+  it('formats null balances as an em dash and negative balances distinctly', () => {
+    render(<AccountTreeView data={DATA} />);
+    const negativeRow = screen.getByTestId('account-tree-row-acc-40000000');
+    expect(negativeRow.textContent).toContain('-5,00');
+
+    const nullBalanceRow = screen.getByTestId('account-tree-row-acc-50000001');
+    expect(nullBalanceRow.textContent).toContain('—');
+  });
+
+  it('calls onColumnsReady with the tree column definitions', () => {
+    const onColumnsReady = vi.fn();
+    render(<AccountTreeView data={DATA} onColumnsReady={onColumnsReady} />);
+    expect(onColumnsReady).toHaveBeenCalled();
+    const cols = onColumnsReady.mock.calls.at(-1)[0];
+    expect(cols.map((c) => c.key)).toEqual(['searchKey', 'name', 'accountType', 'active', 'ytdDebit', 'ytdCredit', 'ytdBalance']);
+  });
+
+  it('opens the New Sub-account modal with no current record when nothing is selected', () => {
+    render(<AccountTreeView data={DATA} />);
+    fireEvent.click(screen.getByText('+ newSubAccount'));
+
+    expect(screen.getByTestId('new-account-modal-stub')).toBeInTheDocument();
+    expect(screen.getByTestId('modal-current-record-id')).toHaveTextContent('none');
+  });
+
+  it('opens the modal with the selected row as the current record', () => {
+    render(<AccountTreeView data={DATA} />);
+    fireEvent.click(screen.getByTestId('account-tree-row-acc-40000000'));
+    fireEvent.click(screen.getByText('+ newSubAccount'));
+
+    expect(screen.getByTestId('modal-current-record-id')).toHaveTextContent('acc-40000000');
+  });
+
+  it('closes the modal via onClose without side effects', () => {
+    render(<AccountTreeView data={DATA} />);
+    fireEvent.click(screen.getByText('+ newSubAccount'));
+    fireEvent.click(screen.getByTestId('modal-close'));
+
+    expect(screen.queryByTestId('new-account-modal-stub')).not.toBeInTheDocument();
+  });
+
+  it('closes the modal and calls onDataMutated when a new account is saved', () => {
+    const onDataMutated = vi.fn();
+    render(<AccountTreeView data={DATA} onDataMutated={onDataMutated} />);
+    fireEvent.click(screen.getByText('+ newSubAccount'));
+    fireEvent.click(screen.getByTestId('modal-save'));
+
+    expect(screen.queryByTestId('new-account-modal-stub')).not.toBeInTheDocument();
+    expect(onDataMutated).toHaveBeenCalled();
+  });
+});

--- a/tools/app-shell/src/windows/custom/chart-of-accounts/__tests__/NewAccountModal.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/chart-of-accounts/__tests__/NewAccountModal.vitest.jsx
@@ -1,0 +1,248 @@
+// @vitest-environment jsdom
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { toast } from 'sonner';
+
+vi.mock('@/i18n', () => ({ useUI: () => (key) => key }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+// Render the dialog inline (no portal / pointer-events friction) — same pattern
+// used by AddPaymentModal.vitest.jsx.
+vi.mock('@/components/ui/dialog.jsx', () => ({
+  Dialog: ({ open, children, onOpenChange }) =>
+    open ? (
+      <div data-testid="dialog">
+        <button type="button" data-testid="dialog-overlay-close" onClick={() => onOpenChange(false)} />
+        {children}
+      </div>
+    ) : null,
+  DialogContent: ({ children, ...rest }) => <div {...rest}>{children}</div>,
+  DialogHeader: ({ children, ...rest }) => <div {...rest}>{children}</div>,
+  DialogTitle: ({ children, ...rest }) => <div {...rest}>{children}</div>,
+  DialogFooter: ({ children, ...rest }) => <div {...rest}>{children}</div>,
+}));
+
+// Stub the generated AccountCodeField — expose a single input so tests can
+// drive onChange(fullCode) directly without depending on its own split-field logic.
+vi.mock('@generated/chart-of-accounts/custom/AccountCodeField', () => ({
+  default: ({ value, onChange }) => (
+    <input
+      data-testid="account-code-stub"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+
+import NewAccountModal from '../NewAccountModal.jsx';
+
+const BASE_URL = 'http://localhost/sws/neo/chart-of-accounts';
+const TOKEN = 'test-token';
+
+// '4000' is an explicit summary row (no leaf references it, so no virtual
+// duplicate); '5000' only exists as a virtual group derived from a leaf row's
+// parentCode4 — covering both parent-option sources without overlap.
+const ACCOUNTS = [
+  { id: 'acc-4000', searchKey: '4000', name: 'Sales', summaryLevel: 'Y' },
+  { id: 'acc-50000001', searchKey: '50000001', name: 'Purchases US', summaryLevel: 'N', parentCode4: '5000', parentCode4Name: 'Purchases' },
+];
+
+function baseProps(overrides = {}) {
+  return {
+    isOpen: true,
+    onClose: vi.fn(),
+    onSaved: vi.fn(),
+    currentRecord: null,
+    allAccounts: ACCOUNTS,
+    apiBaseUrl: BASE_URL,
+    token: TOKEN,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('NewAccountModal', () => {
+  it('does not render when closed', () => {
+    render(<NewAccountModal {...baseProps({ isOpen: false })} />);
+    expect(screen.queryByTestId('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders the title and parent options sorted by code when open', () => {
+    render(<NewAccountModal {...baseProps()} />);
+    expect(screen.getByText('newSubAccount')).toBeInTheDocument();
+    const select = screen.getByTestId('new-account-modal-parent');
+    const optionTexts = Array.from(select.querySelectorAll('option')).map((o) => o.textContent);
+    expect(optionTexts).toEqual([
+      'selectParentAccount',
+      '4000 — Sales',
+      '5000 — Purchases',
+    ]);
+  });
+
+  it('auto-selects the current record as parent when it is itself a 4-digit summary account', () => {
+    render(<NewAccountModal {...baseProps({ currentRecord: { id: 'acc-4000', searchKey: '4000', summaryLevel: 'Y' } })} />);
+    expect(screen.getByTestId('new-account-modal-parent')).toHaveValue('acc-4000');
+    expect(screen.getByTestId('account-code-stub')).toHaveValue('4000');
+  });
+
+  it('auto-selects the matching 4-digit parent from the leaf account prefix', () => {
+    render(<NewAccountModal {...baseProps({ currentRecord: { id: 'acc-50000001', searchKey: '50000001', summaryLevel: 'N' } })} />);
+    expect(screen.getByTestId('new-account-modal-parent')).toHaveValue('group-5000');
+  });
+
+  it('falls back to no parent selection when nothing matches', () => {
+    render(<NewAccountModal {...baseProps({ currentRecord: { id: 'x', searchKey: '9999', summaryLevel: 'N' } })} />);
+    expect(screen.getByTestId('new-account-modal-parent')).toHaveValue('');
+  });
+
+  it('falls back to no parent selection when currentRecord is null', () => {
+    render(<NewAccountModal {...baseProps({ currentRecord: null })} />);
+    expect(screen.getByTestId('new-account-modal-parent')).toHaveValue('');
+  });
+
+  it('builds virtual parent groups from allAccounts when no explicit 4-digit summary row exists', () => {
+    const flatOnly = [
+      { id: 'acc-1', searchKey: '60000001', name: 'Leaf', summaryLevel: 'N', parentCode4: '6000', parentCode4Name: 'Expenses' },
+    ];
+    render(<NewAccountModal {...baseProps({ allAccounts: flatOnly, currentRecord: null })} />);
+    const select = screen.getByTestId('new-account-modal-parent');
+    const optionTexts = Array.from(select.querySelectorAll('option')).map((o) => o.textContent);
+    expect(optionTexts).toContain('6000 — Expenses');
+  });
+
+  it('fetches accounts from the API when allAccounts is empty', async () => {
+    globalThis.fetch = vi.fn(() =>
+      Promise.resolve({ ok: true, json: async () => ({ response: { data: ACCOUNTS } }) }),
+    );
+    render(<NewAccountModal {...baseProps({ allAccounts: [] })} />);
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalledWith(
+      `${BASE_URL}/elementValue?_startRow=0&_endRow=9999`,
+      expect.objectContaining({ headers: { Authorization: `Bearer ${TOKEN}` } }),
+    ));
+    await waitFor(() => {
+      const select = screen.getByTestId('new-account-modal-parent');
+      expect(select.querySelectorAll('option').length).toBeGreaterThan(1);
+    });
+  });
+
+  it('does not fetch accounts when allAccounts already has rows', () => {
+    globalThis.fetch = vi.fn();
+    render(<NewAccountModal {...baseProps()} />);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('falls back to an empty list when the account fetch fails', async () => {
+    globalThis.fetch = vi.fn(() => Promise.resolve({ ok: false }));
+    render(<NewAccountModal {...baseProps({ allAccounts: [] })} />);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    const select = screen.getByTestId('new-account-modal-parent');
+    expect(select.querySelectorAll('option').length).toBe(1); // only the placeholder
+  });
+
+  it('falls back to an empty list when the account fetch throws', async () => {
+    globalThis.fetch = vi.fn(() => Promise.reject(new Error('network down')));
+    render(<NewAccountModal {...baseProps({ allAccounts: [] })} />);
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    const select = screen.getByTestId('new-account-modal-parent');
+    expect(select.querySelectorAll('option').length).toBe(1);
+  });
+
+  it('shows validation errors and does not submit when required fields are missing', () => {
+    globalThis.fetch = vi.fn();
+    render(<NewAccountModal {...baseProps()} />);
+    fireEvent.click(screen.getByTestId('new-account-modal-save'));
+
+    expect(screen.getAllByRole('alert')).toHaveLength(3); // parent, name, code
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it('clears the name error as soon as the user types', () => {
+    render(<NewAccountModal {...baseProps()} />);
+    fireEvent.click(screen.getByTestId('new-account-modal-save'));
+    expect(screen.getAllByRole('alert')).toHaveLength(3);
+
+    fireEvent.change(screen.getByTestId('new-account-modal-name'), { target: { value: 'New sub account' } });
+    expect(screen.getAllByRole('alert')).toHaveLength(2);
+  });
+
+  it('submits the correct POST body and calls onSaved on success', async () => {
+    globalThis.fetch = vi.fn(() => Promise.resolve({ ok: true, json: async () => ({}) }));
+    const onSaved = vi.fn();
+    render(<NewAccountModal {...baseProps({ onSaved, currentRecord: { id: 'acc-4000', searchKey: '4000', summaryLevel: 'Y' } })} />);
+
+    fireEvent.change(screen.getByTestId('new-account-modal-name'), { target: { value: '  US Sales  ' } });
+    fireEvent.change(screen.getByTestId('account-code-stub'), { target: { value: '40001234' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('new-account-modal-save'));
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(`${BASE_URL}/elementValue`, expect.objectContaining({
+      method: 'POST',
+      headers: { Authorization: `Bearer ${TOKEN}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ searchKey: '40001234', name: 'US Sales', accountType: 'E' }),
+    }));
+    expect(toast.success).toHaveBeenCalledWith('newSubAccountSuccess');
+    expect(onSaved).toHaveBeenCalled();
+  });
+
+  it('shows an error toast and does not call onSaved when the server rejects the request', async () => {
+    globalThis.fetch = vi.fn(() => Promise.resolve({ ok: false, status: 400, text: async () => 'Duplicate code' }));
+    const onSaved = vi.fn();
+    render(<NewAccountModal {...baseProps({ onSaved, currentRecord: { id: 'acc-4000', searchKey: '4000', summaryLevel: 'Y' } })} />);
+
+    fireEvent.change(screen.getByTestId('new-account-modal-name'), { target: { value: 'US Sales' } });
+    fireEvent.change(screen.getByTestId('account-code-stub'), { target: { value: '40001234' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('new-account-modal-save'));
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('newSubAccountError');
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it('shows an error toast when the save request throws a network error', async () => {
+    globalThis.fetch = vi.fn(() => Promise.reject(new Error('offline')));
+    render(<NewAccountModal {...baseProps({ currentRecord: { id: 'acc-4000', searchKey: '4000', summaryLevel: 'Y' } })} />);
+
+    fireEvent.change(screen.getByTestId('new-account-modal-name'), { target: { value: 'US Sales' } });
+    fireEvent.change(screen.getByTestId('account-code-stub'), { target: { value: '40001234' } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('new-account-modal-save'));
+    });
+
+    expect(toast.error).toHaveBeenCalledWith('newSubAccountError');
+  });
+
+  it('switching the parent selector updates the code prefix and clears its error', () => {
+    render(<NewAccountModal {...baseProps({ currentRecord: null })} />);
+    fireEvent.click(screen.getByTestId('new-account-modal-save'));
+    expect(screen.getAllByRole('alert')).toHaveLength(3); // no parent selected yet
+
+    fireEvent.change(screen.getByTestId('new-account-modal-parent'), { target: { value: 'group-5000' } });
+
+    expect(screen.getByTestId('new-account-modal-parent')).toHaveValue('group-5000');
+    expect(screen.getByTestId('account-code-stub')).toHaveValue('5000');
+    expect(screen.getAllByRole('alert')).toHaveLength(2); // parent error cleared
+  });
+
+  it('calls onClose when the cancel button is clicked', () => {
+    const onClose = vi.fn();
+    render(<NewAccountModal {...baseProps({ onClose })} />);
+    fireEvent.click(screen.getByTestId('new-account-modal-cancel'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls onClose when the dialog reports a close via onOpenChange', () => {
+    const onClose = vi.fn();
+    render(<NewAccountModal {...baseProps({ onClose })} />);
+    fireEvent.click(screen.getByTestId('dialog-overlay-close'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/tools/app-shell/src/windows/custom/not-posted-documents/NotPostedDocumentsPage.jsx
+++ b/tools/app-shell/src/windows/custom/not-posted-documents/NotPostedDocumentsPage.jsx
@@ -14,6 +14,44 @@ function formatDate(raw) {
   return s.slice(0, 10);
 }
 
+function MultiSelect({ options, selected, onToggle }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef(null);
+
+  useEffect(() => {
+    function handler(e) {
+      if (ref.current && !ref.current.contains(e.target)) setOpen(false);
+    }
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, []);
+
+  const selectedLabels = options.filter(o => selected.has(o.value)).map(o => o.label);
+
+  return (
+    <div className="npd-multiselect" ref={ref}>
+      <button type="button" className="npd-multiselect-trigger" onClick={() => setOpen(v => !v)}>
+        <span className={selected.size === 0 ? 'npd-placeholder' : ''}>
+          {selected.size === 0 ? '—' : selectedLabels.join(', ')}
+        </span>
+        <svg className={`npd-chevron${open ? ' open' : ''}`} width="10" height="10" viewBox="0 0 10 10" fill="none">
+          <path d="M1.5 3.5l3.5 3 3.5-3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      </button>
+      {open && (
+        <div className="npd-multiselect-dropdown">
+          {options.map(o => (
+            <label key={o.value} className="npd-multiselect-option">
+              <input type="checkbox" checked={selected.has(o.value)} onChange={() => onToggle(o.value)} />
+              <span>{o.label}</span>
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
   const ui = useUI();
   // apiBaseUrl already points to the spec (e.g. .../swebsf/not-posted-documents)
@@ -30,11 +68,10 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
     })
       .then(r => r.ok ? r.json() : null)
       .then(j => {
-        if (j?.response?.data?.[0]) {
-          const d = j.response.data[0];
+        if (j) {
           setFilterOptions({
-            documentTypes: d.documentTypes ?? [],
-            accountingStatuses: d.accountingStatuses ?? [],
+            documentTypes: j.documentTypes ?? [],
+            accountingStatuses: j.accountingStatuses ?? [],
           });
         }
       })
@@ -44,7 +81,15 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
 
   // ── Filter state ─────────────────────────────────────────────────────────────
   const [document, setDocument] = useState('');
-  const [accountingStatus, setAccountingStatus] = useState('');
+  const [accountingStatuses, setAccountingStatuses] = useState(new Set());
+
+  function toggleAccountingStatus(value) {
+    setAccountingStatuses(prev => {
+      const next = new Set(prev);
+      if (next.has(value)) next.delete(value); else next.add(value);
+      return next;
+    });
+  }
   const [dateFrom, setDateFrom] = useState('');
   const [dateTo, setDateTo] = useState('');
 
@@ -64,7 +109,8 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
     try {
       const params = new URLSearchParams();
       if (filters.document) params.set('document', filters.document);
-      if (filters.accountingStatus) params.set('accountingStatus', filters.accountingStatus);
+      if (filters.accountingStatuses?.size > 0)
+        params.set('accountingStatus', [...filters.accountingStatuses].join(','));
       if (filters.dateFrom) params.set('dateFrom', filters.dateFrom);
       if (filters.dateTo) params.set('dateTo', filters.dateTo);
 
@@ -77,10 +123,7 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
         if (fetchAbortRef.current === ctrl) setLoadError(json?.message || res.statusText);
         return;
       }
-      // Handler returns { response: { data: [{ rows: [...], total: N }] } } OR
-      // { response: { data: rows[] } } depending on NEO wrapper. Handle both.
-      const data = json?.response?.data;
-      const rowsData = Array.isArray(data) ? (data[0]?.rows ?? data) : [];
+      const rowsData = json?.rows ?? [];
       if (fetchAbortRef.current === ctrl) setRows(rowsData);
     } catch (e) {
       if (e.name !== 'AbortError' && fetchAbortRef.current === ctrl) setLoadError(e.message);
@@ -91,11 +134,11 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
 
   // ── Initial load ──────────────────────────────────────────────────────────────
   useEffect(() => {
-    fetchRows({ document: '', accountingStatus: '', dateFrom: '', dateTo: '' });
+    fetchRows({ document: '', accountingStatuses: new Set(), dateFrom: '', dateTo: '' });
   }, [fetchRows]);
 
   function handleApply() {
-    fetchRows({ document, accountingStatus, dateFrom, dateTo });
+    fetchRows({ document, accountingStatuses, dateFrom, dateTo });
     setSelected(new Set());
   }
 
@@ -138,7 +181,7 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
       const json = await res.json().catch(() => null);
       if (res.ok && json?.response?.data?.[0]?.success !== false) {
         toast.success(`${row.description ?? row.documentId} — ${ui('documentPosted')}`);
-        fetchRows({ document, accountingStatus, dateFrom, dateTo });
+        fetchRows({ document, accountingStatuses, dateFrom, dateTo });
         setSelected(p => { const n = new Set(p); n.delete(row.documentId); return n; });
       } else {
         toast.error(json?.response?.data?.[0]?.message || json?.message || ui('postingFailed'));
@@ -180,7 +223,7 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
       } else {
         toast.error(ui('postingFailed'));
       }
-      fetchRows({ document, accountingStatus, dateFrom, dateTo });
+      fetchRows({ document, accountingStatuses, dateFrom, dateTo });
       setSelected(new Set());
     } catch {
       toast.error(ui('postingFailed'));
@@ -284,12 +327,11 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
 
         <div className="npd-filter-field">
           <label>{ui('filterAccountingStatus')}</label>
-          <select value={accountingStatus} onChange={e => setAccountingStatus(e.target.value)}>
-            <option value="">—</option>
-            {filterOptions.accountingStatuses.map(o => (
-              <option key={o.value} value={o.value}>{o.label}</option>
-            ))}
-          </select>
+          <MultiSelect
+            options={filterOptions.accountingStatuses}
+            selected={accountingStatuses}
+            onToggle={toggleAccountingStatus}
+          />
         </div>
 
         <div className="npd-filter-field">

--- a/tools/app-shell/src/windows/custom/not-posted-documents/NotPostedDocumentsPage.jsx
+++ b/tools/app-shell/src/windows/custom/not-posted-documents/NotPostedDocumentsPage.jsx
@@ -179,12 +179,12 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
         }
       );
       const json = await res.json().catch(() => null);
-      if (res.ok && json?.response?.data?.[0]?.success !== false) {
+      if (res.ok && json?.success !== false) {
         toast.success(`${row.description ?? row.documentId} — ${ui('documentPosted')}`);
         fetchRows({ document, accountingStatuses, dateFrom, dateTo });
         setSelected(p => { const n = new Set(p); n.delete(row.documentId); return n; });
       } else {
-        toast.error(json?.response?.data?.[0]?.message || json?.message || ui('postingFailed'));
+        toast.error(json?.message || ui('postingFailed'));
       }
     } catch (e) {
       toast.error(ui('postingFailed'));
@@ -213,9 +213,8 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
         }
       );
       const json = await res.json().catch(() => null);
-      const d = json?.response?.data?.[0];
-      const ok = d?.ok ?? 0;
-      const total = d?.total ?? rowsToPost.length;
+      const ok = json?.ok ?? 0;
+      const total = json?.total ?? rowsToPost.length;
       if (ok === total) {
         toast.success(ui('postingComplete'));
       } else if (ok > 0) {

--- a/tools/app-shell/src/windows/custom/not-posted-documents/NotPostedDocumentsPage.jsx
+++ b/tools/app-shell/src/windows/custom/not-posted-documents/NotPostedDocumentsPage.jsx
@@ -179,12 +179,12 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
         }
       );
       const json = await res.json().catch(() => null);
-      if (res.ok && json?.success !== false) {
+      if (res.ok && json?.success === true) {
         toast.success(`${row.description ?? row.documentId} — ${ui('documentPosted')}`);
         fetchRows({ document, accountingStatuses, dateFrom, dateTo });
         setSelected(p => { const n = new Set(p); n.delete(row.documentId); return n; });
       } else {
-        toast.error(json?.message || ui('postingFailed'));
+        toast.error(json?.message || res.statusText || ui('postingFailed'));
       }
     } catch (e) {
       toast.error(ui('postingFailed'));

--- a/tools/app-shell/src/windows/custom/not-posted-documents/NotPostedDocumentsPage.jsx
+++ b/tools/app-shell/src/windows/custom/not-posted-documents/NotPostedDocumentsPage.jsx
@@ -14,7 +14,7 @@ function formatDate(raw) {
   return s.slice(0, 10);
 }
 
-function MultiSelect({ options, selected, onToggle }) {
+function MultiSelect({ options, selected, onToggle, 'data-testid': dataTestId }) {
   const [open, setOpen] = useState(false);
   const ref = useRef(null);
 
@@ -29,7 +29,7 @@ function MultiSelect({ options, selected, onToggle }) {
   const selectedLabels = options.filter(o => selected.has(o.value)).map(o => o.label);
 
   return (
-    <div className="npd-multiselect" ref={ref}>
+    <div className="npd-multiselect" ref={ref} data-testid={dataTestId}>
       <button type="button" className="npd-multiselect-trigger" onClick={() => setOpen(v => !v)}>
         <span className={selected.size === 0 ? 'npd-placeholder' : ''}>
           {selected.size === 0 ? '—' : selectedLabels.join(', ')}
@@ -330,7 +330,7 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
             options={filterOptions.accountingStatuses}
             selected={accountingStatuses}
             onToggle={toggleAccountingStatus}
-            data-testid="MultiSelect__b28bb1" />
+            data-testid="npd-filter-accounting-status" />
         </div>
 
         <div className="npd-filter-field">

--- a/tools/app-shell/src/windows/custom/not-posted-documents/NotPostedDocumentsPage.jsx
+++ b/tools/app-shell/src/windows/custom/not-posted-documents/NotPostedDocumentsPage.jsx
@@ -330,7 +330,7 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
             options={filterOptions.accountingStatuses}
             selected={accountingStatuses}
             onToggle={toggleAccountingStatus}
-          />
+            data-testid="MultiSelect__b28bb1" />
         </div>
 
         <div className="npd-filter-field">
@@ -347,7 +347,6 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
           {loading ? '…' : ui('search') || 'Search'}
         </button>
       </div>
-
       {/* ── Toolbar ──────────────────────────────────────────────────────────── */}
       <div className="npd-toolbar">
         <div className="npd-toolbar-left">
@@ -366,7 +365,6 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
           {rows.length} {ui('records') || 'records'}
         </span>
       </div>
-
       {/* ── Table ────────────────────────────────────────────────────────────── */}
       {renderTableContent()}
     </div>

--- a/tools/app-shell/src/windows/custom/not-posted-documents/__tests__/NotPostedDocumentsPage.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/not-posted-documents/__tests__/NotPostedDocumentsPage.vitest.jsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act, within } from '@testing-library/react';
 import { toast } from 'sonner';
 
 import NotPostedDocumentsPage from '../NotPostedDocumentsPage.jsx';
@@ -58,6 +58,35 @@ describe('NotPostedDocumentsPage', () => {
     render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
     await waitFor(() => expect(screen.getByTestId('npd-filter-document-type')).toBeInTheDocument());
     expect(screen.getByTestId('npd-filter-apply')).toBeInTheDocument();
+  });
+
+  // Regression: MultiSelect used to drop unknown props, so data-testid never
+  // reached the DOM and the accounting-status filter was unqueryable in tests
+  // (and by any consumer relying on it).
+  it('renders the accounting status MultiSelect with its data-testid and supports toggling an option', async () => {
+    globalThis.fetch = vi.fn((url) => {
+      if (url.includes('_mode=filter-options')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            documentTypes: [],
+            accountingStatuses: [{ value: 'N', label: 'Unposted' }],
+          }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ rows: [], total: 0 }) });
+    });
+
+    render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
+
+    const multiSelect = await waitFor(() => screen.getByTestId('npd-filter-accounting-status'));
+    expect(multiSelect).toBeInTheDocument();
+
+    const trigger = within(multiSelect).getByRole('button');
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByText('Unposted'));
+
+    expect(trigger).toHaveTextContent('Unposted');
   });
 
   it('shows empty state when no rows returned', async () => {

--- a/tools/app-shell/src/windows/custom/not-posted-documents/__tests__/NotPostedDocumentsPage.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/not-posted-documents/__tests__/NotPostedDocumentsPage.vitest.jsx
@@ -84,9 +84,60 @@ describe('NotPostedDocumentsPage', () => {
 
     const trigger = within(multiSelect).getByRole('button');
     fireEvent.click(trigger);
-    fireEvent.click(screen.getByText('Unposted'));
+    const optionCheckbox = within(multiSelect).getByRole('checkbox');
+    fireEvent.click(optionCheckbox);
 
     expect(trigger).toHaveTextContent('Unposted');
+
+    // Toggling the same option again must deselect it (Set delete branch)
+    fireEvent.click(optionCheckbox);
+    expect(trigger).toHaveTextContent('—');
+  });
+
+  it('closes the accounting status dropdown when clicking outside of it', async () => {
+    globalThis.fetch = vi.fn((url) => {
+      if (url.includes('_mode=filter-options')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            documentTypes: [],
+            accountingStatuses: [{ value: 'N', label: 'Unposted' }],
+          }),
+        });
+      }
+      return Promise.resolve({ ok: true, json: async () => ({ rows: [], total: 0 }) });
+    });
+
+    render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
+
+    const multiSelect = await waitFor(() => screen.getByTestId('npd-filter-accounting-status'));
+    fireEvent.click(within(multiSelect).getByRole('button'));
+    expect(within(multiSelect).getByRole('checkbox')).toBeInTheDocument();
+
+    fireEvent.mouseDown(document.body);
+
+    expect(within(multiSelect).queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  it('shows an ellipsis and disables the row post button while a post is in flight', async () => {
+    globalThis.fetch = mkFetch(ROWS);
+    render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
+    await waitFor(() => screen.getByTestId('npd-post-row-doc-1'));
+
+    let resolvePost;
+    globalThis.fetch.mockImplementationOnce(
+      () => new Promise((resolve) => { resolvePost = resolve; }),
+    );
+
+    const postButton = screen.getByTestId('npd-post-row-doc-1');
+    fireEvent.click(postButton);
+
+    await waitFor(() => expect(postButton).toHaveTextContent('…'));
+    expect(postButton).toBeDisabled();
+
+    await act(async () => {
+      resolvePost({ ok: true, json: async () => ({ success: true, message: 'Document posted' }) });
+    });
   });
 
   it('shows empty state when no rows returned', async () => {

--- a/tools/app-shell/src/windows/custom/not-posted-documents/__tests__/NotPostedDocumentsPage.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/not-posted-documents/__tests__/NotPostedDocumentsPage.vitest.jsx
@@ -36,20 +36,14 @@ function mkFetch(rows = []) {
       return Promise.resolve({
         ok: true,
         json: async () => ({
-          response: {
-            data: [
-              {
-                documentTypes: [{ value: 'SI', label: 'Sales Invoice' }],
-                accountingStatuses: [],
-              },
-            ],
-          },
+          documentTypes: [{ value: 'SI', label: 'Sales Invoice' }],
+          accountingStatuses: [],
         }),
       });
     }
     return Promise.resolve({
       ok: true,
-      json: async () => ({ response: { data: rows } }),
+      json: async () => ({ rows, total: rows.length }),
     });
   });
 }
@@ -121,7 +115,7 @@ describe('NotPostedDocumentsPage', () => {
     await waitFor(() => screen.getByTestId('npd-post-row-doc-1'));
 
     globalThis.fetch.mockImplementationOnce(() =>
-      Promise.resolve({ ok: true, json: async () => ({ response: { data: [{ success: true }] } }) }),
+      Promise.resolve({ ok: true, json: async () => ({ success: true, message: 'Document posted' }) }),
     );
 
     await act(async () => {
@@ -194,7 +188,7 @@ describe('NotPostedDocumentsPage', () => {
             res({ ok: true, json: async () => ({}) });
         });
       }
-      return Promise.resolve({ ok: true, json: async () => ({ response: { data: [] } }) });
+      return Promise.resolve({ ok: true, json: async () => ({ rows: [], total: 0 }) });
     });
 
     const { unmount } = render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
@@ -227,7 +221,7 @@ describe('NotPostedDocumentsPage', () => {
     globalThis.fetch.mockImplementationOnce(() =>
       Promise.resolve({
         ok: true,
-        json: async () => ({ response: { data: [{ ok: 2, total: 2 }] } }),
+        json: async () => ({ ok: 2, total: 2, success: true }),
       }),
     );
 
@@ -251,7 +245,7 @@ describe('NotPostedDocumentsPage', () => {
     globalThis.fetch.mockImplementationOnce(() =>
       Promise.resolve({
         ok: true,
-        json: async () => ({ response: { data: [{ ok: 1, total: 2 }] } }),
+        json: async () => ({ ok: 1, total: 2, success: false }),
       }),
     );
 
@@ -273,7 +267,7 @@ describe('NotPostedDocumentsPage', () => {
     globalThis.fetch.mockImplementationOnce(() =>
       Promise.resolve({
         ok: true,
-        json: async () => ({ response: { data: [{ ok: 0, total: 1 }] } }),
+        json: async () => ({ ok: 0, total: 1, success: false }),
       }),
     );
 
@@ -352,7 +346,7 @@ describe('NotPostedDocumentsPage', () => {
       }
       return Promise.resolve({
         ok: true,
-        json: async () => ({ response: { data: [] } }),
+        json: async () => ({ rows: [], total: 0 }),
       });
     });
 
@@ -372,9 +366,7 @@ describe('NotPostedDocumentsPage', () => {
     globalThis.fetch.mockImplementationOnce(() =>
       Promise.resolve({
         ok: true,
-        json: async () => ({
-          response: { data: [{ success: false, message: 'Accounting period closed' }] },
-        }),
+        json: async () => ({ success: false, message: 'Accounting period closed' }),
       }),
     );
 

--- a/tools/app-shell/src/windows/custom/not-posted-documents/__tests__/NotPostedDocumentsPage.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/not-posted-documents/__tests__/NotPostedDocumentsPage.vitest.jsx
@@ -457,6 +457,28 @@ describe('NotPostedDocumentsPage', () => {
     expect(toast.error).toHaveBeenCalledWith('Accounting period closed');
   });
 
+  // ── postRow: ambiguous/unparseable body must not be treated as success ─────
+  it('shows error toast when postRow gets a 200 with an unparseable body (e.g. proxy error page)', async () => {
+    globalThis.fetch = mkFetch(ROWS);
+    render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
+    await waitFor(() => screen.getByTestId('npd-post-row-doc-1'));
+
+    globalThis.fetch.mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+        statusText: 'OK',
+        json: async () => { throw new SyntaxError('Unexpected token <'); },
+      }),
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('npd-post-row-doc-1'));
+    });
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
   // ── postRow: network error ────────────────────────────────────────────────
   it('shows error toast when postRow fetch throws', async () => {
     globalThis.fetch = mkFetch(ROWS);

--- a/tools/app-shell/src/windows/custom/not-posted-documents/not-posted-documents.css
+++ b/tools/app-shell/src/windows/custom/not-posted-documents/not-posted-documents.css
@@ -238,3 +238,83 @@
 .npd-error {
   color: var(--npd-red-700);
 }
+
+/* ── Multi-select ───────────────────────────────────────────────────────────── */
+
+.npd-multiselect {
+  position: relative;
+  min-width: 160px;
+}
+
+.npd-multiselect-trigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  height: 32px;
+  padding: 0 8px;
+  border: 1px solid var(--npd-gray-200);
+  border-radius: 6px;
+  font-size: 13px;
+  background: #fff;
+  color: var(--npd-gray-800);
+  cursor: pointer;
+  text-align: left;
+  outline: none;
+}
+
+.npd-multiselect-trigger:focus {
+  border-color: var(--npd-blue-600);
+  box-shadow: 0 0 0 2px rgba(0, 117, 173, 0.12);
+}
+
+.npd-multiselect-trigger .npd-placeholder {
+  color: var(--npd-gray-400);
+}
+
+.npd-chevron {
+  flex-shrink: 0;
+  color: var(--npd-gray-400);
+  transition: transform 0.15s;
+}
+
+.npd-chevron.open {
+  transform: rotate(180deg);
+}
+
+.npd-multiselect-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 100%;
+  background: #fff;
+  border: 1px solid var(--npd-gray-200);
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.10);
+  z-index: 100;
+  padding: 4px 0;
+}
+
+.npd-multiselect-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  font-size: 13px;
+  cursor: pointer;
+  white-space: nowrap;
+  color: var(--npd-gray-800);
+}
+
+.npd-multiselect-option:hover {
+  background: var(--npd-gray-50);
+}
+
+.npd-multiselect-option input[type="checkbox"] {
+  accent-color: var(--npd-blue-600);
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+  flex-shrink: 0;
+}


### PR DESCRIPTION
## Summary
- Fix the Not Posted Documents grid returning 0 rows: translate accounting-status search keys to `AD_Ref_List` UUIDs before calling `NoPostedDocumentDS`, and default to a curated status set on initial load.
- Filter the document type dropdown dynamically by joining against `c_acctschema_table`, so newly-enabled modules appear automatically with no code change.
- Add missing `data-testid` to `MultiSelect`.
- Fix stale response-envelope parsing in `postRow`/`postSelected` — `NeoResponse.ok()` writes the body directly, no `response.data` wrapper.
- Update test mocks to match the flat response format; update the `not-posted-documents.md` guide to document the dynamic filter mechanism.
- Add cross-domain plan for the domain boundary pre-push check (touches `window:not-posted-documents`, `app-shell-core` i18n keys, and `generator-change` in `push-to-neo.js`).

## Test plan
- [x] `NotPostedDocumentsPage.vitest.jsx` — 23/23 passing
- [x] Manual: grid returns rows on initial load and with explicit accounting-status filter
- [x] Manual: document type dropdown reflects only types with active accounting configured
- [x] Manual: single-post and bulk-post show correct success/error toasts matching the flat response