### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.10",
-        "@etendosoftware/schema-forge-cli": "0.3.10",
-        "@etendosoftware/schema-forge-core": "0.3.10",
+        "@etendosoftware/app-shell-core": "0.3.11",
+        "@etendosoftware/schema-forge-cli": "0.3.11",
+        "@etendosoftware/schema-forge-core": "0.3.11",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2537,9 +2537,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.10",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.10/550cf86980af88d7e833e4021707abc76c57500a",
-      "integrity": "sha512-0zpc0ivozpgDeCmfHVTbzpw1WrCBtHfaQGM/vCaMrdb9uvhsejCgBT3UDEq6ozm6pXUADwJogaBGi8RU8uSeJQ==",
+      "version": "0.3.11",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.11/268b46ac911bdcf10e847d5bbc092c760e32f8e8",
+      "integrity": "sha512-9UBHRPvMzLRSgLWpYgyCT5swXvNjE4SN7bUlN8tOcebOf3yRWGT4TS6c+fiLWhCtEHOug77FvkjGxozV7HEyNQ==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2566,9 +2566,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.10",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.10/52852e4f27b2394983043b1b3f60f807357d33e3",
-      "integrity": "sha512-TpJ8/H3gbVdQ+yrrbgxRsxc8B4L1+1iX1fAdctNnGgc83EvcslhpcMCBDrGEunaYtOW4c4txKOa2mMFLlxHGLA==",
+      "version": "0.3.11",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.11/1280c3a54e4b1469fe239a3559fa05e21558557b",
+      "integrity": "sha512-XRVNvjXzNEVOYk3mgo3qr1N1BCCb0jykKUTK57BC/T7aplYtx9ZY/zfSmrkOqcpcBfUJmHugUm/Nziozf8y7cQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2578,9 +2578,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.10",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.10/76946715800224c9a640b68c90d27dfc2a861d58",
-      "integrity": "sha512-V1CL8HxlVymuDQKRiBvTKF0ZTdDBouIADK/F08ctGDIXMK9S9E9hs6kJOqw/W4VrM/xHWbhrWFrG7GW0o3ZK4A==",
+      "version": "0.3.11",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.11/6a5ee05c32446aa93f129ee0b1ec64805bd52787",
+      "integrity": "sha512-uJKivAKEnSZgt7P3w+sHWGeCYW+5aRtBk4ly6z/5+P5LtubiOxt0QMM0C5mwC4DhM/ICkoe7fFIsz+ti6YMoCw==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2624,9 +2624,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.10",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.10/6899859f817dcc5ef039d5383bfad32035664d4a",
-      "integrity": "sha512-4R+YjUiMqnYc9ecY9OmNU8hlO4C7OkJ2RXKUFJkf4dmdE6DnJufzwd7Hbvia0sV/na34GnPMc8vq0/aVu3TUHw==",
+      "version": "0.3.11",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.11/550f634d05c0b1069ade538f4a51c920fef1fadf",
+      "integrity": "sha512-8VYM58UaodqyiW9/OZaRgpXk1aR3LLBmnL45xm/7DdU8r166Hmeod4stVqIVKRAjoFc10vQynA9xIj5i86/zLQ==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -2651,23 +2651,6 @@
         "@noble/hashes": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@faker-js/faker": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.5.0.tgz",
