### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.31",
-        "@etendosoftware/schema-forge-cli": "0.3.31",
-        "@etendosoftware/schema-forge-core": "0.3.31",
+        "@etendosoftware/app-shell-core": "0.3.32",
+        "@etendosoftware/schema-forge-cli": "0.3.32",
+        "@etendosoftware/schema-forge-core": "0.3.32",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.31",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.31/71a2d81fe80e4c63e87c4eed24197e06caacb043",
-      "integrity": "sha512-N41ccOVnZ9G5nQIzKD4OnWsMn9m/HCFXCKPlso1D+CjNneiYb4GfMUt0zAdcDoRSGSeD87KC5wg3Xs6NUHdgdg==",
+      "version": "0.3.32",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.32/510a0af2f09d1724d9f684e9c46e5e9ba5a5ea01",
+      "integrity": "sha512-0WPWfO4GaOp9JAr9b4eekFeTbpn8ir4tEwENBdyhUuCi9hBHQgyMxJpJW7cMT80nLmRrcl7ux9pL/+iKqttjxw==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.31",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.31/d208c92bcba7033b41bc08aaccc5c1f1113a3dc1",
-      "integrity": "sha512-5F8Sfhvg9tQ95o7dmTWv+mlnOmo2dw/Zgk4VmS3VkHCnrHt3IkWlGR7BCZ0t6lc0Csz6zepeTAa6iPdyVzpmpQ==",
+      "version": "0.3.32",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.32/5fbe8a0f68321737c2ac072e736feeeb2b13b561",
+      "integrity": "sha512-idGjZ1FMm5fZnFpbuJnWO7+Adg6dd5neFHyTyqWQJb/oIKIzDMPTo431Zz6SWTNNymBrjWd832sBNTjujFQktQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.31",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.31/7a4f1180ab51b4147916d2733cc5e33c1569491e",
-      "integrity": "sha512-PC3m/CzY9rTHik7h6di7N1CBdPbgohvAYHtYrym4IwqJE9HQtd9iWj3Cs1ds5SfcSzLT7g7ZIhfqun3v9hMd5g==",
+      "version": "0.3.32",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.32/da312453b82597050d27f21024f329fd1a594b40",
+      "integrity": "sha512-S7cgF2ltJdwv52P8RAgjujYy/Tt03DZVJr/gI5I8qy7EtgaLFYDI9GHUHmlBQenDH74zzN4nQcjhSm4gyS4vmg==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.31",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.31/620a1cc816ad2c64c0602cbfb24619357208de2e",
-      "integrity": "sha512-E8VmGHaBDa1vpuNQjcCjTyE6ub/NUSL+p7p+P4BSkUGpF/Q1Lz1kV94Y+F5lUaT4gcP9Xl9VDkHWTBCxMkGDeg==",
+      "version": "0.3.32",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.32/46ff92323d093b32f1ad12a86e3d384e6a43c90d",
+      "integrity": "sha512-AHVlRSytUoKutbrQC415QeO5C41uzBvbcKsWW6BUplsLhLmmXb9Olb0zuE5Ty8vFG2gCENKgGmoWIVYq9iCb2w==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13780,8 +13780,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.31",
-        "@etendosoftware/etendo-go-core": "0.3.31",
+        "@etendosoftware/app-shell-core": "0.3.32",
+        "@etendosoftware/etendo-go-core": "0.3.32",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.31",
-    "@etendosoftware/schema-forge-cli": "0.3.31",
-    "@etendosoftware/schema-forge-core": "0.3.31",
+    "@etendosoftware/app-shell-core": "0.3.32",
+    "@etendosoftware/schema-forge-cli": "0.3.32",
+    "@etendosoftware/schema-forge-core": "0.3.32",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.31",
-        "@etendosoftware/etendo-go-core": "0.3.31",
+        "@etendosoftware/app-shell-core": "0.3.32",
+        "@etendosoftware/etendo-go-core": "0.3.32",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,21 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-      "version": "0.3.31",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.31/71a2d81fe80e4c63e87c4eed24197e06caacb043",
-      "integrity": "sha512-N41ccOVnZ9G5nQIzKD4OnWsMn9m/HCFXCKPlso1D+CjNneiYb4GfMUt0zAdcDoRSGSeD87KC5wg3Xs6NUHdgdg==",
-=======
-      "version": "0.3.31-preview.feature-ETP-4714.20260811194733.f5120d1",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.31-preview.feature-ETP-4714.20260811194733.f5120d1/0f0afd57fa7d3ad228470bbc9d5237141754c2ae",
-      "integrity": "sha512-Xh8bjykEgVMXVec/p13VftqKgXLL6jeZVJLLaR7pC5uo2uxkTT/erTRjfpZtEku+L4n3P7cuJ+KKAXt80ftUMw==",
->>>>>>> origin/feature/ETP-4714
-=======
-      "version": "0.3.31-preview.feature-ETP-4771.20260812102137.7504bbc",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.31-preview.feature-ETP-4771.20260812102137.7504bbc/22c756c8d900d2e9cf326f49445352b0c1b23cae",
-      "integrity": "sha512-F4MBtlD88bSqQvvhUI9Anz8woFgaihG78ST/w4pUXlo+9ngoPlrQUYHS5/KOKEz0UL3I4DQ0mNJ0VUSB3TaJBA==",
->>>>>>> origin/feature/ETP-4771
+      "version": "0.3.32",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.32/510a0af2f09d1724d9f684e9c46e5e9ba5a5ea01",
+      "integrity": "sha512-0WPWfO4GaOp9JAr9b4eekFeTbpn8ir4tEwENBdyhUuCi9hBHQgyMxJpJW7cMT80nLmRrcl7ux9pL/+iKqttjxw==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2488,21 +2476,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-<<<<<<< HEAD
-<<<<<<< HEAD
-      "version": "0.3.31",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.31/d208c92bcba7033b41bc08aaccc5c1f1113a3dc1",
-      "integrity": "sha512-5F8Sfhvg9tQ95o7dmTWv+mlnOmo2dw/Zgk4VmS3VkHCnrHt3IkWlGR7BCZ0t6lc0Csz6zepeTAa6iPdyVzpmpQ==",
-=======
-      "version": "0.3.31-preview.feature-ETP-4714.20260811194733.f5120d1",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.31-preview.feature-ETP-4714.20260811194733.f5120d1/c116d9baf0950528d08eed0cef8c06dd57a0be1a",
-      "integrity": "sha512-jK6VthdG/TQO9Kvx8MB1GQO8d8iwn+X6yAk2thUA+udHOhOM/akQFzB7ABfAIsigmak34CBMBaBxKRR8WN11dQ==",
->>>>>>> origin/feature/ETP-4714
-=======
-      "version": "0.3.31-preview.feature-ETP-4771.20260812102137.7504bbc",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.31-preview.feature-ETP-4771.20260812102137.7504bbc/9400e8e6be87c839c2122e969cbf67fdbf347e08",
-      "integrity": "sha512-qJVkMSy4A2F69TSW/bHmeSxEVvAM1BTSAxc+Pih6HjFVFA81h+sDTl40BG3p5GzUTzXgbmUUcwl+7boZnMNNYA==",
->>>>>>> origin/feature/ETP-4771
+      "version": "0.3.32",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.32/5fbe8a0f68321737c2ac072e736feeeb2b13b561",
+      "integrity": "sha512-idGjZ1FMm5fZnFpbuJnWO7+Adg6dd5neFHyTyqWQJb/oIKIzDMPTo431Zz6SWTNNymBrjWd832sBNTjujFQktQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -16,8 +16,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.31",
-    "@etendosoftware/etendo-go-core": "0.3.31",
+    "@etendosoftware/app-shell-core": "0.3.32",
+    "@etendosoftware/etendo-go-core": "0.3.32",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.32`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.