### PR TITLE
Feature ETP-4723: Reset line description when product changes

### DIFF
--- a/tools/app-shell/src/components/contract-ui/DetailView.jsx
+++ b/tools/app-shell/src/components/contract-ui/DetailView.jsx
@@ -73,7 +73,7 @@ import { evalTabReadOnly } from './evalTabReadOnly.js';
 import { resolveIdentifier } from '@/lib/resolveIdentifier.js';
 import {
   buildCalloutFormState, extractAuxValues, normalizeCalloutQty,
-  normalizeCalloutResponse, applyQtyZeroGuard, roundAmounts,
+  normalizeCalloutResponse, applyQtyZeroGuard, resetDescriptionOnProductChange, roundAmounts,
   resolveSnapshotIdentifiers,
 } from '@/lib/lineFieldChange.js';
 import { getCatalogOptions } from '@/lib/selectorCatalog.js';
@@ -2586,6 +2586,7 @@ export function DetailView({
       // a valid netUnitPrice instead of null/0 at save time.
       calculateNetUnitPrice(result, taxRateCacheRef, hook);
       applyQtyZeroGuard(result, rowValues);
+      resetDescriptionOnProductChange(result, field);
       // Fallback: when callout returns no lineNetAmount (e.g. SL_Invoice_Amt throws
       // PriceAdjustment exception for products without standard cost), compute qty × price.
       // Uses lineConfig fields so orders, invoices, and future window types all benefit.

--- a/tools/app-shell/src/lib/__tests__/lineFieldChange.jest.test.js
+++ b/tools/app-shell/src/lib/__tests__/lineFieldChange.jest.test.js
@@ -6,6 +6,7 @@ import {
   normalizeCalloutQty,
   normalizeCalloutResponse,
   applyQtyZeroGuard,
+  resetDescriptionOnProductChange,
   roundAmounts,
   shouldFireCascade,
   buildCascadeState,
@@ -280,6 +281,42 @@ describe('applyQtyZeroGuard', () => {
     const rowValues = { movementQuantity: 2 };
     applyQtyZeroGuard(result, rowValues);
     assert.equal('movementQuantity' in result, false);
+  });
+
+});
+
+// ─── resetDescriptionOnProductChange ──────────────────────────────────────────
+
+describe('resetDescriptionOnProductChange', () => {
+
+  it('resets description to empty string when product changes and callout omitted it', () => {
+    const result = {};
+    resetDescriptionOnProductChange(result, 'product');
+    assert.equal(result.description, '');
+  });
+
+  it('does not overwrite a description the callout already returned', () => {
+    const result = { description: 'From callout' };
+    resetDescriptionOnProductChange(result, 'product');
+    assert.equal(result.description, 'From callout');
+  });
+
+  it('does nothing when the changed field is not product', () => {
+    const result = { unitPrice: 44 };
+    resetDescriptionOnProductChange(result, 'unitPrice');
+    assert.equal('description' in result, false);
+  });
+
+  it('[corner] empty-string description from callout is preserved (not re-reset)', () => {
+    const result = { description: '' };
+    resetDescriptionOnProductChange(result, 'product');
+    assert.equal(result.description, '');
+  });
+
+  it('[corner] explicit null description is treated as absent and reset', () => {
+    const result = { description: null };
+    resetDescriptionOnProductChange(result, 'product');
+    assert.equal(result.description, '');
   });
 
 });

--- a/tools/app-shell/src/lib/lineFieldChange.js
+++ b/tools/app-shell/src/lib/lineFieldChange.js
@@ -104,6 +104,22 @@ export function applyQtyZeroGuard(result, rowValues) {
 }
 
 /**
+ * Resets the manually-entered line description when the product changes.
+ *
+ * Classic product callouts (SL_Order_Product / SL_Invoice_Product) recompute
+ * price, discount and tax on product change but never touch description, so
+ * without this guard the grid keeps showing the previous product's
+ * description instead of clearing it for re-entry (ETP-4723).
+ *
+ * Mutates result in place.
+ */
+export function resetDescriptionOnProductChange(result, field) {
+  if (field === 'product' && result.description == null) {
+    result.description = '';
+  }
+}
+
+/**
  * Rounds amount fields to 2 decimal places.
  * Classic callouts sometimes return values with many decimals.
  * Mutates result in place.


### PR DESCRIPTION
## Summary
- Product callouts (`SL_Order_Product`/`SL_Invoice_Product`) recompute price, discount and tax on product change but never touch `description`, so the line grid kept showing the previous product's manually-entered description instead of clearing it for re-entry.
- Adds `resetDescriptionOnProductChange(result, field)` in `tools/app-shell/src/lib/lineFieldChange.js`, wired into `DetailView.jsx`'s shared line-callout handler — a single fix point covering every generated document (Sales Order, Sales Quotation, Purchase Order, Sales Invoice, Purchase Invoice), no backend/NEO changes required.

## Test plan
- [x] Unit tests added in `lineFieldChange.jest.test.js` (5 new cases) — full suite passes 78/78
- [x] Manually verified in local env (`localhost:3101`) across all 5 affected windows: Pedido de Venta, Presupuesto de Venta, Factura de Venta, Pedido de Compra, Factura de Compra — product change clears description while price/tax/total still recompute correctly
- [x] Pre-push hook passed (tests, SonarQube, UI/contract drift check)

Fixes ETP-4723