### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.30

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.29",
-        "@etendosoftware/schema-forge-cli": "0.3.29",
-        "@etendosoftware/schema-forge-core": "0.3.29",
+        "@etendosoftware/app-shell-core": "0.3.30",
+        "@etendosoftware/schema-forge-cli": "0.3.30",
+        "@etendosoftware/schema-forge-core": "0.3.30",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.29",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.29/3da18884a1f00599a337ad6a42c1b89f926bacfb",
-      "integrity": "sha512-hwX7OqdAmIZwK2p9pXBokDs/hNZT9jJgCfcWtbsfbic2xKmZsSnf0NtUTvm0AVj9TL6qK+Ow3ub1rFd94cicLQ==",
+      "version": "0.3.30",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.30/f4409951f27bb90ee78bff3285ac924ed7db69d9",
+      "integrity": "sha512-8yufrHFk0KMmi3diyzhYtSN7IfeXa/xTcz9zO6HqxPP8KxxZZkEtW6YVbL0plnbPNKyyqI4fdYBCfItkbJPr8w==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.29",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.29/97c510d208fbfab9ee8512a3cfe44f30f41743ac",
-      "integrity": "sha512-1z1l8N58aloQCBjl8LtoT1B/03zd31Jdv7VYW+LxZWryJdV6J7x9Krg4R0DfK6DZrlcXE/UO4q5OOqAFn1YDQw==",
+      "version": "0.3.30",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.30/8d9a0af780cfc13ef4c83831cb94138b25a9e671",
+      "integrity": "sha512-e1f/sA23K3EiJB19nTpTWBAD1VtqHrUw/IH542KjeNY7rNWFhoSMqsz3MHMNSeY2r1mZ2+0FsHiKIh8IC7FhHw==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.29",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.29/36c0cdf1ad5171ff470d913664925e3dd58570f3",
-      "integrity": "sha512-OEJcBJzlPXvsEDeGmXpQ+cX+KIuv8voDlaCC/nf7PeUe6xmsyXqLhH89Fff3DCpApHZ3Ooe7KI21jQkoW+6hkw==",
+      "version": "0.3.30",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.30/40d41c049914973246d47e273c8e38516e12a7ae",
+      "integrity": "sha512-NXfYJfxlIesrez7Xth9lwJS8kDm5Dmd2rX8l4vUJdze1qe/mlWF7WSF88guAEFFBn3hvQVepUrC6m49xI/sflQ==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.29",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.29/d040fabfec94c2d74db0bc56d1b0cce14edd1efd",
-      "integrity": "sha512-dCCxxR8DTTYXQ2zFeR4t3UFK04XSjfgRe1ufdAfzOzM0uk5OfP+vo9URI7e0B9CSghVyna42rJ3gQR5vVy7JXA==",
+      "version": "0.3.30",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.30/9a67649709266839b0d2aed1b684121cb24dc9b2",
+      "integrity": "sha512-cA3DWwUfV365AxrKQU/Q4B6989TbZWsoFTiC95PfMi0LSR2fI5MgLHuan1DQ+kLY5m4ar4HRqGi5OcQC9rQEsA==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13780,8 +13780,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.29",
-        "@etendosoftware/etendo-go-core": "0.3.29",
+        "@etendosoftware/app-shell-core": "0.3.30",
+        "@etendosoftware/etendo-go-core": "0.3.30",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.29",
-    "@etendosoftware/schema-forge-cli": "0.3.29",
-    "@etendosoftware/schema-forge-core": "0.3.29",
+    "@etendosoftware/app-shell-core": "0.3.30",
+    "@etendosoftware/schema-forge-cli": "0.3.30",
+    "@etendosoftware/schema-forge-core": "0.3.30",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.29",
-        "@etendosoftware/etendo-go-core": "0.3.29",
+        "@etendosoftware/app-shell-core": "0.3.30",
+        "@etendosoftware/etendo-go-core": "0.3.30",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.29",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.29/3da18884a1f00599a337ad6a42c1b89f926bacfb",
-      "integrity": "sha512-hwX7OqdAmIZwK2p9pXBokDs/hNZT9jJgCfcWtbsfbic2xKmZsSnf0NtUTvm0AVj9TL6qK+Ow3ub1rFd94cicLQ==",
+      "version": "0.3.30",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.30/f4409951f27bb90ee78bff3285ac924ed7db69d9",
+      "integrity": "sha512-8yufrHFk0KMmi3diyzhYtSN7IfeXa/xTcz9zO6HqxPP8KxxZZkEtW6YVbL0plnbPNKyyqI4fdYBCfItkbJPr8w==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.29",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.29/97c510d208fbfab9ee8512a3cfe44f30f41743ac",
-      "integrity": "sha512-1z1l8N58aloQCBjl8LtoT1B/03zd31Jdv7VYW+LxZWryJdV6J7x9Krg4R0DfK6DZrlcXE/UO4q5OOqAFn1YDQw==",
+      "version": "0.3.30",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.30/8d9a0af780cfc13ef4c83831cb94138b25a9e671",
+      "integrity": "sha512-e1f/sA23K3EiJB19nTpTWBAD1VtqHrUw/IH542KjeNY7rNWFhoSMqsz3MHMNSeY2r1mZ2+0FsHiKIh8IC7FhHw==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.29",
-    "@etendosoftware/etendo-go-core": "0.3.29",
+    "@etendosoftware/app-shell-core": "0.3.30",
+    "@etendosoftware/etendo-go-core": "0.3.30",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.30`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.