### PR TITLE
Feature ETP-4336: Add visual required asterisk and amortization total footer

### DIFF
--- a/docs/generated-custom-windows/assets.md
+++ b/docs/generated-custom-windows/assets.md
@@ -358,3 +358,47 @@ field declared under `entities.assets.fields`, it becomes the first entry in the
 - **Generated output updated:** `artifacts/assets/generated/web/assets/AssetsTable.jsx` —
   `searchKey` is now the first column in the `columns` array, appearing as **Search Key** in
   the list/grid view
+
+## ETP-4336 — Cosmetic required asterisk on conditionally-required fields
+
+`AssetsDetailPanel.jsx` sets `requiredVisual: true` on 6 field literals so their labels show
+the red `*` while editing, even though the fields are not declared `required: true`:
+
+- `currency` ("Moneda")
+- `depreciationAmt` ("Valor a amortizar" — column `Amortizationvalueamt`)
+- `annualDepreciation` ("% Amortización anual")
+- `usableLifeYears` ("Vida útil - Años")
+- `usableLifeMonths` ("Vida útil - Meses")
+- `depreciationStartDate` ("Fecha inicio")
+
+This is purely cosmetic — `EntityForm` does not enforce validation from `requiredVisual`, only
+from `required`. It exists because these fields' real obligatoriness is **conditional** on
+"Tipo de cálculo" (`calculateType`, Time vs. Percentage): e.g. `usableLifeYears` is only
+mandatory when calculation type is "Time" and the schedule is yearly, so a real
+`required: true` would incorrectly block submission when the field is hidden or not yet
+applicable. `assetValue` ("Valor del activo") does **not** carry the flag. The asterisk only
+renders while editing — the panel marks these fields read-only in view mode, and `EntityForm`
+gates the marker on `!isReadOnly`.
+
+`requiredVisual` is a reusable `EntityForm` field-descriptor prop, not a `decisions.json`
+option — see `docs/ui-customization.md` for the generic reference.
+
+## ETP-4336 — Amortization Plan total footer
+
+`AssetsAmortizationPanel.jsx` now renders a `<tfoot>` row under the plan lines table showing
+the accumulated total of the **Amount** column — the sum of `amortizationAmount` across all
+fetched lines, formatted with `formatCurrency(orgCurrency, ...)`. This is a hand-authored
+`<table>` (not the generic `DataTable`), so the footer is implemented directly in the panel.
+
+- The total cell is left-aligned, matching the rest of the Amount column in this panel —
+  numbers here are left-aligned by design, unlike right-aligned amount columns elsewhere.
+- The footer only renders when there is at least one plan line (`lines.length > 0`); the
+  empty-state and loading branches show no table at all.
+- **Alert color rule:** the total renders in `text-red-500` when it does **not** match the
+  asset's "amount to amortize" — `data.depreciationAmt` (column `Amortizationvalueamt`, the
+  "Valor a amortizar" field). Both values are rounded to 2 decimals before comparison, with a
+  `0.005` tolerance for float drift (`amortizationTotalMismatch` in the component). When
+  `depreciationAmt` is `null`/`undefined`, the alert is never forced — the total renders in the
+  normal `text-foreground` color.
+
+- **File changed:** `tools/app-shell/src/windows/custom/assets/AssetsAmortizationPanel.jsx`

