### PR TITLE
Feature ETP-4908: Render document QR as precomputed data field

### DIFF
--- a/artifacts/print-goods-shipment/helpers.js
+++ b/artifacts/print-goods-shipment/helpers.js
@@ -1,25 +1,7 @@
-var QRCode = require('qrcode');
-
-// All other formatting helpers now come from the canonical
+// All formatting helpers come from the canonical
 // templates/reports/helpers/report-html-helpers.js (both the on-screen HTML
 // preview and the jsreport PDF/XLSX render path build their helper set from
-// there — see buildJsreportHelpersString()). qrCode is report-specific and
-// stays here as the one real extra this report needs.
-// Async helper: generates QR code as base64 data URL
-// Usage in template: {{qrCode header}}
-// jsreport supports async helpers that return promises
-function qrCode(header) {
-  if (!header || typeof header !== 'object') {
-    return QRCode.toDataURL('no data', { width: 120, margin: 1 });
-  }
-  var parts = [];
-  if (header.doc_type) parts.push('T:' + header.doc_type);
-  if (header.documentno) parts.push('N:' + header.documentno);
-  if (header.movementdate) parts.push('D:' + String(header.movementdate).substring(0, 10));
-  if (header.bp_name) parts.push('BP:' + header.bp_name);
-  if (header.org_taxid) parts.push('TID:' + header.org_taxid);
-  if (header.status) parts.push('S:' + header.status);
-
-  var data = parts.length > 0 ? parts.join('|') : 'empty';
-  return QRCode.toDataURL(data, { width: 120, margin: 1 });
-}
+// there — see buildJsreportHelpersString()). The document QR is no longer a
+// helper either: it is precomputed as plain data (header.qrDataUrl) via
+// computeDocumentQrDataUrl() before render, so this report declares no
+// report-specific helpers (ETP-4908).

--- a/artifacts/print-goods-shipment/template.hbs
+++ b/artifacts/print-goods-shipment/template.hbs
@@ -103,7 +103,7 @@
   {{!-- Footer with QR --}}
   <div style="display:flex; justify-content:space-between; align-items:flex-end; margin-top:6mm; padding-top:4mm; border-top:1px solid #e2e8f0;">
     <div style="flex-shrink:0;">
-      <img src="{{qrCode header}}" width="80" height="80" style="display:block;" />
+      <img src="{{header.qrDataUrl}}" width="80" height="80" style="display:block;" />
       <div style="font-size:6pt; color:#94a3b8; margin-top:1mm; max-width:80px; text-align:center;">Scan to verify</div>
     </div>
     <div style="font-size:7pt; color:#94a3b8; text-align:right;">

--- a/artifacts/print-payment-in/helpers.js
+++ b/artifacts/print-payment-in/helpers.js
@@ -1,27 +1,7 @@
-var QRCode = require('qrcode');
-
-// All other formatting helpers now come from the canonical
+// All formatting helpers come from the canonical
 // templates/reports/helpers/report-html-helpers.js (both the on-screen HTML
 // preview and the jsreport PDF/XLSX render path build their helper set from
-// there — see buildJsreportHelpersString()). qrCode is report-specific and
-// stays here as the one real extra this report needs.
-// Async helper: generates QR code as base64 data URL
-// Usage in template: {{qrCode header}}
-// jsreport supports async helpers that return promises
-function qrCode(header) {
-  if (!header || typeof header !== 'object') {
-    return QRCode.toDataURL('no data', { width: 120, margin: 1 });
-  }
-  var parts = [];
-  if (header.doc_type) parts.push('T:' + header.doc_type);
-  if (header.documentno) parts.push('N:' + header.documentno);
-  if (header.paymentdate) parts.push('D:' + String(header.paymentdate).substring(0, 10));
-  if (header.bp_name) parts.push('BP:' + header.bp_name);
-  if (header.amount) parts.push('$:' + header.amount);
-  if (header.currency) parts.push('C:' + header.currency);
-  if (header.org_taxid) parts.push('TID:' + header.org_taxid);
-  if (header.status) parts.push('S:' + header.status);
-
-  var data = parts.length > 0 ? parts.join('|') : 'empty';
-  return QRCode.toDataURL(data, { width: 120, margin: 1 });
-}
+// there — see buildJsreportHelpersString()). The document QR is no longer a
+// helper either: it is precomputed as plain data (header.qrDataUrl) via
+// computeDocumentQrDataUrl() before render, so this report declares no
+// report-specific helpers (ETP-4908).

--- a/artifacts/print-payment-in/template.hbs
+++ b/artifacts/print-payment-in/template.hbs
@@ -131,7 +131,7 @@
   {{!-- Footer with QR --}}
   <div style="display:flex; justify-content:space-between; align-items:flex-end; margin-top:6mm; padding-top:4mm; border-top:1px solid #e2e8f0;">
     <div style="flex-shrink:0;">
-      <img src="{{qrCode header}}" width="80" height="80" style="display:block;" />
+      <img src="{{header.qrDataUrl}}" width="80" height="80" style="display:block;" />
       <div style="font-size:6pt; color:#94a3b8; margin-top:1mm; max-width:80px; text-align:center;">Scan to verify</div>
     </div>
     <div style="font-size:7pt; color:#94a3b8; text-align:right;">

--- a/artifacts/print-purchase-order/helpers.js
+++ b/artifacts/print-purchase-order/helpers.js
@@ -1,27 +1,7 @@
-var QRCode = require('qrcode');
-
-// All other formatting helpers now come from the canonical
+// All formatting helpers come from the canonical
 // templates/reports/helpers/report-html-helpers.js (both the on-screen HTML
 // preview and the jsreport PDF/XLSX render path build their helper set from
-// there — see buildJsreportHelpersString()). qrCode is report-specific and
-// stays here as the one real extra this report needs.
-// Async helper: generates QR code as base64 data URL
-// Usage in template: {{qrCode header}}
-// jsreport supports async helpers that return promises
-function qrCode(header) {
-  if (!header || typeof header !== 'object') {
-    return QRCode.toDataURL('no data', { width: 120, margin: 1 });
-  }
-  var parts = [];
-  if (header.doc_type) parts.push('T:' + header.doc_type);
-  if (header.documentno) parts.push('N:' + header.documentno);
-  if (header.dateordered) parts.push('D:' + String(header.dateordered).substring(0, 10));
-  if (header.bp_name) parts.push('BP:' + header.bp_name);
-  if (header.grandtotal) parts.push('$:' + header.grandtotal);
-  if (header.currency) parts.push('C:' + header.currency);
-  if (header.org_taxid) parts.push('TID:' + header.org_taxid);
-  if (header.status) parts.push('S:' + header.status);
-
-  var data = parts.length > 0 ? parts.join('|') : 'empty';
-  return QRCode.toDataURL(data, { width: 120, margin: 1 });
-}
+// there — see buildJsreportHelpersString()). The document QR is no longer a
+// helper either: it is precomputed as plain data (header.qrDataUrl) via
+// computeDocumentQrDataUrl() before render, so this report declares no
+// report-specific helpers (ETP-4908).

--- a/artifacts/print-purchase-order/template.hbs
+++ b/artifacts/print-purchase-order/template.hbs
@@ -153,7 +153,7 @@
   {{!-- Footer with QR --}}
   <div style="display:flex; justify-content:space-between; align-items:flex-end; margin-top:6mm; padding-top:4mm; border-top:1px solid #e2e8f0;">
     <div style="flex-shrink:0;">
-      <img src="{{qrCode header}}" width="80" height="80" style="display:block;" />
+      <img src="{{header.qrDataUrl}}" width="80" height="80" style="display:block;" />
       <div style="font-size:6pt; color:#94a3b8; margin-top:1mm; max-width:80px; text-align:center;">Scan to verify</div>
     </div>
     <div style="font-size:7pt; color:#94a3b8; text-align:right;">

