### PR TITLE
Feature ETP-4268: Hide Process button on goods-movements when processed

### DIFF
--- a/docs/plans/ETP-4268-cross-domain.md
+++ b/docs/plans/ETP-4268-cross-domain.md
@@ -91,3 +91,30 @@ All shared component changes are opt-in (guarded by null-checks or prop absence)
 Reverting goods-movements/decisions.json and regenerating restores the window to its
 previous state without affecting any other window. The generator changes are additive
 and backward-compatible.
+
+## Addendum (2026-07-06) — Process button not hiding when processed
+
+**Domain**: `platform-change` only — `DetailView.jsx` bugfix, no window/generator files touched.
+
+`getDraftModeCompleted` always compared `draftMode.completedStatuses` against
+`_headerData.documentStatus`, ignoring the window's configured `statusField`.
+`goods-movements` has no `documentStatus` field (its status lives in the boolean
+`processed` field), so `completedStatuses` never matched and the Process button
+stayed visible after processing. Fixed to resolve the status value via `statusField`
+(falling back to `documentStatus` for backward compatibility) and normalize
+boolean-ish values (`true`/`'Y'`, `false`/`'N'`) before comparing, matching the
+precedent in `statusBadge.js`.
+
+Files: `tools/app-shell/src/components/contract-ui/DetailView.jsx`,
+`tools/app-shell/src/components/contract-ui/__tests__/DetailView.completedStatuses.test.js`,
+`tools/app-shell/src/components/contract-ui/__tests__/DetailView.draftModeStatusField.vitest.jsx`
+(new).
+
+**Tests**: `node --test` on the updated regex suite — 6/6 pass. `vitest run` on the
+new behavioral file + `DetailView.saveButtons.vitest.jsx` — 15/15 pass.
+`node cli/src/validate-pipeline.js --scope=goods-movements` and `--scope=sales-quotation`
+— both 0 violations (confirms no regression on the `documentStatus`-array window).
+
+**Rollback**: single-function change, no config/contract changes; revert the commit
+to restore prior (buggy) behavior — no other window is affected since `statusField`
+is opt-in and defaults to the previous `documentStatus` lookup when unset.

--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -1030,11 +1030,21 @@ function getSaveBtnCls(toolbarButtonSize) {
   return toolbarButtonSize === 'default' ? 'h-10 gap-2' : 'gap-1.5';
 }
 
