### PR TITLE
Feature ETP-4509: Map GOClient roles to AD_Window_Access + AD_Process_Access

### DIFF
--- a/cli/sql/goclient-seed-process-access.sql
+++ b/cli/sql/goclient-seed-process-access.sql
@@ -1,0 +1,312 @@
+-- ETP-4509 (expansion) — Seed AD_Process_Access rows for the 4 canonical
+-- Etendo Go operational roles on GOClient (document-action processes tied
+-- to each role's FULL-access windows).
+--
+-- See docs/etendo-ad/roles-users-reference.md for the window->process
+-- mapping mechanism (AD_Field button -> AD_Column.ad_process_id -> AD_Tab
+-- -> AD_Window, cross-checked against GOClient Admin/GOuser's own automatic
+-- grants), and the read-only-tier decision (zero process access granted --
+-- every button process found on a read-only window is state-changing, none
+-- are safe view-only actions).
+
+-- NOT THE AUTHORITATIVE ARTIFACT -- same convention as the other
+-- cli/sql/goclient-seed-*.sql scripts. The real, tracked deliverable is
+--   {etendo_root}/modules/com.etendoerp.go/referencedata/sampledata/GOClient/AD_PROCESS_ACCESS.xml
+
+-- AD_Process_Access has the same single isreadwrite (Y/N) flag as
+-- AD_Window_Access -- existence-based access, no separate CRUD tier. Every
+-- row here uses isreadwrite='Y' (matching GOClient Admin/GOuser's own
+-- automatic grants for the same processes).
+
+-- AD_ORG_ID is always '0', matching the AD_Window_Access convention.
+
+-- Idempotent: guarded by NOT EXISTS on (ad_role_id, ad_process_id) -- there
+-- is no DB-level UNIQUE constraint for this pair (same as AD_Window_Access).
+
+BEGIN;
+
+-- === FINANCE (127AE77FE2994067B7FE6495FC21D51E) ===
+-- Add Payment From Journal
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '0A150924EC42449E8B209BA187DFE7DE', '5BE14AA10165490A9ADEFB7532F7FA94', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_process_id='5BE14AA10165490A9ADEFB7532F7FA94');
+
+-- Add Payment From Journal Line
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'FD1E3E14341A4943BABB8BB96ABF61E6', 'DE1B382FDD2540199D223586F6E216D0', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_process_id='DE1B382FDD2540199D223586F6E216D0');
+
+-- Bank Statement Process
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '6BB68B901C154AECBF635D0D80ABBDCB', '58A9261BACEF45DDA526F29D8557272D', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_process_id='58A9261BACEF45DDA526F29D8557272D');
+
+-- Bank Statement Process Force
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'CFFBE2A8F29945C49CB9C7A7EC520C7D', '2DDE7D3618034C38A4462B7F3456C28D', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_process_id='2DDE7D3618034C38A4462B7F3456C28D');
+
+-- Import Statement
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'A4F969156DC040DFB72652387E0CACFB', '7AC7BE9024E448A0BB863C159DA762F9', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_process_id='7AC7BE9024E448A0BB863C159DA762F9');
+
+-- Reconcile
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '2B72CEA16A274A088A69A0A86E7D6F5E', 'EB3D56BDD37E4229B67DBAB9F9A9B167', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_process_id='EB3D56BDD37E4229B67DBAB9F9A9B167');
+
+-- Reconcile
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '3DEE15F3875D4C5E862A6F1B8586ED48', 'FF8080812E2F8EAE012E2F94CF470014', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_process_id='FF8080812E2F8EAE012E2F94CF470014');
+
+-- Reconciliation Details
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '4BB3490DAE4049AF81AD9944BD6F7044', '3C4A5FB206B74C3CA9FE20116FCA0464', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_process_id='3C4A5FB206B74C3CA9FE20116FCA0464');
+
+-- Reconciliation Process Force
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '7100203031B146B8947863C7D064818A', '6BF16EFC772843AC9A17552AE0B26AB7', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_process_id='6BF16EFC772843AC9A17552AE0B26AB7');
+
+-- Reconciliation Summary
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'C7883183370549C798BD166DC1B71812', 'BBA11D1A061346459AF6148920FE6629', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_process_id='BBA11D1A061346459AF6148920FE6629');
+
+-- Transaction Process
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '9AD883960F9A4A8487983C5C140F310C', 'F68F2890E96D4D85A1DEF0274D105BCE', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_process_id='F68F2890E96D4D85A1DEF0274D105BCE');
+
+-- Execute Payment
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '7E573E9ACA5D4A04AA5C389C75E741C9', 'E011F492B0814A74B63CD1F3B9FF0526', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_process_id='E011F492B0814A74B63CD1F3B9FF0526');
+
+-- Payment Process
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '918CDFAFC8DC4228939B7C9CE10B082D', '6255BE488882480599C81284B70CD9B3', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_process_id='6255BE488882480599C81284B70CD9B3');
+
+-- Reverse Payment
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '99053C7A7EDA4208AACFA6CB3088BB54', '29D17F515727436DBCE32BC6CA28382B', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_process_id='29D17F515727436DBCE32BC6CA28382B');
+
+-- === SALES (2A159DF4F4B944A6AA903202AD35B545) ===
+-- Calculate Promotions
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '5ECCBE463BEA43A39D76F6A8BC2DDB16', '9EB2228A60684C0DBEC12D5CD8D85218', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_process_id='9EB2228A60684C0DBEC12D5CD8D85218');
+
+-- Change Debt Payment
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'CBDC344354E346CD8E9A2E08E2C4B7B9', '800024', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_process_id='800024');
+
+-- Copy Lines
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '0E77D5EE423E4694807971D203C4FF7A', '211', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_process_id='211');
+
+-- Copy Product Template
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'DB797B924F5A4E4DB34733ACB284FC71', '800022', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_process_id='800022');
+
+-- Explode
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '238A95DAF42B4BC3B91794D3B61FA1A5', 'DFC78024B1F54CBB95DC73425BA6687F', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_process_id='DFC78024B1F54CBB95DC73425BA6687F');
+
+-- Process Order
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '0371E576BB7348C888EF45BEE0C922A2', '104', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_process_id='104');
+
+-- APRM Process Invoice
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '3F777A28BE7841A1A2E77D0C7604BD48', 'B54318B49E984B9CB855AEFB1F474CD6', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_process_id='B54318B49E984B9CB855AEFB1F474CD6');
+
+-- Copy Lines
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '42A043B521074C79B967BA7840C01F2C', '210', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_process_id='210');
+
+-- Explode
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '1B9919A214E64749B2E5F91F0AE4BD66', '6E1ADD5C8B6B4ACB82237DAA8114451E', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_process_id='6E1ADD5C8B6B4ACB82237DAA8114451E');
+
+-- Generate Receipt from Invoice
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'E20015327DEC43AAB067F69C9AA8F66E', '142', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_process_id='142');
+
+-- Process Invoice
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'D72D9201E82B40D5B512372F4FCE39DE', '111', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_process_id='111');
+
+-- Update Payment Plan
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '656B3B864E754573A6473FB3174B040B', 'FB740AB61B0E42B198D2C88D3A0D0CE6', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_process_id='FB740AB61B0E42B198D2C88D3A0D0CE6');
+
+-- Create Order
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '2AA8408C73B84BCDAF035D4BBFED1A33', 'A3FE1F9892394386A49FB707AA50A0FA', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_process_id='A3FE1F9892394386A49FB707AA50A0FA');
+
+-- Create Invoice (Volume Discount)
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '0A7DE2F14BCC42B79113FA2BA3906ED4', '800068', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_process_id='800068');
+
+-- Create Price List
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'C0A51298512741AAA509CB7058F7A0F6', '103', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_process_id='103');
+
+-- Create Price List Version
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '1FF23426E0844CA9815618EA54FA294E', '800069', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_process_id='800069');
+
+-- === PURCHASING (A826430F723E4C1B9A53EBB0746A98C0) ===
+-- Change Debt Payment
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '931CC81434A34EEE83867145183AEA1A', '800024', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_process_id='800024');
+
+-- Copy Lines
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '71E8F59FD2F045FC993546181C7DA35B', '211', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_process_id='211');
+
+-- Explode
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '3C1401164A254E599C0786CD953267CD', 'DFC78024B1F54CBB95DC73425BA6687F', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_process_id='DFC78024B1F54CBB95DC73425BA6687F');
+
+-- Process Order
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '0E5CB8544EFE4324AF19FD10F7DA119C', '104', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_process_id='104');
+
+-- APRM Process Invoice
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '8AE6B6870EE7415FB7973002AE0EDC59', 'B54318B49E984B9CB855AEFB1F474CD6', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_process_id='B54318B49E984B9CB855AEFB1F474CD6');
+
+-- Copy Lines
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '3377BCA3426C43278198472B5427AC4F', '210', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_process_id='210');
+
+-- Explode
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '452219FCBDD441F0A7A3DCF6A463BB8B', '6E1ADD5C8B6B4ACB82237DAA8114451E', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_process_id='6E1ADD5C8B6B4ACB82237DAA8114451E');
+
+-- Generate Receipt from Invoice
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'F54C14AED63349E8937D2CC44CAF816E', '142', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_process_id='142');
+
+-- Process Invoice
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '9FF2878C0D034A4F96A3F15EC9F5A0C5', '111', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_process_id='111');
+
+-- Update Payment Plan
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'E9233459AB42471CB07CCA115A2B9F51', 'FB740AB61B0E42B198D2C88D3A0D0CE6', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_process_id='FB740AB61B0E42B198D2C88D3A0D0CE6');
+
+-- Create Invoice (Volume Discount)
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '7C1411A0B7AE4E1A9B510674A510A685', '800068', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_process_id='800068');
+
+-- Create Variants
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '649E530DBBCD4E4AAB2382825B51F4A5', '3C386BC12832466790E50F2F8C5EBD85', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_process_id='3C386BC12832466790E50F2F8C5EBD85');
+
+-- Verify BOM
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'DF93480D4EC14CCC9681182B4A20A080', '136', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_process_id='136');
+
+-- === INVENTORY (55E05A4B43514A029D6FB6B8D94B49D4) ===
+-- Create Variants
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '24EB553E677C43508E11A8E21B7A3524', '3C386BC12832466790E50F2F8C5EBD85', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_process_id='3C386BC12832466790E50F2F8C5EBD85');
+
+-- Verify BOM
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '9746F59698AE4B5F8D26C1902B4FB247', '136', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_process_id='136');
+
+-- Move a Storage Bin
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '62FD0B1FE3FB40ACB9707154769A5610', '800048', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_process_id='800048');
+
+-- Process Movements
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '079640F54D8745D4BDB36F7C4D7F81FF', '122', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_process_id='122');
+
+-- Create Inventory Count List
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '2BEAE471BB03441DB715C34EE18F74CF', '105', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_process_id='105');
+
+-- Process Inventory Count
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'C003490CB40C495E9ED8B6A9B00CF981', '107', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_process_id='107');
+
+-- Update Quantity
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'CEDAA9429943470A87D8F3D5590F6B45', '106', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_process_id='106');
+
+-- Calculate Freight Amount
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'B4D90A286BC44A69A9A80BB0CBD52EAB', '800141', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_process_id='800141');
+
+-- Explode
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '581784B65A4E4BA38C4645F2F24F8849', 'DAE719940FE9463F8A3E3C401BBAFC53', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_process_id='DAE719940FE9463F8A3E3C401BBAFC53');
+
+-- Generate Invoice from Receipt
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'E59351B0025F478D913A4F07E85C6C15', '154', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_process_id='154');
+
+-- Process Shipment
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '62C55F050F684B2580E4CAE137D34C06', '109', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_process_id='109');
+
+-- Process Shipment Java
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '3F592858594C44938CD9F970F8FB7A3F', '49DEE812BF0545269781FCEBF2235924', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_process_id='49DEE812BF0545269781FCEBF2235924');
+
+-- Update Attributes from Shipment
+INSERT INTO ad_process_access (ad_process_access_id, ad_process_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '8A895BF10FFE425AAB207FDA2D57B10A', '800010', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_process_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_process_id='800010');
+
+COMMIT;

