### PR TITLE
Feature ETP-4538: Reactivate posted amortizations

### DIFF
--- a/artifacts/amortization/contract.json
+++ b/artifacts/amortization/contract.json
@@ -1,7 +1,8 @@
 {
   "version": "0.36.0",
   "generatedAt": "2026-07-14T13:57:24.059Z",
-  "checksum": "98b37336732f2c74",
+  "updatedAt": "2026-07-16T15:04:16.418Z",
+  "checksum": "6fa3fb426053dcc9",
   "frontendContract": {
     "window": {
       "id": "800026",
@@ -19,7 +20,7 @@
           "label": "Reactivate",
           "labelKey": "reactivate",
           "visibleWhenFieldTrue": "processed",
-          "visibleWhenFieldFalse": "posted",
+          "preUnpost": true,
           "columnName": "Processed"
         },
         {
@@ -30,14 +31,6 @@
           "visibleWhenFieldFalse": "posted",
           "successKey": "documentPosted",
           "visibleWhenFieldTrue": "processed"
-        },
-        {
-          "key": "unpost",
-          "label": "Unpost",
-          "action": "unpost",
-          "labelKey": "unpost",
-          "visibleWhenFieldTrue": "posted",
-          "successKey": "documentUnposted"
         }
       ],
       "processOverrides": {
@@ -512,7 +505,7 @@
           "label": "Reactivate",
           "labelKey": "reactivate",
           "visibleWhenFieldTrue": "processed",
-          "visibleWhenFieldFalse": "posted",
+          "preUnpost": true,
           "columnName": "Processed"
         },
         {
@@ -523,14 +516,6 @@
           "visibleWhenFieldFalse": "posted",
           "successKey": "documentPosted",
           "visibleWhenFieldTrue": "processed"
-        },
-        {
-          "key": "unpost",
-          "label": "Unpost",
-          "action": "unpost",
-          "labelKey": "unpost",
-          "visibleWhenFieldTrue": "posted",
-          "successKey": "documentUnposted"
         }
       ],
       "processOverrides": {

--- a/artifacts/amortization/contract.mcp.json
+++ b/artifacts/amortization/contract.mcp.json
@@ -1,7 +1,7 @@
 {
   "version": "0.36.0",
   "generatedAt": "2026-07-14T13:57:24.059Z",
-  "contractChecksum": "98b37336732f2c74",
+  "contractChecksum": "6fa3fb426053dcc9",
   "apiPrediction": {
     "specName": "amortization",
     "baseUrl": "/sws/neo/amortization",

--- a/artifacts/amortization/decisions.json
+++ b/artifacts/amortization/decisions.json
@@ -34,7 +34,7 @@
         "label": "Reactivate",
         "labelKey": "reactivate",
         "visibleWhenFieldTrue": "processed",
-        "visibleWhenFieldFalse": "posted",
+        "preUnpost": true,
         "columnName": "Processed"
       },
       {
@@ -45,14 +45,6 @@
         "visibleWhenFieldFalse": "posted",
         "successKey": "documentPosted",
         "visibleWhenFieldTrue": "processed"
-      },
-      {
-        "key": "unpost",
-        "label": "Unpost",
-        "action": "unpost",
-        "labelKey": "unpost",
-        "visibleWhenFieldTrue": "posted",
-        "successKey": "documentUnposted"
       }
     ],
     "labelOverrides": {

--- a/artifacts/amortization/generated/__tests__/HeaderTable.test.js
+++ b/artifacts/amortization/generated/__tests__/HeaderTable.test.js
@@ -51,29 +51,19 @@ describe('Amortization HeaderPage — post menuAction', () => {
     assert.match(pageSrc, /data\?\.posted/);
   });
 
-  it('declares an independent unpost action gated on posted (Option A)', () => {
-    // Option A adds a standalone Unpost (Descontabilizar) menu action.
-    assert.match(pageSrc, /neoAction:\s*'unpost'/);
-    // The unpost entry must be visible only when the document is posted.
-    const unpostLine = pageSrc
-      .split('\n')
-      .find((l) => l.includes("key: 'unpost'"));
-    assert.ok(unpostLine, "Expected a menuAction with key: 'unpost'");
-    assert.match(unpostLine, /neoAction:\s*'unpost'/);
-    assert.match(unpostLine, /data\?\.posted === 'Y'\s*\|\|\s*data\?\.posted === true/);
-    // Unpost is NOT gated on processed — it only depends on posted.
-    assert.doesNotMatch(unpostLine, /data\?\.processed/);
+  it('does not generate the legacy unpost action', () => {
+    assert.doesNotMatch(pageSrc, /key:\s*'unpost'/);
+    assert.doesNotMatch(pageSrc, /neoAction:\s*'unpost'/);
   });
 
-  it('reactivate no longer carries preUnpost and is gated on !posted && processed', () => {
+  it('reactivate is visible for processed documents and pre-unposts when needed', () => {
     const reactivateLine = pageSrc
       .split('\n')
       .find((l) => l.includes("key: 'reactivate'"));
     assert.ok(reactivateLine, "Expected a menuAction with key: 'reactivate'");
-    // Option A removed the preUnpost coupling from reactivate.
-    assert.doesNotMatch(reactivateLine, /preUnpost/);
-    // reactivate visible only when not posted and already processed.
-    assert.match(reactivateLine, /!\(data\?\.posted === 'Y'\s*\|\|\s*data\?\.posted === true\)/);
+    assert.match(reactivateLine, /preUnpost:\s*true/);
+    assert.match(reactivateLine, /columnName:\s*'Processed'/);
+    assert.doesNotMatch(reactivateLine, /data\?\.posted/);
     assert.match(reactivateLine, /data\?\.processed === 'Y'\s*\|\|\s*data\?\.processed === true/);
   });
 

--- a/artifacts/amortization/generated/web/amortization/HeaderPage.jsx
+++ b/artifacts/amortization/generated/web/amortization/HeaderPage.jsx
@@ -257,9 +257,8 @@ export default function HeaderPage({ windowName, recordId, ...props }) {
         toolbarButtonSize="default"
         customTabs={[{ key: 'attachments', labelKey: 'attachments', Component: AttachmentsTab, placement: 'tab', props: { tableName: "A_Amortization", config: {} } }]}
         menuActions={({ data, status }) => [
-          { key: 'reactivate', label: 'Reactivate', visible: !(data?.posted === 'Y' || data?.posted === true) && (data?.processed === 'Y' || data?.processed === true), labelKey: 'reactivate', columnName: 'Processed',  },
-          { key: 'post', label: 'Post', visible: !(data?.posted === 'Y' || data?.posted === true) && (data?.processed === 'Y' || data?.processed === true), labelKey: 'post', successKey: 'documentPosted', neoAction: 'post',  },
-          { key: 'unpost', label: 'Unpost', visible: (data?.posted === 'Y' || data?.posted === true), labelKey: 'unpost', successKey: 'documentUnposted', neoAction: 'unpost',  }
+          { key: 'reactivate', label: 'Reactivate', visible: (data?.processed === 'Y' || data?.processed === true), labelKey: 'reactivate', preUnpost: true, columnName: 'Processed',  },
+          { key: 'post', label: 'Post', visible: !(data?.posted === 'Y' || data?.posted === true) && (data?.processed === 'Y' || data?.processed === true), labelKey: 'post', successKey: 'documentPosted', neoAction: 'post',  }
         ]}
         draftMode={draftModeWithConfirm}
         requiredHeaderFields={requiredHeaderFields}

--- a/docs/generated-custom-windows/amortization.md
+++ b/docs/generated-custom-windows/amortization.md
@@ -19,7 +19,7 @@ Records are typically created from the **Assets** window via the **Create Amorti
   - Press **Confirmar** to open a confirmation modal showing the current total, line count, and a lock warning, then confirm the document.
 - Once **processed** (`processed='Y'`):
   - The remaining editable field (Description) and all line fields become read-only.
-  - A **Reactivar** option appears in the three-dot menu to unprocess the document.
+  - A **Reactivar** option appears in the three-dot menu to unprocess the document, including when it is posted. When posted, the action first unposts the document and then reactivates it; when not posted, it only reactivates. There is no separate **Descontabilizar** action in Etendo Go.
 - The header **Delete** (trash) button is hidden in all states via `window.hideDeleteButton` (see `docs/decisions-reference.md` / `docs/ui-customization.md` for the flag mechanics).
 - Attach files via the **Adjuntos** tab.
 - The document-level **Delete** action (list row trash icon and detail toolbar) is hidden unconditionally, in both draft and processed status (`window.hideDeleteButton: true`) — this is stricter than the previous processed-only behavior. Deleting individual **lines** while in draft is unaffected and still available.
@@ -42,7 +42,7 @@ Records are typically created from the **Assets** window via the **Create Amorti
 - **Header field locking**: Name, Accounting Date, Starting Date, and Currency are classified `readOnly` in `decisions.json`, so they are locked in every state (not just once processed). Description stays editable in draft and locks when the document is processed. The header **Delete** button is hidden in all states via `window.hideDeleteButton`.
 - **Line lock**: all line fields carry `readOnlyLogic: @Processed@='Y'` and become read-only once the document is processed.
 - **Confirmar button**: wired via `draftMode.processField: "Processed"`. Only visible while draft; disabled when no lines; opens the confirm modal. The modal fetches the record and line count independently, calculates the total from line amounts (not from the stored header field), shows a warning, and submits `POST /action/Processed`. On success, the detail view refetches the header.
-- **Reactivar menu action**: appears in the three-dot menu only when `processed='Y'`. Calls `/action/Processed` again, which the backend interprets as an unprocess request. After success, the page reloads.
+- **Reactivar menu action**: appears in the three-dot menu only when `processed='Y'`, regardless of the accounting `posted` value. It uses `preUnpost: true`, so posted records first call `/action/unpost` and then `/action/Processed`; unposted records skip the unpost step and only call `/action/Processed`. After success, the page reloads. The independent **Descontabilizar** menu action is intentionally not exposed for amortizations.
 - **Status pill**: `statusField: "processed"` in `decisions.json` causes DetailView to render a `DocumentStatusPill` next to the Cancel button. Values: `'Y'` → "✓ Procesado" (green/success), `'N'` → "Borrador" (neutral/grey). Tone mapping lives in `tools/app-shell/src/lib/statusBadge.js` (`getStatusTone`).
 - **Lines total footer**: computed from visible lines (`lines.reduce()`) so it updates immediately on any mutation — no server round-trip needed. `TOTALAMORTIZATION` on the header is kept in sync by `ETGO_A_AMORTLINE_TOTAL_TRG` (AFTER trigger on `A_AMORTIZATIONLINE`) and is the authoritative value shown in the list view column.
 - **New record currency default**: the `currency` field defaults to the org's functional currency via `defaultExpr: "@$C_Currency_ID@"` in decisions.json. Currency is classified `readOnly`, so it is displayed but never editable from this window.
@@ -103,7 +103,7 @@ Records are typically created from the **Assets** window via the **Create Amorti
   - `statusField: "processed"` — drives the `DocumentStatusPill` in the toolbar (green for 'Y', grey for 'N').
   - `asset.grow: true` and `amortizationPercentage.grow: true` for balanced column distribution.
   - `draftMode: { processField: "Processed", label: "confirm", confirmModal: "AmortizationConfirmModal", disableWhenEmpty: true }`.
-  - `menuActions: [{ key: "reactivate", visibleWhenFieldTrue: "processed", columnName: "Processed" }]`.
+  - `menuActions: [{ key: "reactivate", visibleWhenFieldTrue: "processed", preUnpost: true, columnName: "Processed" }]`; there is no standalone `unpost` action for amortizations.
   - `hideDeleteButton: true`, `hideCreate: true`, `summaryFields: []`, `hidePrint: true`, `hideLink: true`.
   - `currency.defaultExpr: "@$C_Currency_ID@"`; `currency.visibility: "readOnly"`.
   - Header fields `name`, `accountingDate`, `startingDate`, `currency`: `visibility: "readOnly"`. Only `description` stays editable.
@@ -247,3 +247,9 @@ This iteration tightens the Amortization window to a read-focused, assets-driven
 3. Confirm there is no "Others" tab and no Accounting Status field anywhere in the header.
 4. Expand a line — confirm the dimension panel shows exactly Organisation (read-only) + Project, Cost Center, Contact. Confirm no Product selector is present.
 5. On a processed document, confirm an empty-dimension line shows no "+ Añadir dimensiones" trigger, while a line with dimensions still displays its value chips.
+
+## ETP-4538 — Reactivate replaces Unpost on posted amortizations
+
+- The three-dot menu no longer exposes the independent **Descontabilizar** (`unpost`) action for amortization documents.
+- **Reactivar** is visible whenever the document is processed (`processed='Y'`), including records whose accounting status is posted (`posted='Y'`). For posted records, `preUnpost: true` makes the UI call the existing unpost endpoint before triggering the `Processed` action; for unposted records, only the `Processed` action runs. This matches the Etendo Go document lifecycle rule: reactivation is the single user action and accounting reversal is part of that flow.
+- Role-based access restrictions for **Reactivar** are deferred until the role permissions model exists.

--- a/tools/app-shell/src/components/contract-ui/__tests__/DetailView.neoActionMenu.vitest.jsx
+++ b/tools/app-shell/src/components/contract-ui/__tests__/DetailView.neoActionMenu.vitest.jsx
@@ -11,7 +11,7 @@
  * Harness mirrors DetailView.render.vitest.jsx; the only addition is the
  * controllable `@/hooks/useNeoAction` mock.
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -147,6 +147,20 @@ function renderDetailView(props = {}) {
   );
 }
 
+function setCurrentRecord(posted) {
+  const record = { id: '123', documentNo: 'SO-001', documentStatus: 'DR', processed: false };
+  if (posted !== undefined) record.posted = posted;
+  mockHook.selected = record;
+  mockHook.editing = record;
+}
+
+const reactivatePreUnpostAction = {
+  key: 'reactivate',
+  label: 'Reactivate',
+  preUnpost: true,
+  columnName: 'Processed',
+};
+
 describe('DetailView — neoAction menu branch (ETP-4298)', () => {
   beforeEach(() => {
     neoExecuteMock.mockClear();
@@ -154,6 +168,8 @@ describe('DetailView — neoAction menu branch (ETP-4298)', () => {
     toast.success.mockClear();
     toast.error.mockClear();
     mockHook.fetchById.mockClear();
+    mockHook.handleProcess.mockClear();
+    setCurrentRecord(undefined);
   });
 
   it('calls neoAction.execute(id, "post") and refreshes via fetchById on success', async () => {
@@ -186,5 +202,56 @@ describe('DetailView — neoAction menu branch (ETP-4298)', () => {
     expect(toast.error).toHaveBeenCalledWith('Cannot post');
     expect(mockHook.fetchById).not.toHaveBeenCalled();
     expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it('unposts first, then dispatches the columnName process when the current record is posted', async () => {
+    const user = userEvent.setup();
+    setCurrentRecord('Y');
+    renderDetailView({ menuActions: [reactivatePreUnpostAction] });
+
+    await user.click(screen.getByTestId('action-more'));
+    await user.click(screen.getByTestId('menu-action-reactivate'));
+
+    await waitFor(() => {
+      expect(neoExecuteMock).toHaveBeenCalledWith('123', 'unpost');
+      expect(mockHook.handleProcess).toHaveBeenCalledWith({ columnName: 'Processed', name: 'reactivate' });
+    });
+    expect(neoExecuteMock.mock.invocationCallOrder[0]).toBeLessThan(
+      mockHook.handleProcess.mock.invocationCallOrder[0],
+    );
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch the columnName process when the pre-unpost step fails', async () => {
+    const user = userEvent.setup();
+    setCurrentRecord('Y');
+    neoExecuteMock.mockResolvedValue({ success: false, message: 'Cannot unpost' });
+    renderDetailView({ menuActions: [reactivatePreUnpostAction] });
+
+    await user.click(screen.getByTestId('action-more'));
+    await user.click(screen.getByTestId('menu-action-reactivate'));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Cannot unpost'));
+    expect(neoExecuteMock).toHaveBeenCalledWith('123', 'unpost');
+    expect(mockHook.handleProcess).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['N'],
+    [false],
+    [undefined],
+  ])('skips pre-unpost and dispatches the columnName process directly when posted is %s', async (posted) => {
+    const user = userEvent.setup();
+    setCurrentRecord(posted);
+    renderDetailView({ menuActions: [reactivatePreUnpostAction] });
+
+    await user.click(screen.getByTestId('action-more'));
+    await user.click(screen.getByTestId('menu-action-reactivate'));
+
+    await waitFor(() => {
+      expect(mockHook.handleProcess).toHaveBeenCalledWith({ columnName: 'Processed', name: 'reactivate' });
+    });
+    expect(neoExecuteMock).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Replace the standalone Amortization Unpost/Descontabilizar menu action with Reactivate
- Keep Reactivate visible for processed amortizations, including posted ones
- Add pre-unpost behavior so posted records unpost before running the Processed reactivate action
- Update Amortization docs and add runtime DetailView coverage for preUnpost + columnName actions

## Validation
- make regen ONLY=amortization SKIP_EXTRACT=1 PUSH_TO_NEO=1
- npx sf-validate-pipeline --scope=amortization --format=text
- node --test artifacts/amortization/generated/__tests__/HeaderTable.test.js
- npm run test:vitest -- src/components/contract-ui/__tests__/DetailView.neoActionMenu.vitest.jsx

Jira: ETP-4538