### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.5",
-        "@etendosoftware/schema-forge-cli": "0.3.5",
-        "@etendosoftware/schema-forge-core": "0.3.5",
+        "@etendosoftware/app-shell-core": "0.3.3",
+        "@etendosoftware/schema-forge-cli": "0.3.3",
+        "@etendosoftware/schema-forge-core": "0.3.3",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2573,9 +2573,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.5/8e779eb500d54811e3573ea5367efbc65edf039b",
-      "integrity": "sha512-4p+LtREP+GQKS65pLUwKkKCW5yjsQHpMlQx6zRZCn7Olb8AQ8Sf5Q0HVeOBHB/11JZWQmJhA30SQ88CRugL0Rg==",
+      "version": "0.3.3",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.3/18facdf264bc1d46f3c41f485f1096f52308327a",
+      "integrity": "sha512-TDOL/MDa8z9l2iW/a8sjQqAb4hrPSU+RoDnDuqKtG7zKMc1ZI0WnyimQA6gxAjSd3BlKP5Ctt9Q2JiHw6pITZw==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2601,21 +2601,10 @@
         "tailwind-merge": "^2.2.0"
       }
     },
-    "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.5/3ea0284c7ee1275c638b36b96d1d534048f372c5",
-      "integrity": "sha512-B3nzJfIbBS+nUYYHlDS+TmUmv4f9vIxGzjK/2SMhxceacFV0NF+xuE2ItAyV0MUYf0lDjEWBU00D3kNLHJUgLw==",
-      "peerDependencies": {
-        "lucide-react": "^0.400.0",
-        "react": "^18.3.0",
-        "react-dom": "^18.3.0",
-        "react-router-dom": "^7.0.0"
-      }
-    },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.5/c8c4c7aff85ce3367d101bfe3b25e538d54cadfc",
-      "integrity": "sha512-9i0YjIXQWp1MfaMu7nZ5iJxd66DzwZPjrOh3iGYlJXQl91jReuI6BFhXSv3hpLAPwgCz08orArxQAV9R6LNzpA==",
+      "version": "0.3.3",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.3/4c8a4b86e9ded5b36ab43b01c48d17b40c3092e4",
+      "integrity": "sha512-dAB9NkzJHd6TtHr6I8cFRK5+ccalkwDypKZsakj2hqJs5ds+2BfafCNZqfuzS6ppz9/oasOCgOJ4EsbO0+i9CA==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2658,9 +2647,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.5/523f884c7cccfbb92a5ac6a813878ee02b820c14",
-      "integrity": "sha512-85WCL7uyvPwq0L3297UxBaQf/v5PUr9Zn3jvZZvM/hJgB3R1JaIqr1qbjF2svPn0frOus2V4yW/ZbRqSLI/R8g==",
+      "version": "0.3.3",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.3/71262b7e45825114d0d1d22a82c60de53a4ef199",
+      "integrity": "sha512-C9v5uCfMBPlteXBDRJKim1eVzkn3QGewiJ+nZaPcTBPh89adLgy7wC/c1W/xb1QH6FHUFqo2AIvdGgCZiVJqBQ==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13626,8 +13615,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.5",
-        "@etendosoftware/etendo-go-core": "0.3.5",
+        "@etendosoftware/app-shell-core": "0.3.3",
+        "@etendosoftware/etendo-go-core": "0.3.3",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -14116,6 +14105,17 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "tools/app-shell/node_modules/@etendosoftware/etendo-go-core": {
+      "version": "0.3.3",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.3/803a9bf0de0856bfda3762d485916cdf8e6da360",
+      "integrity": "sha512-WmgrrddVHtZcmrdxdFGkh0ZJY3yGxzhizTWsTVrg694BeuntoOw3/SayB9ZudZCahvEFLjoAu2vM8WyG6Ix9tQ==",
+      "peerDependencies": {
+        "lucide-react": "^0.400.0",
+        "react": "^18.3.0",
+        "react-dom": "^18.3.0",
+        "react-router-dom": "^7.0.0"
       }
     },
     "tools/app-shell/node_modules/esbuild": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.5",
