### PR TITLE
Feature ETP-4682: Add content-addressed pre-push step cache

### DIFF
--- a/.githooks/lib/step-cache.sh
+++ b/.githooks/lib/step-cache.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# .githooks/lib/step-cache.sh
+#
+# Content-addressed cache for pre-push steps. Mirrored verbatim across repos —
+# edit it in one and sync, never fork the logic.
+#
+# WHY THIS IS CHEAP
+# The pre-push hook hard-fails on a dirty working tree, so by the time a step
+# runs, the working tree IS the HEAD commit. That makes `git rev-parse HEAD:<path>`
+# an exact content key for a file or an entire subtree, in ~17ms, with no manual
+# hashing and no risk of hashing something the step will not actually read.
+#
+# OPT-IN BY DESIGN
+# Every function is inert unless PRE_PUSH_CACHE=1 is exported. A plain `git push`
+# behaves exactly as it did before this file existed: no skips, no new output, no
+# new files. Only tooling that deliberately opts in gets the cache.
+#
+# WHAT MUST NEVER BE CACHED
+# Any step whose verdict depends on state outside the working tree. In particular
+# every Sonar step: the Quality Gate is computed server-side against the base
+# branch's analysis, so an unchanged tree yields a different verdict once the base
+# moves. Caching it would manufacture false greens, which is strictly worse than
+# being slow.
+
+STEP_CACHE_FILE="${STEP_CACHE_FILE:-$REPO_DIR/tmp/pre-push/step-cache}"
+
+step_cache_enabled() { [ "${PRE_PUSH_CACHE:-0}" = "1" ]; }
+
+# step_cache_key <tools-fingerprint> <input>...
+#
+# Each <input> is either `path` (this repo) or `<repo dir>|<path>` for an input
+# owned by a sibling checkout. Prints a sha256 over every input's content sha plus
+# the tools fingerprint.
+#
+# Returns non-zero — and prints nothing — if ANY input cannot be resolved. That is
+# the fail-open path: an unresolvable key means the caller runs the step. A cache
+# miss costs seconds; a false hit costs correctness.
+#
+# The tools fingerprint is not decoration. An identical XML tree passed under
+# python 3.13 and failed under Homebrew's python@3.14 (broken pyexpat) on the very
+# same commit. A key built only from file contents would have cached that verdict
+# and hidden the breakage.
+step_cache_key() {
+  local tools="$1"; shift
+  local acc="tools=${tools}" input dir path sha
+
+  for input in "$@"; do
+    if [[ "$input" == *"|"* ]]; then
+      dir="${input%%|*}"
+      path="${input##*|}"
+    else
+      dir="$REPO_DIR"
+      path="$input"
+    fi
+    sha="$(git -C "$dir" rev-parse "HEAD:${path}" 2>/dev/null)" || return 1
+    [ -n "$sha" ] || return 1
+    acc="${acc};${input}=${sha}"
+  done
+
+  printf '%s' "$acc" | shasum -a 256 2>/dev/null | cut -d' ' -f1
+}
+
+# step_cache_lookup <step> <key> — zero exit means "this exact key already passed".
+step_cache_lookup() {
+  local step="$1" key="$2"
+  [ -n "$key" ] || return 1
+  [ -f "$STEP_CACHE_FILE" ] || return 1
+  grep -qxF "step-${step}=${key}" "$STEP_CACHE_FILE" 2>/dev/null
+}
+
+# step_cache_store <step> <key> — record a pass. Best-effort: an unwritable cache
+# must never turn a green push red, so every failure path is swallowed.
+step_cache_store() {
+  local step="$1" key="$2"
+  [ -n "$key" ] || return 0
+  mkdir -p "$(dirname "$STEP_CACHE_FILE")" 2>/dev/null || return 0
+  if [ -f "$STEP_CACHE_FILE" ]; then
+    grep -v "^step-${step}=" "$STEP_CACHE_FILE" > "${STEP_CACHE_FILE}.tmp" 2>/dev/null || true
+    mv "${STEP_CACHE_FILE}.tmp" "$STEP_CACHE_FILE" 2>/dev/null || true
+  fi
+  echo "step-${step}=${key}" >> "$STEP_CACHE_FILE" 2>/dev/null || true
+  return 0
+}
+
+# step_cache_invalidate <step> — drop any recorded pass for a step that just failed.
+step_cache_invalidate() {
+  local step="$1"
+  [ -f "$STEP_CACHE_FILE" ] || return 0
+  grep -v "^step-${step}=" "$STEP_CACHE_FILE" > "${STEP_CACHE_FILE}.tmp" 2>/dev/null || true
+  mv "${STEP_CACHE_FILE}.tmp" "$STEP_CACHE_FILE" 2>/dev/null || true
+  return 0
+}
+
+# step_cache_compute <tools> <input>... — convenience wrapper for call sites.
+# Prints the key when the cache is on and every input resolved; prints nothing
+# otherwise, so an empty result simply means "run this step".
+step_cache_compute() {
+  step_cache_enabled || return 0
+  step_cache_key "$@" 2>/dev/null || true
+}

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -56,6 +56,10 @@ SPIN_FRAMES=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
 
 # Per-step duration cache (used as ETA baseline across runs).
 DURATIONS_FILE="$REPO_DIR/tmp/pre-push/durations"
