### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.31

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.30",
-        "@etendosoftware/schema-forge-cli": "0.3.30",
-        "@etendosoftware/schema-forge-core": "0.3.30",
+        "@etendosoftware/app-shell-core": "0.3.31",
+        "@etendosoftware/schema-forge-cli": "0.3.31",
+        "@etendosoftware/schema-forge-core": "0.3.31",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.30",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.30/f4409951f27bb90ee78bff3285ac924ed7db69d9",
-      "integrity": "sha512-8yufrHFk0KMmi3diyzhYtSN7IfeXa/xTcz9zO6HqxPP8KxxZZkEtW6YVbL0plnbPNKyyqI4fdYBCfItkbJPr8w==",
+      "version": "0.3.31",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.31/71a2d81fe80e4c63e87c4eed24197e06caacb043",
+      "integrity": "sha512-N41ccOVnZ9G5nQIzKD4OnWsMn9m/HCFXCKPlso1D+CjNneiYb4GfMUt0zAdcDoRSGSeD87KC5wg3Xs6NUHdgdg==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.30",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.30/8d9a0af780cfc13ef4c83831cb94138b25a9e671",
-      "integrity": "sha512-e1f/sA23K3EiJB19nTpTWBAD1VtqHrUw/IH542KjeNY7rNWFhoSMqsz3MHMNSeY2r1mZ2+0FsHiKIh8IC7FhHw==",
+      "version": "0.3.31",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.31/d208c92bcba7033b41bc08aaccc5c1f1113a3dc1",
+      "integrity": "sha512-5F8Sfhvg9tQ95o7dmTWv+mlnOmo2dw/Zgk4VmS3VkHCnrHt3IkWlGR7BCZ0t6lc0Csz6zepeTAa6iPdyVzpmpQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.30",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.30/40d41c049914973246d47e273c8e38516e12a7ae",
-      "integrity": "sha512-NXfYJfxlIesrez7Xth9lwJS8kDm5Dmd2rX8l4vUJdze1qe/mlWF7WSF88guAEFFBn3hvQVepUrC6m49xI/sflQ==",
+      "version": "0.3.31",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.31/7a4f1180ab51b4147916d2733cc5e33c1569491e",
+      "integrity": "sha512-PC3m/CzY9rTHik7h6di7N1CBdPbgohvAYHtYrym4IwqJE9HQtd9iWj3Cs1ds5SfcSzLT7g7ZIhfqun3v9hMd5g==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.30",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.30/9a67649709266839b0d2aed1b684121cb24dc9b2",
-      "integrity": "sha512-cA3DWwUfV365AxrKQU/Q4B6989TbZWsoFTiC95PfMi0LSR2fI5MgLHuan1DQ+kLY5m4ar4HRqGi5OcQC9rQEsA==",
+      "version": "0.3.31",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.31/620a1cc816ad2c64c0602cbfb24619357208de2e",
+      "integrity": "sha512-E8VmGHaBDa1vpuNQjcCjTyE6ub/NUSL+p7p+P4BSkUGpF/Q1Lz1kV94Y+F5lUaT4gcP9Xl9VDkHWTBCxMkGDeg==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13780,8 +13780,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.30",
-        "@etendosoftware/etendo-go-core": "0.3.30",
+        "@etendosoftware/app-shell-core": "0.3.31",
+        "@etendosoftware/etendo-go-core": "0.3.31",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.30",
-    "@etendosoftware/schema-forge-cli": "0.3.30",
-    "@etendosoftware/schema-forge-core": "0.3.30",
+    "@etendosoftware/app-shell-core": "0.3.31",
+    "@etendosoftware/schema-forge-cli": "0.3.31",
+    "@etendosoftware/schema-forge-core": "0.3.31",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.30",
-        "@etendosoftware/etendo-go-core": "0.3.30",
+        "@etendosoftware/app-shell-core": "0.3.31",
+        "@etendosoftware/etendo-go-core": "0.3.31",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.30",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.30/f4409951f27bb90ee78bff3285ac924ed7db69d9",
-      "integrity": "sha512-8yufrHFk0KMmi3diyzhYtSN7IfeXa/xTcz9zO6HqxPP8KxxZZkEtW6YVbL0plnbPNKyyqI4fdYBCfItkbJPr8w==",
+      "version": "0.3.31",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.31/71a2d81fe80e4c63e87c4eed24197e06caacb043",
+      "integrity": "sha512-N41ccOVnZ9G5nQIzKD4OnWsMn9m/HCFXCKPlso1D+CjNneiYb4GfMUt0zAdcDoRSGSeD87KC5wg3Xs6NUHdgdg==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.30",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.30/8d9a0af780cfc13ef4c83831cb94138b25a9e671",
-      "integrity": "sha512-e1f/sA23K3EiJB19nTpTWBAD1VtqHrUw/IH542KjeNY7rNWFhoSMqsz3MHMNSeY2r1mZ2+0FsHiKIh8IC7FhHw==",
+      "version": "0.3.31",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.31/d208c92bcba7033b41bc08aaccc5c1f1113a3dc1",
+      "integrity": "sha512-5F8Sfhvg9tQ95o7dmTWv+mlnOmo2dw/Zgk4VmS3VkHCnrHt3IkWlGR7BCZ0t6lc0Csz6zepeTAa6iPdyVzpmpQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.30",
-    "@etendosoftware/etendo-go-core": "0.3.30",
+    "@etendosoftware/app-shell-core": "0.3.31",
+    "@etendosoftware/etendo-go-core": "0.3.31",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.31`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.