--- a/artifacts/print-return-material-receipt/helpers.js
+++ b/artifacts/print-return-material-receipt/helpers.js
@@ -1,25 +1,7 @@
-var QRCode = require('qrcode');
-
-// All other formatting helpers now come from the canonical
+// All formatting helpers come from the canonical
 // templates/reports/helpers/report-html-helpers.js (both the on-screen HTML
 // preview and the jsreport PDF/XLSX render path build their helper set from
-// there — see buildJsreportHelpersString()). qrCode is report-specific and
-// stays here as the one real extra this report needs.
-// Async helper: generates QR code as base64 data URL
-// Usage in template: {{qrCode header}}
-// jsreport supports async helpers that return promises
-function qrCode(header) {
-  if (!header || typeof header !== 'object') {
-    return QRCode.toDataURL('no data', { width: 120, margin: 1 });
-  }
-  var parts = [];
-  if (header.doc_type) parts.push('T:' + header.doc_type);
-  if (header.documentno) parts.push('N:' + header.documentno);
-  if (header.movementdate) parts.push('D:' + String(header.movementdate).substring(0, 10));
-  if (header.bp_name) parts.push('BP:' + header.bp_name);
-  if (header.org_taxid) parts.push('TID:' + header.org_taxid);
-  if (header.status) parts.push('S:' + header.status);
-
-  var data = parts.length > 0 ? parts.join('|') : 'empty';
-  return QRCode.toDataURL(data, { width: 120, margin: 1 });
-}
+// there — see buildJsreportHelpersString()). The document QR is no longer a
+// helper either: it is precomputed as plain data (header.qrDataUrl) via
+// computeDocumentQrDataUrl() before render, so this report declares no
+// report-specific helpers (ETP-4908).

--- a/artifacts/print-return-material-receipt/template.hbs
+++ b/artifacts/print-return-material-receipt/template.hbs
@@ -103,7 +103,7 @@
   {{!-- Footer with QR --}}
   <div style="display:flex; justify-content:space-between; align-items:flex-end; margin-top:6mm; padding-top:4mm; border-top:1px solid #e2e8f0;">
     <div style="flex-shrink:0;">
-      <img src="{{qrCode header}}" width="80" height="80" style="display:block;" />
+      <img src="{{header.qrDataUrl}}" width="80" height="80" style="display:block;" />
       <div style="font-size:6pt; color:#94a3b8; margin-top:1mm; max-width:80px; text-align:center;">Scan to verify</div>
     </div>
     <div style="font-size:7pt; color:#94a3b8; text-align:right;">

--- a/artifacts/print-return-to-vendor-shipment/helpers.js
+++ b/artifacts/print-return-to-vendor-shipment/helpers.js
@@ -1,25 +1,7 @@
-var QRCode = require('qrcode');
-
-// All other formatting helpers now come from the canonical
+// All formatting helpers come from the canonical
 // templates/reports/helpers/report-html-helpers.js (both the on-screen HTML
 // preview and the jsreport PDF/XLSX render path build their helper set from
-// there — see buildJsreportHelpersString()). qrCode is report-specific and
-// stays here as the one real extra this report needs.
-// Async helper: generates QR code as base64 data URL
-// Usage in template: {{qrCode header}}
-// jsreport supports async helpers that return promises
-function qrCode(header) {
-  if (!header || typeof header !== 'object') {
-    return QRCode.toDataURL('no data', { width: 120, margin: 1 });
-  }
-  var parts = [];
-  if (header.doc_type) parts.push('T:' + header.doc_type);
-  if (header.documentno) parts.push('N:' + header.documentno);
-  if (header.movementdate) parts.push('D:' + String(header.movementdate).substring(0, 10));
-  if (header.bp_name) parts.push('BP:' + header.bp_name);
-  if (header.org_taxid) parts.push('TID:' + header.org_taxid);
-  if (header.status) parts.push('S:' + header.status);
-
-  var data = parts.length > 0 ? parts.join('|') : 'empty';
-  return QRCode.toDataURL(data, { width: 120, margin: 1 });
-}
+// there — see buildJsreportHelpersString()). The document QR is no longer a
+// helper either: it is precomputed as plain data (header.qrDataUrl) via
+// computeDocumentQrDataUrl() before render, so this report declares no
+// report-specific helpers (ETP-4908).

--- a/artifacts/print-return-to-vendor-shipment/template.hbs
+++ b/artifacts/print-return-to-vendor-shipment/template.hbs
@@ -103,7 +103,7 @@
   {{!-- Footer with QR --}}
   <div style="display:flex; justify-content:space-between; align-items:flex-end; margin-top:6mm; padding-top:4mm; border-top:1px solid #e2e8f0;">
     <div style="flex-shrink:0;">
-      <img src="{{qrCode header}}" width="80" height="80" style="display:block;" />
+      <img src="{{header.qrDataUrl}}" width="80" height="80" style="display:block;" />
       <div style="font-size:6pt; color:#94a3b8; margin-top:1mm; max-width:80px; text-align:center;">Scan to verify</div>
     </div>
     <div style="font-size:7pt; color:#94a3b8; text-align:right;">

--- a/artifacts/print-sales-invoice/helpers.js
+++ b/artifacts/print-sales-invoice/helpers.js
@@ -1,27 +1,7 @@
-var QRCode = require('qrcode');
-
-// All other formatting helpers now come from the canonical
+// All formatting helpers come from the canonical
 // templates/reports/helpers/report-html-helpers.js (both the on-screen HTML
 // preview and the jsreport PDF/XLSX render path build their helper set from
-// there — see buildJsreportHelpersString()). qrCode is report-specific and
-// stays here as the one real extra this report needs.
-// Async helper: generates QR code as base64 data URL
-// Usage in template: {{qrCode header}}
-// jsreport supports async helpers that return promises
-function qrCode(header) {
-  if (!header || typeof header !== 'object') {
-    return QRCode.toDataURL('no data', { width: 120, margin: 1 });
-  }
-  var parts = [];
-  if (header.doc_type) parts.push('T:' + header.doc_type);
-  if (header.documentno) parts.push('N:' + header.documentno);
-  if (header.dateinvoiced) parts.push('D:' + String(header.dateinvoiced).substring(0, 10));
-  if (header.bp_name) parts.push('BP:' + header.bp_name);
-  if (header.grandtotal) parts.push('$:' + header.grandtotal);
-  if (header.currency) parts.push('C:' + header.currency);
-  if (header.org_taxid) parts.push('TID:' + header.org_taxid);
-  if (header.status) parts.push('S:' + header.status);
-
-  var data = parts.length > 0 ? parts.join('|') : 'empty';
-  return QRCode.toDataURL(data, { width: 120, margin: 1 });
-}
+// there — see buildJsreportHelpersString()). The document QR is no longer a
+// helper either: it is precomputed as plain data (header.qrDataUrl) via
+// computeDocumentQrDataUrl() before render, so this report declares no
+// report-specific helpers (ETP-4908).

--- a/artifacts/print-sales-invoice/template.hbs
+++ b/artifacts/print-sales-invoice/template.hbs
@@ -144,7 +144,7 @@
   {{!-- Footer with QR --}}
   <div style="display:flex; justify-content:space-between; align-items:flex-end; margin-top:6mm; padding-top:4mm; border-top:1px solid #e2e8f0;">
     <div style="flex-shrink:0;">
-      <img src="{{qrCode header}}" width="80" height="80" style="display:block;" />
+      <img src="{{header.qrDataUrl}}" width="80" height="80" style="display:block;" />
       <div style="font-size:6pt; color:#94a3b8; margin-top:1mm; max-width:80px; text-align:center;">Scan to verify</div>
     </div>
     <div style="font-size:7pt; color:#94a3b8; text-align:right;">

