### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.16",
-        "@etendosoftware/schema-forge-cli": "0.3.16",
-        "@etendosoftware/schema-forge-core": "0.3.16",
+        "@etendosoftware/app-shell-core": "0.3.17",
+        "@etendosoftware/schema-forge-cli": "0.3.17",
+        "@etendosoftware/schema-forge-core": "0.3.17",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2537,9 +2537,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.16",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.16/aac8f7c6eeebf385dcbf32fb3d3a0ed607dd80d9",
-      "integrity": "sha512-oi7ToKK9iBxQ1S2+wwsCuSMC/8KBqpzt+IhigsF9r24W3iGl22TirjnTUeXJWCX6G8PgnLxqpUhBlztuJaXQ4Q==",
+      "version": "0.3.17",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.17/48a22a97a62b229a394880dbf61935f5df652a2b",
+      "integrity": "sha512-Bt+MO11xxdb3zc6Rq+5cm2aGl/J3J0FklZ1sIY/RtOymt3GCHU6oGeX5QngYBqQ+EPpt1NkQbeSMgNM6dvx+AQ==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2566,9 +2566,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.16",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.16/43fe7998fd30783941c530606dbe46cf73e3ed43",
-      "integrity": "sha512-S36iFbgYetOr92mvmRI/4gRyJu1UGrFzaKlKylE9J48xFwmx3OKxoYgcx54Ym6rJZsYBoFJ8TTHuLIPZlBodzg==",
+      "version": "0.3.17",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.17/ac8dc46242dc1626085f02dc08358c6b239467c4",
+      "integrity": "sha512-H52T9Vj0qwjttoC/kQZDupxEK6QEbXqoWrT/s+tfDTp1993uLMKVml+4Da9JkRVV1Yz6eTXN6Vsjvcse77sw9w==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2578,9 +2578,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.16",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.16/d1944aa3cefc204dfa79b6293f0035a3d8df4550",
-      "integrity": "sha512-QR/EqBGySol09q5FY3RS7e7Non7BxftVBqYQpaG7BQeh5szuexepn/uyUH3aWZqjskDBtNDVGeu2xbuNbgsH7Q==",
+      "version": "0.3.17",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.17/94bff8409bdd432aac856e0d99ce9227bb29523f",
+      "integrity": "sha512-Xxhe5ung8mNGWafhsTg9jVN0gVm3VoRLPAxcQUwX1FA36c8AGluk11AKjNxO+9t/087pzFN2zmneTmgwpogjhg==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2624,9 +2624,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.16",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.16/4ed555f19046dc98284e61b2e1f70091e0bcf1c0",
-      "integrity": "sha512-KsMor+h2w3/oaQSTYuQ1/XEMONgAvigfv5QtSxf+xBZ1zTBCU/OBKsJyT+ZS1oA2J84+pO269wp89ZrgleTvhQ==",
+      "version": "0.3.17",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.17/398160b7535a44f9916292f45cf346f83b2107d4",
+      "integrity": "sha512-8tG46jA8GVQ6NtXiJut7uilKVGIQ3HArxacFKrEwV1hoyJeaFJT5BpdMqXW4h+RVW4vnB+ancxMKiVpIvNzMLA==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13523,8 +13523,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.16",
-        "@etendosoftware/etendo-go-core": "0.3.16",
+        "@etendosoftware/app-shell-core": "0.3.17",
+        "@etendosoftware/etendo-go-core": "0.3.17",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.16",
-    "@etendosoftware/schema-forge-cli": "0.3.16",
-    "@etendosoftware/schema-forge-core": "0.3.16",
+    "@etendosoftware/app-shell-core": "0.3.17",
+    "@etendosoftware/schema-forge-cli": "0.3.17",
+    "@etendosoftware/schema-forge-core": "0.3.17",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.16",
-        "@etendosoftware/etendo-go-core": "0.3.16",
+        "@etendosoftware/app-shell-core": "0.3.17",
+        "@etendosoftware/etendo-go-core": "0.3.17",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -2436,9 +2436,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.16",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.16/aac8f7c6eeebf385dcbf32fb3d3a0ed607dd80d9",
-      "integrity": "sha512-oi7ToKK9iBxQ1S2+wwsCuSMC/8KBqpzt+IhigsF9r24W3iGl22TirjnTUeXJWCX6G8PgnLxqpUhBlztuJaXQ4Q==",
+      "version": "0.3.17",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.17/48a22a97a62b229a394880dbf61935f5df652a2b",
+      "integrity": "sha512-Bt+MO11xxdb3zc6Rq+5cm2aGl/J3J0FklZ1sIY/RtOymt3GCHU6oGeX5QngYBqQ+EPpt1NkQbeSMgNM6dvx+AQ==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2465,9 +2465,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.16",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.16/43fe7998fd30783941c530606dbe46cf73e3ed43",
-      "integrity": "sha512-S36iFbgYetOr92mvmRI/4gRyJu1UGrFzaKlKylE9J48xFwmx3OKxoYgcx54Ym6rJZsYBoFJ8TTHuLIPZlBodzg==",
+      "version": "0.3.17",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.17/ac8dc46242dc1626085f02dc08358c6b239467c4",
+      "integrity": "sha512-H52T9Vj0qwjttoC/kQZDupxEK6QEbXqoWrT/s+tfDTp1993uLMKVml+4Da9JkRVV1Yz6eTXN6Vsjvcse77sw9w==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -15,8 +15,8 @@
     "test:all": "npm run test && npm run test:vitest"
   },
   "dependencies": {
-    "@etendosoftware/app-shell-core": "0.3.16",
-    "@etendosoftware/etendo-go-core": "0.3.16",
+    "@etendosoftware/app-shell-core": "0.3.17",
+    "@etendosoftware/etendo-go-core": "0.3.17",
     "@iconicapp/iconic-react": "^1.1.4",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.17`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.