### PR TITLE
Feature ETP-4028: Fix Tarifa selector styling in invoice confirm modal

### DIFF
--- a/tools/app-shell/src/components/contract-ui/CreateInvoiceConfirmModal.jsx
+++ b/tools/app-shell/src/components/contract-ui/CreateInvoiceConfirmModal.jsx
@@ -5,6 +5,13 @@ import { formatCurrency } from '@/lib/formatCurrency.js';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { overlayStyle, cardStyle, btnPrimaryStyle, btnSecondaryStyle, closeBtnStyle, Spinner } from './ConfirmDocumentModal';
 
+// Radix Select has no empty-string value, so the picker uses '__empty__' as its
+// placeholder sentinel — translate it back to '' before it reaches priceListId,
+// and back to the sentinel when feeding the current value into the Select.
+const resolvePriceListValue = (val) => (val === '__empty__' ? '' : val);
+const toPriceListSelectValue = (id) => id || '__empty__';
+const priceListPlaceholder = (ui, isLoading) => (isLoading ? ui('loading') : ui('noPriceListsAvailable'));
+
 /**
  * Generic "Create Invoice" confirmation modal — used by both goods-shipment and
  * goods-receipt. Shows a summary card and a checkbox before executing the action.
@@ -133,13 +140,13 @@ export default function CreateInvoiceConfirmModal({
               {ui('salesPriceListField')}
             </label>
             <Select
-              value={priceListId || '__empty__'}
-              onValueChange={val => setPriceListId(val === '__empty__' ? '' : val)}
+              value={toPriceListSelectValue(priceListId)}
+              onValueChange={val => setPriceListId(resolvePriceListValue(val))}
               disabled={loadingPriceLists || priceLists.length === 0}
               data-testid="Select__invoice-confirm-price-list"
             >
               <SelectTrigger id="invoice-confirm-price-list" data-testid="invoice-confirm-price-list-select">
-                <SelectValue placeholder={loadingPriceLists ? ui('loading') : ui('noPriceListsAvailable')} data-testid="SelectValue__invoice-confirm-price-list" />
+                <SelectValue placeholder={priceListPlaceholder(ui, loadingPriceLists)} data-testid="SelectValue__invoice-confirm-price-list" />
               </SelectTrigger>
               <SelectContent data-testid="SelectContent__invoice-confirm-price-list">
                 {loadingPriceLists && <SelectItem value="__empty__" data-testid="SelectItem__invoice-confirm-price-list-loading">{ui('loading')}</SelectItem>}

--- a/tools/app-shell/src/components/contract-ui/CreateInvoiceConfirmModal.jsx
+++ b/tools/app-shell/src/components/contract-ui/CreateInvoiceConfirmModal.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { createPortal } from 'react-dom';
 import { useUI } from '@/i18n';
 import { formatCurrency } from '@/lib/formatCurrency.js';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { overlayStyle, cardStyle, btnPrimaryStyle, btnSecondaryStyle, closeBtnStyle, Spinner } from './ConfirmDocumentModal';
 
 /**
@@ -131,26 +132,25 @@ export default function CreateInvoiceConfirmModal({
             <label htmlFor="invoice-confirm-price-list" style={{ fontSize: 12, fontWeight: 500, color: 'hsl(var(--muted-foreground))' }}>
               {ui('salesPriceListField')}
             </label>
-            <select
-              id="invoice-confirm-price-list"
-              data-testid="invoice-confirm-price-list-select"
-              value={priceListId}
-              onChange={e => setPriceListId(e.target.value)}
+            <Select
+              value={priceListId || '__empty__'}
+              onValueChange={val => setPriceListId(val === '__empty__' ? '' : val)}
               disabled={loadingPriceLists || priceLists.length === 0}
-              style={{
-                padding: '8px 10px', borderRadius: 8, fontSize: 13,
-                border: '1px solid hsl(var(--border-subtle))', background: 'hsl(var(--card))',
-                color: 'hsl(var(--foreground))',
-              }}
+              data-testid="Select__invoice-confirm-price-list"
             >
-              {loadingPriceLists && <option value="">{ui('loading')}</option>}
-              {!loadingPriceLists && priceLists.length === 0 && (
-                <option value="">{ui('noPriceListsAvailable')}</option>
-              )}
-              {priceLists.map(p => (
-                <option key={p.id} value={p.id}>{p['name'] ?? p.id}</option>
-              ))}
-            </select>
+              <SelectTrigger id="invoice-confirm-price-list" data-testid="invoice-confirm-price-list-select">
+                <SelectValue placeholder={loadingPriceLists ? ui('loading') : ui('noPriceListsAvailable')} data-testid="SelectValue__invoice-confirm-price-list" />
+              </SelectTrigger>
+              <SelectContent data-testid="SelectContent__invoice-confirm-price-list">
+                {loadingPriceLists && <SelectItem value="__empty__" data-testid="SelectItem__invoice-confirm-price-list-loading">{ui('loading')}</SelectItem>}
+                {!loadingPriceLists && priceLists.length === 0 && (
+                  <SelectItem value="__empty__" data-testid="SelectItem__invoice-confirm-price-list-empty">{ui('noPriceListsAvailable')}</SelectItem>
+                )}
+                {priceLists.map(p => (
+                  <SelectItem key={p.id} value={p.id} data-testid={`option-invoice-confirm-price-list-${p.id}`}>{p['name'] ?? p.id}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
         )}
 

--- a/tools/app-shell/src/components/contract-ui/__tests__/CreateInvoiceConfirmModal.vitest.jsx
+++ b/tools/app-shell/src/components/contract-ui/__tests__/CreateInvoiceConfirmModal.vitest.jsx
@@ -17,6 +17,26 @@ vi.mock('@/components/contract-ui/ConfirmDocumentModal', async (importOriginal) 
   return actual;
 });
 
+// Radix Select cannot run in JSDOM — replace with a native <select> that
+// honours value/onValueChange and renders options via SelectItem.
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children, value, onValueChange }) => (
+    <div>
+      <select
+        value={value ?? ''}
+        onChange={(e) => onValueChange?.(e.target.value)}
+        data-testid="select-control"
+      >
+        {children}
+      </select>
+    </div>
+  ),
+  SelectTrigger: ({ children, ...props }) => <span {...props}>{children}</span>,
+  SelectValue: () => null,
+  SelectContent: ({ children }) => <>{children}</>,
+  SelectItem: ({ children, value }) => <option value={value}>{children}</option>,
+}));
+
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import CreateInvoiceConfirmModal from '@/components/contract-ui/CreateInvoiceConfirmModal';
@@ -395,7 +415,7 @@ describe('CreateInvoiceConfirmModal', () => {
       ]);
       renderModal({ showPriceListPicker: true, isSOTrx: true, apiBaseUrl });
       await waitFor(() => {
-        const select = screen.getByTestId('invoice-confirm-price-list-select');
+        const select = screen.getByTestId('select-control');
         expect(select.value).toBe('pl-b');
       });
     });
@@ -407,7 +427,7 @@ describe('CreateInvoiceConfirmModal', () => {
       ]);
       renderModal({ showPriceListPicker: true, isSOTrx: true, apiBaseUrl });
       await waitFor(() => {
-        const select = screen.getByTestId('invoice-confirm-price-list-select');
+        const select = screen.getByTestId('select-control');
         expect(select.value).toBe('pl-a');
       });
     });
@@ -450,7 +470,7 @@ describe('CreateInvoiceConfirmModal', () => {
       await waitFor(() => {
         expect(screen.getByTestId('invoice-confirm-price-list-select')).toBeInTheDocument();
       });
-      fireEvent.change(screen.getByTestId('invoice-confirm-price-list-select'), { target: { value: 'pl-b' } });
+      fireEvent.change(screen.getByTestId('select-control'), { target: { value: 'pl-b' } });
       fireEvent.click(screen.getByText('soCreateDocsBtn'));
       expect(onConfirm).toHaveBeenCalledWith('pl-b');
     });


### PR DESCRIPTION
## Summary
Follow-up fix to ETP-4028 (already merged into epic/ETP-3504): the "Tarifa" price-list picker shown in the invoice-creation modal ("Gestionar documentos", triggered from a completed goods-shipment/goods-receipt) rendered as a plain unstyled native `<select>`, visually inconsistent with the rest of Etendo's UI.

- Replaced the native `<select>` with the app's shared styled `Select` component (`@/components/ui/select`) in `CreateInvoiceConfirmModal.jsx` — same component used everywhere else in the app (e.g. `EntityForm.jsx`, `ProcessParamDialog.jsx`).
- Updated `CreateInvoiceConfirmModal.vitest.jsx` to mock `@/components/ui/select` (Radix Select doesn't run in JSDOM), following the existing pattern from `ProcessParamDialog.vitest.jsx`.
- Extracted three small helper functions to bring the component's Sonar cognitive-complexity metric back under the CI threshold — no behavior change.

## Test plan
- [x] 42/42 unit tests in `CreateInvoiceConfirmModal.vitest.jsx` pass
- [x] Full app-shell vitest suite (10939 tests) passes, no regressions
- [x] Visually verified in a local dev instance — the Tarifa dropdown now matches the rest of Etendo's styled selectors (checkmark, rounded corners, shadow)
- [x] Full pre-push hook (unit tests + SonarQube quality gate) passed cleanly on push, no bypass