### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.5",
-        "@etendosoftware/schema-forge-cli": "0.3.5",
-        "@etendosoftware/schema-forge-core": "0.3.5",
+        "@etendosoftware/app-shell-core": "0.3.6",
+        "@etendosoftware/schema-forge-cli": "0.3.6",
+        "@etendosoftware/schema-forge-core": "0.3.6",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2573,9 +2573,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.5/8e779eb500d54811e3573ea5367efbc65edf039b",
-      "integrity": "sha512-4p+LtREP+GQKS65pLUwKkKCW5yjsQHpMlQx6zRZCn7Olb8AQ8Sf5Q0HVeOBHB/11JZWQmJhA30SQ88CRugL0Rg==",
+      "version": "0.3.6",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.6/879d7a16161c422578f09f9cb0156bae1d7bb70e",
+      "integrity": "sha512-Jxub2Z3phM2RuB/W67k0B23YmHVCl0ZJGEqZkahXHx1ctIN9tWklyVXMTfWK/Fdl0RzAHen4uqdXScEf1ZXKlg==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2602,9 +2602,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.5/3ea0284c7ee1275c638b36b96d1d534048f372c5",
-      "integrity": "sha512-B3nzJfIbBS+nUYYHlDS+TmUmv4f9vIxGzjK/2SMhxceacFV0NF+xuE2ItAyV0MUYf0lDjEWBU00D3kNLHJUgLw==",
+      "version": "0.3.6",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.6/1a6ce3c7310e5ecb299dddab96599fbceaa932fa",
+      "integrity": "sha512-3f9JPs+NqF1IPLqypICG8Un+dh8hxxzzLywcHUxukoI5sUkhtZwJcNDpgkp+8ZDegIV29sv6WWyK5255SDTvKw==",
       "peerDependencies": {
         "lucide-react": "^0.400.0",
         "react": "^18.3.0",
@@ -2613,9 +2613,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.5/c8c4c7aff85ce3367d101bfe3b25e538d54cadfc",
-      "integrity": "sha512-9i0YjIXQWp1MfaMu7nZ5iJxd66DzwZPjrOh3iGYlJXQl91jReuI6BFhXSv3hpLAPwgCz08orArxQAV9R6LNzpA==",
+      "version": "0.3.6",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.6/472b8e547463865348b429d23ca0649e2b8dc259",
+      "integrity": "sha512-XQTnSMXoxWmljqcb3UkyfgResXG33tYgBISqG4fEG4vtvIvSWgh8nZeLrezix22dKSb8Gh2P/tA2U9kzbzf2rA==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2658,9 +2658,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.5/523f884c7cccfbb92a5ac6a813878ee02b820c14",
-      "integrity": "sha512-85WCL7uyvPwq0L3297UxBaQf/v5PUr9Zn3jvZZvM/hJgB3R1JaIqr1qbjF2svPn0frOus2V4yW/ZbRqSLI/R8g==",
+      "version": "0.3.6",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.6/883a7fb44816bf55115622c1b97732033b722ba3",
+      "integrity": "sha512-sFSu7tkuPEAfaC3QLxJA5nmxO6Q5OLPXl8BMsIRsgx6KpFDyO7f7LDqQq1MAholDumBXrCOZoCYd4Ay4sMBW9w==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13626,8 +13626,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.5",
-        "@etendosoftware/etendo-go-core": "0.3.5",
+        "@etendosoftware/app-shell-core": "0.3.6",
+        "@etendosoftware/etendo-go-core": "0.3.6",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.5",
-    "@etendosoftware/schema-forge-cli": "0.3.5",
-    "@etendosoftware/schema-forge-core": "0.3.5",
+    "@etendosoftware/app-shell-core": "0.3.6",
+    "@etendosoftware/schema-forge-cli": "0.3.6",
+    "@etendosoftware/schema-forge-core": "0.3.6",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.5",
-        "@etendosoftware/etendo-go-core": "0.3.5",
+        "@etendosoftware/app-shell-core": "0.3.6",
+        "@etendosoftware/etendo-go-core": "0.3.6",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -2255,9 +2255,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.5/8e779eb500d54811e3573ea5367efbc65edf039b",
-      "integrity": "sha512-4p+LtREP+GQKS65pLUwKkKCW5yjsQHpMlQx6zRZCn7Olb8AQ8Sf5Q0HVeOBHB/11JZWQmJhA30SQ88CRugL0Rg==",
+      "version": "0.3.6",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.6/879d7a16161c422578f09f9cb0156bae1d7bb70e",
+      "integrity": "sha512-Jxub2Z3phM2RuB/W67k0B23YmHVCl0ZJGEqZkahXHx1ctIN9tWklyVXMTfWK/Fdl0RzAHen4uqdXScEf1ZXKlg==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2284,9 +2284,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.5/3ea0284c7ee1275c638b36b96d1d534048f372c5",
-      "integrity": "sha512-B3nzJfIbBS+nUYYHlDS+TmUmv4f9vIxGzjK/2SMhxceacFV0NF+xuE2ItAyV0MUYf0lDjEWBU00D3kNLHJUgLw==",
+      "version": "0.3.6",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.6/1a6ce3c7310e5ecb299dddab96599fbceaa932fa",
+      "integrity": "sha512-3f9JPs+NqF1IPLqypICG8Un+dh8hxxzzLywcHUxukoI5sUkhtZwJcNDpgkp+8ZDegIV29sv6WWyK5255SDTvKw==",
       "peerDependencies": {
         "lucide-react": "^0.400.0",
         "react": "^18.3.0",
@@ -12066,14 +12066,14 @@
       "optional": true
     },
     "@etendosoftware/app-shell-core": {
-      "version": "0.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.5/8e779eb500d54811e3573ea5367efbc65edf039b",
-      "integrity": "sha512-4p+LtREP+GQKS65pLUwKkKCW5yjsQHpMlQx6zRZCn7Olb8AQ8Sf5Q0HVeOBHB/11JZWQmJhA30SQ88CRugL0Rg=="
+      "version": "0.3.6",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.6/879d7a16161c422578f09f9cb0156bae1d7bb70e",
+      "integrity": "sha512-Jxub2Z3phM2RuB/W67k0B23YmHVCl0ZJGEqZkahXHx1ctIN9tWklyVXMTfWK/Fdl0RzAHen4uqdXScEf1ZXKlg=="
     },
     "@etendosoftware/etendo-go-core": {
-      "version": "0.3.5",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.5/3ea0284c7ee1275c638b36b96d1d534048f372c5",
-      "integrity": "sha512-B3nzJfIbBS+nUYYHlDS+TmUmv4f9vIxGzjK/2SMhxceacFV0NF+xuE2ItAyV0MUYf0lDjEWBU00D3kNLHJUgLw=="
+      "version": "0.3.6",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.6/1a6ce3c7310e5ecb299dddab96599fbceaa932fa",
+      "integrity": "sha512-3f9JPs+NqF1IPLqypICG8Un+dh8hxxzzLywcHUxukoI5sUkhtZwJcNDpgkp+8ZDegIV29sv6WWyK5255SDTvKw=="
     },
     "@exodus/bytes": {
       "version": "1.15.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -15,8 +15,8 @@
     "test:all": "npm run test && npm run test:vitest"
   },
   "dependencies": {
-    "@etendosoftware/app-shell-core": "0.3.5",
-    "@etendosoftware/etendo-go-core": "0.3.5",
+    "@etendosoftware/app-shell-core": "0.3.6",
+    "@etendosoftware/etendo-go-core": "0.3.6",
     "@iconicapp/iconic-react": "^1.1.4",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.6`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.