### PR TITLE
Feature ETP-4843: Clarify pending-cost posting error message

### DIFF
--- a/tools/app-shell/src/locales/en_US.json
+++ b/tools/app-shell/src/locales/en_US.json
@@ -19826,7 +19826,7 @@
     "backendError.matchRulePriorityConflict": "A rule with this priority already exists for the selected scope",
     "backendError.priceListCannotDeactivateDefault": "A tariff marked as default cannot be deactivated.",
     "backendError.productCategoryCannotSetMultipleDefault": "Only one product category can be marked as default.",
-    "backendError.costNotCalculated": "The cost of the product could not be calculated.",
+    "backendError.costNotCalculated": "The product cost has not been calculated yet. The system calculates it automatically; please try posting the document again in a few minutes.",
     "backendError.conversionRateNotDraft": "Cannot modify the document conversion rate when the invoice is not in draft status.",
     "uomTypeArea": "Area",
     "uomTypeLength": "Length",

--- a/tools/app-shell/src/locales/es_ES.json
+++ b/tools/app-shell/src/locales/es_ES.json
@@ -20076,7 +20076,7 @@
     "backendError.matchRulePriorityConflict": "Ya existe una regla con esta prioridad para el ámbito seleccionado",
     "backendError.priceListCannotDeactivateDefault": "No es posible desactivar una tarifa marcada como por defecto.",
     "backendError.productCategoryCannotSetMultipleDefault": "Solo una categoría de producto puede estar marcada como valor por defecto.",
-    "backendError.costNotCalculated": "No se pudo calcular el costo del producto.",
+    "backendError.costNotCalculated": "El costo del producto aún no ha sido calculado. El sistema lo calcula automáticamente; por favor, intente contabilizar el documento en unos minutos.",
     "backendError.conversionRateNotDraft": "No es posible modificar el tipo de cambio del documento cuando la factura no está en estado Borrador.",
     "uomTypeArea": "Área",
     "uomTypeLength": "Longitud",


### PR DESCRIPTION
## What
Reworded the `backendError.costNotCalculated` translation key in `tools/app-shell/src/locales/es_ES.json` and `en_US.json` — replaces a generic, unhelpful error ("No se pudo calcular el costo del producto.") with an actionable one explaining the cost calculation is automatic/asynchronous and to retry posting in a few minutes.

## Why
ETP-4843 — users saw this confusing message when posting ("Contabilizar") a purchase/sales delivery note (albarán) immediately after confirming it, before the async background cost-calculation process finished. Scope was confirmed with the user as a frontend-only copy fix (no core Etendo change).

## Pipeline
- **DEV** → **REVIEW** (Alex: APPROVE — advisory only, Alex shares the workflow bot's GitHub identity so a real second-party approval is still required before merge) → **QA** (Sentinel: PASS — confirmed the fix reaches both goods-receipt and goods-shipment windows via the shared `DetailMoreActionsMenu`/`translateBackendError` path) → **DOCS** (Sage: confirmed no doc updates needed).

Jira: ETP-4843