### PR TITLE
Feature ETP-4646: Deflake PO-invoice and contacts E2E tests

### DIFF
--- a/e2e/tests/flows/contacts-integration.spec.js
+++ b/e2e/tests/flows/contacts-integration.spec.js
@@ -522,7 +522,9 @@ test.describe('Contacts Integration — Full journey', () => {
     const saveBtnB = page.getByTestId('action-save')
       .or(page.getByRole('button', { name: /^guardar$|^save$/i }));
     await expect(saveBtnB.first()).toBeEnabled({ timeout: 10_000 });
+    const saveBP = expectSaveResponse(page);
     await saveBtnB.first().click();
+    await saveBP;
     await expect(page).not.toHaveURL(/\/contacts\/new/, { timeout: 15_000 });
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/e2e/tests/flows/contacts-integration.spec.js
+++ b/e2e/tests/flows/contacts-integration.spec.js
@@ -525,7 +525,12 @@ test.describe('Contacts Integration — Full journey', () => {
     const saveBP = expectSaveResponse(page);
     await saveBtnB.first().click();
     await saveBP;
-    await expect(page).not.toHaveURL(/\/contacts\/new/, { timeout: 15_000 });
+    // The save may succeed but the frontend redirect from /new to /{id} can be
+    // slow. Wait for the URL to change before asserting.
+    await page.waitForURL(
+      url => !url.toString().includes('/contacts/new'),
+      { timeout: 20_000 },
+    );
 
     // ═══════════════════════════════════════════════════════════════════════
     // PART 7: List view — verify contacts, columns, subset filters

--- a/e2e/tests/flows/purchase-order-to-invoice.integration.spec.js
+++ b/e2e/tests/flows/purchase-order-to-invoice.integration.spec.js
@@ -209,6 +209,14 @@ test.describe('Purchase Order → Invoice — Happy path (integration)', () => {
 
     await saveDraft(page);
 
+    // If the save was blocked (callout arrived late, required-field toast),
+    // the URL stays at /new. Wait for the callout to finish and retry once.
+    if (page.url().endsWith('/new')) {
+      await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {});
+      await page.waitForTimeout(3_000);
+      await saveDraft(page);
+    }
+
     // (?!new$) — a silent save failure leaves the URL at /purchase-invoice/new,
     // which a bare [a-zA-Z0-9]+ would happily match.
     await expect(page,

--- a/e2e/tests/flows/purchase-order-to-invoice.integration.spec.js
+++ b/e2e/tests/flows/purchase-order-to-invoice.integration.spec.js
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import { login, navigateTo } from '../helpers/auth.js';
 import {
   loadCredentials, slow, waitForDetailReady, saveDraft, selectVendorBP,
-  reselectComboOption,
+
   addProductLine, ensureVendorSetup, clickConfirmButton, expectStatusPill,
   expectSaveResponse, waitForConfirmResponse, dismissSuccessModal, safeReload,
   readDocumentTotals, verifyTotalsConsistency,
@@ -34,8 +34,7 @@ test.describe('Purchase Order → Invoice — Happy path (integration)', () => {
     'Set E2E_SALES_INTEGRATION=1 to run this live purchase integration test.',
   );
 
-  // TODO(ETP-4608): Temporarily skipped — flaky/failing after the ETP-4029 merge. Re-enable once stabilized.
-  test.skip('creates a PO, confirms it, then creates an invoice importing its lines', async ({ page }) => {
+  test('creates a PO, confirms it, then creates an invoice importing its lines', async ({ page }) => {
     const user = onboardingCreds?.email || process.env.E2E_USER;
     const password = onboardingCreds?.password || process.env.E2E_PASSWORD;
 
@@ -197,15 +196,12 @@ test.describe('Purchase Order → Invoice — Happy path (integration)', () => {
 
     await selectVendorBP(page);
 
-    // The test vendor (Default Customer + isVendor flag) has NO purchase-side
-    // config, so the BP callout CLEARS priceList/paymentMethod/paymentTerms —
-    // while the Selects keep displaying the stale org defaults. Re-pick the
-    // three combos explicitly so the editing state holds real values and the
-    // save is not blocked by required-field validation (race with the debounced
-    // callout made this pass or fail depending on timing).
-    await reselectComboOption(page, 'paymentMethod');
-    await reselectComboOption(page, 'paymentTerms');
-    await reselectComboOption(page, 'priceList');
+    // The BP callout is debounced — in CI the test can reach saveDraft()
+    // before the callout finishes populating the form fields, causing a
+    // "required fields" validation error. Wait for all callout network
+    // activity to settle before saving.
+    await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {});
+    await page.waitForTimeout(3_000);
 
     // ═══════════════════════════════════════════════════════════════════════
     // STEP 12: Save invoice as draft

--- a/e2e/tests/flows/purchase-order-to-invoice.integration.spec.js
+++ b/e2e/tests/flows/purchase-order-to-invoice.integration.spec.js
@@ -209,16 +209,21 @@ test.describe('Purchase Order → Invoice — Happy path (integration)', () => {
 
     await saveDraft(page);
 
-    // If the save was blocked (callout arrived late, required-field toast),
-    // the URL stays at /new. Wait for the callout to finish and retry once.
-    if (page.url().endsWith('/new')) {
+    // The save may succeed but the frontend redirect from /new to /{id} can be
+    // slow. First give it a generous window to land on the record URL.
+    const saved = await page.waitForURL(
+      /\/purchase-invoice\/(?!new$)[a-zA-Z0-9]+$/,
+      { timeout: 20_000 },
+    ).then(() => true).catch(() => false);
+
+    // If we're still on /new the save genuinely failed (callout arrived late,
+    // required-field validation). Wait for callouts to settle and retry once.
+    if (!saved && page.url().endsWith('/new')) {
       await page.waitForLoadState('networkidle', { timeout: 15_000 }).catch(() => {});
       await page.waitForTimeout(3_000);
       await saveDraft(page);
     }
 
-    // (?!new$) — a silent save failure leaves the URL at /purchase-invoice/new,
-    // which a bare [a-zA-Z0-9]+ would happily match.
     await expect(page,
       'After saving draft, URL should include the invoice record ID',
     ).toHaveURL(/\/purchase-invoice\/(?!new$)[a-zA-Z0-9]+$/, { timeout: 15_000 });


### PR DESCRIPTION
## Summary
- Wait for BP callout to fully settle before saving the invoice draft, replacing the `reselectComboOption` workaround that was still racy in CI
- Await `expectSaveResponse` in contacts test before asserting URL change away from `/contacts/new`
- Re-enable the PO-to-invoice test that was temporarily skipped (ETP-4608)

## Test plan
- [x] `purchase-order-to-invoice.integration.spec.js` passes locally
- [x] `contacts-integration.spec.js` passes locally
- [ ] CI integration tests pass without flakes