### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.18",
-        "@etendosoftware/schema-forge-cli": "0.3.18",
-        "@etendosoftware/schema-forge-core": "0.3.18",
+        "@etendosoftware/app-shell-core": "0.3.19",
+        "@etendosoftware/schema-forge-cli": "0.3.19",
+        "@etendosoftware/schema-forge-core": "0.3.19",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2537,9 +2537,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.18",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.18/d5ed69b6585c445ed0e581d98704bbe07df41b67",
-      "integrity": "sha512-V5isq19jhqdl/kih9XUXpt3RD2EuMk3+stys9ComvzO6C7Qn2r7E3sk2cgeEqE9s9QmOQF6EXBItz69Far7Riw==",
+      "version": "0.3.19",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.19/75d1c01d69633738e5efda5d01b4728ea9ba5d5a",
+      "integrity": "sha512-dFG9Cv1n2XTkitsmPrP4wTg1JcfrbgJUjiaF1koxL6OtBk+IbDBVhun6lqMS5ZVvxdD/kQn7WbFoVHjkZXScOQ==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2566,9 +2566,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.18",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.18/94bd9e44f782ec172280f91a7cb6007a6e44ba52",
-      "integrity": "sha512-OCs5KyaxXejE0pDbnHVk49HxYHNVf7VfLpmmXu/f8cxCf3Dy0e/kj6Ya0qh/aJJolcoir7nlNf7JJEyIDY9VPA==",
+      "version": "0.3.19",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.19/bb36a78ebbdf72ef155179bd862884df27d8e23f",
+      "integrity": "sha512-eeW3VNSmMO7X88RTZf9T5LQAvCPiz3bf132Wsj2oK5K7uXOPViw4Nbu+DBgBy6yd5h4v+AxYANr5e1yIhzuexQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2578,9 +2578,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.18",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.18/2d3f609826e9ac76884b7a503327ca2e7fda72a8",
-      "integrity": "sha512-JDfV+eT1/ihEQ5YzLa3aQa0mEUeBr5EthBdOIXou4O04+WHi0JZkpTQ/lCT5jtD56w0A++86bku3wxVw1NcLYw==",
+      "version": "0.3.19",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.19/7e9c54e410f870e7059271c6c53665179ce8e988",
+      "integrity": "sha512-hmnSiblR9tjGiCOm6Xc0Af0Slg73Knx+HDkAPbcp3t1+H4ksdKcUV7PCVzohw6IvRjVzitv2DxgfH8pkLMXEhA==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2624,9 +2624,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.18",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.18/81c08b55eb0f0cfd67a164ce9d4a6c392d0984b6",
-      "integrity": "sha512-L1L+iyQk1VEKutAs+WrdYm+9CoMWKgMWQJ8W5DEVb+W1rqjZnEcyvVoxJ3zFwZKV8ut0QEjUCFdhPhBwfl0CZA==",
+      "version": "0.3.19",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.19/b9df206a9513f3e06b1dd5a13dbee040cfc9c69b",
+      "integrity": "sha512-9ZHel5Zqgbmwm0Wip2AGxp3TJXfdfR8BbIQB2khW9n5+VCxZwjVSnIV9EE90cjTG0QAo/D27lpwURISfT3Jrnw==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13523,8 +13523,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.18",
-        "@etendosoftware/etendo-go-core": "0.3.18",
+        "@etendosoftware/app-shell-core": "0.3.19",
+        "@etendosoftware/etendo-go-core": "0.3.19",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.18",
-    "@etendosoftware/schema-forge-cli": "0.3.18",
-    "@etendosoftware/schema-forge-core": "0.3.18",
+    "@etendosoftware/app-shell-core": "0.3.19",
+    "@etendosoftware/schema-forge-cli": "0.3.19",
+    "@etendosoftware/schema-forge-core": "0.3.19",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.18",
-        "@etendosoftware/etendo-go-core": "0.3.18",
+        "@etendosoftware/app-shell-core": "0.3.19",
+        "@etendosoftware/etendo-go-core": "0.3.19",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -2436,9 +2436,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.18",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.18/d5ed69b6585c445ed0e581d98704bbe07df41b67",
-      "integrity": "sha512-V5isq19jhqdl/kih9XUXpt3RD2EuMk3+stys9ComvzO6C7Qn2r7E3sk2cgeEqE9s9QmOQF6EXBItz69Far7Riw==",
+      "version": "0.3.19",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.19/75d1c01d69633738e5efda5d01b4728ea9ba5d5a",
+      "integrity": "sha512-dFG9Cv1n2XTkitsmPrP4wTg1JcfrbgJUjiaF1koxL6OtBk+IbDBVhun6lqMS5ZVvxdD/kQn7WbFoVHjkZXScOQ==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2465,9 +2465,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.18",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.18/94bd9e44f782ec172280f91a7cb6007a6e44ba52",
-      "integrity": "sha512-OCs5KyaxXejE0pDbnHVk49HxYHNVf7VfLpmmXu/f8cxCf3Dy0e/kj6Ya0qh/aJJolcoir7nlNf7JJEyIDY9VPA==",
+      "version": "0.3.19",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.19/bb36a78ebbdf72ef155179bd862884df27d8e23f",
+      "integrity": "sha512-eeW3VNSmMO7X88RTZf9T5LQAvCPiz3bf132Wsj2oK5K7uXOPViw4Nbu+DBgBy6yd5h4v+AxYANr5e1yIhzuexQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2793,9 +2793,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2815,9 +2812,6 @@
       "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2839,9 +2833,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2862,9 +2853,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2884,9 +2872,6 @@
       "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4066,9 +4051,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4083,9 +4065,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4100,9 +4079,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4117,9 +4093,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4134,9 +4107,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4151,9 +4121,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4168,9 +4135,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4185,9 +4149,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4202,9 +4163,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4219,9 +4177,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4236,9 +4191,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4253,9 +4205,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4270,9 +4219,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -15,8 +15,8 @@
     "test:all": "npm run test && npm run test:vitest"
   },
   "dependencies": {
-    "@etendosoftware/app-shell-core": "0.3.18",
-    "@etendosoftware/etendo-go-core": "0.3.18",
+    "@etendosoftware/app-shell-core": "0.3.19",
+    "@etendosoftware/etendo-go-core": "0.3.19",
     "@iconicapp/iconic-react": "^1.1.4",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.19`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.