--- a/cli/sql/goclient-seed-window-access.sql
+++ b/cli/sql/goclient-seed-window-access.sql
@@ -1,0 +1,192 @@
+-- ETP-4509 — Seed AD_Window_Access rows for the 4 canonical Etendo Go
+-- operational roles on GOClient (3-tier full/read-only/none model).
+--
+-- See docs/etendo-ad/roles-users-reference.md for:
+--   - the ETGO_SF_ENTITY/ETGO_SF_SPEC -> AD_Window_ID resolution mechanism
+--     and its reliability findings (the "highest-risk item" for this task)
+--   - the full business-term -> AD_Window_ID resolution table, including
+--     the items that could NOT be confidently resolved (skipped here, see
+--     below)
+--   - why AD_Process_Access is explicitly OUT OF SCOPE for this pass
+--
+-- NOT THE AUTHORITATIVE ARTIFACT — same convention as
+-- cli/sql/goclient-seed-roles.sql (ETP-4508). The real, tracked deliverable
+-- is the GOClient sampledata XML:
+--   {etendo_root}/modules/com.etendoerp.go/referencedata/sampledata/GOClient/
+--     AD_WINDOW_ACCESS.xml
+-- This script is a LOCAL DEV-SEEDING CONVENIENCE ONLY, to reproduce the same
+-- DB rows on a fresh local dev DB without a full sampledata re-import.
+--
+-- 3-tier model, represented via AD_Window_Access.ISREADWRITE (the ONLY
+-- CRUD-ish flag this table actually has — CORRECTS the ETP-4509 task brief's
+-- assumption of separate allowview/allowedit/etc. flags; those do not exist
+-- on this table in this Etendo version):
+--   no row            = NONE  (role cannot open the window at all)
+--   ISREADWRITE = 'N' = READ-ONLY
+--   ISREADWRITE = 'Y' = FULL
+--
+-- AD_ORG_ID is always '0' (matches the existing GOClient Admin /
+-- CreateRoleStep convention — role-level access, not org-scoped).
+--
+-- Idempotent: every INSERT is guarded by NOT EXISTS on
+-- (ad_role_id, ad_window_id) since there is no DB-level UNIQUE constraint
+-- for this pair (verified via pg_constraint) — safe to re-run.
+--
+-- Usage:
+--   PGPASSWORD=<pwd> psql -h <host> -p <port> -U <user> -d <db> \
+--     -f cli/sql/goclient-seed-window-access.sql
+--
+-- After running: this changes business data only (AD_Window_Access is not
+-- AD dictionary/metadata), so ./gradlew export.database is NOT required for
+-- this script itself. It IS required after the sampledata XML files are
+-- regenerated/edited for GOClient, per the module's export.sample.data /
+-- prepareOnboardingSampledata pipeline.
+
+BEGIN;
+
+-- Fixed references
+--   GOClient       = 802509E12436405C86BA1FD5B1DF508C
+--   Finance role   = 127AE77FE2994067B7FE6495FC21D51E
+--   Sales role     = 2A159DF4F4B944A6AA903202AD35B545
+--   Purchasing role= A826430F723E4C1B9A53EBB0746A98C0
+--   Inventory role = 55E05A4B43514A029D6FB6B8D94B49D4
+
+-- Unresolved / intentionally SKIPPED (see roles-users-reference.md):
+--   Finance "Contabilidad"        — no single AD_Window confidently matches
+--                                   this generic label (Plan contable and
+--                                   Asientos already cover the two obvious
+--                                   accounting concepts separately)
+--   Finance "Conciliación bancaria" — the Etendo Go "bank-reconciliation"
+--                                   spec (ETGO_SF_SPEC) has NO AD_Window_ID
+--                                   at all (spec_type='R', aggregate/report
+--                                   view); no equivalent core AD_Window
+--                                   exists either. Cannot be represented via
+--                                   AD_Window_Access.
+
+-- === FINANCE (127AE77FE2994067B7FE6495FC21D51E) ===
+-- FULL: chart-of-accounts (Plan contable), simple-g-l-journal (Asientos),
+--       financial-account (Bancos), payment-out (Pagos), payment-in (Cobros),
+--       tax + tax-category (Impuestos — both windows granted, ambiguous
+--       between the two, see roles-users-reference.md)
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'A10092A354BD428D90BB56936793EE8A', '118', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_window_id='118');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '7264D0A449A04D70A5F0C466B76026C2', 'B917E8A7B0864ACEA9D941E3B7494E53', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_window_id='B917E8A7B0864ACEA9D941E3B7494E53');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '7970DB73E9BC45429FE69CE97F6A113E', '94EAA455D2644E04AB25D93BE5157B6D', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_window_id='94EAA455D2644E04AB25D93BE5157B6D');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'C78E3D1B261B44D78BE29151D6A1DF2E', '6F8F913FA60F4CBD93DC1D3AA696E76E', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_window_id='6F8F913FA60F4CBD93DC1D3AA696E76E');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'EAE55C6F5E144E1591143B2EB2EB69CB', 'E547CE89D4C04429B6340FFA44E70716', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_window_id='E547CE89D4C04429B6340FFA44E70716');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '433D0752311A4BD493BAEC411BCAAEDB', '137', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_window_id='137');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'AD7BFD7FDA214B6FB968C0AC13B4C0B7', '138', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_window_id='138');
+
+-- Finance READ-ONLY: sales-invoice (Facturas de venta), purchase-invoice (Facturas de compra)
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '09DD0E7C9901487DA3C9F60E72D2EB37', '167', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'N'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_window_id='167');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '0D06A7A2CCF145338F89CA6F4C17D6C0', '183', '127AE77FE2994067B7FE6495FC21D51E', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'N'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='127AE77FE2994067B7FE6495FC21D51E' AND ad_window_id='183');
+
+-- === SALES (2A159DF4F4B944A6AA903202AD35B545) ===
+-- FULL: sales-order (Pedidos de venta), sales-invoice (Facturas de venta),
+--       sales-quotation (Presupuestos), contacts (Clientes + Contactos —
+--       same underlying Business Partner window, see roles-users-reference.md),
+--       price-list (Tarifas)
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'FF3FC9D96F7E47F396C292C454305D32', '143', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_window_id='143');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '16CDD7B7D8364A3B9680E1FBBCE198DD', '167', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_window_id='167');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'D3C99AC68EAD4AC4BDBA9A7D25A500F1', '6CB5B67ED33F47DFA334079D3EA2340E', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_window_id='6CB5B67ED33F47DFA334079D3EA2340E');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '8FACAD0EDC6E47FDAD432D10D5EE1BAF', '123', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_window_id='123');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '57759D6E642C4D6FBD3437F86E2753C3', '146', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_window_id='146');
+
+-- Sales READ-ONLY: product (Productos)
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '428FDB982FC843E99A3B23E1A29C63EE', '140', '2A159DF4F4B944A6AA903202AD35B545', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'N'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='2A159DF4F4B944A6AA903202AD35B545' AND ad_window_id='140');
+
+-- === PURCHASING (A826430F723E4C1B9A53EBB0746A98C0) ===
+-- FULL: purchase-order (Pedidos de compra), purchase-invoice (Facturas de compra),
+--       contacts (Proveedores — same window as Sales' Clientes/Contactos),
+--       product (Productos)
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '7ECA0E681AE44B3C91871200A94DC64B', '181', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_window_id='181');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'A47F128EB3644FC0AB63C258819BCED6', '183', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_window_id='183');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '66EB496FFBE2430E9AAD8071A22A3FC2', '123', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_window_id='123');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '74DB944FE7C64DF4BB3A62F2CDD4CBA2', '140', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_window_id='140');
+
+-- Purchasing READ-ONLY: physical-inventory (Inventario)
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '22075878CBF344EDA58F22014E5412F2', '168', 'A826430F723E4C1B9A53EBB0746A98C0', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'N'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='A826430F723E4C1B9A53EBB0746A98C0' AND ad_window_id='168');
+
+-- === INVENTORY (55E05A4B43514A029D6FB6B8D94B49D4) ===
+-- FULL: product (Productos), warehouse (Almacenes), goods-movements
+--       (Movimientos de inventario), physical-inventory (Stock — same window
+--       as Purchasing's Inventario, see roles-users-reference.md),
+--       goods-receipt (Entradas de mercancía), goods-shipment (Salidas de mercancía)
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'E17ADC1467F84095B1454CCD1DCD031A', '140', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_window_id='140');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '878F59319DDC49C0ADBE428DAEE0CABD', '139', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_window_id='139');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '92E43F1ED2694802A55B78995FF2D855', '170', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_window_id='170');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '424864411F2F4CBE8F3BBEF6AD14F4BD', '168', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_window_id='168');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT '0030E47161C44749AA9094204AC85369', '184', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_window_id='184');
+
+INSERT INTO ad_window_access (ad_window_access_id, ad_window_id, ad_role_id, ad_client_id, ad_org_id, isactive, created, createdby, updated, updatedby, isreadwrite)
+SELECT 'FEB53303178A438C80C5992FCB4690FA', '169', '55E05A4B43514A029D6FB6B8D94B49D4', '802509E12436405C86BA1FD5B1DF508C', '0', 'Y', now(), '100', now(), '100', 'Y'
+WHERE NOT EXISTS (SELECT 1 FROM ad_window_access WHERE ad_role_id='55E05A4B43514A029D6FB6B8D94B49D4' AND ad_window_id='169');
+
+COMMIT;

