### PR TITLE
Epic ETP-3504: Bump @playwright/test to 1.58.2 (fix accidental version downgrade)

### DIFF
--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -717,6 +717,14 @@ Patterns that already end in `/**` (e.g. the generic `**/sws/**` catch-all) are 
 
 This was diagnosed against a large batch of pre-existing `.mocked.spec.js` failures (55 tests across ~22 files, then 5 more once the first fix landed) that had nothing to do with the PRs under test — the bug pre-dated them. Reach for the two-route pattern by default in any new `page.route()` call whose real endpoint can receive a sub-path (detail GET by id, `/action/...`, `/defaults`, `/selectors/...`) — especially anything under `/action/<name>`, which is always 2+ segments deep.
 
+### Root cause of the above: a silently downgraded `@playwright/test` pin
+
+The glob-crossing bug described above is not a permanent Playwright limitation — it's specific to `@playwright/test` `1.50.0`. Verified empirically: the exact same isolated repro (two `page.route()` calls, no app code) fails on `1.50.0` and passes cleanly on `1.58.2`.
+
+`e2e/package.json` was pinned to `"1.50.0"` (no caret) by an unrelated commit that was only trying to bump the `schema_forge_core` preview pin (`7c38d5cf2`, ETP-4763) — the Playwright downgrade from `"^1.50.0"` was accidental collateral. Because `e2e/` has **no committed lockfile**, this silently forced every fresh `npm install` onto that exact old version from then on, with no warning. It also explains why the 55-test failure wasn't reproducible for everyone on the team: anyone who ran `npm install` before that commit landed, or who had a stale `node_modules` with a newer resolved version already on disk, never hit it.
+
+**Current pin:** exact `"1.58.2"` (still no caret, deliberately — see reasoning below). If you ever need to bump this again, pin exactly and verify the new version doesn't reintroduce glob-matching regressions before merging; don't switch to a caret range, since a caret + no lockfile is what let this drift happen unnoticed in the first place. Do not remove the two-route fixes above when bumping — they're correct regardless of Playwright version and are cheap insurance against this exact class of regression recurring silently.
+
 ### Canonical reference
 
 `e2e/tests/flows/row-quick-actions.mocked.spec.js` covers the four pilot windows (sales-order, purchase-order, sales-invoice, purchase-invoice) and is the recommended starting point for any list-row UI test. It demonstrates: mocked list+detail endpoints, per-window expected-button matrix, hover→overlay assertion, edit-navigates-to-detail flow, and delete-opens-dialog flow.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -12,6 +12,6 @@
     "report": "npx playwright show-report"
   },
   "devDependencies": {
-    "@playwright/test": "1.50.0"
+    "@playwright/test": "1.58.2"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,70 +25,7 @@
     "e2e": {
       "name": "@schema-forge/e2e",
       "devDependencies": {
-        "@playwright/test": "1.50.0"
-      }
-    },
-    "e2e/node_modules/@playwright/test": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.50.0.tgz",
-      "integrity": "sha512-ZGNXbt+d65EGjBORQHuYKj+XhCewlwpnSd/EDuLPZGSiEWmgOJB5RmMCCYGy5aMfTs9wx61RivfDKi8H/hcMvw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright": "1.50.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "e2e/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "e2e/node_modules/playwright": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.0.tgz",
-      "integrity": "sha512-+GinGfGTrd2IfX1TA4N2gNmeIksSb+IAe589ZH+FlmpV3MYTx6+buChGIuDLQwrGNCw2lWibqV50fU510N7S+w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "playwright-core": "1.50.0"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "e2e/node_modules/playwright-core": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.0.tgz",
-      "integrity": "sha512-CXkSSlr4JaZs2tZHI40DsZUN/NIwgaUPsyLuOAaIZp2CyF2sN5MM5NJsyB188lFSSozFxQ5fPT4qM+f0tH/6wQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
+        "@playwright/test": "1.58.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -3218,6 +3155,22 @@
       "peerDependencies": {
         "react": ">= 16.8",
         "react-dom": ">= 16.8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -9942,6 +9895,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {


### PR DESCRIPTION
## Summary

A previous commit (`7c38d5cf2`, ETP-4763) accidentally downgraded the `@playwright/test` pin from `^1.50.0` to an exact `1.50.0` as a side effect of an unrelated change (bumping the core's pin). This exact pin turned out to carry a real Playwright 1.50.0 glob-matching bug — verified empirically: an isolated repro fails on 1.50.0 and passes on 1.58.2.

That bug was the real root cause of the ~55 mocked E2E tests that were failing, which had already been fixed in PR #1076 with a route-glob-pattern workaround. This PR bumps `@playwright/test` to `1.58.2`, fixing the underlying version issue as well.

The workaround from #1076 is kept in place — it's robust regardless of the Playwright version — but now the root cause is also resolved at the dependency level.

## Changes
- `015c1dd7c` — Bump `@playwright/test` 1.50.0 -> 1.58.2
- `74ec794a2` — Document the finding in `docs/e2e-testing-guide.md`

## Test plan
- [x] Full E2E suite verified green post-bump: **496 passed / 0 failed / 17 skipped**