### PR TITLE
Feature ETP-4438: Fix selector loop and error fallback

### DIFF
--- a/docs/feedback.md
+++ b/docs/feedback.md
@@ -175,3 +175,29 @@ merged significant new features. The following need to be documented:
 - `invoiceStatus` field changed from `discarded` → `readOnly` so NEO serves the computed value
 
 Owner: whoever next touches the goods-shipment window.
+
+---
+
+## [2026-07-03] ETP-4438 - Selector Loading Loop and Error Fallback Crash
+
+**Components:**
+- `tools/app-shell/src/components/contract-ui/SelectorInput.jsx`
+- `tools/app-shell/src/hooks/useEntity.js`
+
+**Symptoms:**
+1. Selector dropdowns could remain stuck on `Cargando...` while repeatedly calling the same selector endpoint after parent rerenders.
+2. Failed API responses with non-JSON bodies, such as an HTML 404 page, could crash error extraction with `translate is not defined` instead of surfacing a controlled error message.
+
+**Root causes:**
+- `DetailView` and `EntityForm` can recreate `selectorContext` as a new object on every render even when its values are unchanged. `SelectorInput.fetchPage` depended on that object by reference, so the callback identity changed, the `SelectContent` ref callback was detached and reattached, and its fetch/listener body ran again.
+- `extractErrorMessage()` declared `translate()` inside the `try` block that also awaited `res.json()`. If JSON parsing failed, the fallback outside that block referenced `translate` out of scope.
+
+**Fix:**
+- `SelectorInput` now derives a stable `contextKey` from `selectorContext` content and uses it as the callback/effect dependency, so equivalent selector context values do not re-identify the fetch/ref callback.
+- `extractErrorMessage()` now declares `translate()` before the JSON parse attempt, keeping the generic `Error <status>` fallback available for non-JSON responses.
+
+**Tests updated:**
+- `SelectorInput.vitest.jsx` verifies equivalent `selectorContext` values with new object references do not reattach the selector scroll ref on parent rerenders.
+- `useEntity.helpers.vitest.jsx` verifies non-JSON responses and unrecognized JSON payloads fall back to `Error <status>`.
+
+**Lesson:** For selector context objects created by parent renders, compare by content at callback boundaries. For error handling, keep final fallback helpers outside parsing blocks that can throw.

--- a/tools/app-shell/src/components/contract-ui/SelectorInput.jsx
+++ b/tools/app-shell/src/components/contract-ui/SelectorInput.jsx
@@ -48,6 +48,12 @@ export function SelectorInput({
   const hasMoreRef = useRef(true);
   const offsetRef = useRef(0);
 
+  // Compare selectorContext by content, not by reference. DetailView/EntityForm
+  // recreate the context object on every render even when values are identical,
+  // which would otherwise make fetchPage (and the SelectContent ref callback that
+  // depends on it) re-identify on every render and re-trigger fetches indefinitely.
+  const contextKey = JSON.stringify(selectorContext ?? {});
+
   const fetchPage = useCallback((offset) => {
     if (!selectorUrl || !token || loadingRef.current || !hasMoreRef.current) return;
     loadingRef.current = true;
@@ -77,14 +83,13 @@ export function SelectorInput({
         setFetching(false);
       })
       .catch(() => { loadingRef.current = false; setFetching(false); });
-  }, [selectorUrl, selectorContext, token]);
+  }, [selectorUrl, contextKey, token]);
 
   // Invalidate cached options when the URL or the selector context changes.
   // We do NOT eager-fetch here — the identifier (`<field>$_identifier`) usually
   // arrives with the default/record payload, so the trigger can render the label
   // without a list. The actual fetch is deferred to the first time the user opens
   // the dropdown.