--- a/artifacts/print-sales-order/helpers.js
+++ b/artifacts/print-sales-order/helpers.js
@@ -1,27 +1,7 @@
-var QRCode = require('qrcode');
-
-// All other formatting helpers now come from the canonical
+// All formatting helpers come from the canonical
 // templates/reports/helpers/report-html-helpers.js (both the on-screen HTML
 // preview and the jsreport PDF/XLSX render path build their helper set from
-// there — see buildJsreportHelpersString()). qrCode is report-specific and
-// stays here as the one real extra this report needs.
-// Async helper: generates QR code as base64 data URL
-// Usage in template: {{qrCode header}}
-// jsreport supports async helpers that return promises
-function qrCode(header) {
-  if (!header || typeof header !== 'object') {
-    return QRCode.toDataURL('no data', { width: 120, margin: 1 });
-  }
-  var parts = [];
-  if (header.doc_type) parts.push('T:' + header.doc_type);
-  if (header.documentno) parts.push('N:' + header.documentno);
-  if (header.dateordered) parts.push('D:' + String(header.dateordered).substring(0, 10));
-  if (header.bp_name) parts.push('BP:' + header.bp_name);
-  if (header.grandtotal) parts.push('$:' + header.grandtotal);
-  if (header.currency) parts.push('C:' + header.currency);
-  if (header.org_taxid) parts.push('TID:' + header.org_taxid);
-  if (header.status) parts.push('S:' + header.status);
-
-  var data = parts.length > 0 ? parts.join('|') : 'empty';
-  return QRCode.toDataURL(data, { width: 120, margin: 1 });
-}
+// there — see buildJsreportHelpersString()). The document QR is no longer a
+// helper either: it is precomputed as plain data (header.qrDataUrl) via
+// computeDocumentQrDataUrl() before render, so this report declares no
+// report-specific helpers (ETP-4908).

--- a/artifacts/print-sales-order/template.hbs
+++ b/artifacts/print-sales-order/template.hbs
@@ -153,7 +153,7 @@
   {{!-- Footer with QR --}}
   <div style="display:flex; justify-content:space-between; align-items:flex-end; margin-top:6mm; padding-top:4mm; border-top:1px solid #e2e8f0;">
     <div style="flex-shrink:0;">
-      <img src="{{qrCode header}}" width="80" height="80" style="display:block;" />
+      <img src="{{header.qrDataUrl}}" width="80" height="80" style="display:block;" />
       <div style="font-size:6pt; color:#94a3b8; margin-top:1mm; max-width:80px; text-align:center;">Scan to verify</div>
     </div>
     <div style="font-size:7pt; color:#94a3b8; text-align:right;">

--- a/artifacts/print-sales-quotation/helpers.js
+++ b/artifacts/print-sales-quotation/helpers.js
@@ -1,27 +1,7 @@
-var QRCode = require('qrcode');
-
-// All other formatting helpers now come from the canonical
+// All formatting helpers come from the canonical
 // templates/reports/helpers/report-html-helpers.js (both the on-screen HTML
 // preview and the jsreport PDF/XLSX render path build their helper set from
-// there — see buildJsreportHelpersString()). qrCode is report-specific and
-// stays here as the one real extra this report needs.
-// Async helper: generates QR code as base64 data URL
-// Usage in template: {{qrCode header}}
-// jsreport supports async helpers that return promises
-function qrCode(header) {
-  if (!header || typeof header !== 'object') {
-    return QRCode.toDataURL('no data', { width: 120, margin: 1 });
-  }
-  var parts = [];
-  if (header.doc_type) parts.push('T:' + header.doc_type);
-  if (header.documentno) parts.push('N:' + header.documentno);
-  if (header.dateordered) parts.push('D:' + String(header.dateordered).substring(0, 10));
-  if (header.bp_name) parts.push('BP:' + header.bp_name);
-  if (header.grandtotal) parts.push('$:' + header.grandtotal);
-  if (header.currency) parts.push('C:' + header.currency);
-  if (header.org_taxid) parts.push('TID:' + header.org_taxid);
-  if (header.status) parts.push('S:' + header.status);
-
-  var data = parts.length > 0 ? parts.join('|') : 'empty';
-  return QRCode.toDataURL(data, { width: 120, margin: 1 });
-}
+// there — see buildJsreportHelpersString()). The document QR is no longer a
+// helper either: it is precomputed as plain data (header.qrDataUrl) via
+// computeDocumentQrDataUrl() before render, so this report declares no
+// report-specific helpers (ETP-4908).

--- a/artifacts/print-sales-quotation/template.hbs
+++ b/artifacts/print-sales-quotation/template.hbs
@@ -153,7 +153,7 @@
   {{!-- Footer with QR --}}
   <div style="display:flex; justify-content:space-between; align-items:flex-end; margin-top:6mm; padding-top:4mm; border-top:1px solid #e2e8f0;">
     <div style="flex-shrink:0;">
