### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.20",
-        "@etendosoftware/schema-forge-cli": "0.3.20",
-        "@etendosoftware/schema-forge-core": "0.3.20",
+        "@etendosoftware/app-shell-core": "0.3.21",
+        "@etendosoftware/schema-forge-cli": "0.3.21",
+        "@etendosoftware/schema-forge-core": "0.3.21",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2537,9 +2537,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.20",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.20/55c406bbf3cd5fa87af0c3574925e55d840cd662",
-      "integrity": "sha512-3f0BRHRCMFZFg78ekflamn7FisGBvDibMO7DEAgt+EpajBZPGfmyJ/Eqw9MgLdciTiYr8usFvTNkQic3sSF97Q==",
+      "version": "0.3.21",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.21/340bcaf7d0de1cdf77018be957bf3ae17aa9e274",
+      "integrity": "sha512-SEIp2nYDC3B6kkWtavKUTLSsfRK81YPKE62VP3PdvRuhE9xG9WUkNMLcXTRnmYIsFibV4mMatGJeKTseiSaYnw==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2566,9 +2566,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.20",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.20/a398bd2b294f2ecbab574e3d8b26a43845f55e9a",
-      "integrity": "sha512-c0rQjxuTC0Cfh7XGdHWqP1opR2z3kJEnkHLvnWd6TGnTJnSxof6kOjB139PnwvkKj8mrmgGqadrd6KzO9FRYgg==",
+      "version": "0.3.21",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.21/477056e05d721a68652d89475afdd6a4c75bdf31",
+      "integrity": "sha512-yej7unwIeyNTmYsyaWF6Ocf9nmWHPpHH9sMKaC7cqbwZc+TVWGQKDk6/eiKDe2HT8f1uLdbfloWb7EcFnk2+xg==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2578,9 +2578,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.20",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.20/a400c0e6db678e49d3cf5a6fc5eaa04192e4673e",
-      "integrity": "sha512-mxCZx7ZEI663RKwa2YirVh2c76MG7VuDYPaOojF8vzzSeMOZ03Lm1pl3tyuYyH/m60d9J2qn53kxFVdd2YfK2A==",
+      "version": "0.3.21",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.21/a2ba1a2436b4410b32212887b0c5e3840d1acc78",
+      "integrity": "sha512-lAX3W9b6HZNHOIUUukzF6hfyYZzvuOgMmEpI6Zp28L6K99aFBdYL4T7WSl5pokigpKc6M4viptpMbl5gNxwoSg==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2624,9 +2624,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.20",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.20/d620b89c9bf38faa4f6b1c79212dcf600e76fd7f",
-      "integrity": "sha512-uIQEUYu2Fksxih9SV5z4s7pGXCI+10Ahq7zyEEfe1CFQf3Xj00XgCbbEXjeTxtb4OjDPO5Pz9UHNiVrtSm6xWQ==",
+      "version": "0.3.21",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.21/7ef1e8fd77c074f66507392a33f6bcce357b854f",
+      "integrity": "sha512-K+dU/R1RPZGQFQxEDKQdZ5E+lce9rY+jbtyi7htyYmuYhz1Q80ghbyT2yb2f6jOhx9HubeO3h4irecfr8MEy/w==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13523,8 +13523,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.20",
-        "@etendosoftware/etendo-go-core": "0.3.20",
+        "@etendosoftware/app-shell-core": "0.3.21",
+        "@etendosoftware/etendo-go-core": "0.3.21",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.20",
-    "@etendosoftware/schema-forge-cli": "0.3.20",
-    "@etendosoftware/schema-forge-core": "0.3.20",
+    "@etendosoftware/app-shell-core": "0.3.21",
+    "@etendosoftware/schema-forge-cli": "0.3.21",
+    "@etendosoftware/schema-forge-core": "0.3.21",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.20",
-        "@etendosoftware/etendo-go-core": "0.3.20",
+        "@etendosoftware/app-shell-core": "0.3.21",
+        "@etendosoftware/etendo-go-core": "0.3.21",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -2436,9 +2436,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.20",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.20/55c406bbf3cd5fa87af0c3574925e55d840cd662",
-      "integrity": "sha512-3f0BRHRCMFZFg78ekflamn7FisGBvDibMO7DEAgt+EpajBZPGfmyJ/Eqw9MgLdciTiYr8usFvTNkQic3sSF97Q==",
+      "version": "0.3.21",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.21/340bcaf7d0de1cdf77018be957bf3ae17aa9e274",
+      "integrity": "sha512-SEIp2nYDC3B6kkWtavKUTLSsfRK81YPKE62VP3PdvRuhE9xG9WUkNMLcXTRnmYIsFibV4mMatGJeKTseiSaYnw==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2465,9 +2465,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.20",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.20/a398bd2b294f2ecbab574e3d8b26a43845f55e9a",
-      "integrity": "sha512-c0rQjxuTC0Cfh7XGdHWqP1opR2z3kJEnkHLvnWd6TGnTJnSxof6kOjB139PnwvkKj8mrmgGqadrd6KzO9FRYgg==",
+      "version": "0.3.21",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.21/477056e05d721a68652d89475afdd6a4c75bdf31",
+      "integrity": "sha512-yej7unwIeyNTmYsyaWF6Ocf9nmWHPpHH9sMKaC7cqbwZc+TVWGQKDk6/eiKDe2HT8f1uLdbfloWb7EcFnk2+xg==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -15,8 +15,8 @@
     "test:all": "npm run test && npm run test:vitest"
   },
   "dependencies": {
-    "@etendosoftware/app-shell-core": "0.3.20",
-    "@etendosoftware/etendo-go-core": "0.3.20",
+    "@etendosoftware/app-shell-core": "0.3.21",
+    "@etendosoftware/etendo-go-core": "0.3.21",
     "@iconicapp/iconic-react": "^1.1.4",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.21`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.