--- a/docs/plans/ETP-4336-cross-domain.md
+++ b/docs/plans/ETP-4336-cross-domain.md
@@ -1,0 +1,71 @@
+# ETP-4336 — Cross-domain plan: visual required asterisk + amortization total footer
+
+## Why this change is cross-domain
+
+Two related Assets-window improvements share a single **reusable platform
+primitive**, so the change necessarily spans the generic component layer and the
+`assets` window:
+
+1. A visual-only required asterisk (`requiredVisual`) is added to the shared
+   `EntityForm` component so any field descriptor can show the required marker
+   **without enforcing validation** — needed for fields whose obligatoriness is
+   conditional on another field. This is a platform capability; the `assets`
+   window is its first consumer. Splitting it per window would push window-local
+   asterisk hacks instead of a reusable prop.
+2. The Amortization Plan tab gains a footer total with an alert color when the
+   sum does not match the amount to amortize. This lives in the window's
+   hand-authored custom panel.
+
+Because the reusable prop lives in a **platform-change** file and the consumer
+edits + docs live in **window:assets** and **repo-infra**, the diff crosses
+domains by design.
+
+## Domains touched (dominios)
+
+- **platform-change** — `tools/app-shell/src/components/contract-ui/EntityForm.jsx`:
+  the required asterisk is OR-ed with a new `requiredVisual` field-descriptor prop
+  at all four render sites (`labelMarker`, `requiredAsterisk`,
+  `requiredAsteriskIfEditable`, and `PopupSearchField`'s inline marker), gated by
+  `!isReadOnly`. The `required={...}` validation props are untouched — the flag is
+  cosmetic only. Reusable by any window.
+- **repo-infra** — `docs/ui-customization.md`: documents `requiredVisual` as a
+  reusable `EntityForm` field-descriptor prop (entry #16 + decision-tree line), so
+  future windows can discover it.
+- **window:assets**
+  - `tools/app-shell/src/windows/custom/assets/AssetsDetailPanel.jsx`:
+    `requiredVisual: true` on 6 conditionally-required fields (`currency`,
+    `depreciationAmt`, `annualDepreciation`, `usableLifeYears`,
+    `usableLifeMonths`, `depreciationStartDate`).
+  - `tools/app-shell/src/windows/custom/assets/AssetsAmortizationPanel.jsx`:
+    a `<tfoot>` totaling the Amount column, rendered in alert color when the total
+    does not match `depreciationAmt` (the "amount to amortize"), with a 0.005
+    float tolerance and safe handling of a missing expected value.
+  - `tools/app-shell/src/windows/custom/assets/__tests__/AssetsAmortizationPanel.vitest.jsx`:
+    tests for the footer total + alert behavior.
+  - `docs/generated-custom-windows/assets.md`: two ETP-4336 sections documenting
+    both changes.
+
+No backend, DB, NEO push, or schema/contract changes. The `schema_forge_core`
+repo is not touched by this branch.
+
+## Tests
+
+- **Vitest** — `AssetsAmortizationPanel.vitest.jsx`: 7 new tests covering the
+  summed total, alert class when total ≠ `depreciationAmt`, no alert when it
+  matches, the 0.005 float tolerance edge (`0.1 + 0.2` vs `0.3`), no alert when
+  `depreciationAmt` is null/undefined, and no footer when there are zero lines.
+  Full file green (39 passed). Four pre-existing single-line assertions were
+  updated from `getByText` to `getAllByText(...).toHaveLength(2)` because with one
+  line the footer total mirrors the row amount (expected, not a defect).
+- The `requiredVisual` change on `EntityForm` is a cosmetic, additive prop
+  (OR-ed with existing `required`, no validation impact); no behavior branch was
+  altered.
+
+## Rollback
+
+Single-branch revert. The change is an additive `EntityForm` prop + window-local
+field-descriptor flags + a hand-authored `<tfoot>` + additive tests and docs, with
+no DB migration, no NEO push, and no schema/contract change. Reverting the branch
+restores the previous labels (no asterisk) and the plan table without a footer.
+The `requiredVisual` prop is additive, so removing it is inert for every other
+window.

--- a/docs/ui-customization.md
+++ b/docs/ui-customization.md
@@ -546,6 +546,37 @@ Both `debitField` and `creditField` must be amount-typed fields on the **lines**
 
 ---
 
+### 16. `requiredVisual` — cosmetic required asterisk (field descriptor prop)
+
+**What it does:** renders the red required asterisk `*` next to a field's label in `EntityForm`
+**without enforcing any validation**. It is OR-ed with `required` in every asterisk render site
+(`labelMarker`, `requiredAsterisk`, `requiredAsteriskIfEditable`, and `PopupSearchField`'s inline
+marker), and — like the `required` asterisk — only shows on editable fields (`!isReadOnly`); it
+never renders on a read-only display. The `required={...}` prop passed down to the underlying
+input/select is untouched by `requiredVisual` — it still depends on `required` only.
+
+**Use when:** a field's obligatoriness is **conditional** on another field's value (e.g. a
+calculation-type toggle that makes different fields mandatory depending on its selection), so a
+real `required: true` would incorrectly block submission when the field isn't actually
+applicable yet, but the user should still see it visually flagged as required once it is
+relevant.
+
+Set directly on the field descriptor object passed to `EntityForm` — **not** a `decisions.json`
+key. It is typically declared inline on the field literals inside a window's hand-authored
+custom panel:
+
+```jsx
+// windows/custom/{window}/{Window}DetailPanel.jsx
+{ key: 'usableLifeYears', column: 'UseLifeYears', type: 'number', requiredVisual: true, /* ... */ }
+```
+
+**Real example:** `assets` — `currency`, `depreciationAmt`, `annualDepreciation`,
+`usableLifeYears`, `usableLifeMonths`, and `depreciationStartDate` in `AssetsDetailPanel.jsx`
+carry `requiredVisual: true` because their obligatoriness depends on the "Tipo de cálculo"
+(`calculateType`) selection.
+
+---
+
 ## Decision tree: which option to use?
 
 ```
@@ -591,8 +622,10 @@ I need to customize the UI of a window
     ├─ Empty state when lines tab is empty → linesEmptyState prop + addLineGuard
     ├─ Gate add-line button on header field → addLineGuard prop
     ├─ Hide ⋮ menu on new/processed records → hideMoreMenu prop (boolean or function)
-    └─ Hover overlay with per-row actions on the list (Edit/Duplicate/Email/kebab/Delete)
-        └─ → window.rowQuickActions (on by default; declare only to disable or override)
+    ├─ Hover overlay with per-row actions on the list (Edit/Duplicate/Email/kebab/Delete)
+    │   └─ → window.rowQuickActions (on by default; declare only to disable or override)
+    └─ Show a required-looking asterisk on a conditionally-required field, without validation
+        └─ → requiredVisual: true on the field descriptor (EntityForm prop, not decisions.json)
 ```
 
 ---

--- a/tools/app-shell/src/components/contract-ui/EntityForm.jsx
+++ b/tools/app-shell/src/components/contract-ui/EntityForm.jsx
@@ -616,7 +616,7 @@ function PopupSearchField(props) {
       <Label
         className="text-sm text-foreground font-medium"
         data-testid="Label__a8d626">
-        {props.label}{props.f.required ? <span className="text-red-500 ml-0.5">*</span> : ""}
+        {props.label}{(props.f.required || props.f.requiredVisual) ? <span className="text-red-500 ml-0.5">*</span> : ""}
       </Label>
       <PopupSearchInput
         field={props.f}
@@ -638,8 +638,13 @@ function getCheckboxStateClass(checked) {
       : 'bg-transparent';
 }
 
+// Callers of this helper (PopupSearchField's sibling paths, DependentFkField,
+// the lookup/search label) are only reached along the editable branch of their
+// wrapping renderers (the isReadOnly branch early-returns to a read-only
+// display before the label is built), so no explicit isReadOnly gate is needed
+// here — see labelMarker/requiredAsteriskIfEditable for the gated equivalents.
 function requiredAsterisk(f) {
-  return f.required ? <span className="text-red-500 ml-0.5">*</span> : '';
+  return (f.required || f.requiredVisual) ? <span className="text-red-500 ml-0.5">*</span> : '';
 }
 
 /**
@@ -648,9 +653,12 @@ function requiredAsterisk(f) {
  * for the form (Figma list-modal style), a muted "(opcional)" suffix is shown.
  * Generic + opt-in: forms that don't pass `optionalSuffix` keep the old behaviour
  * (asterisk only). The suffix text comes from the i18n `optional` key.
+ * `f.requiredVisual` renders the same asterisk WITHOUT enforcing validation — for
+ * fields whose obligatoriness is conditional on another field and can't use a real
+ * `required: true`.
  */
 function labelMarker(f, isReadOnly, optionalSuffix, ui) {
-  if (f.required && !isReadOnly) return <span className="text-[#F53D6B] ml-0.5">*</span>;
+  if ((f.required || f.requiredVisual) && !isReadOnly) return <span className="text-[#F53D6B] ml-0.5">*</span>;
   if (optionalSuffix && !isReadOnly) {
     return <span className="ml-1 font-normal text-[#6C6C89]">({ui('optional')})</span>;
   }
@@ -686,7 +694,7 @@ function buildSearchSelectorUrl(apiBaseUrl, entity, f, apiSelectorEntry) {
 }
 
 function requiredAsteriskIfEditable(f, isReadOnly) {
-  return f.required && !isReadOnly ? <span className="text-red-500 ml-0.5">*</span> : '';
+  return (f.required || f.requiredVisual) && !isReadOnly ? <span className="text-red-500 ml-0.5">*</span> : '';
 }
 
 function getInputStateClass(isReadOnly) {

--- a/tools/app-shell/src/windows/custom/assets/AssetsAmortizationPanel.jsx
+++ b/tools/app-shell/src/windows/custom/assets/AssetsAmortizationPanel.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Loader2, ArrowUpRight } from 'lucide-react';
 import { useUI } from '@/i18n';
@@ -166,6 +166,19 @@ export default function AssetsAmortizationPanel({ data, recordId: recordIdProp, 
     return () => window.removeEventListener('neo:processSuccess', handleProcessSuccess);
   }, [recordId, fetchLines]);
 
+  const totalAmortizationAmount = useMemo(
+    () => lines.reduce((sum, line) => sum + (Number(line.amortizationAmount) || 0), 0),
+    [lines],
+  );
+
+  // Compare against the expected amount to amortize with a small tolerance,
+  // since both values are floats. No expected value → never force the alert color.
+  const expectedAmortizationAmount = data?.depreciationAmt;
+  const amortizationTotalMismatch = expectedAmortizationAmount != null
+    && Math.abs(
+      Math.round(totalAmortizationAmount * 100) / 100 - Math.round(Number(expectedAmortizationAmount) * 100) / 100,
+    ) > 0.005;
+
   const renderBody = () => {
     if (loading) {
       return (
@@ -245,6 +258,21 @@ export default function AssetsAmortizationPanel({ data, recordId: recordIdProp, 
                 );
               })}
             </tbody>
+            <tfoot>
+              <tr className="border-t border-border/50 font-semibold">
+                <td className="py-3 pr-2" style={{ width: 40 }} />
+                <td className="py-3 pr-4" />
+                <td className="py-3 pr-4" />
+                <td
+                  className={`py-3 pr-4 ${
+                    amortizationTotalMismatch ? 'text-red-500' : 'text-foreground'
+                  }`}
+                >
+                  {formatCurrency(orgCurrency, totalAmortizationAmount)}
+                </td>
+                <td className="py-3" />
+              </tr>
+            </tfoot>
           </table>
         </div>
     );

--- a/tools/app-shell/src/windows/custom/assets/AssetsDetailPanel.jsx
+++ b/tools/app-shell/src/windows/custom/assets/AssetsDetailPanel.jsx
@@ -175,7 +175,7 @@ export default function AssetsDetailPanel({ data, token, apiBaseUrl, catalogs, a
   ];
 
   const group2Fields = [
-    { key: 'currency', column: 'C_Currency_ID', type: 'selector', label: ui('assetsCurrencyLabel'), section: 'principal', reference: 'Currency', inputMode: 'selector', defaultValue: '@C_Currency_ID@', readOnlyLogic: (record) => Number(record.depreciatedPlan || 0) > 0 || Number(record.depreciatedValue || 0) > 0 },
+    { key: 'currency', column: 'C_Currency_ID', type: 'selector', label: ui('assetsCurrencyLabel'), section: 'principal', reference: 'Currency', inputMode: 'selector', defaultValue: '@C_Currency_ID@', readOnlyLogic: (record) => Number(record.depreciatedPlan || 0) > 0 || Number(record.depreciatedValue || 0) > 0, requiredVisual: true },
     // The Asset amount triple (AssetValue, ResidualAssetValue, DepreciationAmt). ETP-4333:
     //  • calloutOn: 'blur' — EntityForm renders these via DeferredInput: typing only updates a
     //    local buffer; on blur a single onChange commits the value. The deferral-to-blur UX
@@ -186,17 +186,17 @@ export default function AssetsDetailPanel({ data, token, apiBaseUrl, catalogs, a
     //    no async round-trip to race. The Java remains the source of truth (see computeAssetAmounts).
     { key: 'assetValue', column: 'AssetValueAmt', type: 'number', label: ui('assetsAssetValueLabel'), section: 'principal', calloutOn: 'blur' },
     { key: 'residualAssetValue', column: 'Residualassetvalueamt', type: 'number', label: ui('assetsResidualValueLabel'), section: 'principal', calloutOn: 'blur' },
-    { key: 'depreciationAmt', column: 'Amortizationvalueamt', type: 'number', label: ui('assetsDepreciationAmtLabel'), section: 'principal', calloutOn: 'blur' },
+    { key: 'depreciationAmt', column: 'Amortizationvalueamt', type: 'number', label: ui('assetsDepreciationAmtLabel'), section: 'principal', calloutOn: 'blur', requiredVisual: true },
     { key: 'previouslyDepreciatedAmt', column: 'Depreciatedpreviousamt', type: 'number', label: ui('assetsPrevDepreciatedLabel'), section: 'principal', defaultValue: '0' },
   ];
 
   const deprecFields = [
     { key: 'depreciationType', column: 'Amortizationtype', type: 'select', label: ui('assetsOptLinear'), required: true, section: 'principal', options: [{ value: 'LI', label: ui('assetsOptLinear') }] },
     { key: 'calculateType', column: 'Amortizationcalctype', type: 'select', required: true, section: 'principal', options: [{ value: 'PE', label: ui('assetsOptPercentage') }, { value: 'TI', label: ui('assetsOptTime') }] },
-    { key: 'annualDepreciation', column: 'Amortizationpercentage', type: 'number', label: ui('assetsAnnualDepreciationLabel'), section: 'principal', displayLogic: (record) => isDepreciate(record) && record.calculateType !== 'TI' },
+    { key: 'annualDepreciation', column: 'Amortizationpercentage', type: 'number', label: ui('assetsAnnualDepreciationLabel'), section: 'principal', displayLogic: (record) => isDepreciate(record) && record.calculateType !== 'TI', requiredVisual: true },
     { key: 'amortize', column: 'Assetschedule', type: 'select', required: true, section: 'principal', options: [{ value: 'MO', label: ui('assetsOptMonthly') }, { value: 'YE', label: ui('assetsOptYearly') }], displayLogic: (record) => isDepreciate(record) && record.calculateType === 'TI' },
-    { key: 'usableLifeYears', column: 'UseLifeYears', type: 'number', section: 'principal', displayLogic: (record) => isDepreciate(record) && record.calculateType === 'TI' && record.amortize === 'YE' },
-    { key: 'usableLifeMonths', column: 'UseLifeMonths', type: 'number', section: 'principal', displayLogic: (record) => isDepreciate(record) && record.calculateType === 'TI' && record.amortize !== 'YE' },
+    { key: 'usableLifeYears', column: 'UseLifeYears', type: 'number', section: 'principal', displayLogic: (record) => isDepreciate(record) && record.calculateType === 'TI' && record.amortize === 'YE', requiredVisual: true },
+    { key: 'usableLifeMonths', column: 'UseLifeMonths', type: 'number', section: 'principal', displayLogic: (record) => isDepreciate(record) && record.calculateType === 'TI' && record.amortize !== 'YE', requiredVisual: true },
   ];
 
   function makeDisplayLogic(fields) {
@@ -224,7 +224,7 @@ export default function AssetsDetailPanel({ data, token, apiBaseUrl, catalogs, a
   const dateFields = [
     { key: 'purchaseDate', column: 'Datepurchased', type: 'date', label: ui('assetsPurchaseDateLabel'), section: 'principal' },
     { key: 'cancellationDate', column: 'Cancellationdate', type: 'date', label: ui('assetsCancellationDateLabel'), section: 'principal' },
-    { key: 'depreciationStartDate', column: 'Amortizationstartdate', type: 'date', label: ui('assetsDepStartDateLabel'), section: 'principal' },
+    { key: 'depreciationStartDate', column: 'Amortizationstartdate', type: 'date', label: ui('assetsDepStartDateLabel'), section: 'principal', requiredVisual: true },
     { key: 'depreciationEndDate', column: 'Amortizationenddate', type: 'date', label: ui('assetsDepEndDateLabel'), section: 'principal' },
   ];
 

--- a/tools/app-shell/src/windows/custom/assets/__tests__/AssetsAmortizationPanel.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/assets/__tests__/AssetsAmortizationPanel.vitest.jsx
@@ -86,7 +86,8 @@ describe('AssetsAmortizationPanel', () => {
     await waitFor(() => {
       expect(screen.getByText('25.00%')).toBeInTheDocument();
     });
-    expect(screen.getByText('EUR 1000')).toBeInTheDocument();
+    // Single line -> row amount and footer total both render "EUR 1000".
+    expect(screen.getAllByText('EUR 1000')).toHaveLength(2);
     // Column headers
     expect(screen.getByText('assetsPeriod')).toBeInTheDocument();
     expect(screen.getByText('assetsPercentage')).toBeInTheDocument();
@@ -167,7 +168,8 @@ describe('AssetsAmortizationPanel', () => {
     });
     const { container } = render(<AssetsAmortizationPanel {...BASE_PROPS} />);
     await waitFor(() => {
-      expect(screen.getByText('EUR 100')).toBeInTheDocument();
+      // Single line -> row amount and footer total both render "EUR 100".
+      expect(screen.getAllByText('EUR 100')).toHaveLength(2);
     });
     // The percentage cell should show a dash
     const tds = container.querySelectorAll('td');
@@ -185,7 +187,8 @@ describe('AssetsAmortizationPanel', () => {
     });
     const { container } = render(<AssetsAmortizationPanel {...BASE_PROPS} />);
     await waitFor(() => {
-      expect(screen.getByText('EUR 100')).toBeInTheDocument();
+      // Single line -> row amount and footer total both render "EUR 100".
+      expect(screen.getAllByText('EUR 100')).toHaveLength(2);
     });
     const tds = container.querySelectorAll('td');
     const periodCell = tds[1]; // tds[0] is checkbox
@@ -240,7 +243,8 @@ describe('AssetsAmortizationPanel', () => {
     });
     render(<AssetsAmortizationPanel {...BASE_PROPS} />);
     await waitFor(() => {
-      expect(screen.getByText('EUR 42')).toBeInTheDocument();
+      // Single line -> row amount and footer total both render "EUR 42".
+      expect(screen.getAllByText('EUR 42')).toHaveLength(2);
     });
   });
 
@@ -716,5 +720,151 @@ describe('AssetsAmortizationPanel — neo:processSuccess refetch', () => {
     );
     await new Promise((r) => setTimeout(r, 50));
     expect(globalThis.fetch.mock.calls.length).toBe(before);
+  });
+});
+
+describe('AssetsAmortizationPanel — amortization total footer (ETP-4336)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Footer layout is: [checkbox spacer, empty, empty, total, status spacer].
+  function getFooterTotalCell(container) {
+    const tfoot = container.querySelector('tfoot');
+    if (!tfoot) return null;
+    return tfoot.querySelectorAll('td')[3] ?? null;
+  }
+
+  it('shows the summed total amount in the footer', async () => {
+    const lines = [
+      { id: 'l1', amortizationAmount: 1000 },
+      { id: 'l2', amortizationAmount: 1000 },
+    ];
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: { data: lines } }),
+    });
+    const { container } = render(
+      <AssetsAmortizationPanel {...BASE_PROPS} data={{ id: 'asset-1' }} />
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('Checkbox__amort-row-l1')).toBeInTheDocument();
+    });
+
+    const totalCell = getFooterTotalCell(container);
+    expect(totalCell).not.toBeNull();
+    // formatCurrency is mocked as `${cur} ${val}` — assert the numeric portion
+    // directly rather than any locale-specific formatting.
+    expect(totalCell.textContent).toBe('EUR 2000');
+  });
+
+  it('flags the footer total with the alert class when it does not match data.depreciationAmt', async () => {
+    const lines = [
+      { id: 'l1', amortizationAmount: 1000 },
+      { id: 'l2', amortizationAmount: 1000 },
+    ];
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: { data: lines } }),
+    });
+    const { container } = render(
+      <AssetsAmortizationPanel {...BASE_PROPS} data={{ id: 'asset-1', depreciationAmt: 1500 }} />
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('Checkbox__amort-row-l1')).toBeInTheDocument();
+    });
+
+    const totalCell = getFooterTotalCell(container);
+    expect(totalCell.className).toContain('text-red-500');
+    expect(totalCell.className).not.toContain('text-foreground');
+  });
+
+  it('does not flag the footer total when it matches data.depreciationAmt', async () => {
+    const lines = [
+      { id: 'l1', amortizationAmount: 1000 },
+      { id: 'l2', amortizationAmount: 1000 },
+    ];
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: { data: lines } }),
+    });
+    const { container } = render(
+      <AssetsAmortizationPanel {...BASE_PROPS} data={{ id: 'asset-1', depreciationAmt: 2000 }} />
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('Checkbox__amort-row-l1')).toBeInTheDocument();
+    });
+
+    const totalCell = getFooterTotalCell(container);
+    expect(totalCell.className).toContain('text-foreground');
+    expect(totalCell.className).not.toContain('text-red-500');
+  });
+
+  it('tolerates floating-point rounding noise within 0.005 without flagging the total', async () => {
+    // 0.1 + 0.2 === 0.30000000000000004 as a JS float; the component rounds
+    // both sides to cents before comparing, so this must NOT be flagged.
+    const lines = [
+      { id: 'l1', amortizationAmount: 0.1 },
+      { id: 'l2', amortizationAmount: 0.2 },
+    ];
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: { data: lines } }),
+    });
+    const { container } = render(
+      <AssetsAmortizationPanel {...BASE_PROPS} data={{ id: 'asset-1', depreciationAmt: 0.3 }} />
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('Checkbox__amort-row-l1')).toBeInTheDocument();
+    });
+
+    const totalCell = getFooterTotalCell(container);
+    expect(totalCell.className).toContain('text-foreground');
+    expect(totalCell.className).not.toContain('text-red-500');
+  });
+
+  it('does not flag the total when data.depreciationAmt is null or undefined', async () => {
+    const lines = [
+      { id: 'l1', amortizationAmount: 1000 },
+      { id: 'l2', amortizationAmount: 1000 },
+    ];
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: { data: lines } }),
+    });
+    const { container, rerender } = render(
+      <AssetsAmortizationPanel {...BASE_PROPS} data={{ id: 'asset-1', depreciationAmt: null }} />
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId('Checkbox__amort-row-l1')).toBeInTheDocument();
+    });
+
+    let totalCell = getFooterTotalCell(container);
+    expect(totalCell.className).toContain('text-foreground');
+    expect(totalCell.className).not.toContain('text-red-500');
+
+    rerender(<AssetsAmortizationPanel {...BASE_PROPS} data={{ id: 'asset-1' }} />);
+    totalCell = getFooterTotalCell(container);
+    expect(totalCell.className).toContain('text-foreground');
+    expect(totalCell.className).not.toContain('text-red-500');
+  });
+
+  it('does not render a footer/total row when there are no lines', async () => {
+    globalThis.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ response: { data: [] } }),
+    });
+    const { container } = render(
+      <AssetsAmortizationPanel {...BASE_PROPS} data={{ id: 'asset-1', depreciationAmt: 500 }} />
+    );
+    await waitFor(() => {
+      expect(screen.getByText('assetsNoAmortizationLines')).toBeInTheDocument();
+    });
+    expect(container.querySelector('tfoot')).toBeNull();
   });
 });


### PR DESCRIPTION
- Reusable requiredVisual EntityForm field-descriptor prop: visual-only required asterisk that does not enforce validation, applied to 6 conditionally-required Assets fields (currency, depreciationAmt, annualDepreciation, usableLifeYears, usableLifeMonths, depreciationStartDate).
- Amortization Plan tab: footer row totaling the Amount column, shown in alert color when it does not match the asset's amount to amortize (depreciationAmt).
- Adds Vitest coverage and updates the Assets window guide and ui-customization docs.