### PR TITLE
Feature ETP-4779: Refresh related-docs section after generating a derived document

### DIFF
--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -1674,6 +1674,11 @@ export function DetailView({
   const saveBtnCls = getSaveBtnCls(toolbarButtonSize);
   const [showPrint, setShowPrint] = useState(false);
   const [confirmProcess, setConfirmProcess] = useState(null);
+  // ETP-4779: bumped whenever a menu action generates a derived document
+  // (runDocumentAction / runNeoMenuAction below) so the sibling "Documentos"
+  // related-docs section refetches — hook.fetchById only refreshes the
+  // header `data` prop, it does not know about the related-docs list.
+  const [docsRefreshSignal, setDocsRefreshSignal] = useState(0);
   // showNotes state removed — notes panel is always visible in side-by-side layout
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   // Shared by both the generic delete Dialog and the rich per-window cartel
@@ -3052,6 +3057,7 @@ export function DetailView({
                       const msg = (action.successKey ? ui(action.successKey) : action.successMessage) || ui('actionCompleted');
                       toast.success(msg);
                       hook.fetchById?.(currentId);
+                      setDocsRefreshSignal(v => v + 1);
                     } catch (err) {
                       toast.error(err.message);
                     }
@@ -3063,6 +3069,7 @@ export function DetailView({
                     if (result.success) {
                       toast.success(msg);
                       hook.fetchById?.(currentId);
+                      setDocsRefreshSignal(v => v + 1);
                     } else {
                       toast.error(translateBackendError(result.message, ui) || ui('actionFailed'));
                     }
@@ -4295,6 +4302,7 @@ export function DetailView({
                           totalDiscountPct={Number(data?.etgoTotalDiscount ?? 0)}
                           onTotalDiscountChange={handleTotalDiscountChange}
                           onNotesSave={handleNotesSave}
+                          docsRefreshSignal={docsRefreshSignal}
                           data-testid="BottomComponent__fa3275" />
                       );
                     })() : (
@@ -4346,6 +4354,7 @@ export function DetailView({
                                         apiBaseUrl={apiBaseUrl}
                                         api={api}
                                         layout="chips"
+                                        docsRefreshSignal={docsRefreshSignal}
                                         {...(ct.props || {})}
                                         data-testid="TabComponent__fa3275" />
                                     );

--- a/tools/app-shell/src/components/contract-ui/LinesBottomSection.jsx
+++ b/tools/app-shell/src/components/contract-ui/LinesBottomSection.jsx
@@ -45,6 +45,7 @@ export default function LinesBottomSection({
   totalDiscountPct,
   onTotalDiscountChange,
   onNotesSave,
+  docsRefreshSignal,
   relatedDocuments: RelatedDocumentsComponent,
   totalsField = 'etgoTotalDiscount',
   // Inventory / shipment-style windows (albaranes, recepciones, movimientos)
@@ -81,6 +82,7 @@ export default function LinesBottomSection({
                   apiBaseUrl={apiBaseUrl}
                   api={api}
                   layout="chips"
+                  docsRefreshSignal={docsRefreshSignal}
                   data-testid="RelatedDocumentsComponent__751847" />
               </div>
             </div>

--- a/tools/app-shell/src/windows/custom/payment-out/RelatedDocuments.jsx
+++ b/tools/app-shell/src/windows/custom/payment-out/RelatedDocuments.jsx
@@ -63,7 +63,7 @@ async function fetchLinkedDocuments(recordId, token, apiBaseUrl) {
   return result;
 }
 
-export default function RelatedDocuments({ recordId, data, token, apiBaseUrl }) {
+export default function RelatedDocuments({ recordId, data, token, apiBaseUrl, docsRefreshSignal }) {
   const [docs, setDocs] = useState([]);
   const [loading, setLoading] = useState(true);
   const [refreshKey, setRefreshKey] = useState(0);
@@ -77,7 +77,7 @@ export default function RelatedDocuments({ recordId, data, token, apiBaseUrl }) 
       .then(setDocs)
       .catch(() => setDocs([]))
       .finally(() => setLoading(false));
-  }, [recordId, token, apiBaseUrl, refreshKey]);
+  }, [recordId, token, apiBaseUrl, refreshKey, docsRefreshSignal]);
 
   const chips = [];
 

--- a/tools/app-shell/src/windows/custom/payment-out/__tests__/RelatedDocuments.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/payment-out/__tests__/RelatedDocuments.vitest.jsx
@@ -173,4 +173,31 @@ describe('RelatedDocuments — document linking', () => {
     // Effect returns early before clearing loading.
     expect(screen.getByTestId('rel-docs-shell')).toHaveAttribute('data-loading', 'true');
   });
+
+  // ETP-4779: generating a derived document (e.g. a Payment) from this
+  // window's menu actions must refresh this component the same way the
+  // manual refresh button does — via a `docsRefreshSignal` prop threaded
+  // down from DetailView through LinesBottomSection. Currently
+  // `docsRefreshSignal` is not part of the fetch effect's dependency array,
+  // so incrementing it does NOT trigger a refetch. This test is expected to
+  // FAIL until that fix lands.
+  it('8. refetches lines when docsRefreshSignal prop increments (regression, ETP-4779)', async () => {
+    mockFetchLines([]);
+
+    const { rerender } = renderComp({ docsRefreshSignal: 0 });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('rel-docs-shell')).toHaveAttribute('data-loading', 'false');
+    });
+
+    const callsBefore = global.fetch.mock.calls.length;
+
+    rerender(
+      <RelatedDocuments recordId="rec-1" data={{}} token={TOKEN} apiBaseUrl={API} docsRefreshSignal={1} />
+    );
+
+    await waitFor(() => {
+      expect(global.fetch.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+  });
 });

--- a/tools/app-shell/src/windows/custom/purchase-invoice/RelatedDocuments.jsx
+++ b/tools/app-shell/src/windows/custom/purchase-invoice/RelatedDocuments.jsx
@@ -39,7 +39,7 @@ async function fetchLinkedReturnDeliveries(invoiceId, token, apiBaseUrl) {
   return results.filter(Boolean);
 }
 
-export default function RelatedDocuments({ recordId, data, token, apiBaseUrl }) {
+export default function RelatedDocuments({ recordId, data, token, apiBaseUrl, docsRefreshSignal }) {
   const [purchaseOrder, setPurchaseOrder] = useState(null);
   const [receipts, setReceipts] = useState([]);
   const [payments, setPayments] = useState([]);
@@ -103,7 +103,7 @@ export default function RelatedDocuments({ recordId, data, token, apiBaseUrl }) 
       setOriginInvoice(originResult);
     });
     promise.finally(() => setLoading(false));
-  }, [recordId, apSubtype, data?.salesOrder, data?.linkedReceipts, data?.originInvoice, token, apiBaseUrl, refreshKey]);
+  }, [recordId, apSubtype, data?.salesOrder, data?.linkedReceipts, data?.originInvoice, token, apiBaseUrl, refreshKey, docsRefreshSignal]);
 
   const chips = [];
 

--- a/tools/app-shell/src/windows/custom/purchase-invoice/__tests__/RelatedDocuments.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/purchase-invoice/__tests__/RelatedDocuments.vitest.jsx
@@ -182,6 +182,30 @@ describe('RelatedDocuments (purchase-invoice)', () => {
     );
   });
 
+  // ETP-4779: generating a derived document (e.g. Purchase Invoice from a
+  // Purchase Order, or a Payment) from this window's menu actions must
+  // refresh this component the same way the manual refresh button does —
+  // via a `docsRefreshSignal` prop threaded down from DetailView through
+  // LinesBottomSection. Currently `docsRefreshSignal` is not part of the
+  // fetch effect's dependency array, so incrementing it does NOT trigger a
+  // refetch. This test is expected to FAIL until that fix lands.
+  it('refetches when docsRefreshSignal prop increments (regression, ETP-4779)', async () => {
+    const { rerender } = render(
+      <RelatedDocuments {...DEFAULT_PROPS} docsRefreshSignal={0} />
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('shell').dataset.loading).toBe('false')
+    );
+
+    const callCountBefore = mockFetchChild.mock.calls.length;
+
+    rerender(<RelatedDocuments {...DEFAULT_PROPS} docsRefreshSignal={1} />);
+
+    await waitFor(() =>
+      expect(mockFetchChild.mock.calls.length).toBeGreaterThan(callCountBefore)
+    );
+  });
+
   it('renders purchase order chip when salesOrder resolves from fetchById', async () => {
     mockFetchById.mockResolvedValueOnce({ id: 'po-1', documentNo: 'PO-001' });
 

--- a/tools/app-shell/src/windows/custom/purchase-order/RelatedDocuments.jsx
+++ b/tools/app-shell/src/windows/custom/purchase-order/RelatedDocuments.jsx
@@ -31,7 +31,7 @@ async function fetchPayments(orderId, token, apiBaseUrl) {
   return results.filter(Boolean);
 }
 
-export default function RelatedDocuments({ recordId, data, token, apiBaseUrl }) {
+export default function RelatedDocuments({ recordId, data, token, apiBaseUrl, docsRefreshSignal }) {
   const [related, setRelated] = useState({});
   const [payments, setPayments] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -54,7 +54,7 @@ export default function RelatedDocuments({ recordId, data, token, apiBaseUrl }) 
         setPayments(paymentResults);
         setLoading(false);
       });
-  }, [recordId, token, apiBaseUrl, refreshKey]);
+  }, [recordId, token, apiBaseUrl, refreshKey, docsRefreshSignal]);
 
   const chips = [];
 

