### PR TITLE
Feature ETP-4433: Pre-bundle react-day-picker, bump app-shell-core to 0.2.1

### DIFF
--- a/docs/plans/ETP-4433-cross-domain.md
+++ b/docs/plans/ETP-4433-cross-domain.md
@@ -1,0 +1,20 @@
+# ETP-4433 Cross-Domain Plan
+
+## Domains changed
+
+| Domain | Files | Reason |
+|--------|-------|--------|
+| `platform-change` | `tools/app-shell/vite.config.js` | Add `optimizeDeps.include: ['react-day-picker']` so Vite pre-bundles it despite `app-shell-core` being excluded — this is the fix that eliminates the date-fns locale barrel request storm (ETP-4431/ETP-4433) that caused CI E2E timeouts on a cold dev cache |
+| `root-global-sensitive` | `package.json`, `package-lock.json` (root) | Bump `@etendosoftware/app-shell-core` devDependency from `0.2.0` to `0.2.1` — mechanically the same version bump as `tools/app-shell/package.json`'s own dependency entry, kept in sync so both the root CLI tooling and the app consume the same fixed release |
+
+Both domains are touched by a single, indivisible change: consuming the newly-released `app-shell-core@0.2.1` (which fixes the calendar.jsx date-fns/locale barrel import — see schema_forge_core PR #21) requires bumping the version everywhere it's declared (root devDependency + tools/app-shell dependency), and the `optimizeDeps.include` addition is the accompanying consumer-side half of the same fix.
+
+## Tests
+
+- Cold Vite dev cache (fresh `npm install`, no `.vite` cache) — confirmed request count for `/dashboard` dropped from 1387 to 462 after this change
+- Re-ran the three Playwright specs that were timing out in Jenkins CI (`amortization.mocked.spec.js`, `not-posted-documents.mocked.spec.js`, `goods-shipment-confirm-and-invoice.mocked.spec.js`) against a cold dev server with this fix — all pass in 8-14s (previously ~2.4min timeout)
+- Full `tools/app-shell` unit suite: 8209/8209 tests passing (446 files)
+
+## Rollback
+
+Revert this PR. No DB, backend, or NEO Headless changes — purely a frontend build-tooling dependency bump plus a Vite dev-server optimization hint. Safe to revert independently of schema_forge_core's `app-shell-core@0.2.1` release (the app would simply fall back to the slower cold-start behavior, not break).

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.2.0",
+        "@etendosoftware/app-shell-core": "0.2.1",
         "@etendosoftware/schema-forge-cli": "0.1.10",
         "@etendosoftware/schema-forge-core": "0.1.0",
         "esbuild": "^0.28.0",
@@ -2573,9 +2573,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.2.0",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.2.0/929a4fe35621d4fedd20920da309bd5c8eb32444",
-      "integrity": "sha512-7hgt6+5kG9Z7GEpuFIe0GP0lLFRUwwGkEDAUR222rygq/IPZLxq++BfpdNNvXboDcV6WyH4UI6nBSSIu2V2FIQ==",
+      "version": "0.2.1",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.2.1/73023ddec219f337f21b95e15cd12634c8dd0812",
+      "integrity": "sha512-3oJ71uR9rqHQe06ScNvYyxEXd2HnExg1sJrDC9auCJvljzcM5SSegu+ZSDcUlxxttxi9pXBo8Bx1WBLMnT55nQ==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -13626,7 +13626,7 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.2.0",
+        "@etendosoftware/app-shell-core": "0.2.1",
         "@etendosoftware/etendo-go-core": "0.1.2",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.2.0",
+    "@etendosoftware/app-shell-core": "0.2.1",
     "@etendosoftware/schema-forge-cli": "0.1.10",
     "@etendosoftware/schema-forge-core": "0.1.0",
     "esbuild": "^0.28.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -15,7 +15,7 @@
     "test:all": "npm run test && npm run test:vitest"
   },
   "dependencies": {
-    "@etendosoftware/app-shell-core": "0.2.0",
+    "@etendosoftware/app-shell-core": "0.2.1",
     "@etendosoftware/etendo-go-core": "0.1.2",
     "@iconicapp/iconic-react": "^1.1.4",
     "@phosphor-icons/react": "^2.1.10",

--- a/tools/app-shell/vite.config.js
+++ b/tools/app-shell/vite.config.js
@@ -227,6 +227,15 @@ export default defineConfig(({ mode }) => {
     // subpath on the same raw-source resolution path, so there is only one
     // instance to begin with.
     exclude: ['@etendosoftware/app-shell-core'],
+    // react-day-picker (used by app-shell-core's Calendar) ships ~87 translated
+    // per-locale wrapper files, each importing the date-fns/locale barrel. Since
+    // it's only reachable through the excluded app-shell-core, Vite never
+    // discovers it for pre-bundling either, so on a cold dev cache it's served
+    // raw and loads every locale for every one of its own wrappers — ~1000+
+    // extra requests, 30+ seconds just for page.goto() to settle in CI (ETP-4431
+    // / ETP-4432). Explicitly including it forces pre-bundling (and therefore
+    // tree-shaking) regardless of the exclusion above.
+    include: ['react-day-picker'],
   },
   server: {
     allowedHosts: env.VITE_ALLOWED_HOSTS ? env.VITE_ALLOWED_HOSTS.split(',') : [],


### PR DESCRIPTION
## Summary
Consumer-side follow-up to ETP-4431 (schema_forge_core PR #21, app-shell-core@0.2.1) — fixes the CI E2E timeouts investigated there.

- Bumps `@etendosoftware/app-shell-core` to `0.2.1` (fixes calendar.jsx's `date-fns/locale` barrel import).
- Adds `optimizeDeps.include: ['react-day-picker']` to `tools/app-shell/vite.config.js`. This is the fix that actually eliminates the request storm in this repo: `react-day-picker` ships its own ~87 translated-locale wrapper files that import the `date-fns/locale` barrel independently of app-shell-core's own import style. Since `react-day-picker` is only reachable through the excluded `app-shell-core` (`optimizeDeps.exclude`, needed for an unrelated CurrencyProvider double-Context bug), it never got pre-bundled either without this explicit include.

## Validation
- Cold Vite dev cache (fresh `npm install`, no `.vite` cache) — reproduced the original 1387-request storm before this fix, confirmed 462 requests after.
- Re-ran the exact Playwright specs that were timing out in Jenkins CI (amortization, not-posted-documents, goods-shipment) against a cold dev server with this fix — all pass in 8-14s (previously ~2.4min timeout).
- Full app-shell unit suite: 8209/8209 passing (446 files).

Jira: ETP-4433

## Test plan
- [x] Cold-start network request count: 1387 → 462
- [x] Previously-timing-out Playwright specs pass on cold dev server
- [x] Full unit suite (8209 tests) passing
- [ ] CI