### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.25",
-        "@etendosoftware/schema-forge-cli": "0.3.25",
-        "@etendosoftware/schema-forge-core": "0.3.25",
+        "@etendosoftware/app-shell-core": "0.3.27",
+        "@etendosoftware/schema-forge-cli": "0.3.27",
+        "@etendosoftware/schema-forge-core": "0.3.27",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.25",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.25/783db04fe1163a9c57e452072cf2d6b74c357b7a",
-      "integrity": "sha512-8CTfB5jsBkz60YhFVq4BSlauPAciDfhwRWk/FtoSMCjvAS0uXSsgRZe9gdaxSjCXnThQ8APvZkU4zXZNu7InWQ==",
+      "version": "0.3.27",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.27/39831097889575c735af613b3df9e042c60bea0e",
+      "integrity": "sha512-1wYQRPxrNOxJfBfczq6pOw/ZLvsP2JhT/KTHI0dTy+wFbUqcvNeKwvNOTXJZ74/nUtp3bY1R9XHxqHyt0f4nhA==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.25",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.25/6a0f0942667ee5555e062f4cb1bf088e80a048e5",
-      "integrity": "sha512-74NObrBc+a9FtSS0Ze2311yiuE4kNzj85U0adm3f+VU3VCaJipMIN/XP9109bD00PV0sbVgr/SZtVmHalq7Rng==",
+      "version": "0.3.27",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.27/66689f378d80a750ee96014a597b0b434cd0e08a",
+      "integrity": "sha512-rMIwL6nOVnf3PLkikUOFnHwpmcdbOq266q2qDlsgx7pO9wjFtvqhWiFbH482JY5pybEFWMzZZ6eYYvxgVLuOxg==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.25",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.25/89b412541f35c61b4a24decfe4d157015b74828c",
-      "integrity": "sha512-KffcHEkvKR4J0BYJhwjTKbrQ6G8C+Ysu7fqjmlYm7tgLatwshbiaW1yGysVtXeHkNtRrhI9V/eWJE0rJdduudQ==",
+      "version": "0.3.27",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.27/066fa7ca3f996103c18dce36d52c251a6b249b86",
+      "integrity": "sha512-ySnuD2JC4pk+tb+Jg6S5F+va22XkfBQVcOUYTSoyc7rlgR/4VNmpcRXirBvo2hI0pcFrdrIeK2I+BcdEGrteMw==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.25",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.25/4d8303ce2340a659bcbb67be8134204a9a6f46ca",
-      "integrity": "sha512-4thgqj0NYrizKRE+spHv6FfgjS5oY6lP2nrg4HslL+Cp3HB/1sYbpo+Yycp7OpUawAuQnQ4joS640lq/Et8Abw==",
+      "version": "0.3.27",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.27/f0dcc433f48be9536e051d515059729c74db2e13",
+      "integrity": "sha512-ovl2YnEk0SxlJqENsgNoznYwitvhCh2LmMfKszECpHp9EJL5jiKRkWXlP3RFqZ2dEYHKRS635NBCL6n+RD0fsA==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13771,8 +13771,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.25",
-        "@etendosoftware/etendo-go-core": "0.3.25",
+        "@etendosoftware/app-shell-core": "0.3.27",
+        "@etendosoftware/etendo-go-core": "0.3.27",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.25",
-    "@etendosoftware/schema-forge-cli": "0.3.25",
-    "@etendosoftware/schema-forge-core": "0.3.25",
+    "@etendosoftware/app-shell-core": "0.3.27",
+    "@etendosoftware/schema-forge-cli": "0.3.27",
+    "@etendosoftware/schema-forge-core": "0.3.27",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.25",
-        "@etendosoftware/etendo-go-core": "0.3.25",
+        "@etendosoftware/app-shell-core": "0.3.27",
+        "@etendosoftware/etendo-go-core": "0.3.27",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.25",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.25/783db04fe1163a9c57e452072cf2d6b74c357b7a",
-      "integrity": "sha512-8CTfB5jsBkz60YhFVq4BSlauPAciDfhwRWk/FtoSMCjvAS0uXSsgRZe9gdaxSjCXnThQ8APvZkU4zXZNu7InWQ==",
+      "version": "0.3.27",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.27/39831097889575c735af613b3df9e042c60bea0e",
+      "integrity": "sha512-1wYQRPxrNOxJfBfczq6pOw/ZLvsP2JhT/KTHI0dTy+wFbUqcvNeKwvNOTXJZ74/nUtp3bY1R9XHxqHyt0f4nhA==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.25",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.25/6a0f0942667ee5555e062f4cb1bf088e80a048e5",
-      "integrity": "sha512-74NObrBc+a9FtSS0Ze2311yiuE4kNzj85U0adm3f+VU3VCaJipMIN/XP9109bD00PV0sbVgr/SZtVmHalq7Rng==",
+      "version": "0.3.27",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.27/66689f378d80a750ee96014a597b0b434cd0e08a",
+      "integrity": "sha512-rMIwL6nOVnf3PLkikUOFnHwpmcdbOq266q2qDlsgx7pO9wjFtvqhWiFbH482JY5pybEFWMzZZ6eYYvxgVLuOxg==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.25",
-    "@etendosoftware/etendo-go-core": "0.3.25",
+    "@etendosoftware/app-shell-core": "0.3.27",
+    "@etendosoftware/etendo-go-core": "0.3.27",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.27`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.