-  const contextKey = JSON.stringify(selectorContext ?? {});
   useEffect(() => {
     offsetRef.current = 0;
     hasMoreRef.current = true;

--- a/tools/app-shell/src/components/contract-ui/__tests__/SelectorInput.vitest.jsx
+++ b/tools/app-shell/src/components/contract-ui/__tests__/SelectorInput.vitest.jsx
@@ -157,4 +157,48 @@ describe('SelectorInput', () => {
     renderSelector({ selectorUrl: null });
     expect(screen.queryByText('loading')).toBeNull();
   });
+
+  // Regression for the "Cargando..." infinite-fetch bug: DetailView/EntityForm
+  // recreate `selectorContext` as a brand-new object on every render even when its
+  // content is unchanged. fetchPage — and the SelectContent ref callback that
+  // depends on it — must compare selectorContext by content, not by reference.
+  // Otherwise every parent re-render re-identifies the ref callback, which React
+  // detaches and reattaches (calling it again with the DOM node), re-running its
+  // "fetch + attach scroll listener" body on every render. In production this
+  // flooded the selector endpoint (1700+ requests in 15s) and left the dropdown
+  // stuck on "Cargando..." forever.
+  it('does not reattach the SelectContent ref when selectorContext is a new reference with the same content', () => {
+    const addEventListenerSpy = vi.spyOn(Element.prototype, 'addEventListener');
+
+    const { rerender } = renderSelector({ selectorUrl: '/api/header/selectors/C_BPartner_ID', selectorContext: {} });
+    // The mocked fetch resolves within the initial act() flush, so the ref
+    // callback legitimately reattaches once more when serverOptions settles from
+    // null to the loaded (empty) list — that transition is expected, not the bug.
+    const scrollAttachCountAfterMount = addEventListenerSpy.mock.calls.filter(([type]) => type === 'scroll').length;
+    expect(scrollAttachCountAfterMount).toBeGreaterThan(0);
+
+    // Re-render several times with a NEW object literal each time (same content:
+    // empty). A stable ref callback must NOT be detached/reattached by this.
+    for (let i = 0; i < 5; i++) {
+      rerender(
+        <SelectorInput
+          entityName="header"
+          field={defaultField}
+          value=""
+          displayValue=""
+          onChange={vi.fn()}
+          catalogs={{}}
+          resolvedLabel="Partner"
+          selectorUrl="/api/header/selectors/C_BPartner_ID"
+          selectorContext={{}}
+          token="test-token"
+        />,
+      );
+    }
+
+    const scrollAttachCountAfterRerenders = addEventListenerSpy.mock.calls.filter(([type]) => type === 'scroll').length;
+    expect(scrollAttachCountAfterRerenders).toBe(scrollAttachCountAfterMount);
+
+    addEventListenerSpy.mockRestore();
+  });
 });

--- a/tools/app-shell/src/hooks/__tests__/useEntity.helpers.vitest.jsx
+++ b/tools/app-shell/src/hooks/__tests__/useEntity.helpers.vitest.jsx
@@ -126,9 +126,10 @@ describe('useEntity helpers', () => {
       expect(msg).toBeTruthy();
     });
 
