### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.12",
-        "@etendosoftware/schema-forge-cli": "0.3.12",
-        "@etendosoftware/schema-forge-core": "0.3.12",
+        "@etendosoftware/app-shell-core": "0.3.13",
+        "@etendosoftware/schema-forge-cli": "0.3.13",
+        "@etendosoftware/schema-forge-core": "0.3.13",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2537,9 +2537,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.12",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.12/016d522dbe61db4a998713bb7f7da55b4250e317",
-      "integrity": "sha512-xB8H6JOTk+3s3isYEYGmPHJNwUiXTlcuy40Ii3FgDEAlphinoHiKUc96TT9v+46odA7G+lPWmEGtRKYcPEsDPw==",
+      "version": "0.3.13",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.13/61931adbb42825e08edfc5d86efbac1549ec77e9",
+      "integrity": "sha512-O8y3LhJnZhW96XyR9+D+ah51K6obDvt1aBfS4prTVaO3ICt4lm2wiF8QUNvp/Sf9YE72IOm/1RSoWxMNYnog8w==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2566,9 +2566,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.12",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.12/dabbc7290e0f90c56f3f1065c62132092ebc1e02",
-      "integrity": "sha512-cJV7flDINsEwkUtSon8tDw3Jj2NwqQZKEwB9thCna/CofdrjGrJ6XIEoG8+hrPodhmUUzBGfqB3vEzkVMtLTbA==",
+      "version": "0.3.13",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.13/536ceebbb49c780f702979097106092b67d83cff",
+      "integrity": "sha512-T02JvOchpyt+gw9eCidy9S7NQhfhp5sgrAm1fXHFiz04vil7/Ay53f9Nxdhu3E3SXAfsfBSmWVywx8/hw/6/6Q==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2578,9 +2578,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.12",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.12/9268ae73e2991e9e558c31543f7468bab765aaf0",
-      "integrity": "sha512-Rrj72WPrEzRi4/rqHxT5wz/45uBCBVR6vxwaBjbVwZk1LxQD/zzIhB6P0zdvcI7C117iLUqsWGFY7VjPQtEu/g==",
+      "version": "0.3.13",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.13/e91f095dab1b5bd376afd0f982de61973e670825",
+      "integrity": "sha512-gjptFV4taXssx4jEFcGE9fjJdg+eXZPr1lBseSQc4odD5Cx2jZShQCjGA3GqzUKRVvguVNJKlLKTRB3scfKW7w==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2624,9 +2624,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.12",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.12/70b00ca64ebbcf5d0d3b34b87d7fc01e62950187",
-      "integrity": "sha512-F6QhHgerFPbC9NEJjjVdH+Y64eWWckXZ1fFzNmRdabOdYgdoLuHufjRqPjGolTLM8ZDCi3ERbea4MLRvw3OO/Q==",
+      "version": "0.3.13",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.13/f17422bdba61fb97dc437091976fc3142c41a624",
+      "integrity": "sha512-Xdd5gEyVpy54tL2PUo4dSKzP/kQDUrF1pL098hGXHhdpEiowgC3sgvPPabqpRK+msW7z/Ynap3oZV179Vp4JVQ==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13523,8 +13523,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.12",
-        "@etendosoftware/etendo-go-core": "0.3.12",
+        "@etendosoftware/app-shell-core": "0.3.13",
+        "@etendosoftware/etendo-go-core": "0.3.13",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.12",
-    "@etendosoftware/schema-forge-cli": "0.3.12",
-    "@etendosoftware/schema-forge-core": "0.3.12",
+    "@etendosoftware/app-shell-core": "0.3.13",
+    "@etendosoftware/schema-forge-cli": "0.3.13",
+    "@etendosoftware/schema-forge-core": "0.3.13",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.12",
-        "@etendosoftware/etendo-go-core": "0.3.12",
+        "@etendosoftware/app-shell-core": "0.3.13",
+        "@etendosoftware/etendo-go-core": "0.3.13",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -2436,9 +2436,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.12",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.12/016d522dbe61db4a998713bb7f7da55b4250e317",
-      "integrity": "sha512-xB8H6JOTk+3s3isYEYGmPHJNwUiXTlcuy40Ii3FgDEAlphinoHiKUc96TT9v+46odA7G+lPWmEGtRKYcPEsDPw==",
+      "version": "0.3.13",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.13/61931adbb42825e08edfc5d86efbac1549ec77e9",
+      "integrity": "sha512-O8y3LhJnZhW96XyR9+D+ah51K6obDvt1aBfS4prTVaO3ICt4lm2wiF8QUNvp/Sf9YE72IOm/1RSoWxMNYnog8w==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2465,9 +2465,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.12",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.12/dabbc7290e0f90c56f3f1065c62132092ebc1e02",
-      "integrity": "sha512-cJV7flDINsEwkUtSon8tDw3Jj2NwqQZKEwB9thCna/CofdrjGrJ6XIEoG8+hrPodhmUUzBGfqB3vEzkVMtLTbA==",
+      "version": "0.3.13",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.13/536ceebbb49c780f702979097106092b67d83cff",
+      "integrity": "sha512-T02JvOchpyt+gw9eCidy9S7NQhfhp5sgrAm1fXHFiz04vil7/Ay53f9Nxdhu3E3SXAfsfBSmWVywx8/hw/6/6Q==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -15,8 +15,8 @@
     "test:all": "npm run test && npm run test:vitest"
   },
   "dependencies": {
-    "@etendosoftware/app-shell-core": "0.3.12",
-    "@etendosoftware/etendo-go-core": "0.3.12",
+    "@etendosoftware/app-shell-core": "0.3.13",
+    "@etendosoftware/etendo-go-core": "0.3.13",
     "@iconicapp/iconic-react": "^1.1.4",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.13`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.