### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.28

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.27",
-        "@etendosoftware/schema-forge-cli": "0.3.27",
-        "@etendosoftware/schema-forge-core": "0.3.27",
+        "@etendosoftware/app-shell-core": "0.3.28",
+        "@etendosoftware/schema-forge-cli": "0.3.28",
+        "@etendosoftware/schema-forge-core": "0.3.28",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.27",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.27/39831097889575c735af613b3df9e042c60bea0e",
-      "integrity": "sha512-1wYQRPxrNOxJfBfczq6pOw/ZLvsP2JhT/KTHI0dTy+wFbUqcvNeKwvNOTXJZ74/nUtp3bY1R9XHxqHyt0f4nhA==",
+      "version": "0.3.28",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.28/b9cc718582bb8dc7abe9ff20e759305d64fe54ef",
+      "integrity": "sha512-0EyB+4GOOS+GJw86qHgaBAxU7R3BaXPMJO3cRi+qzz2mCsL4GSKqp1cjxPWJFV0fSTeTq4CIh8fVUORy4HBCQw==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.27",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.27/66689f378d80a750ee96014a597b0b434cd0e08a",
-      "integrity": "sha512-rMIwL6nOVnf3PLkikUOFnHwpmcdbOq266q2qDlsgx7pO9wjFtvqhWiFbH482JY5pybEFWMzZZ6eYYvxgVLuOxg==",
+      "version": "0.3.28",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.28/ec22498832a741092eecae22764f1d7b2473d7c0",
+      "integrity": "sha512-+Ohtn4LiHiryxe9XGgmG2JelFzkRzUHmNJpMvnA5lDEN3R62IzP7ENnPHM4VwOQxOYpnknSnOlAzK8mNu7SEPQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.27",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.27/066fa7ca3f996103c18dce36d52c251a6b249b86",
-      "integrity": "sha512-ySnuD2JC4pk+tb+Jg6S5F+va22XkfBQVcOUYTSoyc7rlgR/4VNmpcRXirBvo2hI0pcFrdrIeK2I+BcdEGrteMw==",
+      "version": "0.3.28",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.28/da801d678b97c69a4fdae53a27102bd3ec1543d7",
+      "integrity": "sha512-OcsJSWbSUU5R8BkpEQHTNXcWVMyfAzVdkvl5Ah01rXNyMJH3lntEUiHQsO+wBJ/utdbYFBaYgOm19ZJicSYNyA==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.27",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.27/f0dcc433f48be9536e051d515059729c74db2e13",
-      "integrity": "sha512-ovl2YnEk0SxlJqENsgNoznYwitvhCh2LmMfKszECpHp9EJL5jiKRkWXlP3RFqZ2dEYHKRS635NBCL6n+RD0fsA==",
+      "version": "0.3.28",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.28/de28ad94881e56ed791be6f3d0a0c4cad66627ac",
+      "integrity": "sha512-+VfQ/W7BxIgjoaXvpjFpHeVsnKugZRClTGk9W3RInxydDK1FFaFH2d37v8ZtN1gctZDC1Mt6ZHBjw7A8ZVVyGw==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13771,8 +13771,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.27",
-        "@etendosoftware/etendo-go-core": "0.3.27",
+        "@etendosoftware/app-shell-core": "0.3.28",
+        "@etendosoftware/etendo-go-core": "0.3.28",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.27",
-    "@etendosoftware/schema-forge-cli": "0.3.27",
-    "@etendosoftware/schema-forge-core": "0.3.27",
+    "@etendosoftware/app-shell-core": "0.3.28",
+    "@etendosoftware/schema-forge-cli": "0.3.28",
+    "@etendosoftware/schema-forge-core": "0.3.28",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.27",
-        "@etendosoftware/etendo-go-core": "0.3.27",
+        "@etendosoftware/app-shell-core": "0.3.28",
+        "@etendosoftware/etendo-go-core": "0.3.28",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.27",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.27/39831097889575c735af613b3df9e042c60bea0e",
-      "integrity": "sha512-1wYQRPxrNOxJfBfczq6pOw/ZLvsP2JhT/KTHI0dTy+wFbUqcvNeKwvNOTXJZ74/nUtp3bY1R9XHxqHyt0f4nhA==",
+      "version": "0.3.28",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.28/b9cc718582bb8dc7abe9ff20e759305d64fe54ef",
+      "integrity": "sha512-0EyB+4GOOS+GJw86qHgaBAxU7R3BaXPMJO3cRi+qzz2mCsL4GSKqp1cjxPWJFV0fSTeTq4CIh8fVUORy4HBCQw==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.27",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.27/66689f378d80a750ee96014a597b0b434cd0e08a",
-      "integrity": "sha512-rMIwL6nOVnf3PLkikUOFnHwpmcdbOq266q2qDlsgx7pO9wjFtvqhWiFbH482JY5pybEFWMzZZ6eYYvxgVLuOxg==",
+      "version": "0.3.28",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.28/ec22498832a741092eecae22764f1d7b2473d7c0",
+      "integrity": "sha512-+Ohtn4LiHiryxe9XGgmG2JelFzkRzUHmNJpMvnA5lDEN3R62IzP7ENnPHM4VwOQxOYpnknSnOlAzK8mNu7SEPQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.27",
-    "@etendosoftware/etendo-go-core": "0.3.27",
+    "@etendosoftware/app-shell-core": "0.3.28",
+    "@etendosoftware/etendo-go-core": "0.3.28",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.28`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.