-    "@etendosoftware/schema-forge-cli": "0.3.5",
-    "@etendosoftware/schema-forge-core": "0.3.5",
+    "@etendosoftware/app-shell-core": "0.3.3",
+    "@etendosoftware/schema-forge-cli": "0.3.3",
+    "@etendosoftware/schema-forge-core": "0.3.3",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.5",
-        "@etendosoftware/etendo-go-core": "0.3.5",
+        "@etendosoftware/app-shell-core": "0.3.3",
+        "@etendosoftware/etendo-go-core": "0.3.3",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -2255,9 +2255,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.5/8e779eb500d54811e3573ea5367efbc65edf039b",
-      "integrity": "sha512-4p+LtREP+GQKS65pLUwKkKCW5yjsQHpMlQx6zRZCn7Olb8AQ8Sf5Q0HVeOBHB/11JZWQmJhA30SQ88CRugL0Rg==",
+      "version": "0.3.3",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.3/18facdf264bc1d46f3c41f485f1096f52308327a",
+      "integrity": "sha512-TDOL/MDa8z9l2iW/a8sjQqAb4hrPSU+RoDnDuqKtG7zKMc1ZI0WnyimQA6gxAjSd3BlKP5Ctt9Q2JiHw6pITZw==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2284,9 +2284,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.5/3ea0284c7ee1275c638b36b96d1d534048f372c5",
-      "integrity": "sha512-B3nzJfIbBS+nUYYHlDS+TmUmv4f9vIxGzjK/2SMhxceacFV0NF+xuE2ItAyV0MUYf0lDjEWBU00D3kNLHJUgLw==",
+      "version": "0.3.3",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.3/803a9bf0de0856bfda3762d485916cdf8e6da360",
+      "integrity": "sha512-WmgrrddVHtZcmrdxdFGkh0ZJY3yGxzhizTWsTVrg694BeuntoOw3/SayB9ZudZCahvEFLjoAu2vM8WyG6Ix9tQ==",
       "peerDependencies": {
         "lucide-react": "^0.400.0",
         "react": "^18.3.0",
@@ -12066,14 +12066,14 @@
       "optional": true
     },
     "@etendosoftware/app-shell-core": {
-      "version": "0.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.5/8e779eb500d54811e3573ea5367efbc65edf039b",
-      "integrity": "sha512-4p+LtREP+GQKS65pLUwKkKCW5yjsQHpMlQx6zRZCn7Olb8AQ8Sf5Q0HVeOBHB/11JZWQmJhA30SQ88CRugL0Rg=="
+      "version": "0.3.3",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.3/18facdf264bc1d46f3c41f485f1096f52308327a",
+      "integrity": "sha512-TDOL/MDa8z9l2iW/a8sjQqAb4hrPSU+RoDnDuqKtG7zKMc1ZI0WnyimQA6gxAjSd3BlKP5Ctt9Q2JiHw6pITZw=="
     },
     "@etendosoftware/etendo-go-core": {
-      "version": "0.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.5/3ea0284c7ee1275c638b36b96d1d534048f372c5",
-      "integrity": "sha512-B3nzJfIbBS+nUYYHlDS+TmUmv4f9vIxGzjK/2SMhxceacFV0NF+xuE2ItAyV0MUYf0lDjEWBU00D3kNLHJUgLw=="
+      "version": "0.3.3",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.3/803a9bf0de0856bfda3762d485916cdf8e6da360",
+      "integrity": "sha512-WmgrrddVHtZcmrdxdFGkh0ZJY3yGxzhizTWsTVrg694BeuntoOw3/SayB9ZudZCahvEFLjoAu2vM8WyG6Ix9tQ=="
     },
     "@exodus/bytes": {
       "version": "1.15.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -15,8 +15,8 @@
     "test:all": "npm run test && npm run test:vitest"
   },
   "dependencies": {
-    "@etendosoftware/app-shell-core": "0.3.5",
-    "@etendosoftware/etendo-go-core": "0.3.5",
+    "@etendosoftware/app-shell-core": "0.3.3",
+    "@etendosoftware/etendo-go-core": "0.3.3",
     "@iconicapp/iconic-react": "^1.1.4",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.3`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.