### PR TITLE
Feature ETP-4848: Default-check invoice option when billing status is under 100%

### DIFF
--- a/artifacts/goods-shipment/custom/GoodsShipmentConfirmModal.jsx
+++ b/artifacts/goods-shipment/custom/GoodsShipmentConfirmModal.jsx
@@ -11,7 +11,7 @@ export default function GoodsShipmentConfirmModal({ base, headers, recordId, dat
       specName="goods-shipment"
       entityName="goodsShipment"
       invoiceAction="createDraftInvoice"
-      defaultCreateInvoice={false}
+      defaultCreateInvoice={true}
       title={ui('goodsShipment.confirmModal.title')}
       docInfo={{
         documentNo: data?.documentNo,

--- a/artifacts/goods-shipment/custom/__tests__/GoodsShipmentConfirmModal.test.js
+++ b/artifacts/goods-shipment/custom/__tests__/GoodsShipmentConfirmModal.test.js
@@ -1,0 +1,52 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(__dirname, '..', 'GoodsShipmentConfirmModal.jsx'), 'utf8');
+
+describe('GoodsShipmentConfirmModal', () => {
+  it('exports a default function component named GoodsShipmentConfirmModal', () => {
+    assert.match(src, /export default function GoodsShipmentConfirmModal/);
+  });
+
+  it('imports ConfirmInOutModal from @/components/contract-ui', () => {
+    assert.match(src, /import ConfirmInOutModal from '@\/components\/contract-ui\/ConfirmInOutModal'/);
+  });
+
+  it('imports useUI from @/i18n', () => {
+    assert.match(src, /import\s*\{[^}]*useUI[^}]*\}\s*from\s*['"]@\/i18n['"]/);
+  });
+
+  // ── ETP-4848: invoice checkbox default ─────────────────────────────────────
+  // GoodsShipmentConfirmModal is only ever mounted by GoodsShipmentActions when
+  // data.invoiceStatus < 100 (see the `!isCompleted && showConfirmModal &&` branch,
+  // the fully-invoiced case renders ConfirmShipmentInvoicedModal instead), so this
+  // modal can hardcode defaultCreateInvoice=true unconditionally.
+  describe('invoice checkbox default (ETP-4848)', () => {
+    it('passes defaultCreateInvoice={true} to ConfirmInOutModal', () => {
+      assert.match(src, /defaultCreateInvoice=\{true\}/);
+    });
+
+    it('does not pass defaultCreateInvoice={false} (regression guard)', () => {
+      assert.doesNotMatch(src, /defaultCreateInvoice=\{false\}/);
+    });
+
+    it('passes a non-empty invoiceAction so the toggle actually renders', () => {
+      assert.match(src, /invoiceAction="createDraftInvoice"/);
+    });
+  });
+
+  it('passes recordId, base, headers through from props', () => {
+    assert.match(src, /base=\{base\}/);
+    assert.match(src, /headers=\{headers\}/);
+    assert.match(src, /recordId=\{recordId\}/);
+  });
+
+  it('passes onConfirmed and onClose through from props', () => {
+    assert.match(src, /onConfirmed=\{onConfirmed\}/);
+    assert.match(src, /onClose=\{onClose\}/);
+  });
+});

--- a/e2e/tests/flows/goods-shipment-confirm-and-invoice.mocked.spec.js
+++ b/e2e/tests/flows/goods-shipment-confirm-and-invoice.mocked.spec.js
@@ -121,15 +121,19 @@ test.describe('Goods Shipment — Confirm modal (draft to complete)', () => {
    * Verifies that GoodsShipmentConfirmModal:
    *  - Opens when the draftMode confirm button is clicked
    *  - Shows the blue summary card (shipmentRef, BP name, total from linkedOrder)
-   *  - Shows the optional invoice generation section with the "Crear factura" card
-   *  - Shows "Confirmar pedido" button when the invoice checkbox is unchecked
+   *  - Shows the optional invoice generation section with the "Crear factura" card,
+   *    checked by default (ETP-4848: GoodsShipmentConfirmModal always renders with
+   *    defaultCreateInvoice=true — its caller only mounts it when invoiceStatus < 100)
+   *  - Reverts the confirm button back to the plain "Confirmar albarán" label when
+   *    the invoice checkbox is unchecked
    *  - Calls documentAction on confirm and closes (reloads page)
    *
-   * The checkbox toggle → "Confirmar + factura →" path is covered implicitly by
-   * GoodsShipmentConfirmModal unit tests and by the CreateInvoiceConfirmModal
-   * describe below (which tests the full invoice creation flow end-to-end).
+   * The "confirm + invoice" happy path (toggle left ON, POST createDraftInvoice) is
+   * covered implicitly by GoodsShipmentConfirmModal unit tests and by the
+   * CreateInvoiceConfirmModal describe below (which tests the full invoice creation
+   * flow end-to-end).
    */
-  test('opens with shipment summary and invoice option; confirm without invoice closes modal', async ({ page }) => {
+  test('opens with shipment summary, invoice option checked by default; unchecking reverts the confirm label; confirm without invoice closes modal', async ({ page }) => {
     const shipment = makeShipment({
       id: 'gs-draft-001',
       documentNo: 'GS-DRAFT-001',
@@ -177,9 +181,24 @@ test.describe('Goods Shipment — Confirm modal (draft to complete)', () => {
     // Document number appears in the subtitle
     await expect(page.getByTestId('confirm-modal-doc-info')).toContainText('GS-DRAFT-001');
     // Invoice toggle card is visible
-    await expect(page.getByTestId('confirm-modal-invoice-toggle')).toBeVisible({ timeout: 5_000 });
-    // Confirm button is visible
-    await expect(page.getByTestId('confirm-modal-confirm-btn')).toBeVisible({ timeout: 5_000 });
+    const invoiceToggle = page.getByTestId('confirm-modal-invoice-toggle');
+    await expect(invoiceToggle).toBeVisible({ timeout: 5_000 });
+
+    // ETP-4848: shipment.invoiceStatus is 0 (< 100, per makeShipment's default) →
+    // GoodsShipmentConfirmModal renders with defaultCreateInvoice=true, so the
+    // toggle must be checked on mount, without any user interaction.
+    await expect(invoiceToggle).toHaveAttribute('aria-checked', 'true');
+
+    // Confirm button is visible and shows the "confirm + invoice" label while the
+    // toggle is checked.
+    const confirmBtn = page.getByTestId('confirm-modal-confirm-btn');
+    await expect(confirmBtn).toBeVisible({ timeout: 5_000 });
+    await expect(confirmBtn).toHaveText(/confirmar y crear factura/i);
+
+    // ── Unchecking the toggle reverts the confirm button to the plain label ──
+    await invoiceToggle.click();
+    await expect(invoiceToggle).toHaveAttribute('aria-checked', 'false');
+    await expect(confirmBtn).toHaveText(/confirmar albarán/i);
 
     // ── Cancel closes the modal synchronously ─────────────────────────────
     // handleClose() → onClose() → setShowConfirmModal(false) → modal unmounts.

--- a/tools/app-shell/src/components/contract-ui/ConfirmInOutModal.jsx
+++ b/tools/app-shell/src/components/contract-ui/ConfirmInOutModal.jsx
@@ -136,8 +136,8 @@ export default function ConfirmInOutModal({
         {/* Body */}
         <div style={{ padding: '20px', display: 'flex', flexDirection: 'column', gap: 14 }}>
 
-          {/* Info row — hidden when only creating invoice (skipDocumentAction) */}
-          {!skipDocumentAction && infoRowBold && (
+          {/* Info row — hidden when only creating invoice (skipDocumentAction) or when no invoice action is available */}
+          {!skipDocumentAction && invoiceAction && infoRowBold && (
             <div style={{ display: 'flex', alignItems: 'flex-start', gap: 10 }}>
               <div style={{ width: 24, height: 24, borderRadius: '50%', background: 'var(--status-success-bg)', border: '1px solid var(--status-success-border)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, marginTop: 1 }}>
                 <svg width="12" height="10" viewBox="0 0 12 10" fill="none" stroke="var(--status-success-fg)" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
@@ -152,8 +152,8 @@ export default function ConfirmInOutModal({
             </div>
           )}
 
-          {/* Toggle card — hidden when only creating invoice (skipDocumentAction) */}
-          {!skipDocumentAction && <div
+          {/* Toggle card — hidden when only creating invoice (skipDocumentAction) or when no invoice action is available */}
+          {!skipDocumentAction && invoiceAction && <div
             role="switch"
             aria-checked={createInvoice}
             data-testid="confirm-modal-invoice-toggle"

--- a/tools/app-shell/src/components/contract-ui/__tests__/ConfirmInOutModal.spec.jsx
+++ b/tools/app-shell/src/components/contract-ui/__tests__/ConfirmInOutModal.spec.jsx
@@ -135,4 +135,39 @@ describe('ConfirmInOutModal', () => {
     fireEvent.click(screen.getByText('Confirm'));
     await waitFor(() => expect(screen.getByText('Server error')).toBeInTheDocument());
   });
+
+  // ── ETP-4848: invoiceAction gating + default-checked toggle ────────────────
+
+  it('does not render the invoice toggle or info row when invoiceAction is omitted', () => {
+    const { invoiceAction, ...propsWithoutInvoiceAction } = BASE_PROPS;
+    render(<ConfirmInOutModal {...propsWithoutInvoiceAction} />);
+    expect(screen.queryByTestId('confirm-modal-invoice-toggle')).not.toBeInTheDocument();
+    expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+    expect(screen.queryByText('You are about to confirm')).not.toBeInTheDocument();
+  });
+
+  it('does not render the invoice toggle when invoiceAction is undefined explicitly', () => {
+    render(<ConfirmInOutModal {...BASE_PROPS} invoiceAction={undefined} />);
+    expect(screen.queryByTestId('confirm-modal-invoice-toggle')).not.toBeInTheDocument();
+  });
+
+  it('confirm button still works and calls only documentAction (no invoice call) when invoiceAction is omitted', async () => {
+    const onConfirmed = vi.fn();
+    const { invoiceAction, ...propsWithoutInvoiceAction } = BASE_PROPS;
+    render(<ConfirmInOutModal {...propsWithoutInvoiceAction} onConfirmed={onConfirmed} />);
+    fireEvent.click(screen.getByText('Confirm'));
+    await waitFor(() => expect(onConfirmed).toHaveBeenCalledWith({ invoice: null }));
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(globalThis.fetch.mock.calls[0][0]).toContain('/action/documentAction');
+  });
+
+  it('toggle renders checked (aria-checked="true") by default when invoiceAction is provided and defaultCreateInvoice=true', () => {
+    render(<ConfirmInOutModal {...BASE_PROPS} invoiceAction="createInvoice" defaultCreateInvoice={true} />);
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('toggle renders unchecked (aria-checked="false") by default when invoiceAction is provided and defaultCreateInvoice=false', () => {
+    render(<ConfirmInOutModal {...BASE_PROPS} invoiceAction="createInvoice" defaultCreateInvoice={false} />);
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false');
+  });
 });

--- a/tools/app-shell/src/windows/custom/shared/ConfirmWithCreditButtonBase.jsx
+++ b/tools/app-shell/src/windows/custom/shared/ConfirmWithCreditButtonBase.jsx
@@ -32,6 +32,8 @@ export default function ConfirmWithCreditButtonBase({
 
   if (status !== 'DR' && status !== 'CO') return null;
 
+  const isFullyInvoiced = parseFloat(data?.invoiceStatus ?? 0) >= 100;
+
   return (
     <>
       {status === 'DR' && (
@@ -57,8 +59,8 @@ export default function ConfirmWithCreditButtonBase({
           recordId={data?.id || recordId}
           specName={specName}
           entityName={entityName}
-          invoiceAction="createReturnInvoice"
-          defaultCreateInvoice={true}
+          invoiceAction={isFullyInvoiced ? undefined : 'createReturnInvoice'}
+          defaultCreateInvoice={!isFullyInvoiced}
           title={confirmModalTitle}
           docInfo={{ bpName: data?.['businessPartner$_identifier'], documentNo: data?.documentNo }}
           infoRowPre={infoRowPre}

--- a/tools/app-shell/src/windows/custom/shared/__tests__/ConfirmWithCreditButtonBase.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/shared/__tests__/ConfirmWithCreditButtonBase.vitest.jsx
@@ -22,8 +22,15 @@ vi.mock('sonner', () => ({
 // own callback wiring (onConfirmed/onClose/onConfirm/navigate) via buttons the
 // tests can click directly — the real modals' internals are out of scope here.
 vi.mock('@/components/contract-ui/ConfirmInOutModal', () => ({
-  default: ({ onConfirmed, onClose }) => (
-    <div data-testid="confirm-inout-modal">
+  // invoiceAction/defaultCreateInvoice are exposed as data-attributes (ETP-4848)
+  // so tests can assert what ConfirmWithCreditButtonBase computed and passed down,
+  // without needing to render the real modal's internals.
+  default: ({ onConfirmed, onClose, invoiceAction, defaultCreateInvoice }) => (
+    <div
+      data-testid="confirm-inout-modal"
+      data-invoice-action={invoiceAction ?? ''}
+      data-default-create-invoice={String(defaultCreateInvoice)}
+    >
       <button data-testid="confirm-inout-confirm-with-id" onClick={() => onConfirmed({ invoice: { id: 'INV-1', documentNo: 'FC-001', amount: 100 } })} />
       <button data-testid="confirm-inout-confirm-no-id" onClick={() => onConfirmed({ invoice: {} })} />
       <button data-testid="confirm-inout-close" onClick={onClose} />
@@ -310,5 +317,63 @@ describe('ConfirmWithCreditButtonBase — modal open/close/confirm wiring', () =
     await waitFor(() => expect(screen.queryByTestId('confirm-result-modal')).not.toBeInTheDocument());
     await waitFor(() => expect(window.location.reload).toHaveBeenCalledTimes(1));
     expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});
+
+// ETP-4848 — DR-status confirm modal must default-check the invoice option
+// whenever the document is not yet fully invoiced (isFullyInvoiced = parseFloat
+// (data?.invoiceStatus ?? 0) >= 100), and must hide the invoice option entirely
+// (invoiceAction=undefined) once it is fully invoiced.
+describe('ConfirmWithCreditButtonBase — DR confirm modal invoice gating by invoiceStatus (ETP-4848)', () => {
+  it('passes invoiceAction="createReturnInvoice" and defaultCreateInvoice=true when invoiceStatus is partial (40)', () => {
+    render(
+      <ConfirmWithCreditButtonBase
+        {...BASE_PROPS}
+        data={{ documentStatus: 'DR', linesCount: 2, invoiceStatus: 40 }}
+      />
+    );
+    fireEvent.click(screen.getByTestId('action-confirm-with-credit'));
+    const modal = screen.getByTestId('confirm-inout-modal');
+    expect(modal).toHaveAttribute('data-invoice-action', 'createReturnInvoice');
+    expect(modal).toHaveAttribute('data-default-create-invoice', 'true');
+  });
+
+  it('passes invoiceAction="createReturnInvoice" and defaultCreateInvoice=true when invoiceStatus is unset', () => {
+    render(
+      <ConfirmWithCreditButtonBase
+        {...BASE_PROPS}
+        data={{ documentStatus: 'DR', linesCount: 2 }}
+      />
+    );
+    fireEvent.click(screen.getByTestId('action-confirm-with-credit'));
+    const modal = screen.getByTestId('confirm-inout-modal');
+    expect(modal).toHaveAttribute('data-invoice-action', 'createReturnInvoice');
+    expect(modal).toHaveAttribute('data-default-create-invoice', 'true');
+  });
+
+  it('passes invoiceAction=undefined and defaultCreateInvoice=false when invoiceStatus is 100 (number)', () => {
+    render(
+      <ConfirmWithCreditButtonBase
+        {...BASE_PROPS}
+        data={{ documentStatus: 'DR', linesCount: 2, invoiceStatus: 100 }}
+      />
+    );
+    fireEvent.click(screen.getByTestId('action-confirm-with-credit'));
+    const modal = screen.getByTestId('confirm-inout-modal');
+    expect(modal).toHaveAttribute('data-invoice-action', '');
+    expect(modal).toHaveAttribute('data-default-create-invoice', 'false');
+  });
+
+  it('passes invoiceAction=undefined and defaultCreateInvoice=false when invoiceStatus is "100" (string, real API shape)', () => {
+    render(
+      <ConfirmWithCreditButtonBase
+        {...BASE_PROPS}
+        data={{ documentStatus: 'DR', linesCount: 2, invoiceStatus: '100' }}
+      />
+    );
+    fireEvent.click(screen.getByTestId('action-confirm-with-credit'));
+    const modal = screen.getByTestId('confirm-inout-modal');
+    expect(modal).toHaveAttribute('data-invoice-action', '');
+    expect(modal).toHaveAttribute('data-default-create-invoice', 'false');
   });
 });


### PR DESCRIPTION
## Summary

On the "Complete" confirmation popup for the 4 delivery-note flows (Sales Shipment, Purchase Receipt, Sales Return, Purchase Return), the "create invoice / create rectificative invoice" checkbox now defaults to **checked** when `invoiceStatus < 100`, and is **hidden entirely** when already at 100%.

Jira: ETP-4848

## Files changed

- `tools/app-shell/src/components/contract-ui/ConfirmInOutModal.jsx` — generic gate on `invoiceAction`
- `artifacts/goods-shipment/custom/GoodsShipmentConfirmModal.jsx` — default flip
- `tools/app-shell/src/windows/custom/shared/ConfirmWithCreditButtonBase.jsx` — `isFullyInvoiced` gating, shared by both return flows

Plus regression tests:
- `ConfirmInOutModal.spec.jsx`
- `ConfirmWithCreditButtonBase.vitest.jsx`
- new `GoodsShipmentConfirmModal.test.js`
- fixed e2e spec `goods-shipment-confirm-and-invoice.mocked.spec.js`

`goods-receipt` needed no change — it already implemented this pattern correctly.

## Note on pre-push hook bypass

The local pre-push hook's live-backend Playwright integration suite failed on `tests/flows/purchase-order-to-invoice.integration.spec.js`. This was investigated via two separate trace runs, and in both cases the failure point had nothing to do with this diff:

- First run: a product-search-drawer debounce/timeout race in the Purchase Order line-add flow.
- Second run: a `waitForResponse` in the `addProductLine` e2e helper (`e2e/tests/helpers/purchase-helpers.js:236`) waiting on a generic `/sws/neo/` response that isn't causally tied to the click that triggers it — pre-existing test-helper flakiness, confirmed unrelated by grepping for any reference to the 3 changed files inside the purchase-order window (zero matches).

Irina pushed with `--no-verify` after this investigation rather than block on an unrelated flaky test. A follow-up fix for the flaky helper is still open (not yet done, not part of this PR).

## Test plan

- [ ] REVIEW (Alex) to run `npx sf-validate-pipeline --scope=goods-shipment,goods-receipt` (or relevant scope) and confirm 0 violations
- [ ] QA (Sentinel) to validate the 4 delivery-note flows manually
- [ ] Follow-up: fix flaky `addProductLine` e2e helper