### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.9",
-        "@etendosoftware/schema-forge-cli": "0.3.9",
-        "@etendosoftware/schema-forge-core": "0.3.9",
+        "@etendosoftware/app-shell-core": "0.3.10",
+        "@etendosoftware/schema-forge-cli": "0.3.10",
+        "@etendosoftware/schema-forge-core": "0.3.10",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2537,9 +2537,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.9",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.9/0c6dc9dc1893449cbb6e5e5912a45ddf731a4edc",
-      "integrity": "sha512-RAc1ThDrLIRvb7ecyaH6SL9KSUp01mmPyuW0tHu+ktGrMd69ag9Cad9YyIGylORfv3LjOBLe9f+X7EbMoYZXgA==",
+      "version": "0.3.10",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.10/550cf86980af88d7e833e4021707abc76c57500a",
+      "integrity": "sha512-0zpc0ivozpgDeCmfHVTbzpw1WrCBtHfaQGM/vCaMrdb9uvhsejCgBT3UDEq6ozm6pXUADwJogaBGi8RU8uSeJQ==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2566,9 +2566,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.9",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.9/14e6b07b241c6562ad4d0ba990b4cbf1e29053eb",
-      "integrity": "sha512-SsAQtayhxFcUipIQdxuy5Gz/9m3pgv13ygiLK0Y4hQcqaXQrPHdAqoUykZM6+3j6RPHXAQ8zCm6IL9B6FJI0Vw==",
+      "version": "0.3.10",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.10/52852e4f27b2394983043b1b3f60f807357d33e3",
+      "integrity": "sha512-TpJ8/H3gbVdQ+yrrbgxRsxc8B4L1+1iX1fAdctNnGgc83EvcslhpcMCBDrGEunaYtOW4c4txKOa2mMFLlxHGLA==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2578,9 +2578,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.9",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.9/fae3eb2a4c3e4135c72a178c49334badd51fcd8b",
-      "integrity": "sha512-q4tJCzX0FTRH0RWZYQZDveKkQ7OVxftIPptQHUe5lPY7DM3nGn/Mo/Kx7ACFA9o0wsbpakejx9f7EXodxH5Mcw==",
+      "version": "0.3.10",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.10/76946715800224c9a640b68c90d27dfc2a861d58",
+      "integrity": "sha512-V1CL8HxlVymuDQKRiBvTKF0ZTdDBouIADK/F08ctGDIXMK9S9E9hs6kJOqw/W4VrM/xHWbhrWFrG7GW0o3ZK4A==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2624,9 +2624,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.9",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.9/eee0964d822c8cf1b09727d292aaa260f18584a1",
-      "integrity": "sha512-nWCrm1UjFnYdEuipPe1WwV2tRV0+RWv/v4ra6ultYTIouF8eUFYaCfnpZJrU1b1SAwipMFR63iTPB7q1MRVT3g==",
+      "version": "0.3.10",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.10/6899859f817dcc5ef039d5383bfad32035664d4a",
+      "integrity": "sha512-4R+YjUiMqnYc9ecY9OmNU8hlO4C7OkJ2RXKUFJkf4dmdE6DnJufzwd7Hbvia0sV/na34GnPMc8vq0/aVu3TUHw==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13523,8 +13523,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.9",
-        "@etendosoftware/etendo-go-core": "0.3.9",
+        "@etendosoftware/app-shell-core": "0.3.10",
+        "@etendosoftware/etendo-go-core": "0.3.10",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.9",
-    "@etendosoftware/schema-forge-cli": "0.3.9",
-    "@etendosoftware/schema-forge-core": "0.3.9",
+    "@etendosoftware/app-shell-core": "0.3.10",
+    "@etendosoftware/schema-forge-cli": "0.3.10",
+    "@etendosoftware/schema-forge-core": "0.3.10",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.9",
-        "@etendosoftware/etendo-go-core": "0.3.9",
+        "@etendosoftware/app-shell-core": "0.3.10",
+        "@etendosoftware/etendo-go-core": "0.3.10",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -2255,9 +2255,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.9",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.9/0c6dc9dc1893449cbb6e5e5912a45ddf731a4edc",
-      "integrity": "sha512-RAc1ThDrLIRvb7ecyaH6SL9KSUp01mmPyuW0tHu+ktGrMd69ag9Cad9YyIGylORfv3LjOBLe9f+X7EbMoYZXgA==",
+      "version": "0.3.10",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.10/550cf86980af88d7e833e4021707abc76c57500a",
+      "integrity": "sha512-0zpc0ivozpgDeCmfHVTbzpw1WrCBtHfaQGM/vCaMrdb9uvhsejCgBT3UDEq6ozm6pXUADwJogaBGi8RU8uSeJQ==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2284,9 +2284,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.9",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.9/14e6b07b241c6562ad4d0ba990b4cbf1e29053eb",
-      "integrity": "sha512-SsAQtayhxFcUipIQdxuy5Gz/9m3pgv13ygiLK0Y4hQcqaXQrPHdAqoUykZM6+3j6RPHXAQ8zCm6IL9B6FJI0Vw==",
+      "version": "0.3.10",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.10/52852e4f27b2394983043b1b3f60f807357d33e3",
+      "integrity": "sha512-TpJ8/H3gbVdQ+yrrbgxRsxc8B4L1+1iX1fAdctNnGgc83EvcslhpcMCBDrGEunaYtOW4c4txKOa2mMFLlxHGLA==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -12067,14 +12067,14 @@
       "optional": true
     },
     "@etendosoftware/app-shell-core": {
-      "version": "0.3.9",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.9/0c6dc9dc1893449cbb6e5e5912a45ddf731a4edc",
-      "integrity": "sha512-RAc1ThDrLIRvb7ecyaH6SL9KSUp01mmPyuW0tHu+ktGrMd69ag9Cad9YyIGylORfv3LjOBLe9f+X7EbMoYZXgA=="
+      "version": "0.3.10",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.10/550cf86980af88d7e833e4021707abc76c57500a",
+      "integrity": "sha512-0zpc0ivozpgDeCmfHVTbzpw1WrCBtHfaQGM/vCaMrdb9uvhsejCgBT3UDEq6ozm6pXUADwJogaBGi8RU8uSeJQ=="
     },
     "@etendosoftware/etendo-go-core": {
-      "version": "0.3.9",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.9/14e6b07b241c6562ad4d0ba990b4cbf1e29053eb",
-      "integrity": "sha512-SsAQtayhxFcUipIQdxuy5Gz/9m3pgv13ygiLK0Y4hQcqaXQrPHdAqoUykZM6+3j6RPHXAQ8zCm6IL9B6FJI0Vw=="
+      "version": "0.3.10",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.10/52852e4f27b2394983043b1b3f60f807357d33e3",
+      "integrity": "sha512-TpJ8/H3gbVdQ+yrrbgxRsxc8B4L1+1iX1fAdctNnGgc83EvcslhpcMCBDrGEunaYtOW4c4txKOa2mMFLlxHGLA=="
     },
     "@exodus/bytes": {
       "version": "1.15.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -15,8 +15,8 @@
     "test:all": "npm run test && npm run test:vitest"
   },
   "dependencies": {
-    "@etendosoftware/app-shell-core": "0.3.9",
-    "@etendosoftware/etendo-go-core": "0.3.9",
+    "@etendosoftware/app-shell-core": "0.3.10",
+    "@etendosoftware/etendo-go-core": "0.3.10",
     "@iconicapp/iconic-react": "^1.1.4",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.10`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.