### PR TITLE
Feature ETP-4676: Add missing login required-field translations

### DIFF
--- a/tools/app-shell/src/locales/en_US.json
+++ b/tools/app-shell/src/locales/en_US.json
@@ -19087,6 +19087,8 @@
     "onboardingNamePlaceholder": "Your name",
     "onboardingEmailLabel": "Email",
     "onboardingEmailPlaceholder": "you@email.com",
+    "onboardingEmailRequired": "Email is required.",
+    "onboardingPasswordRequired": "Password is required.",
     "onboardingPasswordLabel": "Password",
     "onboardingPasswordPlaceholder": "********",
     "onboardingShowPassword": "Show password",

--- a/tools/app-shell/src/locales/es_AR.json
+++ b/tools/app-shell/src/locales/es_AR.json
@@ -18803,6 +18803,8 @@
     "onboardingNamePlaceholder": "Tu nombre",
     "onboardingEmailLabel": "Correo electrónico",
     "onboardingEmailPlaceholder": "tu@email.com",
+    "onboardingEmailRequired": "El correo electrónico es obligatorio.",
+    "onboardingPasswordRequired": "La contraseña es obligatoria.",
     "onboardingPasswordLabel": "Contraseña",
     "onboardingPasswordPlaceholder": "********",
     "onboardingShowPassword": "Mostrar contraseña",

--- a/tools/app-shell/src/locales/es_ES.json
+++ b/tools/app-shell/src/locales/es_ES.json
@@ -19337,6 +19337,8 @@
     "onboardingNamePlaceholder": "Tu nombre",
     "onboardingEmailLabel": "Correo electrónico",
     "onboardingEmailPlaceholder": "tu@email.com",
+    "onboardingEmailRequired": "El correo electrónico es obligatorio.",
+    "onboardingPasswordRequired": "La contraseña es obligatoria.",
     "onboardingPasswordLabel": "Contraseña",
     "onboardingPasswordPlaceholder": "********",
     "onboardingShowPassword": "Mostrar contraseña",


### PR DESCRIPTION
Adds onboardingEmailRequired/onboardingPasswordRequired to en_US, es_ES and es_AR — consumed by the LoginStep inline validation added in schema_forge_core for this same task.