### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.6",
-        "@etendosoftware/schema-forge-cli": "0.3.6",
-        "@etendosoftware/schema-forge-core": "0.3.6",
+        "@etendosoftware/app-shell-core": "0.3.7",
+        "@etendosoftware/schema-forge-cli": "0.3.7",
+        "@etendosoftware/schema-forge-core": "0.3.7",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2573,9 +2573,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.6",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.6/879d7a16161c422578f09f9cb0156bae1d7bb70e",
-      "integrity": "sha512-Jxub2Z3phM2RuB/W67k0B23YmHVCl0ZJGEqZkahXHx1ctIN9tWklyVXMTfWK/Fdl0RzAHen4uqdXScEf1ZXKlg==",
+      "version": "0.3.7",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.7/d35ee7b84b6cfae425fc77e46cf4ed6a48e5e294",
+      "integrity": "sha512-6q2kLWo82BkvfWmeyo9S99/78fud0DtcOG1cPTzT8kvAInTcn6plwgzE2k8CKK0r2PqhHy7SFb1o/LYmqg1edg==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2602,10 +2602,11 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.6",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.6/1a6ce3c7310e5ecb299dddab96599fbceaa932fa",
-      "integrity": "sha512-3f9JPs+NqF1IPLqypICG8Un+dh8hxxzzLywcHUxukoI5sUkhtZwJcNDpgkp+8ZDegIV29sv6WWyK5255SDTvKw==",
+      "version": "0.3.7",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.7/79fa3735d5578ac00dd5ba6b95f96c72f701dfc0",
+      "integrity": "sha512-CdztpgqPSC+VcBLFEvv85urO/oPKIOObhz1h/vbFcdv8Ljn5kA/bFtkzaTdHp2uon9EzZgUp31L9QH6VK6/YIA==",
       "peerDependencies": {
+        "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
@@ -2613,9 +2614,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.6",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.6/472b8e547463865348b429d23ca0649e2b8dc259",
-      "integrity": "sha512-XQTnSMXoxWmljqcb3UkyfgResXG33tYgBISqG4fEG4vtvIvSWgh8nZeLrezix22dKSb8Gh2P/tA2U9kzbzf2rA==",
+      "version": "0.3.7",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.7/bb3a81a1e7e95180204e3b580a88270b54a1b108",
+      "integrity": "sha512-XtESnALbEFmXHc/zFZkt6BhTkpvYGCFzUccFlvVEVv9kl0ZJ7qN7+bGnqpObcYexXUw2iL1vckJma22E0CE9Gg==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2645,6 +2646,7 @@
         "sf-report-preview": "src/report-preview.js",
         "sf-report-serve": "src/report-serve.js",
         "sf-resolve-curated": "src/resolve-curated.js",
+        "sf-slice-labels": "src/slice-labels-cli.js",
         "sf-test": "src/run-contract-tests.js",
         "sf-test-report": "src/test-report-html.js",
         "sf-validate": "src/validate-schema.js",
@@ -2658,9 +2660,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.6",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.6/883a7fb44816bf55115622c1b97732033b722ba3",
-      "integrity": "sha512-sFSu7tkuPEAfaC3QLxJA5nmxO6Q5OLPXl8BMsIRsgx6KpFDyO7f7LDqQq1MAholDumBXrCOZoCYd4Ay4sMBW9w==",
+      "version": "0.3.7",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.7/237d670cc4feff83c926a197be4b46adf9adae76",
+      "integrity": "sha512-lLLLEDqB86yDd1kZBaunUuaMZABa4snqGsntmlgUUYDClVf+mTWJXLOFld7dLe62VVulmuqbbE01R5BCoyISbg==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13626,8 +13628,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.6",
-        "@etendosoftware/etendo-go-core": "0.3.6",
+        "@etendosoftware/app-shell-core": "0.3.7",
+        "@etendosoftware/etendo-go-core": "0.3.7",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.6",
-    "@etendosoftware/schema-forge-cli": "0.3.6",
-    "@etendosoftware/schema-forge-core": "0.3.6",
+    "@etendosoftware/app-shell-core": "0.3.7",
+    "@etendosoftware/schema-forge-cli": "0.3.7",
+    "@etendosoftware/schema-forge-core": "0.3.7",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.6",
-        "@etendosoftware/etendo-go-core": "0.3.6",
+        "@etendosoftware/app-shell-core": "0.3.7",
+        "@etendosoftware/etendo-go-core": "0.3.7",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -2255,9 +2255,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.6",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.6/879d7a16161c422578f09f9cb0156bae1d7bb70e",
-      "integrity": "sha512-Jxub2Z3phM2RuB/W67k0B23YmHVCl0ZJGEqZkahXHx1ctIN9tWklyVXMTfWK/Fdl0RzAHen4uqdXScEf1ZXKlg==",
+      "version": "0.3.7",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.7/d35ee7b84b6cfae425fc77e46cf4ed6a48e5e294",
+      "integrity": "sha512-6q2kLWo82BkvfWmeyo9S99/78fud0DtcOG1cPTzT8kvAInTcn6plwgzE2k8CKK0r2PqhHy7SFb1o/LYmqg1edg==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2284,10 +2284,11 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.6",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.6/1a6ce3c7310e5ecb299dddab96599fbceaa932fa",
-      "integrity": "sha512-3f9JPs+NqF1IPLqypICG8Un+dh8hxxzzLywcHUxukoI5sUkhtZwJcNDpgkp+8ZDegIV29sv6WWyK5255SDTvKw==",
+      "version": "0.3.7",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.7/79fa3735d5578ac00dd5ba6b95f96c72f701dfc0",
+      "integrity": "sha512-CdztpgqPSC+VcBLFEvv85urO/oPKIOObhz1h/vbFcdv8Ljn5kA/bFtkzaTdHp2uon9EzZgUp31L9QH6VK6/YIA==",
       "peerDependencies": {
+        "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
         "react": "^18.3.0",
         "react-dom": "^18.3.0",
@@ -12066,14 +12067,14 @@
       "optional": true
     },
     "@etendosoftware/app-shell-core": {
-      "version": "0.3.6",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.6/879d7a16161c422578f09f9cb0156bae1d7bb70e",
-      "integrity": "sha512-Jxub2Z3phM2RuB/W67k0B23YmHVCl0ZJGEqZkahXHx1ctIN9tWklyVXMTfWK/Fdl0RzAHen4uqdXScEf1ZXKlg=="
+      "version": "0.3.7",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.7/d35ee7b84b6cfae425fc77e46cf4ed6a48e5e294",
+      "integrity": "sha512-6q2kLWo82BkvfWmeyo9S99/78fud0DtcOG1cPTzT8kvAInTcn6plwgzE2k8CKK0r2PqhHy7SFb1o/LYmqg1edg=="
     },
     "@etendosoftware/etendo-go-core": {
-      "version": "0.3.6",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.6/1a6ce3c7310e5ecb299dddab96599fbceaa932fa",
-      "integrity": "sha512-3f9JPs+NqF1IPLqypICG8Un+dh8hxxzzLywcHUxukoI5sUkhtZwJcNDpgkp+8ZDegIV29sv6WWyK5255SDTvKw=="
+      "version": "0.3.7",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.7/79fa3735d5578ac00dd5ba6b95f96c72f701dfc0",
+      "integrity": "sha512-CdztpgqPSC+VcBLFEvv85urO/oPKIOObhz1h/vbFcdv8Ljn5kA/bFtkzaTdHp2uon9EzZgUp31L9QH6VK6/YIA=="
     },
     "@exodus/bytes": {
       "version": "1.15.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -15,8 +15,8 @@
     "test:all": "npm run test && npm run test:vitest"
   },
   "dependencies": {
-    "@etendosoftware/app-shell-core": "0.3.6",
-    "@etendosoftware/etendo-go-core": "0.3.6",
+    "@etendosoftware/app-shell-core": "0.3.7",
+    "@etendosoftware/etendo-go-core": "0.3.7",
     "@iconicapp/iconic-react": "^1.1.4",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.7`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.