### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.8",
-        "@etendosoftware/schema-forge-cli": "0.3.8",
-        "@etendosoftware/schema-forge-core": "0.3.8",
+        "@etendosoftware/app-shell-core": "0.3.9",
+        "@etendosoftware/schema-forge-cli": "0.3.9",
+        "@etendosoftware/schema-forge-core": "0.3.9",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2573,9 +2573,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.8",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.8/1154a49cb6385b5a18fe6276e0c631f966f9f7f1",
-      "integrity": "sha512-2hK5geXPq/2b5zujFDIli2HQBAO2Q6DodvCbYwLeJ1vrz/YyDyGKr9g8KGKMEqCY0oyRVEn2FKCIywOE6q9Xrw==",
+      "version": "0.3.9",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.9/0c6dc9dc1893449cbb6e5e5912a45ddf731a4edc",
+      "integrity": "sha512-RAc1ThDrLIRvb7ecyaH6SL9KSUp01mmPyuW0tHu+ktGrMd69ag9Cad9YyIGylORfv3LjOBLe9f+X7EbMoYZXgA==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2602,9 +2602,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.8",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.8/d0a84e89c92b6f6b3361ed89807d3776ec0e2fa2",
-      "integrity": "sha512-jt5gHVGZI2gbA9bzvaoUIhH+G30nTsXMRNC2tY6+whFJ80EaQdroRqK+sZrWLNek6RXxFdj+dHYtFBpT6AVYjw==",
+      "version": "0.3.9",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.9/14e6b07b241c6562ad4d0ba990b4cbf1e29053eb",
+      "integrity": "sha512-SsAQtayhxFcUipIQdxuy5Gz/9m3pgv13ygiLK0Y4hQcqaXQrPHdAqoUykZM6+3j6RPHXAQ8zCm6IL9B6FJI0Vw==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2614,9 +2614,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.8",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.8/5c57eb3a1c4cb1a2ec933d6307799524f15d7bcd",
-      "integrity": "sha512-Tu4oSQGHM1YKrqyA3WxWwPpxd5L5aB8EPHyapGbXYAdxV/Vz/ok7h3aSqwispamSiSSX1dxUQGv3hGpp3wcc3w==",
+      "version": "0.3.9",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.9/fae3eb2a4c3e4135c72a178c49334badd51fcd8b",
+      "integrity": "sha512-q4tJCzX0FTRH0RWZYQZDveKkQ7OVxftIPptQHUe5lPY7DM3nGn/Mo/Kx7ACFA9o0wsbpakejx9f7EXodxH5Mcw==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2660,9 +2660,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.8",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.8/a1fa92ff7a46112ad357c93823ef6657b6715e4c",
-      "integrity": "sha512-40KbFPYoNqusztIfletFCUTQqGjin+Xd7LTpmRCaybtTAT9Nw3NgXe9kebUsjmxsdO0cQ9pbL7W578CFoYtERA==",
+      "version": "0.3.9",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.9/eee0964d822c8cf1b09727d292aaa260f18584a1",
+      "integrity": "sha512-nWCrm1UjFnYdEuipPe1WwV2tRV0+RWv/v4ra6ultYTIouF8eUFYaCfnpZJrU1b1SAwipMFR63iTPB7q1MRVT3g==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13628,8 +13628,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.8",
-        "@etendosoftware/etendo-go-core": "0.3.8",
+        "@etendosoftware/app-shell-core": "0.3.9",
+        "@etendosoftware/etendo-go-core": "0.3.9",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.8",
-    "@etendosoftware/schema-forge-cli": "0.3.8",
-    "@etendosoftware/schema-forge-core": "0.3.8",
+    "@etendosoftware/app-shell-core": "0.3.9",
+    "@etendosoftware/schema-forge-cli": "0.3.9",
+    "@etendosoftware/schema-forge-core": "0.3.9",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.8",
-        "@etendosoftware/etendo-go-core": "0.3.8",
+        "@etendosoftware/app-shell-core": "0.3.9",
+        "@etendosoftware/etendo-go-core": "0.3.9",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -2255,9 +2255,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.8",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.8/1154a49cb6385b5a18fe6276e0c631f966f9f7f1",
-      "integrity": "sha512-2hK5geXPq/2b5zujFDIli2HQBAO2Q6DodvCbYwLeJ1vrz/YyDyGKr9g8KGKMEqCY0oyRVEn2FKCIywOE6q9Xrw==",
+      "version": "0.3.9",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.9/0c6dc9dc1893449cbb6e5e5912a45ddf731a4edc",
+      "integrity": "sha512-RAc1ThDrLIRvb7ecyaH6SL9KSUp01mmPyuW0tHu+ktGrMd69ag9Cad9YyIGylORfv3LjOBLe9f+X7EbMoYZXgA==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2284,9 +2284,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.8",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.8/d0a84e89c92b6f6b3361ed89807d3776ec0e2fa2",
-      "integrity": "sha512-jt5gHVGZI2gbA9bzvaoUIhH+G30nTsXMRNC2tY6+whFJ80EaQdroRqK+sZrWLNek6RXxFdj+dHYtFBpT6AVYjw==",
+      "version": "0.3.9",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.9/14e6b07b241c6562ad4d0ba990b4cbf1e29053eb",
+      "integrity": "sha512-SsAQtayhxFcUipIQdxuy5Gz/9m3pgv13ygiLK0Y4hQcqaXQrPHdAqoUykZM6+3j6RPHXAQ8zCm6IL9B6FJI0Vw==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -12067,14 +12067,14 @@
       "optional": true
     },
     "@etendosoftware/app-shell-core": {
-      "version": "0.3.8",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.8/1154a49cb6385b5a18fe6276e0c631f966f9f7f1",
-      "integrity": "sha512-2hK5geXPq/2b5zujFDIli2HQBAO2Q6DodvCbYwLeJ1vrz/YyDyGKr9g8KGKMEqCY0oyRVEn2FKCIywOE6q9Xrw=="
+      "version": "0.3.9",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.9/0c6dc9dc1893449cbb6e5e5912a45ddf731a4edc",
+      "integrity": "sha512-RAc1ThDrLIRvb7ecyaH6SL9KSUp01mmPyuW0tHu+ktGrMd69ag9Cad9YyIGylORfv3LjOBLe9f+X7EbMoYZXgA=="
     },
     "@etendosoftware/etendo-go-core": {
-      "version": "0.3.8",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.8/d0a84e89c92b6f6b3361ed89807d3776ec0e2fa2",
-      "integrity": "sha512-jt5gHVGZI2gbA9bzvaoUIhH+G30nTsXMRNC2tY6+whFJ80EaQdroRqK+sZrWLNek6RXxFdj+dHYtFBpT6AVYjw=="
+      "version": "0.3.9",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.9/14e6b07b241c6562ad4d0ba990b4cbf1e29053eb",
+      "integrity": "sha512-SsAQtayhxFcUipIQdxuy5Gz/9m3pgv13ygiLK0Y4hQcqaXQrPHdAqoUykZM6+3j6RPHXAQ8zCm6IL9B6FJI0Vw=="
     },
     "@exodus/bytes": {
       "version": "1.15.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -15,8 +15,8 @@
     "test:all": "npm run test && npm run test:vitest"
   },
   "dependencies": {
-    "@etendosoftware/app-shell-core": "0.3.8",
-    "@etendosoftware/etendo-go-core": "0.3.8",
+    "@etendosoftware/app-shell-core": "0.3.9",
+    "@etendosoftware/etendo-go-core": "0.3.9",
     "@iconicapp/iconic-react": "^1.1.4",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.9`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.