-      <img src="{{qrCode header}}" width="80" height="80" style="display:block;" />
+      <img src="{{header.qrDataUrl}}" width="80" height="80" style="display:block;" />
       <div style="font-size:6pt; color:#94a3b8; margin-top:1mm; max-width:80px; text-align:center;">Scan to verify</div>
     </div>
     <div style="font-size:7pt; color:#94a3b8; text-align:right;">

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.33",
-        "@etendosoftware/schema-forge-cli": "0.3.33",
-        "@etendosoftware/schema-forge-core": "0.3.33",
+        "@etendosoftware/app-shell-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+        "@etendosoftware/schema-forge-cli": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+        "@etendosoftware/schema-forge-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.33",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.33/7b063cbeac3b06b4af1139b766145d355de3be5d",
-      "integrity": "sha512-ciXECoqjoBfzsiVF9ZTfwIysgCKhcS60LQrQeXiIwDrUvT1DMwj3kDMUZx6E/3d064CWsCrrs11iotLZmiyg6A==",
+      "version": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889/74c5be8e0f4bc6dd9091b29b9feb694bf5127980",
+      "integrity": "sha512-O3qkl9Rqw4EtwfSMUjgr3PSvR17ddUdx4feW1185T8G9xgMGBe7eAUSmJ3/8T8qPOrb+ynVPbs42SQAFGO/mZA==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.33",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.33/87c65b4eb74fbf9874504b4ef8e778d71a217550",
-      "integrity": "sha512-obLHGNi9XaINEX7AI+JzbSHxPQhPP3tvLpEt2I1XsyulU7RUkVcI3p7RZkl1YEKzA3KzpUQjLpVAn8AXzpGGfA==",
+      "version": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889/a104f2b536654631a57f9ccf1414434a229874db",
+      "integrity": "sha512-WwfhTPalSE+A4uS2BfOsfx8JAm7oT8+/oi7FOgfn4uxKdRyeQliDZnEFR5bPxGTpfqQfC9egQ/BDfG4I7MvD7A==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.33",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.33/c10ef9375a1689d2cb59a49903360e27ae8e36d4",
-      "integrity": "sha512-2Yu77cbUGcH1Pyz1aPWt0I/z9bJaFv1nFJka1EYPxZ14+caMpbrPgDOh5t/1sBqhBSo9BiXJ8TSU/65ggZPo3g==",
+      "version": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889/ded883691e2a188fe0c2d03896ba5766d067963c",
+      "integrity": "sha512-D/1VRE0+RFQ50NWRB+y3a9yoIb21iDh++6vYn7X8+o9syZjAgp1sJNuogWDQgeTEMNxWICPSFkMsuVvhR3H7XA==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.33",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.33/8c87af753ac1dc7eec36a3a272e7ca2590e3b101",
-      "integrity": "sha512-4qQ+M2qF4VZQGKgc60rhsbKNtIsMkylXBUM/xw7sAsbauPkIqDQygs1xIhiI5krPpI+HbMBs5WJHrhypJDQ0ZQ==",
+      "version": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889/e4df018e136d377de00cb84fdb4980fd72f1e604",
+      "integrity": "sha512-MC0JOVxcinMfLDz4rY2qWgC4hslL3DQKMd742LxAlViUaKSkZzPG5dOkDLcZ8k6mprfruJ/6KmuqQ8XEheNNLg==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13780,8 +13780,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.33",
-        "@etendosoftware/etendo-go-core": "0.3.33",
+        "@etendosoftware/app-shell-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+        "@etendosoftware/etendo-go-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
-        "@etendosoftware/schema-forge-cli": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
-        "@etendosoftware/schema-forge-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+        "@etendosoftware/app-shell-core": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
+        "@etendosoftware/schema-forge-cli": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
+        "@etendosoftware/schema-forge-core": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889/74c5be8e0f4bc6dd9091b29b9feb694bf5127980",
-      "integrity": "sha512-O3qkl9Rqw4EtwfSMUjgr3PSvR17ddUdx4feW1185T8G9xgMGBe7eAUSmJ3/8T8qPOrb+ynVPbs42SQAFGO/mZA==",
+      "version": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1/284088ffe9630c703ce5dd55d444100b526e2d74",
+      "integrity": "sha512-30x1Z7qRIu+JpWbCZY+gB1NFqoYw1/LvWVcxQq2nm1HT+woGljwC3C6ML/HayYUVg8zRrwiG5g1wiBlkeyJNMA==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889/a104f2b536654631a57f9ccf1414434a229874db",
-      "integrity": "sha512-WwfhTPalSE+A4uS2BfOsfx8JAm7oT8+/oi7FOgfn4uxKdRyeQliDZnEFR5bPxGTpfqQfC9egQ/BDfG4I7MvD7A==",
+      "version": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1/fffda081450df9584bc820d761943387d852210d",
+      "integrity": "sha512-cWtFuilvC5EDb7blQfAtupdWz8rpvEt9uqTJSacKafXPdZbAry9oOAONf5oynnQvNtuoCOgIm7ISwlg1+/5kiw==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889/ded883691e2a188fe0c2d03896ba5766d067963c",
-      "integrity": "sha512-D/1VRE0+RFQ50NWRB+y3a9yoIb21iDh++6vYn7X8+o9syZjAgp1sJNuogWDQgeTEMNxWICPSFkMsuVvhR3H7XA==",
+      "version": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1/e03de7810b32abd991e033afbc949a6a220c62f4",
+      "integrity": "sha512-BgklsS+IB96fJIsPtrKmgEiyanNx0myBRBzLHUK5xzNNwsz/yGo/PcaPz4OXOJngXRDCtZdB15lV9X0LOk9/mQ==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889/e4df018e136d377de00cb84fdb4980fd72f1e604",
-      "integrity": "sha512-MC0JOVxcinMfLDz4rY2qWgC4hslL3DQKMd742LxAlViUaKSkZzPG5dOkDLcZ8k6mprfruJ/6KmuqQ8XEheNNLg==",
+      "version": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1/84dfea14915f0c363b72c8f9e222e1365f3646f0",
+      "integrity": "sha512-ijaG/xPPCq/OYBCcQm4Tm6pMimnlIX3NkJkV+9v9lav5emSEEXWRB9wdoNqXrrCbdfewMoWN6WRZ1jdTqy7hgA==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13780,8 +13780,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
-        "@etendosoftware/etendo-go-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+        "@etendosoftware/app-shell-core": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
+        "@etendosoftware/etendo-go-core": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.33",
-    "@etendosoftware/schema-forge-cli": "0.3.33",
-    "@etendosoftware/schema-forge-core": "0.3.33",
+    "@etendosoftware/app-shell-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+    "@etendosoftware/schema-forge-cli": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+    "@etendosoftware/schema-forge-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
-    "@etendosoftware/schema-forge-cli": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
-    "@etendosoftware/schema-forge-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+    "@etendosoftware/app-shell-core": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
+    "@etendosoftware/schema-forge-cli": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
+    "@etendosoftware/schema-forge-core": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/templates/reports/helpers/report-html-helpers.js
+++ b/templates/reports/helpers/report-html-helpers.js
@@ -139,12 +139,14 @@ export function createReportHelpers({ numberFormat } = {}) {
  */
 export function buildDocumentQrText(header) {
   if (!header || typeof header !== 'object') return 'no data';
+  const docDate = header.dateinvoiced || header.dateordered || header.movementdate || header.paymentdate;
+  const docAmount = header.grandtotal || header.amount;
   const parts = [];
   if (header.doc_type) parts.push('T:' + header.doc_type);
   if (header.documentno) parts.push('N:' + header.documentno);
-  if (header.dateinvoiced) parts.push('D:' + String(header.dateinvoiced).substring(0, 10));
+  if (docDate) parts.push('D:' + String(docDate).substring(0, 10));
   if (header.bp_name) parts.push('BP:' + header.bp_name);
-  if (header.grandtotal) parts.push('$:' + header.grandtotal);
+  if (docAmount) parts.push('$:' + docAmount);
   if (header.currency) parts.push('C:' + header.currency);
   if (header.org_taxid) parts.push('TID:' + header.org_taxid);
   if (header.status) parts.push('S:' + header.status);

--- a/templates/reports/helpers/report-html-helpers.js
+++ b/templates/reports/helpers/report-html-helpers.js
@@ -16,9 +16,11 @@
  * dev plugin register the helpers WITHOUT dynamically executing the per-report
  * artifact file (no `new Function` / `eval`, which Sonar flags as S1523).
  *
- * jsreport (PDF/XLSX) is intentionally unchanged: it still consumes the per-report
- * `helpers.js` string directly, which is where report-specific helpers such as
- * `qrCode` live. Those are never part of the local HTML whitelist.
+ * jsreport (PDF/XLSX) still consumes a helpers string built from this module
+ * (see `buildJsreportHelpersString()`), plus any report-specific extras found in
+ * the per-report `helpers.js`. Document QR codes are NOT a helper on either
+ * path: they are precomputed as plain data (`header.qrDataUrl`) via
+ * `computeDocumentQrDataUrl()` before render (ETP-4908).
  *
  * `createReportHelpers()` returns a fresh set with isolated group-break state,
  * matching the previous per-render isolation that `new Function` provided.
@@ -122,6 +124,54 @@ export function createReportHelpers({ numberFormat } = {}) {
     formatDateDisplay,
     sumRowsByCategory,
   };
+}
+
+/**
+ * Build the text encoded in a document report's QR code.
+ *
+ * Exact port of the text-building logic of the historical per-report `qrCode`
+ * Handlebars helper (artifacts/print-*\/helpers.js). Kept pure so it can be
+ * tested without generating an actual QR image.
+ *
+ * @param {object} [header] Document header row.
+ * @returns {string} Pipe-joined field string, 'empty' when the header has no
+ *          known fields, or 'no data' when there is no header object at all.
+ */
+export function buildDocumentQrText(header) {
+  if (!header || typeof header !== 'object') return 'no data';
+  const parts = [];
+  if (header.doc_type) parts.push('T:' + header.doc_type);
+  if (header.documentno) parts.push('N:' + header.documentno);
+  if (header.dateinvoiced) parts.push('D:' + String(header.dateinvoiced).substring(0, 10));
+  if (header.bp_name) parts.push('BP:' + header.bp_name);
+  if (header.grandtotal) parts.push('$:' + header.grandtotal);
+  if (header.currency) parts.push('C:' + header.currency);
+  if (header.org_taxid) parts.push('TID:' + header.org_taxid);
+  if (header.status) parts.push('S:' + header.status);
+  return parts.length > 0 ? parts.join('|') : 'empty';
+}
+
+/**
+ * Precompute a document's QR code as a PNG data URL (`header.qrDataUrl`).
+ *
+ * This replaces the per-report async `qrCode` Handlebars helper: Handlebars
+ * compiles synchronously on the local HTML path, so the QR must be resolved
+ * BEFORE compile and injected as plain data. Templates reference it as
+ * `<img src="{{header.qrDataUrl}}">` on both the HTML and jsreport paths.
+ *
+ * NOT a Handlebars helper — deliberately excluded from `createReportHelpers()`.
+ *
+ * @param {object} [header] Document header row.
+ * @param {object} [options]
+ * @param {object} [options.qrcode] Pre-resolved `qrcode` module. The report
+ *        server passes its own (its Docker image installs node_modules only
+ *        under tools/report-server, unreachable from this module's path);
+ *        other consumers can omit it and rely on the lazy dynamic import.
+ * @returns {Promise<string>} PNG data URL.
+ */
+export async function computeDocumentQrDataUrl(header, { qrcode } = {}) {
+  const QRCode = qrcode || (await import('qrcode')).default;
+  return QRCode.toDataURL(buildDocumentQrText(header), { width: 120, margin: 1 });
 }
 
 /**
@@ -249,7 +299,7 @@ export function registerReportHelpers(handlebars, helpersCode) {
 }
 
 // Helper names covered by the canonical set — anything else found in a report's
-// raw helpers.js (e.g. `qrCode`) is report-specific and must be preserved verbatim.
+// raw helpers.js is report-specific and must be preserved verbatim.
 //
 // Derived from JSREPORT_HELPER_SOURCES (the source-text map) rather than
 // hand-maintained as a third, separate list: a helper added there without
@@ -306,7 +356,7 @@ function extractRequireLines(source) {
  * formatCurrency() or this module directly. Instead, this function emits the
  * canonical helper set as source text (`JSREPORT_HELPER_SOURCES`, the matched
  * string pair of `createReportHelpers()`'s functions) and appends only the
- * report-SPECIFIC extras (e.g. `qrCode` + its `require`) extracted from the
+ * report-SPECIFIC extras (with their `require` lines) extracted from the
  * report's raw `artifacts/<id>/helpers.js`. The result is the single source of
  * truth for both render paths — not a second, hand-maintained copy per report.
  *

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.33",
-        "@etendosoftware/etendo-go-core": "0.3.33",
+        "@etendosoftware/app-shell-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+        "@etendosoftware/etendo-go-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.33",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.33/7b063cbeac3b06b4af1139b766145d355de3be5d",
-      "integrity": "sha512-ciXECoqjoBfzsiVF9ZTfwIysgCKhcS60LQrQeXiIwDrUvT1DMwj3kDMUZx6E/3d064CWsCrrs11iotLZmiyg6A==",
+      "version": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889/74c5be8e0f4bc6dd9091b29b9feb694bf5127980",
+      "integrity": "sha512-O3qkl9Rqw4EtwfSMUjgr3PSvR17ddUdx4feW1185T8G9xgMGBe7eAUSmJ3/8T8qPOrb+ynVPbs42SQAFGO/mZA==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.33",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.33/87c65b4eb74fbf9874504b4ef8e778d71a217550",
-      "integrity": "sha512-obLHGNi9XaINEX7AI+JzbSHxPQhPP3tvLpEt2I1XsyulU7RUkVcI3p7RZkl1YEKzA3KzpUQjLpVAn8AXzpGGfA==",
+      "version": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889/a104f2b536654631a57f9ccf1414434a229874db",
+      "integrity": "sha512-WwfhTPalSE+A4uS2BfOsfx8JAm7oT8+/oi7FOgfn4uxKdRyeQliDZnEFR5bPxGTpfqQfC9egQ/BDfG4I7MvD7A==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
-        "@etendosoftware/etendo-go-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+        "@etendosoftware/app-shell-core": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
+        "@etendosoftware/etendo-go-core": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889/74c5be8e0f4bc6dd9091b29b9feb694bf5127980",
-      "integrity": "sha512-O3qkl9Rqw4EtwfSMUjgr3PSvR17ddUdx4feW1185T8G9xgMGBe7eAUSmJ3/8T8qPOrb+ynVPbs42SQAFGO/mZA==",
+      "version": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1/284088ffe9630c703ce5dd55d444100b526e2d74",
+      "integrity": "sha512-30x1Z7qRIu+JpWbCZY+gB1NFqoYw1/LvWVcxQq2nm1HT+woGljwC3C6ML/HayYUVg8zRrwiG5g1wiBlkeyJNMA==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889/a104f2b536654631a57f9ccf1414434a229874db",
-      "integrity": "sha512-WwfhTPalSE+A4uS2BfOsfx8JAm7oT8+/oi7FOgfn4uxKdRyeQliDZnEFR5bPxGTpfqQfC9egQ/BDfG4I7MvD7A==",
+      "version": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1/fffda081450df9584bc820d761943387d852210d",
+      "integrity": "sha512-cWtFuilvC5EDb7blQfAtupdWz8rpvEt9uqTJSacKafXPdZbAry9oOAONf5oynnQvNtuoCOgIm7ISwlg1+/5kiw==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
-    "@etendosoftware/etendo-go-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+    "@etendosoftware/app-shell-core": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
+    "@etendosoftware/etendo-go-core": "0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.33",
-    "@etendosoftware/etendo-go-core": "0.3.33",
+    "@etendosoftware/app-shell-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
+    "@etendosoftware/etendo-go-core": "0.3.34-preview.feature-ETP-4908.20260814141055.1c9f889",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",

--- a/tools/app-shell/test/report-qr.test.js
+++ b/tools/app-shell/test/report-qr.test.js
@@ -64,6 +64,34 @@ describe('buildDocumentQrText', () => {
     assert.equal(buildDocumentQrText('not-an-object'), 'no data');
   });
 
+  it('uses dateordered for orders/quotations (D: prefix, truncated)', () => {
+    assert.equal(
+      buildDocumentQrText({ documentno: 'SO-1', dateordered: '2026-08-01T09:00:00Z' }),
+      'N:SO-1|D:2026-08-01'
+    );
+  });
+
+  it('uses movementdate for shipments/receipts (no amount/currency fields)', () => {
+    assert.equal(
+      buildDocumentQrText({ doc_type: 'Shipment', documentno: 'SH-1', movementdate: '2026-08-02T00:00:00Z', bp_name: 'ACME', status: 'CO' }),
+      'T:Shipment|N:SH-1|D:2026-08-02|BP:ACME|S:CO'
+    );
+  });
+
+  it('uses paymentdate and amount for payments', () => {
+    assert.equal(
+      buildDocumentQrText({ documentno: 'PAY-1', paymentdate: '2026-08-03T12:00:00Z', amount: '500.00', currency: 'EUR' }),
+      'N:PAY-1|D:2026-08-03|$:500.00|C:EUR'
+    );
+  });
+
+  it('prefers dateinvoiced and grandtotal when multiple candidates exist', () => {
+    assert.equal(
+      buildDocumentQrText({ dateinvoiced: '2026-08-10', dateordered: '2026-08-01', grandtotal: '100', amount: '99' }),
+      'D:2026-08-10|$:100'
+    );
+  });
+
   it('skips falsy field values (empty string, 0, null)', () => {
     assert.equal(
       buildDocumentQrText({ documentno: '', grandtotal: 0, currency: null, status: 'CO' }),

--- a/tools/app-shell/test/report-qr.test.js
+++ b/tools/app-shell/test/report-qr.test.js
@@ -1,0 +1,186 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Handlebars from 'handlebars';
+import {
+  buildDocumentQrText,
+  computeDocumentQrDataUrl,
+  registerReportHelpers,
+} from '../../../templates/reports/helpers/report-html-helpers.js';
+
+// ETP-4908: document QR codes are precomputed as plain data (header.qrDataUrl)
+// before the synchronous Handlebars compile, on BOTH render paths (local HTML
+// preview and jsreport PDF/XLSX). The old async per-report `qrCode` helper is
+// gone — templates must never reference it again, or the render fails with
+// `Missing helper: "qrCode"` on any path whose whitelist excludes it.
+// These functions are a byte-identical port of schema_forge_core's copy
+// (templates/reports/helpers/report-html-helpers.js) so dev and prod produce
+// the same QR.
+
+const ARTIFACTS_DIR = fileURLToPath(new URL('../../../artifacts', import.meta.url));
+
+describe('buildDocumentQrText', () => {
+  const fullHeader = {
+    doc_type: 'AR Invoice',
+    documentno: 'INV-1001',
+    dateinvoiced: '2026-08-10T00:00:00.000Z',
+    bp_name: 'ACME Corp',
+    grandtotal: '1210.00',
+    currency: 'EUR',
+    org_taxid: 'B12345678',
+    status: 'CO',
+  };
+
+  it('joins all known fields with pipes, prefixed, in canonical order', () => {
+    assert.equal(
+      buildDocumentQrText(fullHeader),
+      'T:AR Invoice|N:INV-1001|D:2026-08-10|BP:ACME Corp|$:1210.00|C:EUR|TID:B12345678|S:CO'
+    );
+  });
+
+  it('truncates dateinvoiced to the first 10 chars (date-only)', () => {
+    const text = buildDocumentQrText({ dateinvoiced: '2026-08-10T15:30:00Z' });
+    assert.equal(text, 'D:2026-08-10');
+  });
+
+  it('skips missing fields without leaving empty segments', () => {
+    const text = buildDocumentQrText({ documentno: 'INV-2', status: 'DR' });
+    assert.equal(text, 'N:INV-2|S:DR');
+  });
+
+  it('ignores unknown header fields', () => {
+    assert.equal(buildDocumentQrText({ foo: 'bar', documentno: 'X' }), 'N:X');
+  });
+
+  it('returns "empty" for a header object with no known fields', () => {
+    assert.equal(buildDocumentQrText({}), 'empty');
+  });
+
+  it('returns "no data" when there is no header', () => {
+    assert.equal(buildDocumentQrText(null), 'no data');
+    assert.equal(buildDocumentQrText(undefined), 'no data');
+    assert.equal(buildDocumentQrText('not-an-object'), 'no data');
+  });
+
+  it('skips falsy field values (empty string, 0, null)', () => {
+    assert.equal(
+      buildDocumentQrText({ documentno: '', grandtotal: 0, currency: null, status: 'CO' }),
+      'S:CO'
+    );
+  });
+});
+
+describe('computeDocumentQrDataUrl', () => {
+  it('returns a PNG data URL for a full header', async () => {
+    const url = await computeDocumentQrDataUrl({ documentno: 'INV-1001', status: 'CO' });
+    assert.ok(url.startsWith('data:image/png;base64,'), `unexpected prefix: ${url.slice(0, 30)}`);
+  });
+
+  it('still returns a QR ("no data") when header is missing', async () => {
+    const url = await computeDocumentQrDataUrl(null);
+    assert.ok(url.startsWith('data:image/png;base64,'));
+  });
+
+  it('encodes the exact text and options via an injected qrcode module', async () => {
+    const calls = [];
+    const fakeQrcode = {
+      toDataURL: async (text, options) => {
+        calls.push({ text, options });
+        return 'data:image/png;base64,FAKE';
+      },
+    };
+    const url = await computeDocumentQrDataUrl(
+      { documentno: 'INV-7', currency: 'USD' },
+      { qrcode: fakeQrcode }
+    );
+    assert.equal(url, 'data:image/png;base64,FAKE');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].text, 'N:INV-7|C:USD');
+    assert.deepEqual(calls[0].options, { width: 120, margin: 1 });
+  });
+
+  it('produces identical output for identical headers (deterministic)', async () => {
+    const header = { documentno: 'INV-9' };
+    const [a, b] = await Promise.all([
+      computeDocumentQrDataUrl(header),
+      computeDocumentQrDataUrl(header),
+    ]);
+    assert.equal(a, b);
+  });
+});
+
+describe('print-* artifacts — QR is data, never a helper', () => {
+  const printDirs = readdirSync(ARTIFACTS_DIR).filter((d) => d.startsWith('print-'));
+
+  it('finds the document print artifacts', () => {
+    assert.ok(printDirs.length >= 8, `expected >= 8 print-* artifacts, found ${printDirs.length}`);
+  });
+
+  it('no template.hbs references the removed {{qrCode}} helper', () => {
+    for (const dir of printDirs) {
+      const tpl = readFileSync(join(ARTIFACTS_DIR, dir, 'template.hbs'), 'utf8');
+      assert.ok(!tpl.includes('{{qrCode'), `${dir}/template.hbs still calls the qrCode helper`);
+    }
+  });
+
+  it('every template.hbs renders the QR from {{header.qrDataUrl}}', () => {
+    for (const dir of printDirs) {
+      const tpl = readFileSync(join(ARTIFACTS_DIR, dir, 'template.hbs'), 'utf8');
+      assert.ok(tpl.includes('{{header.qrDataUrl}}'), `${dir}/template.hbs does not render header.qrDataUrl`);
+    }
+  });
+
+  it("no helpers.js requires 'qrcode' or declares a qrCode helper anymore", () => {
+    for (const dir of printDirs) {
+      const helpersPath = join(ARTIFACTS_DIR, dir, 'helpers.js');
+      if (!existsSync(helpersPath)) continue;
+      const src = readFileSync(helpersPath, 'utf8');
+      assert.ok(!src.includes("require('qrcode')"), `${dir}/helpers.js still requires qrcode`);
+      assert.ok(!/function\s+qrCode\b/.test(src), `${dir}/helpers.js still declares a qrCode helper`);
+    }
+  });
+});
+
+describe('document template render (print-sales-invoice, dev HTML path)', () => {
+  const templateContent = readFileSync(join(ARTIFACTS_DIR, 'print-sales-invoice', 'template.hbs'), 'utf8');
+  const helpersPath = join(ARTIFACTS_DIR, 'print-sales-invoice', 'helpers.js');
+  const helpersCode = existsSync(helpersPath) ? readFileSync(helpersPath, 'utf8') : '';
+
+  const header = {
+    doc_type: 'AR Invoice',
+    documentno: 'INV-1001',
+    dateinvoiced: '2026-08-10',
+    bp_name: 'ACME Corp',
+    grandtotal: '1210.00',
+    currency: 'EUR',
+    status: 'CO',
+  };
+
+  it('renders an inline PNG QR without registering any qrCode helper', async () => {
+    const hb = Handlebars.create();
+    registerReportHelpers(hb, helpersCode);
+    header.qrDataUrl = await computeDocumentQrDataUrl(header);
+    const html = hb.compile(templateContent)({
+      css: '',
+      meta: { title: 'Sales Invoice', generatedAt: new Date().toISOString(), filters: [], params: {} },
+      header,
+      lines: [],
+      taxes: [],
+    });
+    assert.match(html, /src="data:image\/png;base64,/);
+    assert.ok(!html.includes('Missing helper'));
+  });
+
+  it('compiling without a qrCode helper no longer throws (template does not reference it)', () => {
+    const hb = Handlebars.create();
+    registerReportHelpers(hb, helpersCode);
+    // Handlebars throws `Missing helper: "qrCode"` at render time when a
+    // template invokes an unregistered helper with an argument — the exact
+    // production failure this ticket fixes.
+    assert.doesNotThrow(() => {
+      hb.compile(templateContent)({ css: '', meta: { filters: [] }, header: {}, lines: [], taxes: [] });
+    });
+  });
+});

--- a/tools/app-shell/test/report-template-helpers-contract.test.js
+++ b/tools/app-shell/test/report-template-helpers-contract.test.js
@@ -1,0 +1,258 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import Handlebars from 'handlebars';
+import { registerReportHelpers } from '../../../templates/reports/helpers/report-html-helpers.js';
+
+// ETP-4908: the server render path (both the local HTML preview and the
+// jsreport PDF/XLSX payload built by report-api.js) registers ONLY the
+// canonical whitelist from `registerReportHelpers()` — it never executes a
+// per-artifact `helpers.js` (a deliberate post-ETP-4083 security decision).
+// A template that invokes ANY helper outside that whitelist compiles fine
+// but throws `Missing helper: "<name>"` at render time in production. That
+// exact bug shipped as `{{qrCode header}}` in the print-* templates (see
+// report-qr.test.js for the qrCode-specific regression coverage); this file
+// guards the GENERAL invariant for every report template, not just qrCode.
+
+const ARTIFACTS_DIR = fileURLToPath(new URL('../../../artifacts', import.meta.url));
+const REPORT_API_PLUGIN = fileURLToPath(
+  new URL('../vite-plugins/report-api.js', import.meta.url)
+);
+
+/**
+ * Recursively find every `template.hbs` under artifacts/ (reports live at
+ * varying depths, e.g. artifacts/print-sales-invoice/template.hbs vs.
+ * artifacts/business-partner/reports/listing/template.hbs).
+ */
+function findTemplates(dir) {
+  const results = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...findTemplates(full));
+    } else if (entry.name === 'template.hbs') {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+// Handlebars built-ins that are never resolved through registerHelper() and
+// therefore must never be checked against the canonical whitelist.
+const HANDLEBARS_BUILTINS = new Set(['if', 'unless', 'each', 'with', 'lookup', 'log']);
+
+/**
+ * Collect the names of every helper a template AST actually invokes — i.e.
+ * every MustacheStatement/BlockStatement/SubExpression whose path carries
+ * params and/or a hash, or that is a block (`{{#name ...}}`). A bare
+ * `{{header.org_name}}` mustache (no params) is a plain data path and is
+ * intentionally NOT collected — that ambiguity is exactly why zero-arg
+ * mustaches are excluded rather than guessed at.
+ */
+function collectHelperNames(source) {
+  const names = new Set();
+  walkProgram(Handlebars.parse(source), names);
+  return names;
+}
+
+function walkProgram(program, names) {
+  if (!program || !Array.isArray(program.body)) return;
+  for (const node of program.body) {
+    if (node.type === 'MustacheStatement' || node.type === 'BlockStatement') {
+      collectFromCallNode(node, names);
+      if (node.program) walkProgram(node.program, names);
+      if (node.inverse) walkProgram(node.inverse, names);
+    }
+  }
+}
+
+function collectFromCallNode(node, names) {
+  const hasArgs = (node.params && node.params.length > 0)
+    || (node.hash && node.hash.pairs && node.hash.pairs.length > 0);
+  const isBlock = node.type === 'BlockStatement';
+  if ((hasArgs || isBlock) && node.path && node.path.type === 'PathExpression') {
+    const name = node.path.original;
+    if (!HANDLEBARS_BUILTINS.has(name)) names.add(name);
+  }
+  for (const param of node.params || []) collectFromExpression(param, names);
+  if (node.hash) {
+    for (const pair of node.hash.pairs || []) collectFromExpression(pair.value, names);
+  }
+}
+
+function collectFromExpression(node, names) {
+  if (node && node.type === 'SubExpression') collectFromCallNode(node, names);
+}
+
+/**
+ * The set of helper names the server render path actually registers —
+ * derived by registering onto a fresh instance and reading the result back,
+ * so this test tracks the real whitelist instead of a hand-copied list that
+ * could drift from report-html-helpers.js.
+ */
+function canonicalRegisteredHelperNames() {
+  const hb = Handlebars.create();
+  registerReportHelpers(hb);
+  return new Set(Object.keys(hb.helpers));
+}
+
+describe('report template ↔ server helper whitelist contract', () => {
+  const templatePaths = findTemplates(ARTIFACTS_DIR);
+  const registeredNames = canonicalRegisteredHelperNames();
+
+  it('finds report templates to check', () => {
+    assert.ok(templatePaths.length > 0, 'expected to find at least one template.hbs under artifacts/');
+  });
+
+  for (const templatePath of templatePaths) {
+    const relPath = templatePath.slice(ARTIFACTS_DIR.length + 1);
+
+    it(`${relPath} only invokes helpers the server render path registers`, () => {
+      const source = readFileSync(templatePath, 'utf8');
+      const invoked = collectHelperNames(source);
+      const unregistered = [...invoked].filter((name) => !registeredNames.has(name));
+      assert.deepEqual(
+        unregistered,
+        [],
+        `template ${relPath} invokes helper(s) [${unregistered.join(', ')}] which the server ` +
+          `render path does not register — use a data field or add it to the canonical whitelist ` +
+          `(templates/reports/helpers/report-html-helpers.js)`
+      );
+    });
+  }
+});
+
+describe('helpers.js hygiene — no dynamic code execution on the server path', () => {
+  const helpersPaths = [];
+  (function findHelpers(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) findHelpers(full);
+      else if (entry.name === 'helpers.js') helpersPaths.push(full);
+    }
+  })(ARTIFACTS_DIR);
+
+  it('finds helpers.js artifacts to check', () => {
+    assert.ok(helpersPaths.length > 0, 'expected to find at least one helpers.js under artifacts/');
+  });
+
+  for (const helpersPath of helpersPaths) {
+    const relPath = helpersPath.slice(ARTIFACTS_DIR.length + 1);
+
+    it(`${relPath} never calls require() or uses an import statement`, () => {
+      const src = readFileSync(helpersPath, 'utf8');
+      // Never executed on the server render path — only read for
+      // formatNumber decimal-precision extraction (extractNumberFormatOptions)
+      // and for extracting report-specific extra helper functions as source
+      // text (buildJsreportHelpersString). A require()/import inside it can
+      // never run and previously produced `require is not defined` at runtime.
+      assert.doesNotMatch(
+        src,
+        /\brequire\s*\(/,
+        `${relPath} calls require() — this file is never executed on the server render path`
+      );
+      assert.doesNotMatch(
+        src,
+        /^[ \t]*import\s/m,
+        `${relPath} uses an import statement — this file is never executed on the server render path`
+      );
+    });
+  }
+});
+
+describe('document print templates — strict render smoke (canonical helpers only)', () => {
+  const printDirs = readdirSync(ARTIFACTS_DIR).filter((d) => d.startsWith('print-'));
+
+  // Minimal, shared synthetic fixture covering the fields the print-*
+  // templates reference (header/lines/taxes) — built from inspecting
+  // print-sales-invoice/template.hbs, the richest of the set. Handlebars
+  // silently renders missing DATA fields as empty strings, so this fixture
+  // only needs to exercise every code path (each/if/ifCond branches),
+  // not every literal field name — the failure mode this test guards
+  // against is a missing HELPER, which throws regardless of data shape.
+  const header = {
+    doc_type: 'AR Invoice',
+    documentno: 'INV-1001',
+    dateinvoiced: '2026-08-10',
+    bp_name: 'ACME Corp',
+    bp_location: 'Main Office',
+    grandtotal: '1210.00',
+    totallines: '1000.00',
+    currency: 'EUR',
+    org_name: 'My Company',
+    org_taxid: 'B12345678',
+    org_address: 'Main St 1',
+    org_city: 'Madrid',
+    org_postal: '28001',
+    payment_term: 'Net 30',
+    payment_method: 'Wire Transfer',
+    delivery_term: 'FOB',
+    poreference: 'PO-1',
+    description: 'Sample notes',
+    status: 'CO',
+    reference_doc: 'REF-1',
+    qrDataUrl: 'data:image/png;base64,FAKE',
+  };
+  const lines = [
+    {
+      line: 1,
+      product_name: 'Widget',
+      quantity: 2,
+      uom: 'EA',
+      priceactual: '10.00',
+      linenetamt: '20.00',
+      tax_name: 'VAT',
+      doc_type: 'Shipment',
+    },
+  ];
+  const taxes = [{ tax_name: 'VAT', taxamt: '2.10' }];
+  const meta = { title: 'Test Document', generatedAt: new Date().toISOString(), filters: [], params: {} };
+
+  for (const dir of printDirs) {
+    it(`renders ${dir}/template.hbs without throwing (registerReportHelpers only)`, () => {
+      const templatePath = join(ARTIFACTS_DIR, dir, 'template.hbs');
+      const helpersPath = join(ARTIFACTS_DIR, dir, 'helpers.js');
+      const templateContent = readFileSync(templatePath, 'utf8');
+      const helpersCode = existsSync(helpersPath) ? readFileSync(helpersPath, 'utf8') : '';
+
+      const hb = Handlebars.create();
+      registerReportHelpers(hb, helpersCode);
+
+      let html;
+      assert.doesNotThrow(() => {
+        html = hb.compile(templateContent)({ css: '', meta, header, lines, taxes });
+      });
+      assert.ok(!html.includes('Missing helper'), `${dir}/template.hbs rendered a "Missing helper" fallback`);
+    });
+  }
+});
+
+describe('report-api.js dev/prod parity — no divergent helper registration', () => {
+  const pluginSrc = readFileSync(REPORT_API_PLUGIN, 'utf8');
+  const canonicalNames = canonicalRegisteredHelperNames();
+
+  it('registers helpers only via registerReportHelpers()/buildJsreportHelpersString(), never ad hoc', () => {
+    // Any `registerHelper('name', ...)` call with a quoted literal name is a
+    // dev-only hack that can register something the production jsreport
+    // helper string / server HTML path does not — the exact pattern that hid
+    // the qrCode gap in dev while it broke in production (ETP-4908).
+    const adHocCalls = [...pluginSrc.matchAll(/registerHelper\(\s*['"]([^'"]+)['"]/g)].map((m) => m[1]);
+    const outsideCanonical = adHocCalls.filter((name) => !canonicalNames.has(name));
+    assert.deepEqual(
+      outsideCanonical,
+      [],
+      `report-api.js calls registerHelper() with name(s) [${outsideCanonical.join(', ')}] outside the ` +
+        `canonical whitelist — this diverges dev rendering from the server, hiding a production gap`
+    );
+  });
+
+  it('imports registerReportHelpers from the canonical shared module', () => {
+    assert.match(
+      pluginSrc,
+      /import\s*\{[^}]*registerReportHelpers[^}]*\}\s*from\s*['"][^'"]*report-html-helpers\.js['"]/,
+      'report-api.js must register HTML helpers through the canonical report-html-helpers.js module'
+    );
+  });
+});

