### PR TITLE
Feature ETP-4424: Add Makefile target for onboarding integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test test-all-coverage test-ci test-ci-coverage test-e2e test-e2e-headless test-e2e-debug test-e2e-ui test-e2e-report test-e2e-record generate regen dev dev-mock build install install-e2e deploy clean help report-serve report-serve-detach report-stop report-preview validate-pipeline method-budget window-leak-budget quality-gate domain-boundary-check sonar sonar-coverage menu-cache uuid xml-regeneration-check dump-delta regen-check regen-check-help regen-check-clean regen-help data-fixes data-fixes-help switch-to-es ensure-locale project-status
+.PHONY: test test-all-coverage test-ci test-ci-coverage test-e2e test-e2e-headless test-e2e-debug test-e2e-ui test-e2e-report test-e2e-record test-e2e-onboarding-integration generate regen dev dev-mock build install install-e2e deploy clean help report-serve report-serve-detach report-stop report-preview validate-pipeline method-budget window-leak-budget quality-gate domain-boundary-check sonar sonar-coverage menu-cache uuid xml-regeneration-check dump-delta regen-check regen-check-help regen-check-clean regen-help data-fixes data-fixes-help switch-to-es ensure-locale project-status
 
 export SF_ROOT := $(CURDIR)
 
@@ -120,6 +120,9 @@ test-e2e-report: ## Show last E2E test report in browser
 
 test-e2e-record: ## Record a test flow (opens browser, generates code)
 	cd e2e && npx playwright codegen --save-storage=auth.json http://localhost:3100 --output=recordings/recorded-flow.spec.js
+
+test-e2e-onboarding-integration: ## Run the live onboarding integration spec (requires a running backend at BASE_URL, default :3100)
+	cd e2e && E2E_ONBOARDING_INTEGRATION=1 npx playwright test tests/flows/onboarding-register.integration.spec.js
 
 install-e2e: ## Install E2E dependencies + browsers
 	cd e2e && npm install && npx playwright install chromium

--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -24,6 +24,7 @@ npm install -g agent-browser && agent-browser install   # Optional: install agen
 | `make test-e2e-ui` | Interactive Playwright UI |
 | `make test-e2e-report` | View last HTML test report |
 | `make test-e2e-record` | Open recorder — you click, it generates code |
+| `make test-e2e-onboarding-integration` | Run the live onboarding integration spec only (requires a live backend, see below) |
 
 ---
 
@@ -46,6 +47,26 @@ The smoke gets a read JWT through `scripts/neo-token-groupadmin.sh` unless `E2E_
 - goods receipt/shipment partner address from selected business partner.
 
 If this smoke fails because generated field-name selector URLs return `404 Field not found or not included`, track it under [ETP-4058](https://etendoproject.atlassian.net/browse/ETP-4058). That bug is intentionally separate from the integration-test scope: the test detects the runtime/generator contract mismatch, but the fix belongs to the Etendo GO / Schema Forge selector URL compatibility task.
+
+---
+
+## Onboarding Register Integration Smoke
+
+`e2e/tests/flows/onboarding-register.integration.spec.js` registers a real new user against a live Etendo GO backend, completes the profile step, selects the "Autónomo" business type, and verifies provisioning finishes and redirects to the dashboard. It also covers 5 corner cases (duplicate email, empty fields, invalid email format, empty profile name, and a mocked provisioning failure). It is skipped by default because it needs a live backend and performs real user/tenant provisioning — it is **not run by any CI job**; it is manual/on-demand only.
+
+Run it explicitly:
+
+```bash
+make test-e2e-onboarding-integration
+```
+
+This sets `E2E_ONBOARDING_INTEGRATION=1` and runs only that spec file against `BASE_URL` (default `http://localhost:3100`). Override the backend with:
+
+```bash
+BASE_URL=http://localhost:8080/etendo/web/com.etendoerp.go make test-e2e-onboarding-integration
+```
+
+Each run creates a unique user (random suffix), so the test is repeatable without manual cleanup.
 
 ---
 


### PR DESCRIPTION
## Summary
- `e2e/tests/flows/onboarding-register.integration.spec.js` was always skipped (gated behind `E2E_ONBOARDING_INTEGRATION=1`, which nothing set — no CI job runs Playwright at all, and no local target set it either)
- Adds `make test-e2e-onboarding-integration` to run this spec on demand against a live backend, and documents it in `docs/e2e-testing-guide.md`

## Test plan
- [x] `--list`/run without env var: all 6 tests report skipped
- [x] `make test-e2e-onboarding-integration` (live backend at :3100): 6/6 passed (happy path + 5 corner cases)
- [x] `node --test 'cli/test/*.test.js'`: 94/94 pass, unaffected
- [x] Reviewed by Alex (REVIEW), Sentinel (QA) — both APPROVE

Jira: ETP-4424