+
+# Content-addressed step cache (inert unless PRE_PUSH_CACHE=1 — see the file).
+# shellcheck source=lib/step-cache.sh
+. "$SCRIPT_DIR/lib/step-cache.sh"
 LAST_DURATION=0
 
 # Look up the last recorded duration (seconds) for a step key, or 0.
@@ -180,7 +184,16 @@ run_step() {
   local run_dir="$3"
   local log_file="$4"
   local cmd="$5"
+  local cache_key="${6:-}"
   local abs_log="$REPO_DIR/$log_file"
+
+  # A hit means every input this step reads is byte-identical to the last time it
+  # passed. Announced loudly and never silently: a quiet skip is how "it passed
+  # locally" turns into a lie.
+  if step_cache_lookup "$step_num" "$cache_key"; then
+    echo "==> [$step_num/5] $step_name... CACHED (inputs unchanged since it last passed)"
+    return 0
+  fi
 
   echo "==> [$step_num/5] $step_name..."
 
@@ -192,10 +205,12 @@ run_step() {
 
   if [ $exit_status -eq 0 ]; then
     echo "==> [$step_num/5] $step_name... SUCCESS ✅ (${LAST_DURATION}s)"
+    step_cache_store "$step_num" "$cache_key"
     [ "$step_num" = "$LAST_FAILED_STEP" ] && rm -f "$LAST_FAILED_FILE"
     true
   else
     echo "==> [$step_num/5] $step_name... FAILED ❌ (${LAST_DURATION}s)"
+    step_cache_invalidate "$step_num"
     fail_with_log "$step_name" "$exit_status" "$abs_log" "$step_num"
   fi
 }
@@ -473,12 +488,18 @@ check_base_conflicts
 # caused entirely by a stale core-package pin that only `npm ci` — not a
 # stale local install — would have caught).
 run_step_0() {
-  run_step "0" "Syncing npm dependencies with package-lock.json (npm ci)" "$REPO_DIR" "tmp/pre-push/npm-ci.log" "npm ci || npm install"
+  # npm ci is a pure function of the lockfile and the node major it installs for.
+  local key
+  key="$(step_cache_compute "node-${NODE_MAJOR}" package.json package-lock.json)"
+  run_step "0" "Syncing npm dependencies with package-lock.json (npm ci)" "$REPO_DIR" "tmp/pre-push/npm-ci.log" "npm ci || npm install" "$key"
 }
 
 # 1. Run data-testid check (fast, runs before expensive checks)
 run_step_1() {
-  run_step "1" "Running data-testid check" "$REPO_DIR" "tmp/pre-push/data-testid-check.log" "npm run check:data-testid"
+  # The checker only ever reads the app-shell sources it scans, plus its own script.
+  local key
+  key="$(step_cache_compute "node-${NODE_MAJOR}" tools/app-shell/src scripts/check-add-data-testid.sh)"
+  run_step "1" "Running data-testid check" "$REPO_DIR" "tmp/pre-push/data-testid-check.log" "npm run check:data-testid" "$key"
 }
 
 # Domain boundary check disabled: repos are now split at the repo level
@@ -534,7 +555,12 @@ process.stdout.write(r.windows.filter(w=>{\
     && require('fs').existsSync('artifacts/'+w.name+'/contract.json')}catch(e){return false}\
 }).map(w=>w.name).join(','))")
   regen_all_cmd="make regen ONLY=$all_windows FROM_CACHE=1"
-  run_step "3" "Regenerating all windows from cache (UI / contract drift check)" "$REPO_DIR" "tmp/pre-push/regen-all.log" "$regen_all_cmd"
+  # Everything the offline regeneration reads: the artifacts it regenerates (which
+  # also hold its outputs, so drift is covered), the committed AD snapshot, the
+  # window registry, and the lockfile that pins the generator itself.
+  local key
+  key="$(step_cache_compute "node-${NODE_MAJOR}" artifacts cli/cache cli/config/regen-windows.json package-lock.json)"
+  run_step "3" "Regenerating all windows from cache (UI / contract drift check)" "$REPO_DIR" "tmp/pre-push/regen-all.log" "$regen_all_cmd" "$key"
 
   echo "==> Verifying no UI / contract drift (git status after regen)..."
   if [ -n "$(git status --porcelain)" ]; then