--- a/tools/app-shell/src/windows/custom/purchase-order/__tests__/RelatedDocuments.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/purchase-order/__tests__/RelatedDocuments.vitest.jsx
@@ -1,0 +1,107 @@
+// Mocks must come before imports (Vitest hoisting)
+
+vi.mock('@/i18n', () => ({
+  useUI: () => (key) => key,
+  useMenuLabel: () => (key) => key,
+  useLocaleSwitch: () => ({ locale: 'en_US' }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+const mockFetchByCriteria = vi.hoisted(() => vi.fn().mockResolvedValue([]));
+const mockFetchChild = vi.hoisted(() => vi.fn().mockResolvedValue([]));
+const mockFetchById = vi.hoisted(() => vi.fn().mockResolvedValue(null));
+
+vi.mock('@/components/related-documents', () => ({
+  DocChip: ({ type }) => <div data-testid={`chip-${type}`}>{type}</div>,
+  RelatedDocumentsShell: ({ children, loading, onRefresh }) => (
+    <div data-testid="shell" data-loading={String(loading)}>
+      {onRefresh && (
+        <button data-testid="refresh-btn" onClick={onRefresh}>
+          Refresh
+        </button>
+      )}
+      {children}
+    </div>
+  ),
+  docChipProps: ({ type }) => ({ type }),
+  fetchByCriteria: mockFetchByCriteria,
+  fetchChild: mockFetchChild,
+  fetchById: mockFetchById,
+}));
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import RelatedDocuments from '../RelatedDocuments.jsx';
+
+const DEFAULT_PROPS = {
+  recordId: 'po-1',
+  data: {},
+  token: 'tok',
+  apiBaseUrl: '/api',
+};
+
+describe('RelatedDocuments (purchase-order)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetchByCriteria.mockResolvedValue([]);
+    mockFetchChild.mockResolvedValue([]);
+    mockFetchById.mockResolvedValue(null);
+  });
+
+  it('renders RelatedDocumentsShell (initially loading=true, then false)', async () => {
+    render(<RelatedDocuments {...DEFAULT_PROPS} />);
+    expect(screen.getByTestId('shell').dataset.loading).toBe('true');
+    await waitFor(() =>
+      expect(screen.getByTestId('shell').dataset.loading).toBe('false')
+    );
+  });
+
+  it('does not fetch when recordId is absent', () => {
+    render(<RelatedDocuments {...DEFAULT_PROPS} recordId={undefined} />);
+    expect(mockFetchByCriteria).not.toHaveBeenCalled();
+    expect(mockFetchChild).not.toHaveBeenCalled();
+    expect(mockFetchById).not.toHaveBeenCalled();
+  });
+
+  it('onRefresh button triggers re-fetch (fetchByCriteria called again)', async () => {
+    render(<RelatedDocuments {...DEFAULT_PROPS} />);
+    await waitFor(() =>
+      expect(screen.getByTestId('shell').dataset.loading).toBe('false')
+    );
+
+    const callsBefore = mockFetchByCriteria.mock.calls.length;
+
+    screen.getByTestId('refresh-btn').click();
+
+    await waitFor(() =>
+      expect(mockFetchByCriteria.mock.calls.length).toBeGreaterThan(callsBefore)
+    );
+  });
+
+  // ETP-4779: generating a derived document (e.g. Goods Receipt / Purchase
+  // Invoice) from this Purchase Order's menu actions must refresh this
+  // component the same way the manual refresh button does — via a
+  // `docsRefreshSignal` prop threaded down from DetailView through
+  // LinesBottomSection. Currently `docsRefreshSignal` is not part of the
+  // fetch effect's dependency array, so incrementing it does NOT trigger a
+  // refetch. This test is expected to FAIL until that fix lands.
+  it('refetches when docsRefreshSignal prop increments (regression, ETP-4779)', async () => {
+    const { rerender } = render(
+      <RelatedDocuments {...DEFAULT_PROPS} docsRefreshSignal={0} />
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId('shell').dataset.loading).toBe('false')
+    );
+
+    const callsBefore = mockFetchByCriteria.mock.calls.length;
+
+    rerender(<RelatedDocuments {...DEFAULT_PROPS} docsRefreshSignal={1} />);
+
+    await waitFor(() =>
+      expect(mockFetchByCriteria.mock.calls.length).toBeGreaterThan(callsBefore)
+    );
+  });
+});