-function getDraftModeCompleted(draftMode, _headerData, isProcessed) {
+// Normalizes boolean-ish status values (true/'Y' -> 'true', false/'N' -> 'false') so
+// windows whose statusField is a boolean flag (e.g. goods-movements' `processed`) can
+// declare completedStatuses as string literals, matching the precedent in statusBadge.js.
+function normalizeStatusValue(value) {
+  if (value === true || value === 'Y') return 'true';
+  if (value === false || value === 'N') return 'false';
+  return value;
+}
+
+function getDraftModeCompleted(draftMode, _headerData, isProcessed, statusField) {
+  const statusValue = _headerData?.[statusField || 'documentStatus'];
   return Boolean(
       draftMode?.enabled && (
           Array.isArray(draftMode.completedStatuses)
-              ? draftMode.completedStatuses.includes(_headerData?.documentStatus)
+              ? draftMode.completedStatuses.includes(normalizeStatusValue(statusValue))
               : (isProcessed || _headerData?.documentStatus === 'CO')
       )
   );
@@ -1909,7 +1919,7 @@ export function DetailView({
   // values hide the Save/Confirm pair. This lets windows like sales-quotation keep the
   // pair visible during intermediate processed states (UE) while still hiding it in
   // terminal states (CA, ETGO_CI, CL, VO).
-  const isDraftModeCompleted = getDraftModeCompleted(draftMode, _headerData, isProcessed);
+  const isDraftModeCompleted = getDraftModeCompleted(draftMode, _headerData, isProcessed, statusField);
   const sqBtnSize = getSqBtnSize(toolbarButtonSize);
   const saveBtnCls = getSaveBtnCls(toolbarButtonSize);
   const [showPrint, setShowPrint] = useState(false);

--- a/tools/app-shell/src/components/contract-ui/__tests__/DetailView.completedStatuses.test.js
+++ b/tools/app-shell/src/components/contract-ui/__tests__/DetailView.completedStatuses.test.js
@@ -14,16 +14,36 @@ const src = readFileSync(join(__dirname, '..', 'DetailView.jsx'), 'utf8');
  * `processed === 'Y'` alone triggers the lock — which broke sales-quotation
  * during Under Evaluation (UE), where Etendo flips processed to Y but the
  * pair must remain visible until the user confirms or rejects.
+ *
+ * ETP-4268 follow-up: the array branch used to always read
+ * `_headerData?.documentStatus`, ignoring a window's configured
+ * `statusField` (decisions.json → window.statusField). This broke
+ * goods-movements, whose status lives in a boolean `processed` field, not
+ * `documentStatus` — the "Procesar" button never hid because
+ * `completedStatuses` never matched. The fix resolves the compared value via
+ * `_headerData?.[statusField || 'documentStatus']` and normalizes
+ * boolean-ish values (true/'Y' -> 'true', false/'N' -> 'false') before the
+ * `.includes(...)` check, so windows can declare completedStatuses as string
+ * literals regardless of whether their status field is an enum or a boolean
+ * flag. See DetailView.draftModeStatusField.vitest.jsx for the behavioral
+ * coverage of this fix.
  */
 describe('DetailView — draftMode.completedStatuses (ETP-3873 regression)', () => {
   it('reads draftMode.completedStatuses as an array branch', () => {
     assert.match(src, /Array\.isArray\(\s*draftMode\.completedStatuses\s*\)/);
   });
 
-  it('matches against the live documentStatus when the array is declared', () => {
+  it('resolves the compared value from statusField, falling back to documentStatus (ETP-4268)', () => {
     assert.match(
       src,
-      /draftMode\.completedStatuses\.includes\(\s*_headerData\?\.documentStatus\s*\)/,
+      /_headerData\?\.\[\s*statusField\s*\|\|\s*['"]documentStatus['"]\s*\]/,
+    );
+  });
+
+  it('normalizes the resolved value through normalizeStatusValue before matching the array (ETP-4268)', () => {
+    assert.match(
+      src,
+      /draftMode\.completedStatuses\.includes\(\s*normalizeStatusValue\(\s*statusValue\s*\)\s*\)/,
     );
   });
 

--- a/tools/app-shell/src/components/contract-ui/__tests__/DetailView.draftModeStatusField.vitest.jsx
+++ b/tools/app-shell/src/components/contract-ui/__tests__/DetailView.draftModeStatusField.vitest.jsx
@@ -1,0 +1,210 @@
+import { render, screen } from '@testing-library/react';
+
+// Behavioral regression coverage for ETP-4268: `getDraftModeCompleted` (and its
+// helper `normalizeStatusValue`) are module-private in DetailView.jsx, so the
+// only way to prove the *behavior* is fixed — not just that the source text
+// looks right — is to render the real component and assert whether the
+// footer Save/Confirm block (data-testid="action-save[-draft]") is present.
+// A regex-only test would have passed on the OLD buggy code too, since the
+// old line also matched a similarly-shaped pattern; it was just wrong at
+// runtime for windows whose statusField isn't "documentStatus".
+//
+// Mirrors the mock setup in DetailView.saveButtons.vitest.jsx so the
+// component mounts in isolation.
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate,
+  useSearchParams: () => [new URLSearchParams()],
+  useLocation: () => ({ pathname: '/test/123', search: '', hash: '' }),
+}));
+
+vi.mock('@/i18n', () => ({
+  useLabel: () => (key) => key,
+  useMenuLabel: () => (key) => key,
+  useUI: () => (key) => key,
+  useLocale: () => ({}),
+  useLocaleSwitch: () => ({ locale: 'en_US', setLocale: vi.fn() }),
+}));
+
+const mockNavigate = vi.fn();
+
+const mockHook = {
+  items: [],
+  selected: null,
+  editing: null,
+  loading: false,
+  saving: false,
+  isSaving: false,
+  isDirtyHeader: false,
+  error: null,
+  children: [],
+  childrenLoading: false,
+  fetchById: vi.fn(),
+  primeSaved: vi.fn(),
+  handleSelect: vi.fn(),
+  handleChange: vi.fn(),
+  handleSave: vi.fn(() => Promise.resolve({ id: '123' })),
+  handleSaveAndProcess: vi.fn(() => Promise.resolve({ id: '123' })),
+  handleCreate: vi.fn(),
+  handleDelete: vi.fn(),
+  handleAddChild: vi.fn(),
+  handleUpdateChild: vi.fn(),
+  handleDeleteChild: vi.fn(),
+  refresh: vi.fn(),
+  setEditing: vi.fn(),
+};
+
+vi.mock('@/hooks/useEntity', () => ({ useEntity: () => ({ ...mockHook }) }));
+vi.mock('@/hooks/useCatalogs', () => ({ useCatalogs: () => ({ catalogs: {}, catalogsLoaded: true }) }));
+vi.mock('@/hooks/useDisplayLogic', () => ({ useDisplayLogic: () => ({}) }));
+vi.mock('@/hooks/useCallout', () => ({
+  useCallout: () => ({ calloutResult: null, calloutLoading: false, executeCallout: vi.fn() }),
+}));
+vi.mock('@/hooks/useLineGrossAmount', () => ({
+  useLineGrossAmount: () => ({ grossAmount: 0, computeGrossAmount: vi.fn() }),
+  ORDER_LINE_CONFIG: { quantityField: 'orderedQuantity', priceField: 'unitPrice' },
+}));
+vi.mock('@/hooks/useDocumentAction', () => ({ useDocumentAction: () => ({ execute: vi.fn(), loading: false }) }));
+vi.mock('@/components/layout/PageMetaContext', () => ({ useSetPageMeta: () => vi.fn() }));
+vi.mock('@/components/layout/FavoritesContext', () => ({
+  useFavorites: () => ({ isFavorite: () => false, toggleFavorite: vi.fn() }),
+}));
+vi.mock('../SummaryBar.jsx', () => ({ SummaryBar: () => null }));
+vi.mock('../DocumentTotalsPanel.jsx', () => ({ default: () => null }));
+vi.mock('../DocumentStatusPill.jsx', () => ({ default: () => null }));
+vi.mock('../DocumentPrintDrawer.jsx', () => ({ default: () => null }));
+vi.mock('@/lib/resolveIdentifier.js', () => ({
+  resolveIdentifier: (data, key) => data?.[key + '$_identifier'] ?? data?.[key] ?? '',
+}));
+vi.mock('@/lib/lineFieldChange.js', () => ({
+  buildCalloutFormState: vi.fn(() => ({})),
+  extractAuxValues: vi.fn(() => ({})),
+  normalizeCalloutQty: vi.fn(),
+  normalizeCalloutResponse: vi.fn(() => ({})),
+  applyQtyZeroGuard: vi.fn(),
+  roundAmounts: vi.fn((v) => v),
+  resolveSnapshotIdentifiers: vi.fn(() => ({})),
+}));
+vi.mock('@/lib/selectorCatalog.js', () => ({ getCatalogOptions: () => [] }));
+vi.mock('@/lib/formatAmount.js', () => ({ formatAmount: (val) => (val != null ? String(val) : '') }));
+vi.mock('@/lib/utils.js', () => ({ cn: (...args) => args.filter(Boolean).join(' ') }));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() } }));
+
+import { DetailView } from '../DetailView.jsx';
+
+const BASE_PROPS = {
+  entity: 'goods-movements',
+  detailEntity: 'goods-movements-line',
+  Form: () => <div data-testid="mock-form">Form</div>,
+  DetailTable: () => <div data-testid="mock-detail-table">Table</div>,
+  DetailForm: null,
+  summary: [],
+  api: { window: { category: 'inventory' } },
+  entityLabel: 'Goods Movements',
+  detailLabel: 'Line',
+  detailTabIndex: 0,
+  titleField: 'documentNo',
+  windowName: 'goods-movements',
+  recordId: '123',
+  token: 'test-token',
+  apiBaseUrl: 'http://localhost:8080/etendo/neo',
+};
+
+function resetHook() {
+  mockNavigate.mockClear();
+  mockHook.isSaving = false;
+  mockHook.isDirtyHeader = false;
+  mockHook.children = [];
+  mockHook.childrenLoading = false;
+  mockHook.handleSave = vi.fn(() => Promise.resolve({ id: '123' }));
+  mockHook.handleSaveAndProcess = vi.fn(() => Promise.resolve({ id: '123' }));
+  mockHook.primeSaved = vi.fn();
+  mockHook.fetchById = vi.fn();
+}
+
+function setRecord(fields) {
+  const rec = { id: '123', documentNo: 'GM-001', ...fields };
+  mockHook.selected = rec;
+  mockHook.editing = rec;
+}
+
+describe('DetailView draftMode completion — statusField resolution (ETP-4268 regression)', () => {
+  beforeEach(resetHook);
+
+  describe('statusField unset — falls back to documentStatus (sales-quotation style)', () => {
+    const draftMode = {
+      enabled: true,
+      draftField: 'documentStatus',
+      draftValue: 'DR',
+      label: 'process',
+      completedStatuses: ['CA', 'ETGO_CI', 'CL', 'VO', 'CJ'],
+    };
+
+    it('hides Save/Confirm when documentStatus is a terminal status in the list', () => {
+      setRecord({ documentStatus: 'CA', processed: true });
+      render(<DetailView {...BASE_PROPS} draftMode={draftMode} />);
+      expect(screen.queryByTestId('action-save')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('action-save-draft')).not.toBeInTheDocument();
+    });
+
+    it('keeps Save/Confirm visible when documentStatus is Under Evaluation (not in the list)', () => {
+      setRecord({ documentStatus: 'UE', processed: true });
+      render(<DetailView {...BASE_PROPS} draftMode={draftMode} />);
+      expect(screen.queryByTestId('action-save')).toBeInTheDocument();
+      expect(screen.queryByTestId('action-save-draft')).toBeInTheDocument();
+    });
+  });
+
+  describe('statusField="processed" (goods-movements) — boolean-ish values normalized', () => {
+    const draftMode = {
+      enabled: true,
+      draftField: 'processed',
+      draftValue: false,
+      label: 'process',
+      completedStatuses: ['true'],
+    };
+
+    it('hides Save/Confirm when processed is boolean true', () => {
+      setRecord({ processed: true });
+      render(<DetailView {...BASE_PROPS} draftMode={draftMode} statusField="processed" />);
+      expect(screen.queryByTestId('action-save')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('action-save-draft')).not.toBeInTheDocument();
+    });
+
+    it('hides Save/Confirm when processed is the AD boolean string "Y"', () => {
+      setRecord({ processed: 'Y' });
+      render(<DetailView {...BASE_PROPS} draftMode={draftMode} statusField="processed" />);
+      expect(screen.queryByTestId('action-save')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('action-save-draft')).not.toBeInTheDocument();
+    });
+
+    it('keeps Save/Confirm visible when processed is boolean false', () => {
+      setRecord({ processed: false });
+      render(<DetailView {...BASE_PROPS} draftMode={draftMode} statusField="processed" />);
+      expect(screen.queryByTestId('action-save')).toBeInTheDocument();
+      expect(screen.queryByTestId('action-save-draft')).toBeInTheDocument();
+    });
+
+    it('keeps Save/Confirm visible when processed is the AD boolean string "N"', () => {
+      setRecord({ processed: 'N' });
+      render(<DetailView {...BASE_PROPS} draftMode={draftMode} statusField="processed" />);
+      expect(screen.queryByTestId('action-save')).toBeInTheDocument();
+      expect(screen.queryByTestId('action-save-draft')).toBeInTheDocument();
+    });
+  });
+
+  describe('draftMode.enabled=false — never hides Save/Confirm regardless of status', () => {
+    it('keeps Save visible even when the status matches completedStatuses', () => {
+      setRecord({ processed: true, documentStatus: 'CA' });
+      render(
+        <DetailView
+          {...BASE_PROPS}
+          statusField="processed"
+          draftMode={{ enabled: false, label: 'process', completedStatuses: ['true'] }}
+        />,
+      );
+      // Not a draft-mode window while disabled: existing-record footer renders
+      // the plain "action-save" button instead of the draft-mode pair.
+      expect(screen.queryByTestId('action-save')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
getDraftModeCompleted always compared against _headerData.documentStatus, ignoring the window's configured statusField. goods-movements has no documentStatus field (its status lives in a boolean `processed` field), so completedStatuses never matched and the Process button stayed visible after processing.

Resolve the status value via statusField (falling back to documentStatus for backward compatibility) and normalize boolean-ish values (true/'Y', false/'N') before comparing, matching the precedent in statusBadge.js.