### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.12

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.11",
-        "@etendosoftware/schema-forge-cli": "0.3.11",
-        "@etendosoftware/schema-forge-core": "0.3.11",
+        "@etendosoftware/app-shell-core": "0.3.12",
+        "@etendosoftware/schema-forge-cli": "0.3.12",
+        "@etendosoftware/schema-forge-core": "0.3.12",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2537,9 +2537,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.11",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.11/268b46ac911bdcf10e847d5bbc092c760e32f8e8",
-      "integrity": "sha512-9UBHRPvMzLRSgLWpYgyCT5swXvNjE4SN7bUlN8tOcebOf3yRWGT4TS6c+fiLWhCtEHOug77FvkjGxozV7HEyNQ==",
+      "version": "0.3.12",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.12/016d522dbe61db4a998713bb7f7da55b4250e317",
+      "integrity": "sha512-xB8H6JOTk+3s3isYEYGmPHJNwUiXTlcuy40Ii3FgDEAlphinoHiKUc96TT9v+46odA7G+lPWmEGtRKYcPEsDPw==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2566,9 +2566,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.11",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.11/1280c3a54e4b1469fe239a3559fa05e21558557b",
-      "integrity": "sha512-XRVNvjXzNEVOYk3mgo3qr1N1BCCb0jykKUTK57BC/T7aplYtx9ZY/zfSmrkOqcpcBfUJmHugUm/Nziozf8y7cQ==",
+      "version": "0.3.12",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.12/dabbc7290e0f90c56f3f1065c62132092ebc1e02",
+      "integrity": "sha512-cJV7flDINsEwkUtSon8tDw3Jj2NwqQZKEwB9thCna/CofdrjGrJ6XIEoG8+hrPodhmUUzBGfqB3vEzkVMtLTbA==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2578,9 +2578,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.11",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.11/6a5ee05c32446aa93f129ee0b1ec64805bd52787",
-      "integrity": "sha512-uJKivAKEnSZgt7P3w+sHWGeCYW+5aRtBk4ly6z/5+P5LtubiOxt0QMM0C5mwC4DhM/ICkoe7fFIsz+ti6YMoCw==",
+      "version": "0.3.12",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.12/9268ae73e2991e9e558c31543f7468bab765aaf0",
+      "integrity": "sha512-Rrj72WPrEzRi4/rqHxT5wz/45uBCBVR6vxwaBjbVwZk1LxQD/zzIhB6P0zdvcI7C117iLUqsWGFY7VjPQtEu/g==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2624,9 +2624,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.11",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.11/550f634d05c0b1069ade538f4a51c920fef1fadf",
-      "integrity": "sha512-8VYM58UaodqyiW9/OZaRgpXk1aR3LLBmnL45xm/7DdU8r166Hmeod4stVqIVKRAjoFc10vQynA9xIj5i86/zLQ==",
+      "version": "0.3.12",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.12/70b00ca64ebbcf5d0d3b34b87d7fc01e62950187",
+      "integrity": "sha512-F6QhHgerFPbC9NEJjjVdH+Y64eWWckXZ1fFzNmRdabOdYgdoLuHufjRqPjGolTLM8ZDCi3ERbea4MLRvw3OO/Q==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13523,8 +13523,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.11",
-        "@etendosoftware/etendo-go-core": "0.3.11",
+        "@etendosoftware/app-shell-core": "0.3.12",
+        "@etendosoftware/etendo-go-core": "0.3.12",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.11",
-    "@etendosoftware/schema-forge-cli": "0.3.11",
-    "@etendosoftware/schema-forge-core": "0.3.11",
+    "@etendosoftware/app-shell-core": "0.3.12",
+    "@etendosoftware/schema-forge-cli": "0.3.12",
+    "@etendosoftware/schema-forge-core": "0.3.12",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.11",
-        "@etendosoftware/etendo-go-core": "0.3.11",
+        "@etendosoftware/app-shell-core": "0.3.12",
+        "@etendosoftware/etendo-go-core": "0.3.12",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -2255,9 +2255,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.11",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.11/268b46ac911bdcf10e847d5bbc092c760e32f8e8",
-      "integrity": "sha512-9UBHRPvMzLRSgLWpYgyCT5swXvNjE4SN7bUlN8tOcebOf3yRWGT4TS6c+fiLWhCtEHOug77FvkjGxozV7HEyNQ==",
+      "version": "0.3.12",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.12/016d522dbe61db4a998713bb7f7da55b4250e317",
+      "integrity": "sha512-xB8H6JOTk+3s3isYEYGmPHJNwUiXTlcuy40Ii3FgDEAlphinoHiKUc96TT9v+46odA7G+lPWmEGtRKYcPEsDPw==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2284,9 +2284,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.11",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.11/1280c3a54e4b1469fe239a3559fa05e21558557b",
-      "integrity": "sha512-XRVNvjXzNEVOYk3mgo3qr1N1BCCb0jykKUTK57BC/T7aplYtx9ZY/zfSmrkOqcpcBfUJmHugUm/Nziozf8y7cQ==",
+      "version": "0.3.12",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.12/dabbc7290e0f90c56f3f1065c62132092ebc1e02",
+      "integrity": "sha512-cJV7flDINsEwkUtSon8tDw3Jj2NwqQZKEwB9thCna/CofdrjGrJ6XIEoG8+hrPodhmUUzBGfqB3vEzkVMtLTbA==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -12067,14 +12067,14 @@
       "optional": true
     },
     "@etendosoftware/app-shell-core": {
-      "version": "0.3.11",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.11/268b46ac911bdcf10e847d5bbc092c760e32f8e8",
-      "integrity": "sha512-9UBHRPvMzLRSgLWpYgyCT5swXvNjE4SN7bUlN8tOcebOf3yRWGT4TS6c+fiLWhCtEHOug77FvkjGxozV7HEyNQ=="
+      "version": "0.3.12",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.12/016d522dbe61db4a998713bb7f7da55b4250e317",
+      "integrity": "sha512-xB8H6JOTk+3s3isYEYGmPHJNwUiXTlcuy40Ii3FgDEAlphinoHiKUc96TT9v+46odA7G+lPWmEGtRKYcPEsDPw=="
     },
     "@etendosoftware/etendo-go-core": {
-      "version": "0.3.11",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.11/1280c3a54e4b1469fe239a3559fa05e21558557b",
-      "integrity": "sha512-XRVNvjXzNEVOYk3mgo3qr1N1BCCb0jykKUTK57BC/T7aplYtx9ZY/zfSmrkOqcpcBfUJmHugUm/Nziozf8y7cQ=="
+      "version": "0.3.12",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.12/dabbc7290e0f90c56f3f1065c62132092ebc1e02",
+      "integrity": "sha512-cJV7flDINsEwkUtSon8tDw3Jj2NwqQZKEwB9thCna/CofdrjGrJ6XIEoG8+hrPodhmUUzBGfqB3vEzkVMtLTbA=="
     },
     "@exodus/bytes": {
       "version": "1.15.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -15,8 +15,8 @@
     "test:all": "npm run test && npm run test:vitest"
   },
   "dependencies": {
-    "@etendosoftware/app-shell-core": "0.3.11",
-    "@etendosoftware/etendo-go-core": "0.3.11",
+    "@etendosoftware/app-shell-core": "0.3.12",
+    "@etendosoftware/etendo-go-core": "0.3.12",
     "@iconicapp/iconic-react": "^1.1.4",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.12`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.