--- a/tools/app-shell/src/windows/custom/shared/preview-cards/RelatedDocumentsCard.jsx
+++ b/tools/app-shell/src/windows/custom/shared/preview-cards/RelatedDocumentsCard.jsx
@@ -95,7 +95,7 @@ function DocRow({ type, doc, ui, navigate }) {
  *   specs        Array<{ key, type, fetch: async(id, token, base) => row[] }>
  *   fetchExtra   async(id, token, base) => Array<{ type, doc }> — optional chained fetch
  */
-export default function RelatedDocumentsCard({ documentId, token, apiBaseUrl, specs = [], fetchExtra }) {
+export default function RelatedDocumentsCard({ documentId, token, apiBaseUrl, specs = [], fetchExtra, docsRefreshSignal }) {
   const ui = useUI();
   const navigate = useNavigate();
   const [items, setItems] = useState([]);
@@ -124,7 +124,7 @@ export default function RelatedDocumentsCard({ documentId, token, apiBaseUrl, sp
         setItems([...specResults.flat(), ...extraResults]);
       })
       .finally(() => setLoading(false));
-  }, [documentId, token, apiBaseUrl, refreshKey]);
+  }, [documentId, token, apiBaseUrl, refreshKey, docsRefreshSignal]);
 
   if (!documentId || specs.length === 0) return null;
 