--- a/docs/etendo-ad/roles-users-reference.md
+++ b/docs/etendo-ad/roles-users-reference.md
@@ -45,16 +45,21 @@ decision outside this task's scope.
 **Correction (2026-07-15): a prior run of this task mistakenly created a new,
 freshly-generated `AD_Role` named "Administrator"
 (`451EED23EC0A44679F15C6789A4EB980`) on GOClient.** This was wrong and has
-been reverted (the role had zero dependents in any FK column with
-`ON DELETE NO ACTION` — `AD_User_Roles`, `AD_Window_Access`,
-`AD_Process_Access`, `AD_Form_Access`, `AD_Role_Inheritance`,
-`AD_Role_OrgAccess` all showed 0 rows; the only rows referencing it were in 3
-OB UI framework tables — `obkmo_widget_class_access`,
-`obuiapp_process_access`, `obuiapp_view_role_access` — all via
-`ON DELETE CASCADE` FKs and present in identical counts on every role, i.e.
-framework bootstrap noise, not real assignment; they were cascade-deleted
-along with the role). It was deleted from the live GOClient DB and the
-`INSERT` block removed from `cli/sql/goclient-seed-roles.sql`.
+been reverted. Before deletion, every FK column referencing `ad_role_id`
+across the schema was checked for dependent rows: the role had zero
+dependents in any FK column with `ON DELETE NO ACTION` — `AD_User_Roles`,
+`AD_Window_Access`, `AD_Process_Access`, `AD_Form_Access`,
+`AD_Role_Inheritance`, `AD_Role_OrgAccess` all showed 0 rows. The only
+non-zero counts were in 3 OB UI framework tables via `ON DELETE CASCADE`
+FKs — `obkmo_widget_class_access` (27 rows), `obuiapp_process_access`
+(138), `obuiapp_view_role_access` (1) — present in the exact same counts on
+every one of the 5 roles that existed at the time, confirming these are
+framework-bootstrap rows populated on role creation regardless of
+`ismanual`, not evidence of real usage. The role was deleted
+(`DELETE FROM ad_role WHERE ad_role_id = '451EED23EC0A44679F15C6789A4EB980'`,
+cascading the 3 framework tables' rows along with it) from the live GOClient
+DB, and the `INSERT` block removed from `cli/sql/goclient-seed-roles.sql`
+— the script now seeds 4 roles.
 
 **"Administrator" is the tenant's pre-existing client-admin role, not a new
 record.** Core Etendo's `InitialClientSetup` (the standard create-client
@@ -158,6 +163,11 @@ the XML wins (it's what ships).
 ## Open question 2 — does GOClient already have an Administrator-equivalent role?
 
 **Yes — and it IS reused (as of the 2026-07-15 correction), not duplicated.**
+See § "Administrator resolution" above for the full rationale: why a
+brand-new "Administrator" role was briefly (and mistakenly) created, why it
+was reverted, and why the tenant's admin role is always resolved by the
+`is_client_admin='Y'` predicate rather than by name or a fixed ID.
+
 GOClient already had 2 roles before this task, auto-created by core Etendo's
 `InitialClientSetup` (the standard "create-client" wizard invoked by
 `EtendoGoJwtServlet.createClient` for every new tenant, GOClient included):
@@ -166,32 +176,6 @@ GOClient already had 2 roles before this task, auto-created by core Etendo's
 |---|---|---|---|
 | GOClient Admin | `9B8D736190724807AB256DC95F20EC5E` | ` CO` | `Y` |
 | GOuser | `6A0A8D73D8284C6088DF36BDCC569161` | `  O` | `N` |
-
-**Superseded decision (originally 2026-06-XX, corrected 2026-07-15):** the
-first draft of this task created a brand-new "Administrator" `AD_Role`
-alongside `GOClient Admin`, reasoning that the 5-role model needed an
-identical, stable literal name across tenants. **This was wrong** — it is
-resolved by *predicate*, not by *name or ID*:
-
-1. **Name is not portable, but that's not a problem — resolve by
-   `is_client_admin='Y'` instead of by name.** `InitialClientSetup` names the
-   admin role `"<ClientName> Admin"` (e.g. "GOClient Admin", "Acme Corp
-   Admin"). ETP-4509/4515/4516 must never hardcode the literal "Administrator"
-   string against `AD_Role.name` — they resolve the tenant's admin role via
-   `WHERE ad_client_id = :client_id AND is_client_admin = 'Y'`, which is
-   already stable and portable across every tenant without needing a fixed
-   name or ID. See the "Administrator resolution" section above.
-2. **Same semantics, no coupling risk.** `GOClient Admin` already carries
-   exactly the semantics the design doc wants for "Administrator" — Client+Org
-   level, `is_client_admin='Y'`, non-manual (blanket auto-granted access kept
-   in sync forever by `AD_ROLE_TRG`). Reusing it via the `is_client_admin`
-   predicate (the same mechanism `EtendoGoJwtDalHelper.findClientAdminUserRole`
-   already uses) introduces no coupling beyond what already exists — no
-   renaming, no touching the live role at all.
-3. **No ID collision, and now no duplicate role either.** The freshly-created
-   "Administrator" role (`451EED23EC0A44679F15C6789A4EB980`) was deleted
-   after confirming it had zero real dependents (see "Administrator
-   resolution" above) — GOClient does not carry a redundant admin role.
 
 **Net effect:** GOClient has **6 roles**: the 2 core bootstrap roles
 (`GOClient Admin`, `GOuser`, untouched) + the **4** new GO operational roles
@@ -357,24 +341,13 @@ flipping `ismanual` from `'Y'` to `'N'` (the opposite direction); going
 required. `cli/sql/goclient-seed-roles.sql` was updated to use `ismanual='Y'`
 in all `INSERT`s so a fresh install seeds correctly the first time.
 
-**Correction record (2026-07-15, part 2 — Administrator role removal):** a
-further review found that the seeded "Administrator" `AD_Role`
-(`451EED23EC0A44679F15C6789A4EB980`) should never have been created as a new
-record — see the "Administrator resolution" section near the top of this doc
-for the full rationale. Before deletion, every FK column referencing
-`ad_role_id` across the schema was checked for dependent rows:
-`AD_User_Roles`, `AD_Window_Access`, `AD_Process_Access`, `AD_Form_Access`,
-`AD_Role_Inheritance`, `AD_Role_OrgAccess`, and all other `ON DELETE NO
-ACTION` FKs to `ad_role` showed **0** rows for this role. The only non-zero
-counts were in 3 OB UI framework tables via `ON DELETE CASCADE` FKs —
-`obkmo_widget_class_access` (27), `obuiapp_process_access` (138),
-`obuiapp_view_role_access` (1) — present in the **exact same counts on every
-one of the 5 roles**, confirming they are framework-bootstrap rows populated
-on role creation regardless of `ismanual`, not evidence of real usage. The
-role was deleted (`DELETE FROM ad_role WHERE ad_role_id =
-'451EED23EC0A44679F15C6789A4EB980'`), cascading the 3 framework tables'
-rows along with it. `cli/sql/goclient-seed-roles.sql` was updated to remove
-the Administrator `INSERT` block entirely — the script now seeds 4 roles.
+**Correction record (2026-07-15, part 2 — Administrator role removal):** the
+seeded "Administrator" `AD_Role` (`451EED23EC0A44679F15C6789A4EB980`) should
+never have been created as a new record. See § "Administrator resolution"
+near the top of this doc for the full rationale, the FK-dependency
+verification, and the exact statement used to delete it —
+`cli/sql/goclient-seed-roles.sql` was updated to remove the Administrator
+`INSERT` block entirely, and the script now seeds 4 roles.
 
 **Correction record (2026-07-15, part 3 — delivery mechanism + minor field
 gap):** transcribing the live DB rows into `AD_ROLE.xml` (see "Open question
@@ -441,3 +414,464 @@ now carries all 6 roles, and `AD_ROLE_ORGACCESS.xml` now carries all 11 rows
 (3 pre-existing + 8 new — 2 per new role), both in ascending-alphanumeric-ID
 order (validated well-formed XML, sort order confirmed programmatically for
 both files).
+
+---
+
+# ETP-4509 — Window access mapping (3-tier, GOClient)
+
+**Scope:** map each of the 4 operational roles to `AD_Window_Access` rows for
+their designated windows (full/read-only), per the business-term table in
+the Jira ticket / phase-1 handoff. Depends on ETP-4508 (roles + org access,
+above) being correct.
+
+## Highest-risk item — ETGO_SF_ENTITY/ETGO_SF_SPEC → AD_Window_ID reliability
+
+**RESOLVED, confirmed reliable for real AD windows.** `ETGO_SF_SPEC` (the
+top-level Etendo Go spec table) has its own **direct** `ad_window_id` column
+— no join through `ETGO_SF_ENTITY`/`AD_TAB` is even needed for the common
+case. Verified live on GOClient across all 49 active `spec_type='W'`
+("window") specs:
+
+- **47/49** have a non-NULL `ad_window_id` that is byte-for-byte consistent
+  with every one of their child `ETGO_SF_ENTITY.ad_tab_id → AD_TAB.ad_window_id`
+  values — **zero mismatches, zero specs spanning more than one AD window**
+  (checked via a full outer join across all active entities/tabs). For these,
+  `ETGO_SF_SPEC.ad_window_id` is a fully reliable, direct FK — use it, no
+  cross-checking needed.
+- **2/49 have `ad_window_id = NULL` by design, not by gap:** `dashboard` (a
+  synthetic aggregate view assembled from several unrelated KPI/trend/task
+  sub-entities — its own child entities like `kpis`/`trends`/`pending-tasks`
+  also have `ad_tab_id = NULL`, confirming they are computed panels with no
+  backing AD_Tab at all) and `not-posted-documents` (a cross-window
+  aggregate report, same shape). Neither corresponds to a single AD window —
+  there is nothing to grant `AD_Window_Access` *to* for these two.
+- **`spec_type='R'` specs (8 active) have `ad_window_id = NULL` for ALL of
+  them, always** — these are Etendo Go's own custom aggregate/report views
+  (`aging-receivable`, `bank-reconciliation`, `bank-statements`,
+  `financial-account-psd2`, `financial-account-transactions`,
+  `financial-accounts-page`, `inventory-stock-report`, `tax-report`). They
+  are a **different spec category** from `spec_type='W'`, not a subset that
+  happens to be missing data. **None of them can ever get an
+  `AD_Window_Access` row** — there is no AD window (Go-exposed or core) that
+  backs them; they're purely computed views assembled by NEO Headless from
+  other entities' data.
+- A handful of individual `ETGO_SF_ENTITY` rows *within* an otherwise
+  window-backed spec have `ad_tab_id = NULL` (e.g. `contacts`' `bp-stats`/
+  `bp-trend` sub-entities) — same pattern as above: synthetic stat/trend
+  panels bolted onto a real window, not evidence the window itself is
+  unmapped.
+
+**Net verdict:** the mapping mechanism itself (`ETGO_SF_SPEC.ad_window_id`)
+is **100% reliable wherever it is populated** (47/49 window specs, zero
+drift/mismatch found). The 2 exceptions among window-type specs, and all 8
+report-type specs, are **correctly** unmapped — they are not real AD
+windows and were never going to be. This is a materially different (better)
+answer than "some specs have missing/unreliable IDs" — the mechanism doesn't
+have gaps, a small category of specs is simply out of its domain.
+
+**Practical consequence for this task:** `bank-reconciliation` (the Go spec
+behind "Conciliación bancaria" in the business-term table, see below) falls
+in the second bullet above — it is a `spec_type='R'` view with no
+`AD_Window_ID`, so **it cannot receive an `AD_Window_Access` row at all**,
+regardless of role or tier. This is the significant, concrete instance of
+"unreliable mapping" the ticket asked to surface.
+
+## Business-term → AD_Window_ID resolution table
+
+Resolved by cross-referencing the Spanish business terms in the Jira table
+against the 49 active `spec_type='W'` specs' `AD_WINDOW_TRL` (`es_ES`) names
+— **not** by searching the full core `AD_MENU` tree, which returns dozens of
+noisy, non-Go-exposed matches for generic terms (verified and discarded as
+an approach; e.g. searching AD_MENU for "Facturas de venta" surfaces a
+payment-plan report, not the actual Sales Invoice window). Only the 49
+Go-exposed specs are actually reachable by an Etendo Go role, so that's the
+correct search universe.
+
+| Business term (role, tier) | Spec (kebab) | `AD_Window_ID` | Confidence |
+|---|---|---|---|
+| Plan contable (Finance, full) | chart-of-accounts | `118` | High — exact concept match ("Árbol de cuentas"/Account Tree) |
+| Asientos (Finance, full) | simple-g-l-journal | `B917E8A7B0864ACEA9D941E3B7494E53` | High — only Go-exposed journal-entry window (core's "Asientos manuales"/G-L Journal, window `132`, is NOT Go-exposed) |
+| Bancos (Finance, full) | financial-account | `94EAA455D2644E04AB25D93BE5157B6D` | High — only Go-exposed banking window; core's `AD_Bank` window (`158`, "Banco-Sucursal") is NOT Go-exposed |
+| Pagos (Finance, full) | payment-out | `6F8F913FA60F4CBD93DC1D3AA696E76E` | High |
+| Cobros (Finance, full) | payment-in | `E547CE89D4C04429B6340FFA44E70716` | High — exact ES name match ("Cobros") |
+| Impuestos (Finance, full) | tax **and** tax-category | `137` and `138` | **Ambiguous** — both are legitimate Go-exposed "tax config" windows (Tax Rate / Tax Category); no single window is uniquely "Impuestos". Resolved by granting **both** rather than guessing one (low over-grant risk, both are within Finance's own domain) |
+| Contabilidad (Finance, full) | — | **none** | **Unresolved, not seeded.** No single Go-exposed window matches this generic label once Plan contable/Asientos are already separately accounted for; the closest candidate (`general-ledger-configuration`, "Esquema contable") is a distinct concept (accounting-schema setup, not general "accounting"). Flagged for product clarification rather than guessed. |
+| Conciliación bancaria (Finance, full) | bank-reconciliation | **none — impossible** | **Unresolved, not seeded — see the highest-risk finding above.** `spec_type='R'`, no `AD_Window_ID` exists at all, in Go or in core AD. |
+| Facturas de venta (Finance RO; Sales, full) | sales-invoice | `167` | High |
+| Facturas de compra (Finance RO; Purchasing, full) | purchase-invoice | `183` | High |
+| Pedidos de venta (Sales, full) | sales-order | `143` | High |
+| Presupuestos (Sales, full) | sales-quotation | `6CB5B67ED33F47DFA334079D3EA2340E` | High |
+| Clientes (Sales, full) | contacts | `123` | High, but see finding below |
+| Contactos (Sales, full) | contacts | `123` | High, but see finding below — **same window as Clientes** |
+| Tarifas (Sales, full) | price-list | `146` | High |
+| Productos (Sales RO; Purchasing full; Inventory full) | product | `140` | High |
+| Pedidos de compra (Purchasing, full) | purchase-order | `181` | High |
+| Proveedores (Purchasing, full) | contacts | `123` | High, but see finding below — **same window as Clientes/Contactos** |
+| Inventario (Purchasing, RO) | physical-inventory | `168` | Moderate — see "Stock vs Inventario" finding below |
+| Almacenes (Inventory, full) | warehouse | `139` | High |
+| Movimientos de inventario (Inventory, full) | goods-movements | `170` | Moderate-high — ES name is "Movimiento entre almacenes" (warehouse-to-warehouse transfer), the closest Go-exposed match |
+| Stock (Inventory, full) | physical-inventory | `168` | Moderate — see finding below |
+| Entradas de mercancía (Inventory, full) | goods-receipt | `184` | High — semantic match (incoming goods from vendor) |
+| Salidas de mercancía (Inventory, full) | goods-shipment | `169` | High — semantic match (outgoing goods to customer) |
+
+**Finding — "Clientes"/"Contactos"/"Proveedores" all collapse to the SAME
+window.** Etendo's Business Partner model is unified: there is no separate
+AD window for customers vs. vendors vs. generic contacts — one window
+(`contacts` spec, `AD_Window_ID 123`, "Business Partner"/"Terceros") serves
+all three business-facing concepts, differentiated by BP flags
+(`iscustomer`/`isvendor`), not by window. So the design table's 3 separate
+line items (Sales' "Clientes", Sales' "Contactos", Purchasing's
+"Proveedores") produce only **one** distinct `AD_Window_Access` row per role
+(Sales gets one row for window `123`; Purchasing gets its own separate row
+for the same window `123`) — not three. This is expected Etendo behavior,
+not a mapping defect.
+
+**Finding — "Stock" (Inventory) and "Inventario" (Purchasing RO) both
+resolve to the same window, `physical-inventory` (168), because no
+Go-exposed window is literally titled either term.** The only inventory-
+quantity window in the Go-exposed catalog is `physical-inventory`
+("Inventario físico"/Physical Inventory) — there is no separate Go-exposed
+"Stock" window (core has several stock-related windows/reports, e.g. "Stock
+Reservation", none Go-exposed). Both business terms were resolved to the
+same `AD_Window_ID`, flagged here as a judgment call rather than a certain
+match.
+
+## Correction to the ETP-4509 task brief — no CRUD-flag columns on AD_Window_Access
+
+The task brief assumed `AD_Window_Access` exposes granular flags (e.g.
+`allowview`/full CRUD flags) to represent the 3-tier model. **This table has
+no such columns in this Etendo version** — confirmed via
+`information_schema.columns`: `ad_window_access` has exactly one access flag,
+`isreadwrite` (`Y`/`N`), plus the standard audit/active columns (`inherited_from`
+and a module-added `em_smfmu_mobileview` are also present but irrelevant
+here). This actually matches (and was already anticipated by) the note in
+the ETP-4508 section above ("`ad_window_access`/`ad_process_access` have a
+single `isreadwrite` (Y/N) flag ... matching the handoff doc's 3-tier
+model"). Final representation used:
+
+- **No row** → NONE (role cannot open the window)
+- **Row, `isreadwrite='N'`** → READ-ONLY
+- **Row, `isreadwrite='Y'`** → FULL
+
+`AD_ORG_ID` is always `'0'`, matching the existing GOClient Admin /
+`CreateRoleStep` convention (role-level access, not org-scoped).
+`AD_PROCESS_ACCESS` has the identical shape (`isreadwrite` only).
+
+## AD_Process_Access — judged OUT OF SCOPE for this pass
+
+**Decision: do not seed `AD_Process_Access` in ETP-4509.** Reasoning:
+
+1. The Jira acceptance criteria for ETP-4509 explicitly scope this task to
+   `AD_Window_Access` rows only; the business-term table is entirely
+   window-based (no process/report is named anywhere in it).
+2. Determining "the processes associated with each window" is not a
+   well-defined, bounded set — Etendo windows carry an open-ended list of
+   toolbar/document actions (Complete, Void, Close, Reactivate, print/export
+   processes, etc.), and picking which of those each role should run per
+   tier is a separate product decision this ticket does not make.
+3. Unlike the window table, there is no equivalent "process access" tier
+   table anywhere in the design doc or Jira to drive a mechanical mapping —
+   inventing one here would be scope creep, not resolution of ambiguity.
+
+**However, this is very likely a real functional gap worth flagging
+explicitly, not just a scoping technicality.** Because the 4 roles are
+`ismanual='Y'` (mandatory, see the ETP-4508 section above), core's
+`AD_ROLE_TRG` trigger — which auto-grants blanket `AD_Process_Access` for
+non-manual roles — never touches them. Confirmed live: all 4 roles show
+**zero** `AD_Process_Access` rows even after this task's `AD_Window_Access`
+seeding. In practice this means a Finance/Sales/Purchasing/Inventory user
+**cannot run any document action** (e.g. "Complete" a Sales Order,
+"Process" a payment, generate a report) even on a window they have FULL
+`AD_Window_Access` to — only CRUD-via-grid would work. **Recommend this be
+picked up explicitly as a near-term follow-up** (either a new Jira task or
+folded into ETP-4510's UI-enforcement phase), since without it the 4
+operational roles are functionally read-mostly regardless of their
+`AD_Window_Access` tier.
+
+## Delivery — `AD_WINDOW_ACCESS.xml`
+
+Same convention as ETP-4508: `cli/sql/goclient-seed-window-access.sql` is a
+**local dev-seeding convenience script only**; the authoritative, tracked
+artifact is
+`{etendo_root}/modules/com.etendoerp.go/referencedata/sampledata/GOClient/AD_WINDOW_ACCESS.xml`
+(newly created — did not exist before this task), transcribed from the live
+DB rows after running the script, in ascending-alphanumeric-ID order,
+identical field layout to the pre-existing `F_B_International_Group`/
+`QA_Testing` clients' own `AD_WINDOW_ACCESS.xml` templates (`AD_WINDOW_ACCESS_ID`,
+`AD_WINDOW_ID`, `AD_ROLE_ID`, `AD_CLIENT_ID`, `AD_ORG_ID`, `ISACTIVE`,
+`CREATED`, `CREATEDBY`, `UPDATED`, `UPDATEDBY`, `ISREADWRITE`).
+No `AD_PROCESS_ACCESS.xml` was created (out of scope, see above).
+
+## Verification (live GOClient DB, 2026-07-15)
+
+```sql
+SELECT r.name AS role_name, w.name AS window_name_en, wt.name AS window_name_es,
+       wa.ad_window_id, wa.isreadwrite
+FROM ad_window_access wa
+JOIN ad_role r ON r.ad_role_id = wa.ad_role_id
+LEFT JOIN ad_window w ON w.ad_window_id = wa.ad_window_id
+LEFT JOIN ad_window_trl wt ON wt.ad_window_id = wa.ad_window_id AND wt.ad_language='es_ES'
+WHERE r.ad_client_id = '802509E12436405C86BA1FD5B1DF508C'
+  AND r.name IN ('Finance','Sales','Purchasing','Inventory')
+ORDER BY r.name, wa.isreadwrite DESC, w.name;
+```
+
+```
+=== Finance (9 rows) ===
+  [FULL] 118                                 Account Tree / Árbol de cuentas
+  [FULL] 94EAA455D2644E04AB25D93BE5157B6D    Financial Account / Cuenta financiera
+  [FULL] E547CE89D4C04429B6340FFA44E70716    Payment In / Cobros
+  [FULL] 6F8F913FA60F4CBD93DC1D3AA696E76E    Payment Out / Pago
+  [FULL] B917E8A7B0864ACEA9D941E3B7494E53    Simple G/L Journal / Asientos Manuales Simplificados
+  [FULL] 138                                 Tax Category / Categoría de Impuesto
+  [FULL] 137                                 Tax Rate / Rango impuesto
+  [RO  ] 183                                 Purchase Invoice / Factura (Proveedor)
+  [RO  ] 167                                 Sales Invoice / Factura (Cliente)
+
+=== Sales (6 rows) ===
+  [FULL] 123                                 Business Partner / Terceros
+  [FULL] 146                                 Price List / Tarifa
+  [FULL] 167                                 Sales Invoice / Factura (Cliente)
+  [FULL] 143                                 Sales Order / Pedido de venta
+  [FULL] 6CB5B67ED33F47DFA334079D3EA2340E    Sales Quotation / Presupuesto de ventas
+  [RO  ] 140                                 Product / Producto
+
+=== Purchasing (5 rows) ===
+  [FULL] 123                                 Business Partner / Terceros
+  [FULL] 140                                 Product / Producto
+  [FULL] 183                                 Purchase Invoice / Factura (Proveedor)
+  [FULL] 181                                 Purchase Order / Pedido de compra
+  [RO  ] 168                                 Physical Inventory / Inventario físico
+
+=== Inventory (6 rows) ===
+  [FULL] 170                                 Goods Movements / Movimiento entre almacenes
+  [FULL] 184                                 Goods Receipt / Albarán (Proveedor)
+  [FULL] 169                                 Goods Shipment / Albarán (Cliente)
+  [FULL] 168                                 Physical Inventory / Inventario físico
+  [FULL] 140                                 Product / Producto
+  [FULL] 139                                 Warehouse and Storage Bins / Almacén y huecos
+```
+
+Total: 26 `AD_Window_Access` rows across the 4 roles (Finance 9, Sales 6,
+Purchasing 5, Inventory 6). Re-running
+`cli/sql/goclient-seed-window-access.sql` a second time confirmed
+idempotency (all 26 `INSERT`s report `0` rows on re-run, guarded by
+`WHERE NOT EXISTS (... ad_role_id, ad_window_id ...)`).
+
+**Open items carried forward:** "Contabilidad" and "Conciliación bancaria" for
+Finance remain unresolved (documented above, not seeded) — **accepted as a
+known limitation by the team (Jira comment on ETP-4509, 2026-07-15); no
+further action planned.** `AD_Process_Access` was initially deferred as
+out-of-scope but was **expanded into this same task** — see the section
+below.
+
+---
+
+# ETP-4509 (expansion) — AD_Process_Access (document-action processes)
+
+**Team decision (2026-07-15):** the AD_Process_Access gap flagged above is
+real and was pulled into this task rather than deferred — with `ismanual='Y'`
+(mandatory) the 4 roles get **zero** automatic process access from
+`AD_ROLE_TRG`, so without this, a user could open a FULL-access window and
+edit its grid, but could not run Complete/Void/Process/Reconcile/etc. on it.
+
+## AD_Process_Access schema/semantics
+
+Confirmed identical shape to `AD_Window_Access`: `information_schema.columns`
+shows exactly one access flag, `isreadwrite` (Y/N), plus the standard
+audit/active columns and `inherited_from` — **no granular
+view/insert/update/delete tier**. So process access is purely
+existence-based per role: a row (with `isreadwrite='Y'`, matching every
+existing grant on GOClient) means the role can run that process; no row
+means it can't. There is **no per-window scoping column on
+`AD_Process_Access` at all** — a grant is global to the role, not tied to a
+specific window, matching how the automatic non-manual grant also works
+(`AD_ROLE_TRG` grants a role access to a *process*, independent of which
+window(s) happen to expose it as a button). This matters mechanically: if a
+role has two FULL windows that share a process (e.g. "Explode" appears as a
+button on both Sales Order and Purchase Order, but as two *different*
+`AD_Process_ID`s — see below), only one row per **(role, process)** pair is
+needed/possible, not one per (role, process, window).
+
+## Window → process mapping approach
+
+**Mechanism: `AD_Field` (button reference) → `AD_Column.ad_process_id` →
+`AD_Tab` → `AD_Window`.** In Etendo, a document-action/utility button on a
+window (Complete, Process, Reconcile, Copy Lines, etc.) is implemented as an
+`AD_Field` placed on one of the window's tabs, whose underlying `AD_Column`
+carries a non-NULL `ad_process_id` (the process the button launches). This
+is a **real, reliable, DB-native mechanism** — it's the exact same mechanism
+`AD_ROLE_TRG` itself uses conceptually (every process reachable from a
+window's own button fields), so it was validated directly against the two
+existing non-manual roles:
+
+```sql
+SELECT DISTINCT c.ad_process_id, p.name, p.isreport,
+  (SELECT count(*) FROM ad_process_access pa
+   WHERE pa.ad_process_id = c.ad_process_id
+     AND pa.ad_role_id IN ('9B8D736190724807AB256DC95F20EC5E','6A0A8D73D8284C6088DF36BDCC569161')
+  ) AS granted_to_admin_guser
+FROM ad_field f
+JOIN ad_column c ON c.ad_column_id = f.ad_column_id
+JOIN ad_process p ON p.ad_process_id = c.ad_process_id
+JOIN ad_tab t ON t.ad_tab_id = f.ad_tab_id
+WHERE f.isactive='Y' AND t.ad_window_id = :window_id AND p.isactive='Y';
+```
+
+**Result: 100% match.** Every button-linked process found for every one of
+the 19 distinct target windows was already granted to **both** GOClient
+Admin and GOuser (`2/2`), confirming the mechanism captures exactly the same
+universe of processes the automatic grant would produce — no guessing
+required, this is a mechanical, DB-verifiable rule: *"a role's process
+access = the union of button-linked processes across the role's FULL-tier
+windows."*
+
+**No `AD_Table_ID`-based join was needed/used** — `AD_Process` does carry an
+`AD_Table_ID` column in some Etendo versions, but the button-field join above
+is strictly more precise (it only returns processes actually wired as a
+button on that specific window's tabs, not every process that merely
+operates on the same underlying table, which would over-grant reports and
+unrelated utility processes tied to the same table from other windows).
+
+**Classic document actions (Complete/Void/Close/Reactivate) are NOT separate
+`AD_Process` rows** — Etendo implements them via a single generic
+"Process X" button per document type (e.g. `Process Order` id `104` for
+Sales/Purchase Order, `Process Invoice` id `111` for Sales/Purchase Invoice,
+`Process Shipment` id `109` for Goods Receipt/Shipment, `Process Inventory
+Count` id `107` for Physical Inventory), which opens a dialog offering
+Complete/Void/Close/Reactivate as options. Granting that one process is
+therefore sufficient to unlock the whole document-action lifecycle for that
+document type — there is nothing further named "Complete" or "Void" to grant
+separately.
+
+**Finding — the SAME conceptual action (Copy Lines, Explode) is often a
+DIFFERENT `AD_Process_ID` per document type.** E.g. `Copy Lines` on Sales
+Order is process `211`, but on Sales Invoice it's process `210` — same name,
+different ID, because each document type implements its own copy-lines
+logic. **Apply:** dedup by `AD_Process_ID`, never by process name, when
+building a role's process-access set (two windows both showing "Copy Lines"
+still need two distinct grants if the underlying process differs).
+
+## Read-only-tier decision: zero process access granted
+
+For the 4 windows carrying READ-ONLY tier somewhere in the design
+(`sales-invoice`/`purchase-invoice` for Finance, `product` for Sales,
+`physical-inventory` for Purchasing), the button-linked processes found were
+inspected individually for a plausible "safe, view-only" candidate
+(Print/Export-style actions the coordinator suggested might be reasonable
+even read-only):
+
+| RO window | Button processes found | Any view-only candidate? |
+|---|---|---|
+| sales-invoice (Finance RO) | APRM Process Invoice, Calculate Promotions, Change Debt Payment, Copy Lines, Explode, Generate Receipt from Invoice, Process Invoice, Update Payment Plan | No — all state-changing |
+| purchase-invoice (Finance RO) | APRM Process Invoice, Change Debt Payment, Copy Lines, Explode, Generate Receipt from Invoice, Process Invoice, Update Payment Plan | No — all state-changing |
+| product (Sales RO) | Create Variants, Verify BOM | No — both create/modify master data |
+| physical-inventory (Purchasing RO) | Create Inventory Count List, Process Inventory Count, Update Quantity | No — all state-changing |
+
+**Decision: grant ZERO `AD_Process_Access` rows for any role/window pair at
+the READ-ONLY tier.** None of the processes wired as buttons on these 4
+windows are print/export/view-type actions — Etendo's grid/form-level
+Print/Export are generic toolbar actions available independent of
+`AD_Process_Access` (they are not gated by a specific process grant the way
+document actions are), so there was no candidate to grant that would
+preserve "read-only" in spirit. Every available button is a genuine
+state-changing document action (Process/Copy/Generate/Update/Create), so
+granting any of them would silently upgrade the read-only tier to
+effectively-full for that window. This reasoning is recorded here rather
+than mechanically re-applied per window, since it turned out to be a clean
+"no" in all 4 cases — there was no ambiguous middle case requiring a
+per-window judgment call.
+
+## Final per-role process sets (deduped by `AD_Process_ID`, FULL-tier windows only)
+
+- **Finance (14 processes)** — from `simple-g-l-journal` (Add Payment From
+  Journal ×2) + `financial-account` (Bank Statement Process/Force, Import
+  Statement, Reconcile ×2, Reconciliation Details/Process Force/Summary,
+  Transaction Process) + `payment-out`/`payment-in` (Execute Payment, Payment
+  Process, Reverse Payment — same 3 process IDs shared by both windows).
+  `chart-of-accounts`, `tax`, `tax-category` have **zero** button processes
+  (pure master-data windows, nothing to grant).
+- **Sales (16 processes)** — from `sales-order` (Calculate Promotions, Change
+  Debt Payment, Copy Lines[211], Copy Product Template, Explode[order-type],
+  Process Order) + `sales-invoice` (APRM Process Invoice, Copy Lines[210],
+  Explode[invoice-type], Generate Receipt from Invoice, Process Invoice,
+  Update Payment Plan) + `sales-quotation` (adds Create Order) + `contacts`
+  (Create Invoice (Volume Discount)) + `price-list` (Create Price List,
+  Create Price List Version).
+- **Purchasing (13 processes)** — from `purchase-order` + `purchase-invoice`
+  (same process families as Sales' order/invoice, but Purchasing-specific
+  process IDs where they differ) + `contacts` (Create Invoice (Volume
+  Discount)) + `product` (Create Variants, Verify BOM).
+- **Inventory (13 processes)** — from `product` (Create Variants, Verify
+  BOM) + `goods-movements` (Move a Storage Bin, Process Movements) +
+  `physical-inventory` (Create Inventory Count List, Process Inventory
+  Count, Update Quantity) + `goods-receipt`/`goods-shipment` (Calculate
+  Freight Amount, Explode[receipt-type], Process Shipment, Process Shipment
+  Java, Update Attributes from Shipment; Generate Invoice from Receipt only
+  on `goods-receipt`). `warehouse` has **zero** button processes.
+
+Total: **56** `AD_Process_Access` rows (Finance 14, Sales 16, Purchasing 13,
+Inventory 13).
+
+## Delivery — `AD_PROCESS_ACCESS.xml`
+
+Same convention as `AD_WINDOW_ACCESS.xml`: `cli/sql/goclient-seed-process-access.sql`
+is a **local dev-seeding convenience script only** (built by a driver script
+that also executed the same statements against the live DB, so file and DB
+state match exactly); the authoritative, tracked artifact is
+`{etendo_root}/modules/com.etendoerp.go/referencedata/sampledata/GOClient/AD_PROCESS_ACCESS.xml`
+(newly created — did not exist before this task), transcribed from the live
+DB rows, ascending-alphanumeric-ID order, identical field layout to the
+pre-existing `F_B_International_Group`/`QA_Testing` clients'
+`AD_PROCESS_ACCESS.xml` templates (`AD_PROCESS_ACCESS_ID`, `AD_PROCESS_ID`,
+`AD_ROLE_ID`, `AD_CLIENT_ID`, `AD_ORG_ID`, `ISACTIVE`, `CREATED`,
+`CREATEDBY`, `UPDATED`, `UPDATEDBY`, `ISREADWRITE`). Every `AD_ROLE_ID`
+written was cross-checked byte-for-byte against the live `AD_ROLE.xml`
+entries before use (same 4 IDs already verified for `AD_WINDOW_ACCESS.xml`
+above).
+
+## Verification (live GOClient DB, 2026-07-15)
+
+```sql
+SELECT r.name, count(*) FROM ad_process_access pa
+JOIN ad_role r ON r.ad_role_id = pa.ad_role_id
+WHERE r.ad_client_id = '802509E12436405C86BA1FD5B1DF508C'
+  AND r.name IN ('Finance','Sales','Purchasing','Inventory')
+GROUP BY r.name ORDER BY r.name;
+```
+
+```
+    name    | count
+------------+-------
+ Finance    |    14
+ Inventory  |    13
+ Purchasing |    13
+ Sales      |    16
+```
+
+**Sanity check — every granted process is a subset of GOClient
+Admin/GOuser's own automatic grants (zero over-grants):**
+
+```sql
+SELECT r.name, p.name, pa.ad_process_id
+FROM ad_process_access pa
+JOIN ad_role r ON r.ad_role_id = pa.ad_role_id
+JOIN ad_process p ON p.ad_process_id = pa.ad_process_id
+WHERE r.ad_client_id = '802509E12436405C86BA1FD5B1DF508C'
+  AND r.name IN ('Finance','Sales','Purchasing','Inventory')
+  AND NOT EXISTS (
+    SELECT 1 FROM ad_process_access pa2
+    WHERE pa2.ad_process_id = pa.ad_process_id
+      AND pa2.ad_role_id IN ('9B8D736190724807AB256DC95F20EC5E','6A0A8D73D8284C6088DF36BDCC569161')
+  );
+-- 0 rows
+```
+
+Re-running `cli/sql/goclient-seed-process-access.sql` a second time confirmed
+idempotency: all 56 `INSERT`s reported `0` rows on re-run.
+
+**Open items carried forward:** "Contabilidad" and "Conciliación bancaria"
+for Finance remain unresolved — accepted as a known limitation (Jira
+comment, no further action). No AD_Process_Access-specific open items
+remain; Phase 2 (ETP-4510+) UI enforcement should treat "no row" as "hide
+the action" for both windows and processes, consistently.

--- a/docs/etendo-ad/tenant-remediation-knowledge.md
+++ b/docs/etendo-ad/tenant-remediation-knowledge.md
@@ -223,9 +223,9 @@
 
 ## ETP-4508 — GOClient reference-role seed (2026-07-15)
 
-- **2026-07-15 — A one-off reference-client seed is OUT OF SCOPE for `cli/src/data-fixes/`.** ETP-4508 needed 5 fixed `AD_Role` records on GOClient (Administrator/Finance/Sales/Purchasing/Inventory) — new reference master data for a single hardcoded client, not a provisioning-gap remediation across the fleet, and with no matching preventive onboarding front (that's deferred to ETP-4515/4516, not yet designed). Routing it through the data-fixes ledger would have forced a premature preventive-front decision and misrepresented a one-off as fleet-wide. **Apply:** followed the `cli/sql/neo-constraints.sql` precedent instead — a plain, idempotent, manually-invoked `.sql` file in `cli/sql/`, outside the ledger/runner. Full reasoning: `docs/etendo-ad/roles-users-reference.md`. **Boundary rule going forward:** data-fixes is for closing a gap on the EXISTING tenant fleet (the two-fronts model); a one-off seed of new reference data for GOClient specifically (with replication to other tenants explicitly deferred to a separate task) belongs in `cli/sql/` instead.
-- **2026-07-15 — `AD_ROLE_TRG` fires on INSERT of a brand-new non-manual role too, not just UPDATE of an existing one.** The existing ETP-4397 note above only documented the DELETE-then-rebuild danger for touching an *existing* role. Confirmed today: inserting 5 fresh `ad_role` rows (`ismanual='N'`) auto-populated `AD_Window_Access`/`AD_Process_Access` for every active window/process matching each role's `userlevel`, with `isreadwrite='Y'` (full) by default — 243-265 window rows and 303-306 process rows per role (also 85 `AD_Form_Access` rows total, missed on first pass — the trigger's `ELSE` branch deletes/rebuilds Window+Process+Form access together, all three must be checked). Verified this is standard (not a bug from my insert) by comparing against the pre-existing core `GOClient Admin` (266/306/17 rows) / `GOuser` (245/303/17 rows) roles, which show the identical pattern. **SUPERSEDED same day, see below — `ismanual='N'` was the wrong call for this task; kept for history.** **Apply (still valid in general):** any role seeded as non-manual gets this trigger-populated blanket grant automatically, never starts from "nothing" — account for all 3 access tables (Window/Process/Form), not just the two most obvious ones.
-- **2026-07-15 — CORRECTION: the 5 ETP-4508 roles must be `ismanual='Y'` (manual), not `'N'`.** Coordinator caught this before merge: ETP-4509 curates each role's `AD_Window_Access` **by hand** (the 3-tier full/read-only/none model), so the roles must be manual — `ad_role_trg()`'s function body has an explicit early-exit (`ELSIF (new.IsManual = 'Y') THEN RETURN NEW`) that skips the whole delete/rebuild block for manual roles, so a manual role never gets ANY auto-derived access, giving ETP-4509 a genuinely empty table to build on instead of a blanket grant to narrow down. **Fix applied:** `UPDATE ad_role SET ismanual='Y' ...` for the 5 role IDs, PLUS explicit `DELETE FROM ad_window_access/ad_process_access/ad_form_access WHERE ad_role_id IN (...)` — the `UPDATE` alone does NOT clean up rows the trigger already inserted while non-manual, because `ad_role_trg()`'s `UPDATE` branch only re-runs the delete/rebuild when `userlevel` changes or when flipping `ismanual` `'Y'→'N'` (the *opposite* direction of this fix); `'N'→'Y'` is a no-op for existing access rows. Verified post-fix: all 5 roles `ismanual='Y'` with 0 window/process/form access rows; `GOClient Admin`/`GOuser` untouched. `cli/sql/goclient-seed-roles.sql` updated to insert `ismanual='Y'` directly so a fresh install never needs this correction. **Apply:** when seeding a role meant for hand-curated access (as opposed to Etendo's automatic userlevel-based derivation), `ismanual='Y'` is a hard requirement, not a style choice — decide this BEFORE the first insert, since fixing it after requires cleaning up 3 access tables, not just flipping one column.
+- **2026-07-15 — A one-off reference-client seed is OUT OF SCOPE for `cli/src/data-fixes/`.** ETP-4508 needed 4 fixed `AD_Role` records on GOClient (Finance/Sales/Purchasing/Inventory) — new reference master data for a single hardcoded client, not a provisioning-gap remediation across the fleet, and with no matching preventive onboarding front (that's deferred to ETP-4515/4516, not yet designed). ("Administrator" is not a 5th seeded role — it resolves to the tenant's existing client-admin role; see `docs/etendo-ad/roles-users-reference.md` § Administrator resolution.) Routing it through the data-fixes ledger would have forced a premature preventive-front decision and misrepresented a one-off as fleet-wide. **Apply:** followed the `cli/sql/neo-constraints.sql` precedent instead — a plain, idempotent, manually-invoked `.sql` file in `cli/sql/`, outside the ledger/runner. Full reasoning: `docs/etendo-ad/roles-users-reference.md`. **Boundary rule going forward:** data-fixes is for closing a gap on the EXISTING tenant fleet (the two-fronts model); a one-off seed of new reference data for GOClient specifically (with replication to other tenants explicitly deferred to a separate task) belongs in `cli/sql/` instead.
+- **2026-07-15 — `AD_ROLE_TRG` fires on INSERT of a brand-new non-manual role too, not just UPDATE of an existing one.** The existing ETP-4397 note above only documented the DELETE-then-rebuild danger for touching an *existing* role. Confirmed today: inserting 5 fresh `ad_role` rows (`ismanual='N'`) auto-populated `AD_Window_Access`/`AD_Process_Access` for every active window/process matching each role's `userlevel`, with `isreadwrite='Y'` (full) by default — 243-265 window rows and 303-306 process rows per role (also 85 `AD_Form_Access` rows total, missed on first pass — the trigger's `ELSE` branch deletes/rebuilds Window+Process+Form access together, all three must be checked). Verified this is standard (not a bug from my insert) by comparing against the pre-existing core `GOClient Admin` (266/306/17 rows) / `GOuser` (245/303/17 rows) roles, which show the identical pattern. **SUPERSEDED same day, see below — `ismanual='N'` was the wrong call for this task; kept for history.** **Apply (still valid in general):** any role seeded as non-manual gets this trigger-populated blanket grant automatically, never starts from "nothing" — account for all 3 access tables (Window/Process/Form), not just the two most obvious ones. (Note: "5 fresh `ad_role` rows" reflects this entry's own moment — the ad-hoc "Administrator" role among those 5 was later removed entirely, not just renamed/adjusted; see `docs/etendo-ad/roles-users-reference.md` § Administrator resolution.)
+- **2026-07-15 — CORRECTION: the 5 ETP-4508 roles must be `ismanual='Y'` (manual), not `'N'`.** Coordinator caught this before merge: ETP-4509 curates each role's `AD_Window_Access` **by hand** (the 3-tier full/read-only/none model), so the roles must be manual — `ad_role_trg()`'s function body has an explicit early-exit (`ELSIF (new.IsManual = 'Y') THEN RETURN NEW`) that skips the whole delete/rebuild block for manual roles, so a manual role never gets ANY auto-derived access, giving ETP-4509 a genuinely empty table to build on instead of a blanket grant to narrow down. **Fix applied:** `UPDATE ad_role SET ismanual='Y' ...` for the 5 role IDs, PLUS explicit `DELETE FROM ad_window_access/ad_process_access/ad_form_access WHERE ad_role_id IN (...)` — the `UPDATE` alone does NOT clean up rows the trigger already inserted while non-manual, because `ad_role_trg()`'s `UPDATE` branch only re-runs the delete/rebuild when `userlevel` changes or when flipping `ismanual` `'Y'→'N'` (the *opposite* direction of this fix); `'N'→'Y'` is a no-op for existing access rows. Verified post-fix: all 5 roles `ismanual='Y'` with 0 window/process/form access rows; `GOClient Admin`/`GOuser` untouched. `cli/sql/goclient-seed-roles.sql` updated to insert `ismanual='Y'` directly so a fresh install never needs this correction. **Apply:** when seeding a role meant for hand-curated access (as opposed to Etendo's automatic userlevel-based derivation), `ismanual='Y'` is a hard requirement, not a style choice — decide this BEFORE the first insert, since fixing it after requires cleaning up 3 access tables, not just flipping one column. (As above: "the 5 ETP-4508 roles" reflects the count at this point in time only — the ad-hoc "Administrator" role was later removed entirely; see `docs/etendo-ad/roles-users-reference.md` § Administrator resolution for the current, correct count.)
 
 ## ETP-4245 — Accounting schema predefinition + 6 dimensions (2026-07-06)
 
@@ -250,3 +250,91 @@
 - **2026-07-14 — Standard System org types (`ad_orgtype`, `ad_client_id='0'`):** `'0'`=Organization (all flags N), `'1'`=Legal with accounting (islegalentity=Y, isacctlegalentity=Y), `'2'`=Generic (all N), `'3'`=Legal without accounting (islegalentity=Y only). Only `'1'` (and any businessunit type) passes the period-control gate. **Apply:** resolve the target type dynamically as the System row with `islegalentity='Y' AND isacctlegalentity='Y'` — do NOT hardcode `'1'`.
 - **2026-07-14 — Org-type provisioning gap (20 staging tenants) — corrective folded INTO R3 as block `C1-pre`.** Symptom: ~20 tenants halt on R3 with `@OrgTypeDoesNotAllowPeriodControl@`. Root cause: each has exactly ONE operative org of type "Organization" (`'0'`) instead of "Legal with accounting" — correct topology, wrong org type. They already have `c_acctschema` + `ad_org_acctschema` link; the ONLY delta needed is `UPDATE ad_org SET ad_orgtype_id=<legal-with-accounting>`. Verified end-to-end on a still-broken tenant: `test` (`473007453A724AAA913B791564E35422`) went Organization/PC=N → Legal with accounting/PC=Y with 516 period controls and R3 APPLIED (532 rows); earlier on the hand-flipped `E9C9219410794AD49897BBEE89E173FE` the full R4→R13 chain proceeded (0 halted). **Delivery decision — in-place edit of R3, NOT a separate migration.** The promotion `UPDATE` was added as block `C1-pre` inside R3's `@apply`, immediately before the C1 period-control `UPDATE`, so promotion + fiscal block + period control commit or roll back together in R3's single transaction. It targets the same `:org_id` R3 wires, resolves the target org type dynamically (System row with `islegalentity='Y' AND isacctlegalentity='Y'` — never hardcodes `'1'`), and is **guarded to fire only when the current type does not allow period control** → idempotent no-op for the 41 healthy tenants (which never re-run R3 anyway, their watermark is past it). A separate pre-R3 migration (`R2x`, dated 2026-06-15 < R3's 2026-06-16) was prototyped first, then discarded: editing R3 in place was chosen because for every tenant that already recorded R3 APPLIED the added statement is a semantic no-op (no divergence from what was recorded), and checksum enforcement is currently deferred. The only tenants whose R3 outcome changes are those where R3 had FAILED (never truly applied) and now succeeds. **Multi-org tenants are untouched** — R3's `:org_id` is the single operative org, and all 20 affected tenants are single-org, so multi-org tenants (e.g. staging "QA Testing") are never promoted.
 - **2026-07-14 — R3 `:org_id` vs `@check` mismatch (note, not fixed).** `applyFix` in `run.js` resolves `:org_id` as the OLDEST operative org (`ORDER BY created LIMIT 1`), but R3's `@check` matches ANY operative org lacking period control. For single-org tenants they coincide (all 20 failing tenants are single-org, unaffected). For multi-org tenants R3 could match `@check` on a non-oldest org yet wire only the oldest — a latent bug to address if/when multi-org period-control remediation is needed.
+
+## ETP-4509 — Etendo Go window-access model + spec→window mapping (2026-07-15)
+
+- **`ETGO_SF_SPEC` carries `ad_window_id` directly** — no join through
+  `ETGO_SF_ENTITY`/`AD_TAB` needed for the common case. Confirmed 100%
+  reliable (zero mismatches) for all 47/49 active `spec_type='W'` specs whose
+  `ad_window_id` is non-NULL, cross-checked against every child
+  `ETGO_SF_ENTITY.ad_tab_id → AD_TAB.ad_window_id`. The 2 window-type specs
+  with NULL `ad_window_id` (`dashboard`, `not-posted-documents`) are
+  synthetic cross-entity aggregates by design, not a mapping gap.
+- **`ETGO_SF_SPEC.spec_type` values are `'W'` (window, 49 active) and `'R'`
+  (report/aggregate view, 8 active) — NOT the literal strings `'window'`/
+  `'report'`.** A query filtering `spec_type = 'window'` silently returns 0
+  rows; use `'W'`/`'R'`. Every `spec_type='R'` spec has `ad_window_id = NULL`
+  ALWAYS, by category, not by omission — these are Go-only computed views
+  (`bank-reconciliation`, `tax-report`, `inventory-stock-report`, etc.) with
+  no backing AD window in core or in Go. **Apply:** before granting
+  `AD_Window_Access` for a Go-exposed feature named in a business
+  requirement, first confirm its spec is `spec_type='W'` — if it's `'R'`,
+  no window-access row can ever represent it; that gap needs a different
+  mechanism (e.g. hiding/showing the feature client-side, or a dedicated
+  permission concept), not `AD_Window_Access`.
+- **`AD_Window_Access`/`AD_Process_Access` have only ONE access flag,
+  `isreadwrite` (Y/N) — no separate `allowview`/`allowinsert`/`allowdelete`
+  CRUD columns.** (Those granular flags exist on `AD_Table_Access`, a
+  different table, not on window/process access.) A 3-tier
+  none/read-only/full model must therefore be represented as: no row = none,
+  `isreadwrite='N'` = read-only, `isreadwrite='Y'` = full. Corrects an
+  assumption in the ETP-4509 task brief that assumed granular CRUD flags on
+  `AD_Window_Access` itself.
+- **Etendo's Business Partner window is unified across customer/vendor/
+  contact roles.** There is no separate AD window per BP "flavor" — one
+  window (`contacts` Go spec, `AD_Window_ID 123`, core "Business Partner"/
+  "Terceros") serves them all, differentiated by BP-level flags
+  (`iscustomer`/`isvendor`), not by window. **Apply:** when a design table
+  lists "Customers"/"Vendors"/"Contacts" as separate access-table rows for
+  different roles, expect them to collapse to the SAME `AD_Window_ID` —
+  granting access to multiple roles for that one window is correct, it is
+  not a sign of a resolution error.
+- **Business-term → window resolution: search the Go-exposed spec catalog
+  (`ETGO_SF_SPEC` + `AD_WINDOW_TRL`), not the full core `AD_MENU` tree.**
+  Searching `AD_MENU`/`AD_MENU_TRL` for a Spanish business term (e.g.
+  "Facturas de venta") returns dozens of noisy matches across unrelated
+  reports/processes that happen to contain the same words, because the
+  core AD menu is far bigger than what Etendo Go actually exposes. Since a
+  Go role can only ever reach the ~49 Go-exposed windows, that is the
+  correct (and much smaller, much less ambiguous) search universe for this
+  kind of mapping task.
+- **Window → document-action-process mapping: `AD_Field` (button) →
+  `AD_Column.ad_process_id` → `AD_Tab` → `AD_Window`.** A window's
+  Complete/Void/Process/Reconcile/etc. buttons are `AD_Field` rows whose
+  underlying `AD_Column` carries a non-NULL `ad_process_id`. This join
+  reliably reproduces the exact universe of processes a non-manual role's
+  automatic grant would cover for that window — verified 100% match (every
+  button process found for 19 target windows was already granted to both
+  GOClient Admin and GOuser). **Apply:** don't join `AD_Process.AD_TABLE_ID`
+  to `AD_Window`/`AD_Tab.AD_TABLE_ID` instead — that over-grants (returns
+  every process touching the same table from unrelated windows/reports,
+  not just the ones actually wired as buttons on the window in question).
+- **Classic document actions (Complete/Void/Close/Reactivate) are NOT
+  separate `AD_Process` rows.** Etendo implements them as ONE generic
+  "Process X" button per document type (`Process Order` id `104`,
+  `Process Invoice` id `111`, `Process Shipment` id `109`, `Process
+  Inventory Count` id `107`, etc.) that opens a dialog offering all the
+  lifecycle actions as options. Granting that single process is sufficient
+  — there is no separate "Complete" or "Void" `AD_Process` to grant.
+- **The same conceptual button ("Copy Lines", "Explode") is often a
+  DIFFERENT `AD_Process_ID` per document type.** E.g. Sales Order's "Copy
+  Lines" is process `211`; Sales Invoice's "Copy Lines" is process `210` —
+  same name, different implementation/ID. **Apply:** when building a role's
+  `AD_Process_Access` set across multiple windows, dedup by `AD_Process_ID`,
+  never by process name.
+- **`AD_Process_Access` has no per-window scoping column at all** — a grant
+  is global to the role, not tied to a specific window (matching how the
+  automatic non-manual-role grant also works). So if a role has two windows
+  that happen to share the exact same process (same ID), only ONE
+  `AD_Process_Access` row is needed for that (role, process) pair, not one
+  per window.
+- **ETP-4509 read-only-tier decision: zero `AD_Process_Access` grants for
+  any read-only-tier window.** Checked all button processes on the 4
+  read-only windows in that task (sales-invoice, purchase-invoice, product,
+  physical-inventory) — every single one was a state-changing action
+  (Process/Copy/Generate/Update/Create); none were print/export/view-type.
+  Etendo's grid/form Print/Export are generic toolbar actions, not gated by
+  `AD_Process_Access`, so there was no safe candidate to grant that would
+  preserve read-only intent. **Apply:** before assuming "some process access
+  makes sense even read-only," actually enumerate the window's button
+  processes first — the answer may legitimately be zero.


### PR DESCRIPTION
## Summary
- Seeds `AD_Window_Access` (3-tier: none/read-only/full via the single `isreadwrite` flag) for Finance, Sales, Purchasing, Inventory on GOClient, per the design doc's per-role window table. Administrator needs no seeding here — GOClient Admin is non-manual and already has blanket full access via `AD_ROLE_TRG`.
- Confirmed the `ETGO_SF_ENTITY`/`ETGO_SF_SPEC` -> `AD_Window_ID` mapping is reliable: 47 of 49 active `spec_type='W'` window specs resolve with zero mismatches; the 2 gaps (dashboard, not-posted-documents) and all 8 active `spec_type='R'` report-type specs have no `AD_Window_ID` by design (Go-only computed views, not AD windows).
- Known accepted gap (documented, not seeded): 2 Finance "full access" items could not be resolved — "Contabilidad" (no confident single window) and "Conciliacion bancaria" (its spec has no `AD_Window_ID` at all, per above).
- Seeds `AD_Process_Access` (56 rows) for the same 4 roles, derived via the `AD_Field(button)` -> `AD_Column.ad_process_id` -> `AD_Tab` -> `AD_Window` mechanism, cross-verified as a strict subset of GOClient Admin/GOuser's own automatic grants (zero over-grants). Read-only-tier windows deliberately get zero process access — every button process on those 4 windows was state-changing, none view-only.
- Delivery: sampledata XML in `com.etendoerp.go` (`AD_WINDOW_ACCESS.xml`, `AD_PROCESS_ACCESS.xml`) is the authoritative artifact — see etendosoftware/com.etendoerp.go#719; `cli/sql/goclient-seed-window-access.sql` and `goclient-seed-process-access.sql` are local dev-seeding convenience scripts.
- Full mapping tables, findings, and verification in `docs/etendo-ad/roles-users-reference.md`.

**Stacked PR:** this PR targets `feature/ETP-4508` and depends on that PR (#887) merging first. Once #887 merges into `epic/ETP-3504`, this PR should be retargeted to `epic/ETP-3504`.

## Test plan
- Contract/data verified field-by-field against the live GOClient dev DB.
- Passed REVIEW (Alex), QA (Sentinel), and DOCS (Sage) pipeline phases.
- `make test-all-coverage` passes (exit 0) after the worktree `node_modules` provisioning fix.