### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.25",
-        "@etendosoftware/schema-forge-cli": "0.3.25",
-        "@etendosoftware/schema-forge-core": "0.3.25",
+        "@etendosoftware/app-shell-core": "0.3.26",
+        "@etendosoftware/schema-forge-cli": "0.3.26",
+        "@etendosoftware/schema-forge-core": "0.3.26",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.25",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.25/783db04fe1163a9c57e452072cf2d6b74c357b7a",
-      "integrity": "sha512-8CTfB5jsBkz60YhFVq4BSlauPAciDfhwRWk/FtoSMCjvAS0uXSsgRZe9gdaxSjCXnThQ8APvZkU4zXZNu7InWQ==",
+      "version": "0.3.26",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.26/1d0cd6f40a1d4212a2e8004cdca49a31212df971",
+      "integrity": "sha512-cHfuEcEiiDbBCnKTt2HCQ3LQ7QyV9eMgqxUpnfdwqESQiLSPyKHLuKIw2y9zuZidBCDKt1tJrDApWvuxbhKpng==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.25",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.25/6a0f0942667ee5555e062f4cb1bf088e80a048e5",
-      "integrity": "sha512-74NObrBc+a9FtSS0Ze2311yiuE4kNzj85U0adm3f+VU3VCaJipMIN/XP9109bD00PV0sbVgr/SZtVmHalq7Rng==",
+      "version": "0.3.26",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.26/8591fdb7ca6f3400dc7fa62ff8acdc60361e25f9",
+      "integrity": "sha512-ezR94xK7kZcnPPn5PJJPnoxDcJB06UADDaQdOADoUHosYloR4JP+gbfUv+CABNd+M9+Wi3vb4+60T5G7Jua6zA==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.25",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.25/89b412541f35c61b4a24decfe4d157015b74828c",
-      "integrity": "sha512-KffcHEkvKR4J0BYJhwjTKbrQ6G8C+Ysu7fqjmlYm7tgLatwshbiaW1yGysVtXeHkNtRrhI9V/eWJE0rJdduudQ==",
+      "version": "0.3.26",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.26/bbac4aa9858966755abd1d75a0d987606ea23033",
+      "integrity": "sha512-wDur0VYt7ye3PCg47fE9hUO9oFcQzdmiFWc31js1O2uA/7ty8Bs11WRg1H+G0NN36Ke22/e1EAVvnnAXkce+aA==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.25",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.25/4d8303ce2340a659bcbb67be8134204a9a6f46ca",
-      "integrity": "sha512-4thgqj0NYrizKRE+spHv6FfgjS5oY6lP2nrg4HslL+Cp3HB/1sYbpo+Yycp7OpUawAuQnQ4joS640lq/Et8Abw==",
+      "version": "0.3.26",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.26/bd32f41e4cf98e8f8a1117d3e4654bfd21cf2737",
+      "integrity": "sha512-Tz9lNF8Ss6exdI3Q7tprsYYuebLcR6CAjDoVQcJ0D6aAZhE7RfRIQhAOVrEdHB8T419COkBx5xeh+LXHkktnkw==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13771,8 +13771,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.25",
-        "@etendosoftware/etendo-go-core": "0.3.25",
+        "@etendosoftware/app-shell-core": "0.3.26",
+        "@etendosoftware/etendo-go-core": "0.3.26",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.25",
-    "@etendosoftware/schema-forge-cli": "0.3.25",
-    "@etendosoftware/schema-forge-core": "0.3.25",
+    "@etendosoftware/app-shell-core": "0.3.26",
+    "@etendosoftware/schema-forge-cli": "0.3.26",
+    "@etendosoftware/schema-forge-core": "0.3.26",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.25",
-        "@etendosoftware/etendo-go-core": "0.3.25",
+        "@etendosoftware/app-shell-core": "0.3.26",
+        "@etendosoftware/etendo-go-core": "0.3.26",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.25",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.25/783db04fe1163a9c57e452072cf2d6b74c357b7a",
-      "integrity": "sha512-8CTfB5jsBkz60YhFVq4BSlauPAciDfhwRWk/FtoSMCjvAS0uXSsgRZe9gdaxSjCXnThQ8APvZkU4zXZNu7InWQ==",
+      "version": "0.3.26",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.26/1d0cd6f40a1d4212a2e8004cdca49a31212df971",
+      "integrity": "sha512-cHfuEcEiiDbBCnKTt2HCQ3LQ7QyV9eMgqxUpnfdwqESQiLSPyKHLuKIw2y9zuZidBCDKt1tJrDApWvuxbhKpng==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.25",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.25/6a0f0942667ee5555e062f4cb1bf088e80a048e5",
-      "integrity": "sha512-74NObrBc+a9FtSS0Ze2311yiuE4kNzj85U0adm3f+VU3VCaJipMIN/XP9109bD00PV0sbVgr/SZtVmHalq7Rng==",
+      "version": "0.3.26",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.26/8591fdb7ca6f3400dc7fa62ff8acdc60361e25f9",
+      "integrity": "sha512-ezR94xK7kZcnPPn5PJJPnoxDcJB06UADDaQdOADoUHosYloR4JP+gbfUv+CABNd+M9+Wi3vb4+60T5G7Jua6zA==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.25",
-    "@etendosoftware/etendo-go-core": "0.3.25",
+    "@etendosoftware/app-shell-core": "0.3.26",
+    "@etendosoftware/etendo-go-core": "0.3.26",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.26`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.