--- a/tools/app-shell/src/windows/custom/shared/preview-cards/__tests__/RelatedDocumentsCard.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/shared/preview-cards/__tests__/RelatedDocumentsCard.vitest.jsx
@@ -110,4 +110,24 @@ describe('RelatedDocumentsCard', () => {
     act(() => { refreshBtn.click(); });
     expect(SPECS[0].fetch).toHaveBeenCalledTimes(2);
   });
+
+  // ETP-4779: generating a derived document (e.g. a Purchase Invoice from a
+  // Sales Order/Quotation preview) must refresh this card the same way the
+  // manual refresh button does — via a `docsRefreshSignal` prop threaded
+  // down from DetailView. Currently `docsRefreshSignal` is not part of the
+  // fetch effect's dependency array, so incrementing it does NOT trigger a
+  // refetch. This test is expected to FAIL until that fix lands.
+  it('refetches when docsRefreshSignal prop increments (regression, ETP-4779)', async () => {
+    SPECS[0].fetch.mockResolvedValue([]);
+    const { rerender } = render(
+      <RelatedDocumentsCard documentId="id-1" token="t" apiBaseUrl="/api" specs={SPECS} docsRefreshSignal={0} />,
+    );
+    await waitFor(() => screen.getByText('noRelatedDocuments'));
+
+    rerender(
+      <RelatedDocumentsCard documentId="id-1" token="t" apiBaseUrl="/api" specs={SPECS} docsRefreshSignal={1} />,
+    );
+
+    await waitFor(() => expect(SPECS[0].fetch).toHaveBeenCalledTimes(2));
+  });
 });


