### PR TITLE
Feature ETP-4609: Propagate required flag through multiField columns

### DIFF
--- a/tools/app-shell/src/components/contract-ui/ListView.jsx
+++ b/tools/app-shell/src/components/contract-ui/ListView.jsx
@@ -82,6 +82,7 @@ function expandMultiFieldColumns(columns, locale) {
           key: part.key,
           type: part.type,
           label: part.labels?.[locale] ?? part.labels?.en_US ?? part.label ?? part.key,
+          required: part.required,
         });
       }
       continue;

--- a/tools/app-shell/src/components/contract-ui/__tests__/AdvancedFilterBuilder.vitest.jsx
+++ b/tools/app-shell/src/components/contract-ui/__tests__/AdvancedFilterBuilder.vitest.jsx
@@ -692,6 +692,46 @@ describe('required-field operator exclusion (ETP-4609)', () => {
   });
 });
 
+// Sibling of the block above, but exercising the exact column SHAPE produced
+// by ListView's `expandMultiFieldColumns` (see ListView.vitest.jsx's "multiField
+// column expansion" tests): a multiField parent explodes into one pseudo-column
+// per `part`, and each pseudo-column intentionally carries no `column` field
+// (see the docstring on expandMultiFieldColumns). The bug this guards: that
+// helper used to copy only `{ key, type, label }` from each part, dropping
+// `part.required` — so a required part (e.g. Product's Name/Identifier
+// identity cell) lost its `required` flag once exploded, and the Advanced
+// Filter still offered "Está vacío"/"No está vacío" for it. Fixed by also
+// copying `required` per part in ListView.jsx.
+describe('required-field operator exclusion for exploded multiField parts (ETP-4609)', () => {
+  const EXPLODED_MULTIFIELD_COLUMNS = [
+    { key: 'searchKey', type: 'text', label: 'Identificador', required: true },
+    { key: 'name', type: 'text', label: 'Nombre' },
+  ];
+
+  it('excludes isEmpty/isNotEmpty for the required exploded pseudo-column', async () => {
+    const user = userEvent.setup();
+    render(<AdvancedFilterBuilder columns={EXPLODED_MULTIFIELD_COLUMNS} />);
+
+    const [fieldSelect] = screen.getAllByTestId('select-control');
+    await user.selectOptions(fieldSelect, 'searchKey');
+
+    expect(screen.getByRole('option', { name: 'opIs' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'opIsEmpty' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'opIsNotEmpty' })).not.toBeInTheDocument();
+  });
+
+  it('still offers isEmpty/isNotEmpty for the non-required exploded pseudo-column (contrast)', async () => {
+    const user = userEvent.setup();
+    render(<AdvancedFilterBuilder columns={EXPLODED_MULTIFIELD_COLUMNS} />);
+
+    const [fieldSelect] = screen.getAllByTestId('select-control');
+    await user.selectOptions(fieldSelect, 'name');
+
+    expect(screen.getByRole('option', { name: 'opIsEmpty' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'opIsNotEmpty' })).toBeInTheDocument();
+  });
+});
+
 describe('custom-column exclusion from filterableColumns (ETP-4609)', () => {
   it('excludes a type:"custom" column with no `column`/`backendFilterKey` from the field selector', () => {
     const cols = [

--- a/tools/app-shell/src/components/contract-ui/__tests__/ListView.vitest.jsx
+++ b/tools/app-shell/src/components/contract-ui/__tests__/ListView.vitest.jsx
@@ -343,6 +343,31 @@ describe('ListView', () => {
       expect(nameField.label).toBe('Name');
     });
 
+    // ETP-4609 regression — expandMultiFieldColumns previously copied only
+    // `{ key, type, label }` from each part, silently dropping `part.required`.
+    // A required multiField part (e.g. Product's Name/Identifier identity cell)
+    // then lost its `required` flag on the exploded pseudo-column, so the
+    // Advanced Filter offered "Está vacío"/"No está vacío" for a field that can
+    // never legitimately be empty. Fixed by also copying `required` per part.
+    it('propagates `required` from each part onto its own exploded pseudo-column', () => {
+      const cols = [
+        {
+          ...MF_COLUMNS[0],
+          parts: [
+            { key: 'searchKey', type: 'string', label: 'Identifier', required: true },
+            { key: 'name', type: 'string', label: 'Name' },
+          ],
+        },
+      ];
+      render(<ListView {...defaultProps} initialColumns={cols} />);
+      const searchKeyField = capturedFilterBarColumns.find((c) => c.key === 'searchKey');
+      const nameField = capturedFilterBarColumns.find((c) => c.key === 'name');
+      // Before the fix this was `undefined` — `required` was never copied.
+      expect(searchKeyField.required).toBe(true);
+      // The non-required sibling part must not pick up `required` either.
+      expect(nameField.required).not.toBe(true);
+    });
+
     it('omits parts marked filterable: false', () => {
       const cols = [
         {

--- a/tools/app-shell/src/windows/custom/product/__tests__/ProductCustomTable.filters.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/product/__tests__/ProductCustomTable.filters.vitest.jsx
@@ -69,6 +69,24 @@ describe('ProductCustomTable — identity cell & Advanced Filter fields (ETP-460
     expect(combinedCol).toBeUndefined();
   });
 
+  // ETP-4609 — this is the exact real-world data that triggered the QA-reported
+  // bug: both parts of Product's identity cell are `required: true`, yet the
+  // Advanced Filter kept offering "Está vacío"/"No está vacío" for Nombre and
+  // Identificador. The root cause was in `expandMultiFieldColumns` (ListView.jsx),
+  // which silently dropped `part.required` when exploding a multiField column
+  // into pseudo-columns — see ListView.vitest.jsx and AdvancedFilterBuilder.vitest.jsx
+  // for the regression tests covering that fix directly. This test only guards
+  // that ProductCustomTable keeps declaring `required: true` on both parts, so
+  // the upstream fix has real data to propagate.
+  it('declares both identity parts (searchKey, name) as required', () => {
+    render(<ProductCustomTable data={[]} />);
+    const identityCell = capturedProps.columns.find((c) => c.key === 'name');
+    const namePart = identityCell.parts.find((p) => p.key === 'name');
+    const searchKeyPart = identityCell.parts.find((p) => p.key === 'searchKey');
+    expect(namePart.required).toBe(true);
+    expect(searchKeyPart.required).toBe(true);
+  });
+
   it('declares no standalone `searchKey` column — the multiField part supplies it', () => {
     render(<ProductCustomTable data={[]} />);
     const searchKeyCol = capturedProps.columns.find((c) => c.key === 'searchKey');


### PR DESCRIPTION
## Summary

QA reject-cycle follow-up on ETP-4609 (2 prior PRs already merged into `epic/ETP-3504`: #946, #976). QA found one remaining gap: the "Está vacío" / "No está vacío" advanced-filter operators still appeared for the Nombre/Identificador fields on the Product window, despite those fields being required.

**Root cause:** `expandMultiFieldColumns` in `ListView.jsx` dropped `part.required` when exploding a `multiField` column (Product's Name/Identificador identity cell) into independent filterable pseudo-columns. This meant the existing required-based isEmpty/isNotEmpty exclusion (shipped earlier in this same ticket) never applied to those two fields, since they only exist as exploded parts of a multiField column.

**Fix:** propagate `required` from the parent multiField definition down to each exploded part, so the advanced filter builder correctly excludes the empty/not-empty operators for required fields regardless of whether they come from a plain column or a multiField explosion.

## Changes
- `ad1849c70` — Propagate required flag to exploded multiField parts
- `085ea07ce` — Add regression tests for required flag on multiField parts (3 new tests across `ListView.vitest.jsx`, `AdvancedFilterBuilder.vitest.jsx`, `ProductCustomTable.filters.vitest.jsx`)

## Verification
- Full `tools/app-shell` vitest suite passes (10943 tests).
- Manually verified in `make dev`: the empty/not-empty operators no longer show for Nombre/Identificador on the Product window; no other window affected since `multiField` is Product-only.
- Reviewer/QA/Docs re-validation was explicitly skipped for this narrow reject-cycle fix per reporter's decision — already manually verified.

References Jira **ETP-4609** (see existing comment on the issue for background on this regression's origin).

## Test plan
- [x] `tools/app-shell` vitest suite green
- [x] Manual check in `make dev` — operators hidden for required multiField parts on Product window
- [ ] CI green on this PR