-      "integrity": "sha512-bsxD8WLS5lIj7aaoCx1YJkktqYj5vlBUE6HWzu2Q51ksrGJ0H737ECCKlFU7Yf8Br45z9t99frBp/J7kzbMPAg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fakerjs"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
-        "npm": ">=10"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -13540,8 +13523,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.10",
-        "@etendosoftware/etendo-go-core": "0.3.10",
+        "@etendosoftware/app-shell-core": "0.3.11",
+        "@etendosoftware/etendo-go-core": "0.3.11",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "generate:contacts-csv": "node scripts/generate-contacts-csv.js"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.10",
-    "@etendosoftware/schema-forge-cli": "0.3.10",
-    "@etendosoftware/schema-forge-core": "0.3.10",
+    "@etendosoftware/app-shell-core": "0.3.11",
+    "@etendosoftware/schema-forge-cli": "0.3.11",
+    "@etendosoftware/schema-forge-core": "0.3.11",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.10",
-        "@etendosoftware/etendo-go-core": "0.3.10",
+        "@etendosoftware/app-shell-core": "0.3.11",
+        "@etendosoftware/etendo-go-core": "0.3.11",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -2255,9 +2255,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.10",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.10/550cf86980af88d7e833e4021707abc76c57500a",
-      "integrity": "sha512-0zpc0ivozpgDeCmfHVTbzpw1WrCBtHfaQGM/vCaMrdb9uvhsejCgBT3UDEq6ozm6pXUADwJogaBGi8RU8uSeJQ==",
+      "version": "0.3.11",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.11/268b46ac911bdcf10e847d5bbc092c760e32f8e8",
+      "integrity": "sha512-9UBHRPvMzLRSgLWpYgyCT5swXvNjE4SN7bUlN8tOcebOf3yRWGT4TS6c+fiLWhCtEHOug77FvkjGxozV7HEyNQ==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2284,9 +2284,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.10",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.10/52852e4f27b2394983043b1b3f60f807357d33e3",
-      "integrity": "sha512-TpJ8/H3gbVdQ+yrrbgxRsxc8B4L1+1iX1fAdctNnGgc83EvcslhpcMCBDrGEunaYtOW4c4txKOa2mMFLlxHGLA==",
+      "version": "0.3.11",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.11/1280c3a54e4b1469fe239a3559fa05e21558557b",
+      "integrity": "sha512-XRVNvjXzNEVOYk3mgo3qr1N1BCCb0jykKUTK57BC/T7aplYtx9ZY/zfSmrkOqcpcBfUJmHugUm/Nziozf8y7cQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -12067,14 +12067,14 @@
       "optional": true
     },
     "@etendosoftware/app-shell-core": {
-      "version": "0.3.10",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.10/550cf86980af88d7e833e4021707abc76c57500a",
-      "integrity": "sha512-0zpc0ivozpgDeCmfHVTbzpw1WrCBtHfaQGM/vCaMrdb9uvhsejCgBT3UDEq6ozm6pXUADwJogaBGi8RU8uSeJQ=="
+      "version": "0.3.11",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.11/268b46ac911bdcf10e847d5bbc092c760e32f8e8",
+      "integrity": "sha512-9UBHRPvMzLRSgLWpYgyCT5swXvNjE4SN7bUlN8tOcebOf3yRWGT4TS6c+fiLWhCtEHOug77FvkjGxozV7HEyNQ=="
     },
     "@etendosoftware/etendo-go-core": {
-      "version": "0.3.10",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.10/52852e4f27b2394983043b1b3f60f807357d33e3",
-      "integrity": "sha512-TpJ8/H3gbVdQ+yrrbgxRsxc8B4L1+1iX1fAdctNnGgc83EvcslhpcMCBDrGEunaYtOW4c4txKOa2mMFLlxHGLA=="
+      "version": "0.3.11",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.11/1280c3a54e4b1469fe239a3559fa05e21558557b",
+      "integrity": "sha512-XRVNvjXzNEVOYk3mgo3qr1N1BCCb0jykKUTK57BC/T7aplYtx9ZY/zfSmrkOqcpcBfUJmHugUm/Nziozf8y7cQ=="
     },
     "@exodus/bytes": {
       "version": "1.15.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -15,8 +15,8 @@
     "test:all": "npm run test && npm run test:vitest"
   },
   "dependencies": {
-    "@etendosoftware/app-shell-core": "0.3.10",
-    "@etendosoftware/etendo-go-core": "0.3.10",
+    "@etendosoftware/app-shell-core": "0.3.11",
+    "@etendosoftware/etendo-go-core": "0.3.11",
     "@iconicapp/iconic-react": "^1.1.4",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.11`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.