@@ -570,7 +596,10 @@ run_step_4() {
   if [ -d "etendo_core/modules/com.etendoerp.go/src-db/database/sourcedata" ]; then
     check_go_module_push_sync
     local regen_cmd="make regen-check FROM_CACHE=1 REGEN_CHECK_PREV_XML_DIR=etendo_core/modules/com.etendoerp.go/src-db/database/sourcedata"
-    run_step "4" "Comparing ETGO_SF_*.xml against com.etendoerp.go" "$REPO_DIR" "tmp/pre-push/offline-regen-check.log" "$regen_cmd"
+    local key
+    key="$(step_cache_compute "node-${NODE_MAJOR}" artifacts cli/cache cli/config/regen-windows.json package-lock.json \
+      "$REPO_DIR/etendo_core/modules/com.etendoerp.go|src-db/database/sourcedata")"
+    run_step "4" "Comparing ETGO_SF_*.xml against com.etendoerp.go" "$REPO_DIR" "tmp/pre-push/offline-regen-check.log" "$regen_cmd" "$key"
   else
     echo "==> [4/5] Comparing ETGO_SF_*.xml against com.etendoerp.go... SKIPPED ⚠️ (sourcedata not found — UI/contract drift above was still checked)"
   fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -615,6 +615,21 @@ run_step_4() {
 LAST_FAILED_STEP=""
 [ -f "$LAST_FAILED_FILE" ] && LAST_FAILED_STEP="$(cat "$LAST_FAILED_FILE" 2>/dev/null || echo "")"
 
+# The quick re-check exists to reach the previously-failed step without paying for
+# the earlier ones again. The step cache does that better AND correctly: with it on,
+# the earlier steps are hits and the full pipeline reaches the failed step almost
+# immediately, so the re-check only duplicates work.
+#
+# Measured: it ran step 2 twice, 208s + 227s of a 445s push.
+#
+# Skipping the step in the FULL run instead would be wrong — the re-check runs
+# BEFORE steps 0..N-1, so an `npm ci` or a regen afterwards can invalidate its
+# result. Dropping the re-check keeps the full pipeline authoritative.
+if step_cache_enabled && [ -n "$LAST_FAILED_STEP" ]; then
+  echo "==> Previous push failed at step $LAST_FAILED_STEP — step cache is on, going straight to the full pipeline."
+  LAST_FAILED_STEP=""
+fi
+
 if [ -n "$LAST_FAILED_STEP" ]; then
   case "$LAST_FAILED_STEP" in
     0|1|2|3|4)


### PR DESCRIPTION
## What

Adds a content-addressed cache for pre-push steps, mirrored verbatim in both repos so it is a shared mechanism rather than a one-off.

A step is skipped when every input it reads is byte-identical to the last time that step passed.

## How the keys work

The hook already hard-fails on a dirty working tree, so by the time a step runs the working tree **is** the HEAD commit. That makes `git rev-parse HEAD:<path>` an exact content sha for a file **or an entire subtree**, in ~17ms — no manual hashing, and no risk of hashing something the step never reads.

`key = sha256(content shas of the declared inputs + a tool fingerprint)`

Foreign-repo inputs are supported via `<repo dir>|<path>`, which is how the offline-regen step keys on `com.etendoerp.go`'s committed XML.

## Opt-in — a plain `git push` is unchanged

Every function is inert unless `PRE_PUSH_CACHE=1` is exported: no skips, no new output, **no files written**. Verified in both repos.

`ship push` sets it for its children; hooks predating this change simply ignore the variable.

## Deliberately never cached

Sonar. The Quality Gate is computed server-side against the base branch, so an unchanged tree yields a different verdict once the base moves. Caching it would manufacture false greens.

## The tool fingerprint is not decoration

An identical XML tree passed under python 3.13 and failed under Homebrew python@3.14 (broken pyexpat) **on the same commit**. A contents-only key would have cached that verdict and hidden the breakage.

## Validated in a real push

```
[0/5] npm ci ......... CACHED (inputs unchanged since it last passed)
[1/5] data-testid .... CACHED (inputs unchanged since it last passed)
```

The keys written by the hook match those computed independently by hand, and the step that failed has zero cache entries — passes are stored, failures are not.

## Measured expectation

Baseline is ~450s wall clock per attempt. Safe caching removes ~186s from schema_forge; the floor per repo is its Sonar step. Full per-scenario numbers and the six invalidation rules are in ETP-4682.

ETP-4682