### PR TITLE
Feature ETP-4779: Fix related-docs refresh race for PO and SO

### DIFF
--- a/artifacts/goods-receipt/custom/GoodsReceiptActions.jsx
+++ b/artifacts/goods-receipt/custom/GoodsReceiptActions.jsx
@@ -14,7 +14,7 @@ import CopyRecordLinkButton from '@/components/contract-ui/CopyRecordLinkButton'
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export default function GoodsReceiptActions({ data, recordId, token, apiBaseUrl }) {
+export default function GoodsReceiptActions({ data, recordId, token, apiBaseUrl, onRefresh }) {
   const ui = useUI();
   const navigate = useNavigate();
   const [showConfirm, setShowConfirm] = useState(false);
@@ -209,7 +209,12 @@ export default function GoodsReceiptActions({ data, recordId, token, apiBaseUrl 
           onClose={() => {
             setConfirmedDocs(null);
             setTimeout(() => {
-              if (!resultNavigatedRef.current) window.location.reload();
+              // ETP-4779 — partial refresh instead of a full page reload: refetch
+              // the header (badge/readonly state) via onRefresh; the "Documentos"
+              // section (RelatedDocuments.jsx, derived from `data.linkedInvoices`)
+              // picks up the newly created invoice automatically once `data`
+              // updates. Skipped when the user navigated away instead of closing.
+              if (!resultNavigatedRef.current) onRefresh?.();
               resultNavigatedRef.current = false;
             }, 0);
           }}
@@ -226,7 +231,9 @@ export default function GoodsReceiptActions({ data, recordId, token, apiBaseUrl 
           onClose={() => {
             setReturnedDoc(null);
             setTimeout(() => {
-              if (!resultNavigatedRef.current) window.location.reload();
+              // ETP-4779 — same partial-refresh rationale as the invoice
+              // confirmation panel above.
+              if (!resultNavigatedRef.current) onRefresh?.();
               resultNavigatedRef.current = false;
             }, 0);
           }}

--- a/artifacts/goods-receipt/custom/__tests__/GoodsReceiptActions.test.js
+++ b/artifacts/goods-receipt/custom/__tests__/GoodsReceiptActions.test.js
@@ -69,4 +69,35 @@ describe('GoodsReceiptActions', () => {
       assert.match(src, /from\s*['"]@\/i18n['"]/);
     });
   });
+
+  // ETP-4779 — QA regression: the "Documentos" related-docs section on
+  // Purchase Goods Receipt required a manual page reload to show a newly
+  // generated Purchase Invoice / return-to-vendor shipment. Root cause: this
+  // component discarded the `onRefresh` prop DetailView's topbarRight slot
+  // already passes (see DetailView.jsx TopbarRightComponent), calling a full
+  // `window.location.reload()` instead — which is also visibly slower and
+  // loses in-memory client state (scroll position, other open modals).
+  describe('partial refresh instead of full page reload (ETP-4779)', () => {
+    it('accepts an onRefresh prop', () => {
+      assert.match(src, /export default function GoodsReceiptActions\(\{[^}]*onRefresh[^}]*\}\)/);
+    });
+
+    it('never calls window.location.reload', () => {
+      assert.doesNotMatch(src, /window\.location\.reload/);
+    });
+
+    it('calls onRefresh (not a reload) when closing the invoice-confirmation result modal, unless the user navigated away', () => {
+      assert.match(
+        src,
+        /setConfirmedDocs\(null\);\s*setTimeout\(\(\) => \{\s*[\s\S]*?if\s*\(!resultNavigatedRef\.current\)\s*onRefresh\?\.\(\);/,
+      );
+    });
+
+    it('calls onRefresh (not a reload) when closing the purchase-return result modal, unless the user navigated away', () => {
+      assert.match(
+        src,
+        /setReturnedDoc\(null\);\s*setTimeout\(\(\) => \{\s*[\s\S]*?if\s*\(!resultNavigatedRef\.current\)\s*onRefresh\?\.\(\);/,
+      );
+    });
+  });
 });

--- a/artifacts/goods-shipment/custom/GoodsShipmentActions.jsx
+++ b/artifacts/goods-shipment/custom/GoodsShipmentActions.jsx
@@ -13,7 +13,7 @@ import CreateInvoiceConfirmModal from '@/components/contract-ui/CreateInvoiceCon
 import { formatCurrency } from '@/lib/formatCurrency.js';
 import CopyRecordLinkButton from '@/components/contract-ui/CopyRecordLinkButton';
 
-export default function GoodsShipmentActions({ data, recordId, token, apiBaseUrl, api }) {
+export default function GoodsShipmentActions({ data, recordId, token, apiBaseUrl, api, onRefresh }) {
   const ui = useUI();
   const tMenu = useMenuLabel();
   const navigate = useNavigate();
@@ -208,7 +208,12 @@ export default function GoodsShipmentActions({ data, recordId, token, apiBaseUrl
           onClose={() => {
             setInvoiceResult(null);
             setTimeout(() => {
-              if (!resultNavigatedRef.current) window.location.reload();
+              // ETP-4779 — partial refresh instead of a full page reload: refetch
+              // the header (badge/readonly state) via onRefresh; the "Documentos"
+              // section (RelatedDocuments.jsx, derived from `data.linkedInvoices`)
+              // picks up the newly created invoice automatically once `data`
+              // updates. Skipped when the user navigated away instead of closing.
+              if (!resultNavigatedRef.current) onRefresh?.();
               resultNavigatedRef.current = false;
             }, 0);
           }}
@@ -244,7 +249,9 @@ export default function GoodsShipmentActions({ data, recordId, token, apiBaseUrl
           if (returnData?.id) {
             navigate(`/return-material-receipt/${returnData.id}`);
           } else {
-            window.location.reload();
+            // ETP-4779 — partial refresh (see rationale above) instead of a full
+            // page reload when there's no id to navigate to.
+            onRefresh?.();
           }
         }}
         onError={(msg) => toast.error(msg)}

--- a/artifacts/goods-shipment/custom/__tests__/GoodsShipmentActions.test.js
+++ b/artifacts/goods-shipment/custom/__tests__/GoodsShipmentActions.test.js
@@ -237,4 +237,34 @@ describe('GoodsShipmentActions', () => {
       assert.doesNotMatch(src, /generateShipmentPdf\(/);
     });
   });
+
+  // ETP-4779 — QA regression: the "Documentos" related-docs section on Sales
+  // Goods Shipment (Albarán de Venta) required a manual page reload to show a
+  // newly generated Sales Invoice. Root cause: this component discarded the
+  // `onRefresh` prop DetailView's topbarRight slot already passes (see
+  // DetailView.jsx TopbarRightComponent), calling a full
+  // `window.location.reload()` instead.
+  describe('partial refresh instead of full page reload (ETP-4779)', () => {
+    it('accepts an onRefresh prop', () => {
+      assert.match(src, /export default function GoodsShipmentActions\(\{[^}]*onRefresh[^}]*\}\)/);
+    });
+
+    it('never calls window.location.reload', () => {
+      assert.doesNotMatch(src, /window\.location\.reload/);
+    });
+
+    it('calls onRefresh (not a reload) when closing the invoice-result modal, unless the user navigated away', () => {
+      assert.match(
+        src,
+        /setInvoiceResult\(null\);\s*setTimeout\(\(\) => \{\s*[\s\S]*?if\s*\(!resultNavigatedRef\.current\)\s*onRefresh\?\.\(\);/,
+      );
+    });
+
+    it('calls onRefresh (not a reload) as the ReturnWizard onSuccess fallback when the created return has no id to navigate to', () => {
+      assert.match(
+        src,
+        /if\s*\(returnData\?\.id\)\s*\{\s*navigate\(`\/return-material-receipt\/\$\{returnData\.id\}`\);\s*\}\s*else\s*\{\s*[\s\S]*?onRefresh\?\.\(\);\s*\}/,
+      );
+    });
+  });
 });

--- a/artifacts/purchase-order/custom/PurchaseOrderActions.jsx
+++ b/artifacts/purchase-order/custom/PurchaseOrderActions.jsx
@@ -346,7 +346,6 @@ export function ConfirmModal({ orderId, data, apiBaseUrl, headers, onClose, onCo
         setOrderConfirmed(true);
         incrementSurveyCounter('order');
         trackTransactionPosted();
-        window.dispatchEvent(new CustomEvent('purchase-order:document-created'));
       } catch (e) {
         setError(e.message || ui('poErrorOccurred'));
         setLoading(false);
@@ -422,6 +421,18 @@ export function ConfirmModal({ orderId, data, apiBaseUrl, headers, onClose, onCo
     const finalInvoice = currentInvoice ?? invoiceResult;
     if (finalReceipt) result.receipt = finalReceipt;
     if (finalInvoice) result.invoice = finalInvoice;
+    // ETP-4779 — dispatch AFTER the receipt/invoice POSTs above have actually
+    // resolved (not right after Step 1's docAction=CO, as before). Dispatching
+    // immediately after Step 1 fired the event before createGoodsReceipt /
+    // createPurchaseInvoice even ran, so RelatedDocuments.jsx's refetch raced
+    // ahead of document creation, found nothing, and — since no later event
+    // fired to catch up — the "Documentos" panel stayed empty until some
+    // unrelated action (e.g. a later "Gestionar factura" call) happened to
+    // dispatch the event again. Only fire when a document actually exists to
+    // show, mirroring CreateDocsModal.handleCreate below.
+    if (finalReceipt || finalInvoice) {
+      window.dispatchEvent(new CustomEvent('purchase-order:document-created'));
+    }
     onConfirmed(result);
   };
 
@@ -442,6 +453,15 @@ export function ConfirmModal({ orderId, data, apiBaseUrl, headers, onClose, onCo
       const result = {};
       if (receiptResult) result.receipt = receiptResult;
       if (invoiceResult) result.invoice = invoiceResult;
+      // ETP-4779 — covers the partial-failure path: e.g. the receipt POST
+      // succeeded (receiptResult set) but the invoice POST then failed, and
+      // the user closes instead of retrying. handleConfirm's own dispatch
+      // (above) never runs in that case since it errors out first, so the
+      // successfully-created receipt would otherwise never notify
+      // RelatedDocuments.jsx.
+      if (receiptResult || invoiceResult) {
+        window.dispatchEvent(new CustomEvent('purchase-order:document-created'));
+      }
       onConfirmed(result);
       return;
     }

--- a/artifacts/purchase-order/custom/RelatedDocuments.jsx
+++ b/artifacts/purchase-order/custom/RelatedDocuments.jsx
@@ -64,6 +64,19 @@ export default function RelatedDocuments({ recordId, data, token, apiBaseUrl }) 
   const navigate = useNavigate();
   const ui = useUI();
 
+  // ETP-4779 — PurchaseOrderActions already dispatches this event right after a
+  // derived document (goods receipt / purchase invoice) is created via the
+  // confirm/manage-docs flow (see ConfirmModal.handleConfirm and
+  // CreateDocsModal.handleCreate in ../PurchaseOrderActions.jsx). This mirrors
+  // the sales-order:document-created convention (see ../../sales-order/custom/
+  // RelatedDocuments.jsx) so this panel refetches automatically instead of
+  // requiring the manual 🔄 refresh button.
+  useEffect(() => {
+    const handler = () => setRefreshKey(k => k + 1);
+    window.addEventListener('purchase-order:document-created', handler);
+    return () => window.removeEventListener('purchase-order:document-created', handler);
+  }, []);
+
   useEffect(() => {
     if (!recordId) return;
     setLoading(true);

--- a/artifacts/purchase-order/custom/__tests__/PurchaseOrderActions.test.js
+++ b/artifacts/purchase-order/custom/__tests__/PurchaseOrderActions.test.js
@@ -59,6 +59,57 @@ describe('PurchaseOrderActions', () => {
     assert.match(src, /dispatchEvent/);
   });
 
+  // ETP-4779 (reject cycle #2) — QA's live retest on localhost:3100 showed the
+  // "Documentos" panel STILL never updated after confirming a Draft order with
+  // "Crear albarán de proveedor" + "Crear factura" both checked, even after
+  // RelatedDocuments.jsx gained its event listener in the previous fix pass.
+  // Root cause, found by reproducing live: handleConfirm dispatched
+  // purchase-order:document-created right after Step 1 (documentAction=CO),
+  // BEFORE Steps 2/3 (createGoodsReceipt / createPurchaseInvoice) had even
+  // run — so the listener's refetch always raced ahead of document creation
+  // and came back empty, with no later event to catch up. CreateDocsModal
+  // (the separate "Gestionar" modal for already-CO orders, further below in
+  // this file) never had this bug — it already dispatched once, after its
+  // POST(s) resolved.
+  describe('event dispatch ordering — must fire AFTER receipt/invoice creation, not right after Step 1 (ETP-4779)', () => {
+    it('does NOT dispatch document-created inside the Step 1 (documentAction) success block', () => {
+      const step1Block = src.match(
+        /if\s*\(!orderConfirmed\)\s*\{\s*try\s*\{[\s\S]*?setOrderConfirmed\(true\);[\s\S]*?\}\s*catch\s*\(e\)\s*\{[\s\S]*?\}\s*\}/,
+      );
+      assert.ok(step1Block, 'could not locate the Step 1 try/catch block');
+      assert.doesNotMatch(
+        step1Block[0],
+        /purchase-order:document-created/,
+        'the event must not be dispatched from inside Step 1 — that runs before the receipt/invoice POSTs',
+      );
+    });
+
+    it('dispatches document-created after both currentReceipt/currentInvoice are resolved, right before onConfirmed(result)', () => {
+      assert.match(
+        src,
+        /const finalReceipt\s*=\s*currentReceipt\s*\?\?\s*receiptResult;\s*const finalInvoice\s*=\s*currentInvoice\s*\?\?\s*invoiceResult;[\s\S]*?if\s*\(finalReceipt\s*\|\|\s*finalInvoice\)\s*\{\s*window\.dispatchEvent\(new CustomEvent\('purchase-order:document-created'\)\);\s*\}\s*onConfirmed\(result\);/,
+      );
+    });
+
+    it('guards the dispatch so it never fires when neither a receipt nor an invoice was created', () => {
+      assert.match(src, /if\s*\(finalReceipt\s*\|\|\s*finalInvoice\)\s*\{\s*window\.dispatchEvent/);
+    });
+
+    it('the errors.length early-return sits BEFORE the dispatch — a failed step must not fire the event for a half-finished result', () => {
+      const errorsIdx = src.indexOf('if (errors.length > 0) {');
+      const dispatchIdx = src.lastIndexOf("window.dispatchEvent(new CustomEvent('purchase-order:document-created'))");
+      assert.ok(errorsIdx >= 0 && dispatchIdx >= 0);
+      assert.ok(errorsIdx < dispatchIdx);
+    });
+
+    it('handleClose also dispatches when closing after a partial success (receipt or invoice already created)', () => {
+      assert.match(
+        src,
+        /const handleClose\s*=\s*\(\)\s*=>\s*\{\s*if\s*\(orderConfirmed\s*\|\|\s*receiptResult\s*\|\|\s*invoiceResult\)\s*\{[\s\S]*?if\s*\(receiptResult\s*\|\|\s*invoiceResult\)\s*\{\s*window\.dispatchEvent\(new CustomEvent\('purchase-order:document-created'\)\);\s*\}\s*onConfirmed\(result\);/,
+      );
+    });
+  });
+
   it('exposes receipt + invoice optional checkboxes inside the confirm modal', () => {
     assert.match(src, /<PoCheckboxCard/);
     assert.match(src, /poCreateReceiptTitle/);

--- a/artifacts/purchase-order/custom/__tests__/RelatedDocuments.test.js
+++ b/artifacts/purchase-order/custom/__tests__/RelatedDocuments.test.js
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dirname, '..', 'RelatedDocuments.jsx'), 'utf8');
+
+describe('purchase-order RelatedDocuments', () => {
+  it('exports a default function component', () => {
+    assert.match(src, /export default function RelatedDocuments/);
+  });
+
+  it('fetches goods-receipt and purchase-invoice as related specs', () => {
+    assert.match(src, /specName:\s*'goods-receipt'/);
+    assert.match(src, /specName:\s*'purchase-invoice'/);
+  });
+
+  // ETP-4779 — QA regression: confirming a Purchase Order (or generating a
+  // Goods Receipt / Purchase Invoice from the "Gestionar" flow) never updated
+  // the "Documentos" section without a manual page refresh — even though
+  // PurchaseOrderActions.jsx already dispatched a
+  // purchase-order:document-created event (ConfirmModal.handleConfirm,
+  // CreateDocsModal.handleCreate) right after each derived document was
+  // created. Root cause: nothing in this component was listening for it — the
+  // only refresh trigger was the manual 🔄 button (RelatedDocumentsShell
+  // onRefresh bumping the local refreshKey). Fix: add the same
+  // window.addEventListener('purchase-order:document-created', ...) pattern
+  // sales-order/custom/RelatedDocuments.jsx already uses for
+  // sales-order:document-created.
+  describe('auto-refresh on purchase-order:document-created (ETP-4779)', () => {
+    it('listens for the purchase-order:document-created custom event', () => {
+      assert.match(src, /addEventListener\(\s*['"]purchase-order:document-created['"]/);
+    });
+
+    it('removes the listener on cleanup', () => {
+      assert.match(src, /removeEventListener\(\s*['"]purchase-order:document-created['"]/);
+    });
+
+    it('bumps refreshKey (the same dependency that drives the fetch effect) when the event fires', () => {
+      assert.match(
+        src,
+        /const handler = \(\) => setRefreshKey\(k => k \+ 1\);\s*window\.addEventListener\(\s*['"]purchase-order:document-created['"],\s*handler\)/,
+      );
+    });
+
+    it('keeps refreshKey in the related-docs fetch effect dependency array', () => {
+      assert.match(src, /\[recordId, token, apiBaseUrl, refreshKey\]/);
+    });
+  });
+});

--- a/artifacts/sales-order/custom/OrderCreateInvoice.jsx
+++ b/artifacts/sales-order/custom/OrderCreateInvoice.jsx
@@ -358,7 +358,6 @@ export function ConfirmModal({ orderId, data, apiBaseUrl, headers, onClose, onCo
         setOrderConfirmed(true);
         incrementSurveyCounter('order');
         trackTransactionPosted();
-        window.dispatchEvent(new CustomEvent('sales-order:document-created'));
       } catch (e) {
         setError(e.message || ui('soErrorOccurred'));
         setLoading(false);
@@ -420,9 +419,25 @@ export function ConfirmModal({ orderId, data, apiBaseUrl, headers, onClose, onCo
 
     // All requested steps succeeded — close the modal with whatever was created.
     // Use the current attempt's result first; fall back to persisted result from a prior attempt.
+    const finalShipment = currentShipment ?? shipmentResult;
+    const finalInvoice  = currentInvoice  ?? invoiceResult;
+    // ETP-4779 — dispatch AFTER the shipment/invoice POSTs above have actually
+    // resolved (not right after Step 1's docAction=CO, as before). Dispatching
+    // immediately after Step 1 fired the event before createShipment /
+    // createDraftInvoice even ran, so RelatedDocuments.jsx's refetch raced
+    // ahead of document creation, found nothing, and — since no later event
+    // fired to catch up — the "Documentos" panel stayed empty (verified live
+    // on localhost:3100: confirming with both checkboxes showed both docs in
+    // the success modal, but the panel behind it never updated). Only fire
+    // when a document actually exists to show, mirroring
+    // CreateDocsModal.handleCreate below and the equivalent fix already
+    // applied to artifacts/purchase-order/custom/PurchaseOrderActions.jsx.
+    if (finalShipment || finalInvoice) {
+      window.dispatchEvent(new CustomEvent('sales-order:document-created'));
+    }
     onConfirmed({
-      shipment: currentShipment ?? shipmentResult,
-      invoice:  currentInvoice  ?? invoiceResult,
+      shipment: finalShipment,
+      invoice:  finalInvoice,
     });
   };
 
@@ -440,6 +455,15 @@ export function ConfirmModal({ orderId, data, apiBaseUrl, headers, onClose, onCo
   // and reopening the modal would re-attempt step 1 → @AlreadyPosted@.
   const handleClose = () => {
     if (orderConfirmed || shipmentResult || invoiceResult) {
+      // ETP-4779 — covers the partial-failure path: e.g. the shipment POST
+      // succeeded (shipmentResult set) but the invoice POST then failed, and
+      // the user closes instead of retrying. handleConfirm's own dispatch
+      // (above) never runs in that case since it errors out first, so the
+      // successfully-created shipment would otherwise never notify
+      // RelatedDocuments.jsx.
+      if (shipmentResult || invoiceResult) {
+        window.dispatchEvent(new CustomEvent('sales-order:document-created'));
+      }
       onConfirmed({
         shipment: shipmentResult,
         invoice:  invoiceResult,

--- a/artifacts/sales-order/custom/__tests__/OrderCreateInvoice.test.js
+++ b/artifacts/sales-order/custom/__tests__/OrderCreateInvoice.test.js
@@ -103,6 +103,59 @@ describe('OrderCreateInvoice', () => {
     assert.match(src, /dispatchEvent/);
   });
 
+  // ETP-4779 — live user report: generating an invoice from a confirmed Sales
+  // Order still required a manual page reload for the "Documentos" panel to
+  // update. Root cause, confirmed by reproducing live on localhost:3100 (same
+  // method used to diagnose and fix the identical bug in
+  // artifacts/purchase-order/custom/PurchaseOrderActions.jsx): handleConfirm
+  // dispatched sales-order:document-created right after Step 1
+  // (documentAction=CO), BEFORE Steps 2/3 (createShipment /
+  // createDraftInvoice) had even run — so RelatedDocuments.jsx's refetch
+  // raced ahead of document creation, found nothing, and — since no later
+  // event fired to catch up — the panel stayed empty. CreateDocsModal (the
+  // separate "Gestionar" modal for already-CO orders, further below in this
+  // file) never had this bug — it already dispatched once, after its POST(s)
+  // resolved. QA's original 2026-08-11 pass on Sales Order happened not to
+  // hit this timing-dependent race.
+  describe('event dispatch ordering — must fire AFTER shipment/invoice creation, not right after Step 1 (ETP-4779)', () => {
+    it('does NOT dispatch document-created inside the Step 1 (documentAction) success block', () => {
+      const step1Block = src.match(
+        /if\s*\(!orderConfirmed\)\s*\{\s*try\s*\{[\s\S]*?setOrderConfirmed\(true\);[\s\S]*?\}\s*catch\s*\(e\)\s*\{[\s\S]*?\}\s*\}/,
+      );
+      assert.ok(step1Block, 'could not locate the Step 1 try/catch block');
+      assert.doesNotMatch(
+        step1Block[0],
+        /sales-order:document-created/,
+        'the event must not be dispatched from inside Step 1 — that runs before the shipment/invoice POSTs',
+      );
+    });
+
+    it('dispatches document-created after both finalShipment/finalInvoice are resolved, right before onConfirmed(...)', () => {
+      assert.match(
+        src,
+        /const finalShipment\s*=\s*currentShipment\s*\?\?\s*shipmentResult;\s*const finalInvoice\s*=\s*currentInvoice\s*\?\?\s*invoiceResult;[\s\S]*?if\s*\(finalShipment\s*\|\|\s*finalInvoice\)\s*\{\s*window\.dispatchEvent\(new CustomEvent\('sales-order:document-created'\)\);\s*\}\s*onConfirmed\(\{/,
+      );
+    });
+
+    it('guards the dispatch so it never fires when neither a shipment nor an invoice was created', () => {
+      assert.match(src, /if\s*\(finalShipment\s*\|\|\s*finalInvoice\)\s*\{\s*window\.dispatchEvent/);
+    });
+
+    it('the errors.length early-return sits BEFORE the dispatch — a failed step must not fire the event for a half-finished result', () => {
+      const errorsIdx = src.indexOf('if (errors.length > 0) {');
+      const dispatchIdx = src.lastIndexOf("window.dispatchEvent(new CustomEvent('sales-order:document-created'))");
+      assert.ok(errorsIdx >= 0 && dispatchIdx >= 0);
+      assert.ok(errorsIdx < dispatchIdx);
+    });
+
+    it('handleClose also dispatches when closing after a partial success (shipment or invoice already created)', () => {
+      assert.match(
+        src,
+        /const handleClose\s*=\s*\(\)\s*=>\s*\{\s*if\s*\(orderConfirmed\s*\|\|\s*shipmentResult\s*\|\|\s*invoiceResult\)\s*\{[\s\S]*?if\s*\(shipmentResult\s*\|\|\s*invoiceResult\)\s*\{\s*window\.dispatchEvent\(new CustomEvent\('sales-order:document-created'\)\);\s*\}\s*onConfirmed\(\{/,
+      );
+    });
+  });
+
   it('navigates to shipment and invoice detail after creation', () => {
     assert.match(src, /\/goods-shipment\//);
     assert.match(src, /\/sales-invoice\//);
@@ -140,8 +193,12 @@ describe('OrderCreateInvoice', () => {
     });
 
     it('falls back to persisted state when assembling onConfirmed payload', () => {
-      assert.match(src, /shipment:\s*currentShipment\s*\?\?\s*shipmentResult/);
-      assert.match(src, /invoice:\s*currentInvoice\s*\?\?\s*invoiceResult/);
+      // ETP-4779 — extracted from the onConfirmed(...) call site into named
+      // consts (finalShipment/finalInvoice) so the dispatch guard below can
+      // reuse them; the fallback logic itself is unchanged.
+      assert.match(src, /const finalShipment\s*=\s*currentShipment\s*\?\?\s*shipmentResult;/);
+      assert.match(src, /const finalInvoice\s*=\s*currentInvoice\s*\?\?\s*invoiceResult;/);
+      assert.match(src, /onConfirmed\(\{\s*shipment:\s*finalShipment,\s*invoice:\s*finalInvoice,\s*\}\);/);
     });
 
     it('locks the shipment checkbox once the shipment was created', () => {

--- a/artifacts/sales-quotation/custom/QuotationConfirmModal.jsx
+++ b/artifacts/sales-quotation/custom/QuotationConfirmModal.jsx
@@ -16,6 +16,7 @@ export default function QuotationConfirmModal({
   apiBaseUrl,
   onClose,
   onSave,
+  onRefresh,
 }) {
   const ui = useUI();
   const [selected, setSelected] = useState('order');
@@ -130,6 +131,10 @@ export default function QuotationConfirmModal({
             + (err?.response?.message || err?.message || `Error (${res.status})`)
           );
         }
+        // ETP-4779 — the sales order now exists; let the "Documentos" section
+        // refetch immediately instead of requiring a full page reload (mirrors
+        // sales-order:document-created / purchase-order:document-created).
+        window.dispatchEvent(new CustomEvent('sales-quotation:document-created'));
 
         // Fetch created order by quotation link
         const criteria = JSON.stringify([{ fieldName: 'quotation', operator: 'equals', value: quotationId }]);
@@ -178,6 +183,8 @@ export default function QuotationConfirmModal({
             err?.response?.message || err?.message || `Error (${res.status})`
           );
         }
+        // ETP-4779 — see rationale above (order path).
+        window.dispatchEvent(new CustomEvent('sales-quotation:document-created'));
         const doc = (await res.json())?.response?.data;
         setCreatedDoc({
           type: 'invoice',
@@ -205,10 +212,13 @@ export default function QuotationConfirmModal({
     window.location.href = `${basePath}/${target}/${createdDoc.id}`;
   };
 
-  // After creating a document, reload the page to refresh state (badge, readonly, etc.)
+  // ETP-4779 — after creating a document, refresh the header state (badge,
+  // readonly, etc.) via onRefresh instead of a full page reload. The
+  // "Documentos" section already refetched off the sales-quotation:document-created
+  // event dispatched in handleConfirm above.
   const handleCloseAfterCreate = () => {
     onClose();
-    window.location.reload();
+    onRefresh?.();
   };
 
   // ── Success state ──────────────────────────────────────────

--- a/artifacts/sales-quotation/custom/QuotationTopbarActions.jsx
+++ b/artifacts/sales-quotation/custom/QuotationTopbarActions.jsx
@@ -32,7 +32,7 @@ const btnCloneStyle = {
   boxShadow: '0px 1px 2px 0px hsl(var(--foreground) / 0.05)',
 };
 
-export default function QuotationTopbarActions({ data, recordId, token, apiBaseUrl, onSave }) {
+export default function QuotationTopbarActions({ data, recordId, token, apiBaseUrl, onSave, onRefresh }) {
   const navigate = useNavigate();
   const ui = useUI();
   const tMenu = useMenuLabel();
@@ -125,6 +125,7 @@ export default function QuotationTopbarActions({ data, recordId, token, apiBaseU
           token={token}
           apiBaseUrl={apiBaseUrl}
           onSave={onSave}
+          onRefresh={onRefresh}
           onClose={() => setShowConfirm(false)}
         />,
         document.body,

--- a/artifacts/sales-quotation/custom/RelatedDocuments.jsx
+++ b/artifacts/sales-quotation/custom/RelatedDocuments.jsx
@@ -11,6 +11,18 @@ export default function RelatedDocuments({ recordId, data, token, apiBaseUrl }) 
   const navigate = useNavigate();
   const ui = useUI();
 
+  // ETP-4779 — QuotationConfirmModal dispatches this event right after
+  // converting the quotation into a sales order / invoice (see
+  // ../QuotationConfirmModal.jsx handleConfirm), mirroring the
+  // sales-order:document-created / purchase-order:document-created convention
+  // so this panel refetches automatically instead of requiring the manual 🔄
+  // refresh button.
+  useEffect(() => {
+    const handler = () => setRefreshKey(k => k + 1);
+    window.addEventListener('sales-quotation:document-created', handler);
+    return () => window.removeEventListener('sales-quotation:document-created', handler);
+  }, []);
+
   useEffect(() => {
     if (!recordId) { setLoading(false); return; }
     setLoading(true);

--- a/artifacts/sales-quotation/custom/__tests__/QuotationConfirmModal.test.js
+++ b/artifacts/sales-quotation/custom/__tests__/QuotationConfirmModal.test.js
@@ -114,4 +114,44 @@ describe('QuotationConfirmModal', () => {
       assert.match(src, /if\s*\(!saved\?\.id\)\s*\{\s*setError\(ui\('sqSaveBeforeConfirmError'\)\);/);
     });
   });
+
+  // ETP-4779 — QA regression: the "Documentos" related-docs section did not
+  // show the newly created Sales Order / Invoice without a full page reload.
+  // Fix: dispatch a sales-quotation:document-created custom event (mirroring
+  // the sales-order:document-created / purchase-order:document-created
+  // convention) right after each conversion action succeeds, and refresh the
+  // header state via the new onRefresh prop instead of window.location.reload.
+  describe('partial refresh instead of full page reload (ETP-4779)', () => {
+    it('accepts an onRefresh prop', () => {
+      assert.match(src, /export default function QuotationConfirmModal\(\{[\s\S]*?onRefresh,?[\s\S]*?\}\)/);
+    });
+
+    it('never calls window.location.reload', () => {
+      assert.doesNotMatch(src, /window\.location\.reload/);
+    });
+
+    it('handleCloseAfterCreate calls onRefresh instead of reloading', () => {
+      assert.match(
+        src,
+        /const handleCloseAfterCreate = \(\) => \{\s*onClose\(\);\s*onRefresh\?\.\(\);\s*\};/,
+      );
+    });
+
+    it('dispatches sales-quotation:document-created right after the order conversion succeeds', () => {
+      const convertIdx = src.indexOf('Convertquotation');
+      const dispatchIdx = src.indexOf("dispatchEvent(new CustomEvent('sales-quotation:document-created'))");
+      assert.ok(convertIdx >= 0 && dispatchIdx >= 0);
+      assert.ok(dispatchIdx > convertIdx);
+      // ...and before the createdDoc order fetch/state update that follows it.
+      const orderFetchIdx = src.indexOf('Fetch created order by quotation link');
+      assert.ok(orderFetchIdx > dispatchIdx);
+    });
+
+    it('dispatches sales-quotation:document-created right after the invoice conversion succeeds', () => {
+      const invoicePostIdx = src.indexOf('createDraftInvoice');
+      const matches = [...src.matchAll(/dispatchEvent\(new CustomEvent\('sales-quotation:document-created'\)\)/g)];
+      assert.ok(matches.length >= 2, `Expected at least 2 dispatch calls (order + invoice paths); found ${matches.length}`);
+      assert.ok(matches[matches.length - 1].index > invoicePostIdx);
+    });
+  });
 });

--- a/artifacts/sales-quotation/custom/__tests__/QuotationTopbarActions.test.js
+++ b/artifacts/sales-quotation/custom/__tests__/QuotationTopbarActions.test.js
@@ -110,6 +110,21 @@ describe('QuotationTopbarActions', () => {
     });
   });
 
+  // ETP-4779 — this component is the topbarRight custom component and must
+  // thread the onRefresh prop DetailView already passes it down to
+  // QuotationConfirmModal, so the confirm flow can refresh the header state
+  // (and dispatch sales-quotation:document-created for the "Documentos"
+  // section) without a full page reload.
+  describe('partial refresh — threads onRefresh down (ETP-4779)', () => {
+    it('accepts an onRefresh prop', () => {
+      assert.match(src, /export default function QuotationTopbarActions\(\{[^}]*onRefresh[^}]*\}\)/);
+    });
+
+    it('threads onRefresh down to QuotationConfirmModal', () => {
+      assert.match(src, /<QuotationConfirmModal[\s\S]*?onRefresh=\{onRefresh\}[\s\S]*?\/>/);
+    });
+  });
+
   // ETP-4717 (Pair 2 — P2): the Send button must NOT be available while the
   // quotation is still Draft (DR) — it must be visible from "Bajo evaluación"
   // (UE) onward. Today it renders unconditionally, with zero status gating.

--- a/artifacts/sales-quotation/custom/__tests__/RelatedDocuments.test.js
+++ b/artifacts/sales-quotation/custom/__tests__/RelatedDocuments.test.js
@@ -1,0 +1,43 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dirname, '..', 'RelatedDocuments.jsx'), 'utf8');
+
+describe('sales-quotation RelatedDocuments', () => {
+  it('exports a default function component', () => {
+    assert.match(src, /export default function RelatedDocuments/);
+  });
+
+  // ETP-4779 — QA regression: converting a Sales Quotation into a Sales Order
+  // or Invoice (QuotationConfirmModal) showed the newly generated document,
+  // but only via a full window.location.reload(), not a partial refresh.
+  // Fix: QuotationConfirmModal now dispatches a
+  // sales-quotation:document-created event right after each conversion
+  // succeeds (mirroring sales-order:document-created /
+  // purchase-order:document-created), and this component listens for it to
+  // bump its local refreshKey instead of requiring the manual 🔄 button.
+  describe('auto-refresh on sales-quotation:document-created (ETP-4779)', () => {
+    it('listens for the sales-quotation:document-created custom event', () => {
+      assert.match(src, /addEventListener\(\s*['"]sales-quotation:document-created['"]/);
+    });
+
+    it('removes the listener on cleanup', () => {
+      assert.match(src, /removeEventListener\(\s*['"]sales-quotation:document-created['"]/);
+    });
+
+    it('bumps refreshKey (the same dependency that drives the fetch effect) when the event fires', () => {
+      assert.match(
+        src,
+        /const handler = \(\) => setRefreshKey\(k => k \+ 1\);\s*window\.addEventListener\(\s*['"]sales-quotation:document-created['"],\s*handler\)/,
+      );
+    });
+
+    it('keeps refreshKey in the related-docs fetch effect dependency array', () => {
+      assert.match(src, /\[recordId, token, apiBaseUrl, refreshKey\]/);
+    });
+  });
+});

--- a/docs/generated-custom-windows/goods-receipt.md
+++ b/docs/generated-custom-windows/goods-receipt.md
@@ -207,6 +207,21 @@ true` was already set in `decisions.json`, and `GoodsReceiptActions.jsx` (the `t
 component) has never rendered a print button of its own. Documented here only so the audit
 trail for ETP-4714 is complete across every window it named.
 
+## Related Documents auto-refresh — ETP-4779
+
+Generating a Purchase Invoice or a return-to-vendor shipment from `GoodsReceiptActions.jsx`
+(the `topbarRight` component) used to close the result modal with a full
+`window.location.reload()` — a visible flash, slower than a data refetch, and it discarded any
+other in-memory client state (scroll position, other open panels). `GoodsReceiptActions` now
+accepts the `onRefresh` prop `DetailView.jsx`'s topbar slot already passes it (`() =>
+hook.fetchById(recordId)`) and calls that instead, in both `ConfirmResultModal.onClose` handlers
+(invoice creation and purchase-return creation) — only when the user closed the modal without
+navigating to the new document (`resultNavigatedRef.current === false`). The **Related
+Documents** tab (`tools/app-shell/src/windows/custom/goods-receipt/RelatedDocuments.jsx`) needs
+no separate refetch of its own: it derives its chips straight from `data.linkedOrders` /
+`linkedInvoices` / `linkedReturns`, which `GoodsReceiptHeaderHandler.afterHandle` enriches on
+every header GET — so refreshing the header via `onRefresh` is sufficient to update it.
+
 ## Theme roles
 
 The window's live artifact custom components use the shared semantic theme.

--- a/docs/generated-custom-windows/goods-shipment.md
+++ b/docs/generated-custom-windows/goods-shipment.md
@@ -192,6 +192,18 @@ removed that custom button from `GoodsShipmentActions.jsx` outright: printing fo
 is now served exclusively by the generic `DetailView.jsx` icon. That left the generic icon
 with no gate at all on this window until the `hidePrintWhen` entry above was added.
 
+## Related Documents auto-refresh — ETP-4779
+
+Generating a Sales Invoice from `GoodsShipmentActions.jsx` (the `topbarRight` component) used to
+close the result modal with a full `window.location.reload()`. `GoodsShipmentActions` now
+accepts the `onRefresh` prop `DetailView.jsx`'s topbar slot already passes it (`() =>
+hook.fetchById(recordId)`) and calls that instead — in the invoice-result `ConfirmResultModal`'s
+`onClose` (skipped when the user navigated to the new invoice instead) and as the `ReturnWizard`
+`onSuccess` fallback when the created return has no id to navigate to. The **Related Documents**
+tab (`artifacts/goods-shipment/custom/RelatedDocuments.jsx`) needs no separate refetch: it
+derives its chips straight from `data.linkedOrders` / `linkedInvoices` / `returnReceipts`, so
+refreshing the header via `onRefresh` is sufficient to update it — no manual reload required.
+
 ## Theme roles
 
 The window's live artifact custom components use the shared semantic theme.

--- a/docs/generated-custom-windows/purchase-order.md
+++ b/docs/generated-custom-windows/purchase-order.md
@@ -278,3 +278,46 @@ detail/record route goes through the generated component), so the generator's li
 list. Fixed by hardcoding the same `listViewOptions={{ hidePrint: true }}` prop directly on
 this file's own `<ListView>` call, matching the existing pattern already used there for
 `dateFilterKey` and other generator-derived list props.
+
+## Related Documents auto-refresh — ETP-4779
+
+The "Documentos" tab (`artifacts/purchase-order/custom/RelatedDocuments.jsx`) did not update
+after confirming a Purchase Order and generating a Goods Receipt / Purchase Invoice — it required
+the manual 🔄 button. This turned out to be **two separate bugs**, found in two passes (the first
+pass fixed only the first one, which manual QA retesting on `localhost:3100` then showed was not
+sufficient):
+
+1. **Missing listener.** `PurchaseOrderActions.jsx` (this window's `topbarRight` component)
+   already dispatched a `purchase-order:document-created` `window` `CustomEvent` after generating
+   a derived document, mirroring the `sales-order:document-created` convention — but nothing was
+   listening for it. Fixed by having `RelatedDocuments.jsx` listen for that event and bump its
+   local `refreshKey` (the same key that drives its `fetchByCriteria`/`fetchChild` effect).
+
+2. **Premature dispatch (found via live reproduction after the listener fix alone didn't resolve
+   the bug in manual testing).** In `ConfirmModal.handleConfirm` — the "Confirmar" flow used to
+   confirm a still-Draft order and optionally generate its receipt/invoice in the same modal —
+   the event was dispatched right after **Step 1** (`documentAction=CO`, confirming the order),
+   *before* **Steps 2/3** (`createGoodsReceipt` / `createPurchaseInvoice`) had even run. The
+   listener added in the previous fix reacted correctly and refetched immediately, but at that
+   point neither derived document existed yet, so the refetch always came back empty — and
+   because nothing dispatched the event again afterward, the panel never learned about the
+   documents Steps 2/3 went on to create. Symptom when reproduced live: confirming with both
+   "Crear albarán de proveedor" and "Crear factura" checked showed the success modal with both
+   documents listed, but the "Documentos" row behind it stayed on "Sin documentos relacionados"
+   forever (not merely delayed) — matching the original bug reports exactly. `CreateDocsModal`
+   (used for the already-`CO` "Gestionar factura"/"Gestionar recepción" flow, a separate modal in
+   the same file) did **not** have this bug — it already dispatched once, after its POST(s)
+   resolved, which is why that flow worked correctly and briefly made the earlier fix look
+   sufficient.
+
+   Fixed by moving the dispatch in `handleConfirm` to fire once, after Steps 2/3 both settle,
+   right before `onConfirmed(result)` — mirroring `CreateDocsModal.handleCreate`'s already-correct
+   placement — and guarding it to only fire when a receipt or invoice actually exists
+   (`finalReceipt || finalInvoice`). Also added the same guarded dispatch to `handleClose`'s
+   partial-failure path (e.g. the receipt POST succeeds but the invoice POST then fails and the
+   user closes instead of retrying), which previously could leave a successfully-created receipt
+   with no event at all.
+
+Verified live end-to-end on `localhost:3100` after the fix: confirming a Draft order with both
+checkboxes shows both the new Recibo and Factura chips in the "Documentos" row immediately,
+before even closing the success modal — no reload, no lag.

--- a/docs/generated-custom-windows/sales-order.md
+++ b/docs/generated-custom-windows/sales-order.md
@@ -325,3 +325,46 @@ applies. See `docs/decisions-reference.md` ("Print Visibility") for the full col
 The confirmation modal uses information roles for its selected document options,
 warning roles for its irreversible-action notice, and success roles for completed
 optional documents. Each state pairs its background, border, and foreground token.
+
+## Related Documents auto-refresh — event dispatch ordering fix — ETP-4779
+
+Sales Order was the reference implementation the ETP-4779 fix (auto-refresh of the "Documentos"
+panel after generating a derived document) was modeled on for `purchase-order`, `goods-receipt`,
+`goods-shipment`, and `sales-quotation` — QA's original 2026-08-11 pass found it already working.
+A later live user report showed it was **not** actually fixed: generating an invoice from a
+confirmed order still required a manual page reload.
+
+**Root cause**, confirmed by reproducing live on `localhost:3100` (same method used for the
+identical bug found in `purchase-order`'s `PurchaseOrderActions.jsx`): in
+`artifacts/sales-order/custom/OrderCreateInvoice.jsx`'s `ConfirmModal.handleConfirm` — the
+"Confirmar" flow used to confirm a still-Draft order and optionally generate its shipment/invoice
+in the same modal — the `sales-order:document-created` `window` `CustomEvent` was dispatched
+right after **Step 1** (`documentAction=CO`), *before* **Steps 2/3** (`createShipment` /
+`createDraftInvoice`) had even run. `RelatedDocuments.jsx`'s listener reacted correctly and
+refetched immediately, but at that point neither derived document existed yet, so the refetch
+always came back empty — and because nothing dispatched the event again afterward, the panel
+never learned about the documents Steps 2/3 went on to create. Verified live: confirming a Draft
+order with both "Crear albarán" and "Crear factura" checked showed the success modal listing both
+documents, but the "Documentos" row behind it kept showing only the pre-existing linked quotation
+chip, forever — not merely delayed. This is a timing-dependent race (QA's original pass happened
+not to hit it), not a regression from any other change.
+
+`CreateDocsModal` (the separate "Gestionar" modal for already-`CO` orders, further down in the
+same file) never had this bug — it already dispatched once, after its POST(s) resolved.
+
+**Fix:** moved the dispatch in `handleConfirm` to fire once, after Steps 2/3 both settle, right
+before `onConfirmed({...})` — mirroring `CreateDocsModal.handleCreate`'s already-correct
+placement — guarded to only fire when a shipment or invoice actually exists
+(`finalShipment || finalInvoice`). Added the same guarded dispatch to `handleClose`'s
+partial-failure path (e.g. the shipment POST succeeds but the invoice POST then fails and the
+user closes instead of retrying), which previously could leave a successfully-created shipment
+with no event at all.
+
+Verified live end-to-end on `localhost:3100` after the fix: confirming a Draft order with both
+checkboxes shows the quotation, Envío, and Factura chips together in the "Documentos" row
+immediately, before even closing the success modal — no reload, no lag.
+
+Same fix pattern, same file shape, as
+`docs/generated-custom-windows/purchase-order.md`'s "Related Documents auto-refresh — ETP-4779"
+section — read that one for the fuller before/after narrative (missing-listener pass +
+premature-dispatch pass) since both bugs were found and fixed in the same two-pass sequence.

--- a/docs/generated-custom-windows/sales-quotation.md
+++ b/docs/generated-custom-windows/sales-quotation.md
@@ -334,6 +334,21 @@ restoring list-view print to always-visible as the new, intended, tested baselin
 detail-view `hidePrintWhen` gate above still applies. See `docs/decisions-reference.md`
 ("Print Visibility") for the full collision writeup.
 
+## Related Documents auto-refresh — ETP-4779
+
+Converting a quotation into a Sales Order or Sales Invoice (`QuotationConfirmModal.jsx`) used to
+refresh the "Documentos" tab only via a full `window.location.reload()` on
+`handleCloseAfterCreate`. `QuotationConfirmModal` now dispatches a
+`sales-quotation:document-created` `window` `CustomEvent` right after each conversion action
+succeeds (`Convertquotation` / `createDraftInvoice`), mirroring the
+`sales-order:document-created` / `purchase-order:document-created` convention those two windows
+already use. `RelatedDocuments.jsx` listens for that event and bumps its local `refreshKey`
+(the same key that drives its `fetchByCriteria` effect), so the newly created order/invoice
+chip appears without a manual reload. `QuotationTopbarActions.jsx` (the `topbarRight` component)
+threads the `onRefresh` prop `DetailView.jsx` already passes it down to `QuotationConfirmModal`,
+which now calls it from `handleCloseAfterCreate` instead of reloading — refreshing the header
+badge/readonly state in place of the event, which only covers the related-docs panel.
+
 ## Theme roles
 
 The window's live artifact custom components use the shared semantic theme.


### PR DESCRIPTION
Follow-up to #1048 (merged) after QA failure on ETP-4779.

## Context

PR #1048 ("Refresh related-docs section after generating a derived document") merged into `epic/ETP-3504`. QA (Emilio Polliotti, 2026-08-11) then failed ETP-4779 in manual validation: the "Documentos" section auto-refresh worked for Sales Order but not Purchase Order (blocking), and Sales Quotation / Goods Shipment / Goods Receipt fell back to a full page reload instead of a partial refresh (non-blocking but inconsistent UX).

## Root causes found and fixed

1. **Missing listener** (Purchase Order, Sales Quotation initially) — `RelatedDocuments.jsx` for these windows wasn't listening for the `document-created` window event other components already dispatched. Fixed by adding the listener.
2. **Full page reload instead of partial refresh** (Goods Receipt, Goods Shipment) — these called `window.location.reload()` instead of using the `onRefresh` prop `DetailView.jsx` already threads down. Fixed by wiring `onRefresh` through instead.
3. **Premature event dispatch (race condition)** — the actual root cause of the still-failing Purchase Order case, and (once manually retested) an identical latent bug in Sales Order: `PurchaseOrderActions.jsx`'s and `OrderCreateInvoice.jsx`'s "Confirm" modals dispatched the `document-created` event right after the initial confirm step, BEFORE the derived document (goods receipt / invoice / shipment) was actually created in later steps — so the listener refetched too early, found nothing, and nothing dispatched again afterward. Fixed by moving the dispatch to fire once, after all derived-document creation steps settle (guarded so it only fires if something was actually created), mirroring the already-correct pattern in the separate "Gestionar"/`CreateDocsModal` flow. Also fixed the equivalent partial-failure path in each modal's close handler.

## Verification

- Both root causes reproduced live on a running dev server (`localhost:3100`) and reverified fixed live.
- Automated tests: 1167/1167 passing.
- `sf-validate-pipeline` clean across all touched windows (goods-receipt, goods-shipment, purchase-order, sales-order, sales-quotation).
- Manual QA (Irina) on `localhost:3100` after the fixes: confirmed working for Purchase Order and Sales Order (the two that had failed/regressed after the first pass). Goods Receipt, Goods Shipment, and Sales Quotation were confirmed working in an earlier manual pass.

## Out of scope

Related: ETP-4919 (out of scope, tracked separately) — invoices with more than one "factura rectificativa" only relate one instead of all. Split out to its own ticket, not part of this PR.