### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.33",
-        "@etendosoftware/schema-forge-cli": "0.3.33",
-        "@etendosoftware/schema-forge-core": "0.3.33",
+        "@etendosoftware/app-shell-core": "0.3.34",
+        "@etendosoftware/schema-forge-cli": "0.3.34",
+        "@etendosoftware/schema-forge-core": "0.3.34",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.33",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.33/7b063cbeac3b06b4af1139b766145d355de3be5d",
-      "integrity": "sha512-ciXECoqjoBfzsiVF9ZTfwIysgCKhcS60LQrQeXiIwDrUvT1DMwj3kDMUZx6E/3d064CWsCrrs11iotLZmiyg6A==",
+      "version": "0.3.34",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.34/4185c89c8c44003fba0ad633a09b88dcdf85ec35",
+      "integrity": "sha512-RgDKaOnJfmZtnkwUCx49xDSZkoyo9QSFgaeWioFyYJ79peqIecthC6xaq+lyXheA1+4z6TrVi78PLtlQkWzeZQ==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.33",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.33/87c65b4eb74fbf9874504b4ef8e778d71a217550",
-      "integrity": "sha512-obLHGNi9XaINEX7AI+JzbSHxPQhPP3tvLpEt2I1XsyulU7RUkVcI3p7RZkl1YEKzA3KzpUQjLpVAn8AXzpGGfA==",
+      "version": "0.3.34",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.34/98d886dbc50bb88a5d9a1b3c88d9570178513586",
+      "integrity": "sha512-yopgFiTBQ/jt0i5yGu7GEQxHXynCVekRwe94ydVJu5mrrKAaJ3zIYdNx79lkZG9OBB8Ql1KXr6Fok8+ntd1RMg==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.33",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.33/c10ef9375a1689d2cb59a49903360e27ae8e36d4",
-      "integrity": "sha512-2Yu77cbUGcH1Pyz1aPWt0I/z9bJaFv1nFJka1EYPxZ14+caMpbrPgDOh5t/1sBqhBSo9BiXJ8TSU/65ggZPo3g==",
+      "version": "0.3.34",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.34/08c9369b9c401c80e03b7ab219ce79eefc491fa1",
+      "integrity": "sha512-gCa9nKro6ZMfLFyKM2rcDurS+DCJBPd6Z48dLtzCvvVaWo3QT0IVlOB3o2KkwFcIw1w2U+TTVkX/+nXCMOCuzQ==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.33",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.33/8c87af753ac1dc7eec36a3a272e7ca2590e3b101",
-      "integrity": "sha512-4qQ+M2qF4VZQGKgc60rhsbKNtIsMkylXBUM/xw7sAsbauPkIqDQygs1xIhiI5krPpI+HbMBs5WJHrhypJDQ0ZQ==",
+      "version": "0.3.34",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.34/bfec042183f3da7b26d974a5e0549ee5a2426ece",
+      "integrity": "sha512-JNpxbqaB6uVGihXiivu3HxCGTH0mMTO0Jax/eXIJh+07WpHrTD7Gp3YPKYQv5R345gPTrHSE3B6Wb3fgQT4pXw==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13780,8 +13780,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.33",
-        "@etendosoftware/etendo-go-core": "0.3.33",
+        "@etendosoftware/app-shell-core": "0.3.34",
+        "@etendosoftware/etendo-go-core": "0.3.34",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.33",
-    "@etendosoftware/schema-forge-cli": "0.3.33",
-    "@etendosoftware/schema-forge-core": "0.3.33",
+    "@etendosoftware/app-shell-core": "0.3.34",
+    "@etendosoftware/schema-forge-cli": "0.3.34",
+    "@etendosoftware/schema-forge-core": "0.3.34",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.33",
-        "@etendosoftware/etendo-go-core": "0.3.33",
+        "@etendosoftware/app-shell-core": "0.3.34",
+        "@etendosoftware/etendo-go-core": "0.3.34",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.33",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.33/7b063cbeac3b06b4af1139b766145d355de3be5d",
-      "integrity": "sha512-ciXECoqjoBfzsiVF9ZTfwIysgCKhcS60LQrQeXiIwDrUvT1DMwj3kDMUZx6E/3d064CWsCrrs11iotLZmiyg6A==",
+      "version": "0.3.34",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.34/4185c89c8c44003fba0ad633a09b88dcdf85ec35",
+      "integrity": "sha512-RgDKaOnJfmZtnkwUCx49xDSZkoyo9QSFgaeWioFyYJ79peqIecthC6xaq+lyXheA1+4z6TrVi78PLtlQkWzeZQ==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.33",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.33/87c65b4eb74fbf9874504b4ef8e778d71a217550",
-      "integrity": "sha512-obLHGNi9XaINEX7AI+JzbSHxPQhPP3tvLpEt2I1XsyulU7RUkVcI3p7RZkl1YEKzA3KzpUQjLpVAn8AXzpGGfA==",
+      "version": "0.3.34",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.34/98d886dbc50bb88a5d9a1b3c88d9570178513586",
+      "integrity": "sha512-yopgFiTBQ/jt0i5yGu7GEQxHXynCVekRwe94ydVJu5mrrKAaJ3zIYdNx79lkZG9OBB8Ql1KXr6Fok8+ntd1RMg==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.33",
-    "@etendosoftware/etendo-go-core": "0.3.33",
+    "@etendosoftware/app-shell-core": "0.3.34",
+    "@etendosoftware/etendo-go-core": "0.3.34",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.34`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.