### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.22",
-        "@etendosoftware/schema-forge-cli": "0.3.22",
-        "@etendosoftware/schema-forge-core": "0.3.22",
+        "@etendosoftware/app-shell-core": "0.3.24",
+        "@etendosoftware/schema-forge-cli": "0.3.24",
+        "@etendosoftware/schema-forge-core": "0.3.24",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2537,9 +2537,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.22",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.22/fd332891f3b9770b2d59101175ae45525e169f43",
-      "integrity": "sha512-EZv0VbQEOhzkbDI58S6/tcnAMim2fSdcOWkCZ/ghmKCo5Zk2HppFiuyjiWeqacoHxNJN4xJN7OpyYUMY6LIEjw==",
+      "version": "0.3.24",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.24/07e1cdc73a0e1028f3ac74b780928ab900607204",
+      "integrity": "sha512-ONhjis1bNk+bwXRRryETqycc3UQ2JPsLg+j0zpIO59x+1jQnKVj5DrkldymqURdea5RMOqrB4QUrFpdJjTuqJw==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2566,9 +2566,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.22",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.22/0d5c339d5dbedcbce6e0d96450fc14f9f3375b12",
-      "integrity": "sha512-kBF525alY8RrXRP5PyS1HFgo4RpmSxu4q4zMcmt0ccAHUgPd+kh3hO23ZvuIwBHxefZJYM2dxeod2aZWIhoisg==",
+      "version": "0.3.24",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.24/fe413fa799fe2a56e33ed3911204f200338449ec",
+      "integrity": "sha512-adK6BfUDwieDeq6DU36FuKJkNSlmzjI3TSfwXlWGVQuHrNoPECvvgOCPu/JWVHhBnmH8k8o9crYF48DbNylogQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2578,9 +2578,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.22",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.22/1ee25b42d29135d8870dcac03fb8f2c0f92b3e53",
-      "integrity": "sha512-x2WGNxfNpBu+KUaGJ5PZPfeM59MnqxzBDjCbmDF19nzEktNendxvE6t1lL5y+jTJfKkFmGu+6WLEcGo/IuWBWQ==",
+      "version": "0.3.24",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.24/17e6a896fa6082a2863a6deac80cfbb68278ce56",
+      "integrity": "sha512-GrOs7IBFnnFxW+BFNqE8LTNff9ZcOvPyeujJfxQUruEgqNnazr5AnhdjDyq2azfCOc/QLdAzFsEBQLfYn+dEjw==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2595,6 +2595,7 @@
         "sf-extract": "src/extract-fields.js",
         "sf-extract-db": "src/extract-from-db.js",
         "sf-extract-rules": "src/extract-rules.js",
+        "sf-flag-debt": "src/flag-debt.js",
         "sf-gen-log": "src/generation-log.js",
         "sf-generate-frontend": "src/generate-frontend.js",
         "sf-generate-reports-manifest": "src/generate-reports-manifest.js",
@@ -2624,9 +2625,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.22",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.22/c78ad34099024be76c5d889934e6a5053662747d",
-      "integrity": "sha512-sTOIHqSxLKh6VsNGWoG1PdSvkgm7pRblghRFm+JdzjjsCKIsuybSPR/8G2sEZ9QQM+E1Vp2g3wS7HsEikuxVbw==",
+      "version": "0.3.24",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.24/02593c63447a0465a5c850ae88de10ec3899b849",
+      "integrity": "sha512-WDgh4jjatJYUaH2HQE/uzQWShvpwap6saZSjDlhQGmQZNz8pj5YCTXqGkMRsLRYCxfzvfSuE5GwJl8tjADXnYA==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13723,8 +13724,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.22",
-        "@etendosoftware/etendo-go-core": "0.3.22",
+        "@etendosoftware/app-shell-core": "0.3.24",
+        "@etendosoftware/etendo-go-core": "0.3.24",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.22",
-    "@etendosoftware/schema-forge-cli": "0.3.22",
-    "@etendosoftware/schema-forge-core": "0.3.22",
+    "@etendosoftware/app-shell-core": "0.3.24",
+    "@etendosoftware/schema-forge-cli": "0.3.24",
+    "@etendosoftware/schema-forge-core": "0.3.24",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -8,8 +8,8 @@
       "name": "@schema-forge/app-shell",
       "version": "0.1.0",
       "dependencies": {
-        "@etendosoftware/app-shell-core": "0.3.22",
-        "@etendosoftware/etendo-go-core": "0.3.22",
+        "@etendosoftware/app-shell-core": "0.3.24",
+        "@etendosoftware/etendo-go-core": "0.3.24",
         "@iconicapp/iconic-react": "^1.1.4",
         "@phosphor-icons/react": "^2.1.10",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -2437,9 +2437,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.22",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.22/fd332891f3b9770b2d59101175ae45525e169f43",
-      "integrity": "sha512-EZv0VbQEOhzkbDI58S6/tcnAMim2fSdcOWkCZ/ghmKCo5Zk2HppFiuyjiWeqacoHxNJN4xJN7OpyYUMY6LIEjw==",
+      "version": "0.3.24",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.24/07e1cdc73a0e1028f3ac74b780928ab900607204",
+      "integrity": "sha512-ONhjis1bNk+bwXRRryETqycc3UQ2JPsLg+j0zpIO59x+1jQnKVj5DrkldymqURdea5RMOqrB4QUrFpdJjTuqJw==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2466,9 +2466,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.22",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.22/0d5c339d5dbedcbce6e0d96450fc14f9f3375b12",
-      "integrity": "sha512-kBF525alY8RrXRP5PyS1HFgo4RpmSxu4q4zMcmt0ccAHUgPd+kh3hO23ZvuIwBHxefZJYM2dxeod2aZWIhoisg==",
+      "version": "0.3.24",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.24/fe413fa799fe2a56e33ed3911204f200338449ec",
+      "integrity": "sha512-adK6BfUDwieDeq6DU36FuKJkNSlmzjI3TSfwXlWGVQuHrNoPECvvgOCPu/JWVHhBnmH8k8o9crYF48DbNylogQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -15,8 +15,8 @@
     "test:all": "npm run test && npm run test:vitest"
   },
   "dependencies": {
-    "@etendosoftware/app-shell-core": "0.3.22",
-    "@etendosoftware/etendo-go-core": "0.3.22",
+    "@etendosoftware/app-shell-core": "0.3.24",
+    "@etendosoftware/etendo-go-core": "0.3.24",
     "@iconicapp/iconic-react": "^1.1.4",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-collapsible": "^1.1.12",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.24`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.