--- a/tools/app-shell/vite-plugins/report-api.js
+++ b/tools/app-shell/vite-plugins/report-api.js
@@ -11,7 +11,7 @@ import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
 const _require = createRequire(import.meta.url);
 import { resolve, join } from 'node:path';
-import { registerReportHelpers, buildJsreportHelpersString } from '../../../templates/reports/helpers/report-html-helpers.js';
+import { registerReportHelpers, buildJsreportHelpersString, computeDocumentQrDataUrl } from '../../../templates/reports/helpers/report-html-helpers.js';
 
 const ARTIFACTS_DIR = resolve(import.meta.dirname, '../../../artifacts');
 const ROOT = resolve(ARTIFACTS_DIR, '..');
@@ -614,32 +614,29 @@ export default function reportApiPlugin() {
               ? { css, meta: { title, generatedAt: new Date().toISOString(), filters: activeFilters, params }, header: documentData.header, lines: documentData.lines, taxes: documentData.taxes }
               : { css, meta: { title, generatedAt: new Date().toISOString(), recordCount, filters: activeFilters, params, totals, groupLabel, descriptionLabel, ...neoMeta }, rows };
 
+            // Document (print-*) reports render a QR of the header. QRCode.toDataURL
+            // is async while Handlebars.compile is sync, so the QR cannot be a helper
+            // on the HTML path — precompute it once here, before the format branch, so
+            // both the local HTML render and the jsreport PDF/XLSX payload see the same
+            // {{header.qrDataUrl}}. A QR failure degrades to a report without QR
+            // instead of failing the whole render.
+            if (documentData?.header && templateData.header) {
+              try {
+                templateData.header.qrDataUrl = await computeDocumentQrDataUrl(documentData.header, { qrcode: _require('qrcode') });
+              } catch (qrErr) {
+                console.warn('[report-api] QR generation failed:', qrErr.message);
+              }
+            }
+
             // Direct HTML render — no jsreport needed for preview
             if (format === 'html') {
               const Handlebars = _require('handlebars');
 
               // Register the trusted in-repo helper set — no dynamic code execution.
               // helpersCode is read (not executed) only to preserve a report's
-              // formatNumber decimals.
+              // formatNumber decimals. Document QR codes are precomputed as data
+              // (header.qrDataUrl) above — never as a helper.
               registerReportHelpers(Handlebars, helpersCode);
-
-              // qrCode is report-specific (only document-type reports reference it)
-              // and async (QRCode.toDataURL returns a Promise) — Handlebars.compile()
-              // is synchronous, so it can't be registered as a per-report extra like
-              // the jsreport path does below. Precompute it once here (generic content
-              // — doc type/number/partner/status — good enough for an on-screen
-              // preview) and register a plain sync helper returning the resolved value.
-              if (documentData?.header) {
-                const QRCode = _require('qrcode');
-                const header = documentData.header;
-                const parts = [];
-                if (header.doc_type) parts.push('T:' + header.doc_type);
-                if (header.documentno) parts.push('N:' + header.documentno);
-                if (header.bp_name) parts.push('BP:' + header.bp_name);
-                if (header.status) parts.push('S:' + header.status);
-                const qrDataUrl = await QRCode.toDataURL(parts.length ? parts.join('|') : 'empty', { width: 120, margin: 1 });
-                Handlebars.registerHelper('qrCode', () => qrDataUrl);
-              }
 
               const template = Handlebars.compile(templateContent);
               const html = template(templateData);
@@ -649,7 +646,7 @@ export default function reportApiPlugin() {
             }
 
             // Serialize the same canonical helpers used above for the HTML preview,
-            // plus only this report's specific extras (e.g. qrCode) — a single
+            // plus only this report's specific extras — a single
             // source of truth for both render paths instead of a hand-maintained
             // copy per report. See buildJsreportHelpersString() for why jsreport
             // (a separate Docker container, reachable only over HTTP) can't just


### PR DESCRIPTION
Jira: ETP-4908.

Root cause: since ETP-4083 the server render path (report-server) registers only the canonical helper whitelist; document templates invoked `{{qrCode header}}` → `Missing helper: "qrCode"` on staging/experimental (older builds: `require is not defined`). Local dev worked via a divergent Vite-plugin hack, hiding the gap.

Changes here: all 8 print-* templates now use the `{{header.qrDataUrl}}` data field (qrCode blocks removed from helpers.js); report-api.js dev plugin injects the QR via the shared `computeDocumentQrDataUrl` (dev/prod parity, full field set with per-doc-type date/amount fallbacks); new regression suite `tools/app-shell/test/report-template-helpers-contract.test.js` (template↔whitelist AST contract over all 20 artifact templates, strict render smoke of the 8 print docs, helpers.js hygiene, dev/prod parity guard); core pins bumped to preview `0.3.34-preview.feature-ETP-4908.20260814144445.3d351b1`.

Counterpart PR (must deploy together; report-server image rebuild required): https://github.com/etendosoftware/schema_forge_core/pull/129 — server-side QR data injection, jsreport canonical helper string (fixes pre-existing PDF `missing helper: "ifCond"`), helper-module sync (also fixes es-ES currency drift; verification tracked in ETP-4910).

Local verification: real report-server render → HTTP 200 with valid QR PNG; PDF via jsreport → HTTP 200 %PDF with embedded QR; negative control on epic reproduced the production error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)