-    it('handles response.json() failure — throws ReferenceError (known bug: translate not in scope)', async () => {
+    it('falls back to "Error <status>" when response.json() fails (non-JSON body, e.g. an HTML error page)', async () => {
       const badRes = { json: async () => { throw new Error('parse fail'); }, status: 500 };
-      await expect(extractErrorMessage(badRes)).rejects.toThrow();
+      const msg = await extractErrorMessage(badRes);
+      expect(msg).toBe('Error 500');
     });
 
     it('uses ui translate function when provided', async () => {
@@ -222,17 +223,12 @@ describe('useEntity helpers', () => {
     });
 
     // --- ultimate fallback: Error + status ---
-    // translate() is defined inside the try block. When json() succeeds but no
-    // message is found, the code exits the try normally and reaches line 167
-    // which calls translate() — translate IS still in scope because it was defined
-    // earlier in the same try block and the try completed normally (no throw).
-    // But wait — re-reading the code: the `return` on line 167 is OUTSIDE the try.
-    // `translate` was declared with `const` inside the try block, so it IS in scope
-    // only inside that try. This means the return on line 167 hits a ReferenceError.
-    // This is a known source bug — document the behavior.
-    it('throws ReferenceError for fallback path (translate out of scope bug)', async () => {
+    // When json() succeeds but no recognizable message is found in the payload,
+    // the function falls through to the generic "Error <status>" message.
+    it('falls back to "Error <status>" when no recognizable message is found', async () => {
       const data = { someIrrelevantKey: 42 };
-      await expect(extractErrorMessage(mockResponse(data, 422), ui)).rejects.toThrow();
+      const msg = await extractErrorMessage(mockResponse(data, 422), ui);
+      expect(msg).toBe('Error 422');
     });
 
     // --- translate without ui function ---

--- a/tools/app-shell/src/hooks/useEntity.js
+++ b/tools/app-shell/src/hooks/useEntity.js
@@ -62,28 +62,32 @@ export function pickMessage(node) {
  * Extract a human-readable error message from a NEO Headless error response.
  */
 export async function extractErrorMessage(res, ui) {
+    // Declared outside the try block (and thus outside the `data = await res.json()`
+    // call that can throw for non-JSON bodies, e.g. an HTML error page) so the final
+    // fallback below — `translate('error', 'Error')` — stays in scope even when
+    // res.json() fails.
+    const translate = (key, fallback, params = {}) => {
+        if (typeof ui !== 'function') {
+            let text = fallback;
+            Object.keys(params).forEach((p) => {
+                text = text.replace(`{${p}}`, params[p]);
+            });
+            return text;
+        }
+
+        const translated = ui(key, params);
+        if (!translated || translated === key) {
+            let text = fallback;
+            Object.keys(params).forEach((p) => {
+                text = text.replace(`{${p}}`, params[p]);
+            });
+            return text;
+        }
+        return translated;
+    };
+
     try {
         const data = await res.json();
-
-        const translate = (key, fallback, params = {}) => {
-            if (typeof ui !== 'function') {
-                let text = fallback;
-                Object.keys(params).forEach((p) => {
-                    text = text.replace(`{${p}}`, params[p]);
-                });
-                return text;
-            }
-
-            const translated = ui(key, params);
-            if (!translated || translated === key) {
-                let text = fallback;
-                Object.keys(params).forEach((p) => {
-                    text = text.replace(`{${p}}`, params[p]);
-                });
-                return text;
-            }
-            return translated;
-        };
 
         const decodeHtml = (input) => {
             if (typeof input !== 'string') return '';


### PR DESCRIPTION
## Summary

Fixes two frontend regressions found while reviewing the Playwright report for `epic/ETP-3504`:

- Prevents selector dropdowns from refetching indefinitely when `selectorContext` is recreated with equivalent values on parent rerenders.
- Prevents `useEntity` error extraction from crashing with `translate is not defined` when a failed API response has a non-JSON body.

Jira: [ETP-4438](https://etendoproject.atlassian.net/browse/ETP-4438)

## Root Cause

`SelectorInput.fetchPage` depended on the `selectorContext` object by reference. `DetailView` and `EntityForm` can create a new object each render, so React re-identified the `SelectContent` ref callback, reattached it, and reran the fetch/listener body.

`extractErrorMessage()` declared `translate()` inside the same `try` block that awaited `res.json()`. When parsing failed, the final fallback referenced `translate` outside its scope.

## Changes

- Use a content-derived `contextKey` for selector context dependencies.
- Add a selector regression test for repeated rerenders with equivalent selector context.
- Move `translate()` outside the JSON parsing block in `extractErrorMessage()`.
- Update `useEntity` helper tests to assert controlled `Error <status>` fallback behavior.
- Document the diagnosed bug pattern in `docs/feedback.md`.

## Delivery Repository

- Repository root: `/Users/sebastianbarrozo/Documents/work/epic/schema-forge-ar`
- Branch: `feature/ETP-4438`
- Base: `epic/ETP-3504`
- Changed-file scope: app-shell selector/error handling tests and feedback documentation.

## Added or Modified Tests

- `tools/app-shell/src/components/contract-ui/__tests__/SelectorInput.vitest.jsx`
- `tools/app-shell/src/hooks/__tests__/useEntity.helpers.vitest.jsx`

## Tests Executed

- `npm run test:vitest -- src/hooks/__tests__/useEntity.helpers.vitest.jsx`
  - Result: 1 file passed, 163 tests passed.
- `npm run test:vitest -- src/hooks src/components/contract-ui`
  - Result: 146 files passed, 3072 tests passed.
- Pre-push hook:
  - merge-tree check: passed
  - data-testid check: passed
  - domain boundary check: passed
  - unit tests and SonarQube analysis: passed
  - offline regeneration check: passed

## Functional Validation

- Selector dropdowns keep a stable fetch/ref callback when parent renders recreate an equivalent `selectorContext`.
- Failed API responses with non-JSON bodies now surface a generic `Error <status>` message instead of throwing a ReferenceError.

## QA

Pending validation by QA: Matias Bernal / Emilio Polliotti


[ETP-4438]: https://etendoproject.atlassian.net/browse/ETP-4438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