### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.17",
-        "@etendosoftware/schema-forge-cli": "0.3.17",
-        "@etendosoftware/schema-forge-core": "0.3.17",
+        "@etendosoftware/app-shell-core": "0.3.18",
+        "@etendosoftware/schema-forge-cli": "0.3.18",
+        "@etendosoftware/schema-forge-core": "0.3.18",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2537,9 +2537,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.17",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.17/48a22a97a62b229a394880dbf61935f5df652a2b",
-      "integrity": "sha512-Bt+MO11xxdb3zc6Rq+5cm2aGl/J3J0FklZ1sIY/RtOymt3GCHU6oGeX5QngYBqQ+EPpt1NkQbeSMgNM6dvx+AQ==",
+      "version": "0.3.18",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.18/d5ed69b6585c445ed0e581d98704bbe07df41b67",
+      "integrity": "sha512-V5isq19jhqdl/kih9XUXpt3RD2EuMk3+stys9ComvzO6C7Qn2r7E3sk2cgeEqE9s9QmOQF6EXBItz69Far7Riw==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2566,9 +2566,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.17",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.17/ac8dc46242dc1626085f02dc08358c6b239467c4",
-      "integrity": "sha512-H52T9Vj0qwjttoC/kQZDupxEK6QEbXqoWrT/s+tfDTp1993uLMKVml+4Da9JkRVV1Yz6eTXN6Vsjvcse77sw9w==",
+      "version": "0.3.18",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.18/94bd9e44f782ec172280f91a7cb6007a6e44ba52",
+      "integrity": "sha512-OCs5KyaxXejE0pDbnHVk49HxYHNVf7VfLpmmXu/f8cxCf3Dy0e/kj6Ya0qh/aJJolcoir7nlNf7JJEyIDY9VPA==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2578,9 +2578,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.17",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.17/94bff8409bdd432aac856e0d99ce9227bb29523f",
-      "integrity": "sha512-Xxhe5ung8mNGWafhsTg9jVN0gVm3VoRLPAxcQUwX1FA36c8AGluk11AKjNxO+9t/087pzFN2zmneTmgwpogjhg==",
+      "version": "0.3.18",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.18/2d3f609826e9ac76884b7a503327ca2e7fda72a8",
+      "integrity": "sha512-JDfV+eT1/ihEQ5YzLa3aQa0mEUeBr5EthBdOIXou4O04+WHi0JZkpTQ/lCT5jtD56w0A++86bku3wxVw1NcLYw==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2624,9 +2624,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.17",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.17/398160b7535a44f9916292f45cf346f83b2107d4",
-      "integrity": "sha512-8tG46jA8GVQ6NtXiJut7uilKVGIQ3HArxacFKrEwV1hoyJeaFJT5BpdMqXW4h+RVW4vnB+ancxMKiVpIvNzMLA==",
+      "version": "0.3.18",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.18/81c08b55eb0f0cfd67a164ce9d4a6c392d0984b6",
+      "integrity": "sha512-L1L+iyQk1VEKutAs+WrdYm+9CoMWKgMWQJ8W5DEVb+W1rqjZnEcyvVoxJ3zFwZKV8ut0QEjUCFdhPhBwfl0CZA==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13523,8 +13523,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.17",
-        "@etendosoftware/etendo-go-core": "0.3.17",
+        "@etendosoftware/app-shell-core": "0.3.18",
+        "@etendosoftware/etendo-go-core": "0.3.18",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.17",
-    "@etendosoftware/schema-forge-cli": "0.3.17",
-    "@etendosoftware/schema-forge-core": "0.3.17",
+    "@etendosoftware/app-shell-core": "0.3.18",
+    "@etendosoftware/schema-forge-cli": "0.3.18",
+    "@etendosoftware/schema-forge-core": "0.3.18",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.17",
-        "@etendosoftware/etendo-go-core": "0.3.17",
+        "@etendosoftware/app-shell-core": "0.3.18",
+        "@etendosoftware/etendo-go-core": "0.3.18",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -2436,9 +2436,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.17",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.17/48a22a97a62b229a394880dbf61935f5df652a2b",
-      "integrity": "sha512-Bt+MO11xxdb3zc6Rq+5cm2aGl/J3J0FklZ1sIY/RtOymt3GCHU6oGeX5QngYBqQ+EPpt1NkQbeSMgNM6dvx+AQ==",
+      "version": "0.3.18",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.18/d5ed69b6585c445ed0e581d98704bbe07df41b67",
+      "integrity": "sha512-V5isq19jhqdl/kih9XUXpt3RD2EuMk3+stys9ComvzO6C7Qn2r7E3sk2cgeEqE9s9QmOQF6EXBItz69Far7Riw==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2465,9 +2465,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.17",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.17/ac8dc46242dc1626085f02dc08358c6b239467c4",
-      "integrity": "sha512-H52T9Vj0qwjttoC/kQZDupxEK6QEbXqoWrT/s+tfDTp1993uLMKVml+4Da9JkRVV1Yz6eTXN6Vsjvcse77sw9w==",
+      "version": "0.3.18",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.18/94bd9e44f782ec172280f91a7cb6007a6e44ba52",
+      "integrity": "sha512-OCs5KyaxXejE0pDbnHVk49HxYHNVf7VfLpmmXu/f8cxCf3Dy0e/kj6Ya0qh/aJJolcoir7nlNf7JJEyIDY9VPA==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -15,8 +15,8 @@
     "test:all": "npm run test && npm run test:vitest"
   },
   "dependencies": {
-    "@etendosoftware/app-shell-core": "0.3.17",
-    "@etendosoftware/etendo-go-core": "0.3.17",
+    "@etendosoftware/app-shell-core": "0.3.18",
+    "@etendosoftware/etendo-go-core": "0.3.18",
     "@iconicapp/iconic-react": "^1.1.4",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.18`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.