### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.19",
-        "@etendosoftware/schema-forge-cli": "0.3.19",
-        "@etendosoftware/schema-forge-core": "0.3.19",
+        "@etendosoftware/app-shell-core": "0.3.20",
+        "@etendosoftware/schema-forge-cli": "0.3.20",
+        "@etendosoftware/schema-forge-core": "0.3.20",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2537,9 +2537,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.19",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.19/75d1c01d69633738e5efda5d01b4728ea9ba5d5a",
-      "integrity": "sha512-dFG9Cv1n2XTkitsmPrP4wTg1JcfrbgJUjiaF1koxL6OtBk+IbDBVhun6lqMS5ZVvxdD/kQn7WbFoVHjkZXScOQ==",
+      "version": "0.3.20",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.20/55c406bbf3cd5fa87af0c3574925e55d840cd662",
+      "integrity": "sha512-3f0BRHRCMFZFg78ekflamn7FisGBvDibMO7DEAgt+EpajBZPGfmyJ/Eqw9MgLdciTiYr8usFvTNkQic3sSF97Q==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2566,9 +2566,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.19",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.19/bb36a78ebbdf72ef155179bd862884df27d8e23f",
-      "integrity": "sha512-eeW3VNSmMO7X88RTZf9T5LQAvCPiz3bf132Wsj2oK5K7uXOPViw4Nbu+DBgBy6yd5h4v+AxYANr5e1yIhzuexQ==",
+      "version": "0.3.20",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.20/a398bd2b294f2ecbab574e3d8b26a43845f55e9a",
+      "integrity": "sha512-c0rQjxuTC0Cfh7XGdHWqP1opR2z3kJEnkHLvnWd6TGnTJnSxof6kOjB139PnwvkKj8mrmgGqadrd6KzO9FRYgg==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2578,9 +2578,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.19",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.19/7e9c54e410f870e7059271c6c53665179ce8e988",
-      "integrity": "sha512-hmnSiblR9tjGiCOm6Xc0Af0Slg73Knx+HDkAPbcp3t1+H4ksdKcUV7PCVzohw6IvRjVzitv2DxgfH8pkLMXEhA==",
+      "version": "0.3.20",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.20/a400c0e6db678e49d3cf5a6fc5eaa04192e4673e",
+      "integrity": "sha512-mxCZx7ZEI663RKwa2YirVh2c76MG7VuDYPaOojF8vzzSeMOZ03Lm1pl3tyuYyH/m60d9J2qn53kxFVdd2YfK2A==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2624,9 +2624,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.19",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.19/b9df206a9513f3e06b1dd5a13dbee040cfc9c69b",
-      "integrity": "sha512-9ZHel5Zqgbmwm0Wip2AGxp3TJXfdfR8BbIQB2khW9n5+VCxZwjVSnIV9EE90cjTG0QAo/D27lpwURISfT3Jrnw==",
+      "version": "0.3.20",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.20/d620b89c9bf38faa4f6b1c79212dcf600e76fd7f",
+      "integrity": "sha512-uIQEUYu2Fksxih9SV5z4s7pGXCI+10Ahq7zyEEfe1CFQf3Xj00XgCbbEXjeTxtb4OjDPO5Pz9UHNiVrtSm6xWQ==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13523,8 +13523,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.19",
-        "@etendosoftware/etendo-go-core": "0.3.19",
+        "@etendosoftware/app-shell-core": "0.3.20",
+        "@etendosoftware/etendo-go-core": "0.3.20",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.19",
-    "@etendosoftware/schema-forge-cli": "0.3.19",
-    "@etendosoftware/schema-forge-core": "0.3.19",
+    "@etendosoftware/app-shell-core": "0.3.20",
+    "@etendosoftware/schema-forge-cli": "0.3.20",
+    "@etendosoftware/schema-forge-core": "0.3.20",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.19",
-        "@etendosoftware/etendo-go-core": "0.3.19",
+        "@etendosoftware/app-shell-core": "0.3.20",
+        "@etendosoftware/etendo-go-core": "0.3.20",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -2436,9 +2436,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.19",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.19/75d1c01d69633738e5efda5d01b4728ea9ba5d5a",
-      "integrity": "sha512-dFG9Cv1n2XTkitsmPrP4wTg1JcfrbgJUjiaF1koxL6OtBk+IbDBVhun6lqMS5ZVvxdD/kQn7WbFoVHjkZXScOQ==",
+      "version": "0.3.20",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.20/55c406bbf3cd5fa87af0c3574925e55d840cd662",
+      "integrity": "sha512-3f0BRHRCMFZFg78ekflamn7FisGBvDibMO7DEAgt+EpajBZPGfmyJ/Eqw9MgLdciTiYr8usFvTNkQic3sSF97Q==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2465,9 +2465,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.19",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.19/bb36a78ebbdf72ef155179bd862884df27d8e23f",
-      "integrity": "sha512-eeW3VNSmMO7X88RTZf9T5LQAvCPiz3bf132Wsj2oK5K7uXOPViw4Nbu+DBgBy6yd5h4v+AxYANr5e1yIhzuexQ==",
+      "version": "0.3.20",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.20/a398bd2b294f2ecbab574e3d8b26a43845f55e9a",
+      "integrity": "sha512-c0rQjxuTC0Cfh7XGdHWqP1opR2z3kJEnkHLvnWd6TGnTJnSxof6kOjB139PnwvkKj8mrmgGqadrd6KzO9FRYgg==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -15,8 +15,8 @@
     "test:all": "npm run test && npm run test:vitest"
   },
   "dependencies": {
-    "@etendosoftware/app-shell-core": "0.3.19",
-    "@etendosoftware/etendo-go-core": "0.3.19",
+    "@etendosoftware/app-shell-core": "0.3.20",
+    "@etendosoftware/etendo-go-core": "0.3.20",
     "@iconicapp/iconic-react": "^1.1.4",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.20`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.