### PR TITLE
Feature ETP-4724: Copy order line description when importing lines into an invoice

### DIFF
--- a/artifacts/purchase-invoice/custom/ImportFromPurchaseOrderModal.jsx
+++ b/artifacts/purchase-invoice/custom/ImportFromPurchaseOrderModal.jsx
@@ -91,6 +91,7 @@ const buildLineBody = async ({ line, qty, invoiceId, lineNo }) => {
     ...(grossUnitPrice ? { grossUnitPrice } : {}),
     ...(discount ? { etgoDiscount: discount } : {}),
     lineNetAmount: unitPrice * qty,
+    description: line.description || null,
     tax: line.tax || null,
     uOM: line.uOM || null,
     lineNo,

--- a/artifacts/purchase-invoice/custom/__tests__/ImportFromPurchaseOrderModal.test.js
+++ b/artifacts/purchase-invoice/custom/__tests__/ImportFromPurchaseOrderModal.test.js
@@ -230,6 +230,7 @@ async function buildLineBody({ line, qty, invoiceId, lineNo }) {
     ...(grossUnitPrice ? { grossUnitPrice } : {}),
     ...(discount ? { etgoDiscount: discount } : {}),
     lineNetAmount: unitPrice * qty,
+    description: line.description || null,
     tax: line.tax || null,
     uOM: line.uOM || null,
     lineNo,

--- a/artifacts/purchase-invoice/custom/__tests__/ImportFromPurchaseOrderModal.test.js
+++ b/artifacts/purchase-invoice/custom/__tests__/ImportFromPurchaseOrderModal.test.js
@@ -57,6 +57,14 @@ describe('ImportFromPurchaseOrderModal — source shape', () => {
     assert.match(src, /buildLineBody=\{buildLineBody\}/);
     assert.match(src, /afterImport=\{afterImport\}/);
   });
+
+  // ETP-4724: buildLineBody must carry the source order line's custom
+  // description through to the created invoice line, otherwise the backend
+  // falls back to the product's default description. This assertion is
+  // expected to FAIL against current source until the fix lands.
+  it('carries the order line description into the built invoice line body', () => {
+    assert.match(src, /description:\s*line\.description\s*\|\|\s*null/);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -189,5 +197,58 @@ describe('ImportFromPurchaseOrderModal — fetchDocuments currency filter', () =
     assert.equal(result.documents.length, 1);
     assert.equal(result.documents[0].id, 'o1');
     assert.equal(result.excludedByCurrency, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildLineBody — behavioral description-passthrough test (ETP-4724)
+//
+// buildLineBody is re-derived verbatim from the CURRENT source below (byte
+// -for-byte, minus the missing `description` line the bug report calls out),
+// so it faithfully reproduces today's (buggy) behavior: the built body never
+// carries `line.description`, so the backend falls back to the product's
+// default description when creating the invoice line.
+//
+// Once the fix lands in ImportFromPurchaseOrderModal.jsx (adding
+// `description: line.description || null` to the returned object), update
+// ONLY the re-derived `buildLineBody` copy below to match — the assertion
+// itself (`result.description === 'Entrega especial'`) does not need to
+// change, and should then pass.
+// ---------------------------------------------------------------------------
+
+async function buildLineBody({ line, qty, invoiceId, lineNo }) {
+  const unitPrice = Number(line.unitPrice) || 0;
+  const listPrice = Number(line.listPrice) || unitPrice;
+  const grossUnitPrice = Number(line.grossUnitPrice) || 0;
+  const discount = Number(line.discount) || 0;
+  return {
+    parentId: invoiceId,
+    product: line.product,
+    invoicedQuantity: qty,
+    unitPrice,
+    listPrice,
+    ...(grossUnitPrice ? { grossUnitPrice } : {}),
+    ...(discount ? { etgoDiscount: discount } : {}),
+    lineNetAmount: unitPrice * qty,
+    tax: line.tax || null,
+    uOM: line.uOM || null,
+    lineNo,
+    salesOrderLine: line.id,
+  };
+}
+
+describe('ImportFromPurchaseOrderModal — buildLineBody description passthrough', () => {
+  it('carries the order line description into the built invoice line body', async () => {
+    const line = {
+      id: 'ol1',
+      product: 'p1',
+      description: 'Entrega especial',
+      unitPrice: 10,
+      listPrice: 10,
+      tax: 't1',
+      uOM: 'u1',
+    };
+    const result = await buildLineBody({ line, qty: 2, invoiceId: 'inv1', lineNo: 10 });
+    assert.equal(result.description, 'Entrega especial');
   });
 });

--- a/artifacts/sales-invoice/custom/ImportFromOrderModal.jsx
+++ b/artifacts/sales-invoice/custom/ImportFromOrderModal.jsx
@@ -91,6 +91,7 @@ const buildLineBody = async ({ line, qty, invoiceId, lineNo }) => {
     ...(grossUnitPrice ? { grossUnitPrice } : {}),
     ...(discount ? { etgoDiscount: discount } : {}),
     lineNetAmount: unitPrice * qty,
+    description: line.description || null,
     tax: line.tax || null,
     uOM: line.uOM || null,
     lineNo,

--- a/artifacts/sales-invoice/custom/__tests__/ImportFromOrderModal.test.js
+++ b/artifacts/sales-invoice/custom/__tests__/ImportFromOrderModal.test.js
@@ -57,6 +57,14 @@ describe('ImportFromOrderModal — source shape', () => {
     assert.match(src, /buildLineBody=\{buildLineBody\}/);
     assert.match(src, /afterImport=\{afterImport\}/);
   });
+
+  // ETP-4724: buildLineBody must carry the source order line's custom
+  // description through to the created invoice line, otherwise the backend
+  // falls back to the product's default description. This assertion is
+  // expected to FAIL against current source until the fix lands.
+  it('carries the order line description into the built invoice line body', () => {
+    assert.match(src, /description:\s*line\.description\s*\|\|\s*null/);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -191,5 +199,58 @@ describe('ImportFromOrderModal — fetchDocuments currency filter', () => {
     assert.equal(result.documents.length, 1);
     assert.equal(result.documents[0].id, 'o1');
     assert.equal(result.excludedByCurrency, false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildLineBody — behavioral description-passthrough test (ETP-4724)
+//
+// buildLineBody is re-derived verbatim from the CURRENT source below (byte
+// -for-byte, minus the missing `description` line the bug report calls out),
+// so it faithfully reproduces today's (buggy) behavior: the built body never
+// carries `line.description`, so the backend falls back to the product's
+// default description when creating the invoice line.
+//
+// Once the fix lands in ImportFromOrderModal.jsx (adding
+// `description: line.description || null` to the returned object), update
+// ONLY the re-derived `buildLineBody` copy below to match — the assertion
+// itself (`result.description === 'Entrega especial'`) does not need to
+// change, and should then pass.
+// ---------------------------------------------------------------------------
+
+async function buildLineBody({ line, qty, invoiceId, lineNo }) {
+  const unitPrice = Number(line.unitPrice) || 0;
+  const listPrice = Number(line.listPrice) || unitPrice;
+  const grossUnitPrice = Number(line.grossUnitPrice) || 0;
+  const discount = Number(line.discount) || 0;
+  return {
+    parentId: invoiceId,
+    product: line.product,
+    invoicedQuantity: qty,
+    unitPrice,
+    listPrice,
+    ...(grossUnitPrice ? { grossUnitPrice } : {}),
+    ...(discount ? { etgoDiscount: discount } : {}),
+    lineNetAmount: unitPrice * qty,
+    tax: line.tax || null,
+    uOM: line.uOM || null,
+    lineNo,
+    cOrderlineId: line.id,
+  };
+}
+
+describe('ImportFromOrderModal — buildLineBody description passthrough', () => {
+  it('carries the order line description into the built invoice line body', async () => {
+    const line = {
+      id: 'ol1',
+      product: 'p1',
+      description: 'Entrega especial',
+      unitPrice: 10,
+      listPrice: 10,
+      tax: 't1',
+      uOM: 'u1',
+    };
+    const result = await buildLineBody({ line, qty: 2, invoiceId: 'inv1', lineNo: 10 });
+    assert.equal(result.description, 'Entrega especial');
   });
 });

--- a/artifacts/sales-invoice/custom/__tests__/ImportFromOrderModal.test.js
+++ b/artifacts/sales-invoice/custom/__tests__/ImportFromOrderModal.test.js
@@ -232,6 +232,7 @@ async function buildLineBody({ line, qty, invoiceId, lineNo }) {
     ...(grossUnitPrice ? { grossUnitPrice } : {}),
     ...(discount ? { etgoDiscount: discount } : {}),
     lineNetAmount: unitPrice * qty,
+    description: line.description || null,
     tax: line.tax || null,
     uOM: line.uOM || null,
     lineNo,


### PR DESCRIPTION
## Summary

- ETP-4724: importing lines from a Sales/Purchase Order into an existing Invoice via the "Import lines from Order" modal (Etendo Go) did not copy the order line's custom Description — the backend fell back to the product's default description instead. The direct "Create Invoice" flow was unaffected, since it goes through the native `CreateInvoiceLinesFromProcess` (which already copies the description); the modal instead POSTs a hand-built payload via `buildLineBody` that simply never included `description`.
- Fixed in both `artifacts/sales-invoice/custom/ImportFromOrderModal.jsx` and `artifacts/purchase-invoice/custom/ImportFromPurchaseOrderModal.jsx` by adding `description: line.description || null` to the built invoice-line payload.

## Commits

1. `Feature ETP-4724: Add failing tests for order description not copied on import` — adds source-shape + behavioral tests asserting `buildLineBody` carries `line.description`; fail against the pre-fix code (4/32 failing).
2. `Feature ETP-4724: Copy order line description when importing lines into an invoice` — the one-line fix in both modals + updates the re-derived `buildLineBody` test copies to match; all tests pass (32/32).

## Test plan

- [x] `node --test 'artifacts/sales-invoice/custom/__tests__/ImportFromOrderModal.test.js' 'artifacts/purchase-invoice/custom/__tests__/ImportFromPurchaseOrderModal.test.js'` — 32/32 passing after the fix (confirmed 4 failing before it, on the tests-only commit)
- [x] Full repo suite (`npm test`) — 5255/5255 passing, no regressions
- [x] Pre-push pipeline (unit tests, Sonar, UI/contract drift check) — passed