### PR DESCRIPTION
## Summary
Fixes ETP-4779 — the "Documentos" (related documents) section of Purchase/Sales Orders, invoices, and payments did not show newly generated derived documents (e.g. a Goods Receipt or Invoice generated from a confirmed Order) without a full manual page reload.

Root cause: `DetailView.jsx`'s generic menu-action handlers (`runDocumentAction`, `runNeoMenuAction`) refreshed the header record on success but never told the sibling related-documents component to refetch its own data — that component only refetches on `recordId`/`token`/`apiBaseUrl` change or a manual refresh-button click.

Fix: added a `docsRefreshSignal` counter, incremented on every successful document-generating menu action, threaded from `DetailView.jsx` through `LinesBottomSection.jsx` into the related-documents fetch effect of `purchase-order`, `purchase-invoice`, `payment-out`, and the shared `RelatedDocumentsCard.jsx` (used by sales-order/sales-quotation/sales-invoice).

`goods-receipt/RelatedDocuments.jsx` was intentionally left untouched — it derives its chips directly from the `data` prop (already refreshed by the existing `hook.fetchById`), so it has no independent fetch to wire.

## Process
Followed the Bug/Pasada1 QA-gated process: analysis posted as a Jira comment on ETP-4779, then 2 commits — failing regression test first (`0492411`), fix second (`5837799`).

## Test plan
- [x] Vitest: 4 target suites green (43/43, including new `docsRefreshSignal` regression assertions)
- [x] Full app-shell vitest suite green (10946 tests), full `npm test` green (1470 tests)
- [x] No new user-visible strings (no i18n changes needed)
- [ ] Manual QA (pending, owner: Irina): confirm PO → generate Goods Receipt + Purchase Invoice, and confirmed Sales Order/Quotation → generate Sales Invoice, both show up in "Documentos" without a page refresh

## Known follow-up (not in scope of this PR)
The standalone preview modals opened from list views (`QuotationPreview.jsx`, `OrderPreview.jsx`, `InvoicePreview.jsx`, `GoodsReceiptPreview.jsx`, `GoodsShipmentPreview.jsx`) also render `RelatedDocumentsCard` but are outside `DetailView`'s menu-action flow, so they don't receive `docsRefreshSignal` yet. Not exercised by this ticket's reproduction steps; flagging for a future ticket if it turns out to matter.