### PR TITLE
Feature ETP-4914: Assets Centro de costo is Por config, not Nunca

### DIFF
--- a/artifacts/assets/contract.json
+++ b/artifacts/assets/contract.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.43.0",
+  "version": "0.44.0",
   "generatedAt": "2026-04-29T19:06:30.936Z",
-  "updatedAt": "2026-08-13T10:27:12.246Z",
-  "checksum": "0a9b37b0def7dd37",
+  "updatedAt": "2026-08-19T15:15:00.244Z",
+  "checksum": "3a2812db53cc826c",
   "frontendContract": {
     "window": {
       "id": "800027",
@@ -772,6 +772,30 @@
             "displayLogic": {
               "raw": "@IsDepreciated@='Y'",
               "evaluable": true
+            }
+          },
+          {
+            "name": "eTADASCostCenter",
+            "apiKey": "eTADASCostCenter",
+            "column": "EM_Etadas_Costcenter_ID",
+            "label": "Cost Center",
+            "type": "foreignKey",
+            "tsType": "string",
+            "visibility": "editable",
+            "required": false,
+            "grid": false,
+            "form": true,
+            "reference": "Costcenter",
+            "inputMode": "selector",
+            "section": "principal",
+            "validation": {
+              "maxLength": 32
+            },
+            "displayLogic": {
+              "raw": "@$Element_CC@='Y' & @IsDepreciated@='Y'",
+              "evaluable": false,
+              "reason": "accounting-dimension",
+              "js": null
             }
           },
           {
@@ -1709,7 +1733,7 @@
             "apiKey": "eTADASCostCenter",
             "column": "EM_Etadas_Costcenter_ID",
             "type": "foreignKey",
-            "visibility": "discarded",
+            "visibility": "editable",
             "required": false
           },
           {
@@ -2210,6 +2234,14 @@
         "url": "/sws/neo/assets/assets/selectors/project"
       },
       {
+        "entity": "assets",
+        "field": "eTADASCostCenter",
+        "column": "EM_Etadas_Costcenter_ID",
+        "reference": "Costcenter",
+        "inputMode": "selector",
+        "url": "/sws/neo/assets/assets/selectors/eTADASCostCenter"
+      },
+      {
         "entity": "amortizationLine",
         "field": "amortization",
         "column": "A_Amortization_ID",
@@ -2503,6 +2535,14 @@
         "description": "Display logic for 'depreciationType' in assets should have evaluable flag"
       },
       {
+        "id": "t-displaylogic-evaluable-assets-eTADASCostCenter",
+        "category": "displaylogic-evaluable",
+        "entity": "assets",
+        "field": "eTADASCostCenter",
+        "runner": "node",
+        "description": "Display logic for 'eTADASCostCenter' in assets should have evaluable flag"
+      },
+      {
         "id": "t-displaylogic-evaluable-assets-everyMonthIs30Days",
         "category": "displaylogic-evaluable",
         "entity": "assets",
@@ -2653,6 +2693,14 @@
         "field": "depreciationType",
         "runner": "node",
         "description": "Display logic for 'depreciationType' in assets should be valid JS"
+      },
+      {
+        "id": "t-displaylogic-valid-assets-eTADASCostCenter",
+        "category": "displaylogic-valid",
+        "entity": "assets",
+        "field": "eTADASCostCenter",
+        "runner": "node",
+        "description": "Display logic for 'eTADASCostCenter' in assets should be valid JS"
       },
       {
         "id": "t-displaylogic-valid-assets-everyMonthIs30Days",
@@ -2909,6 +2957,14 @@
         "field": "description",
         "runner": "node",
         "description": "Field 'description' should be present in assets"
+      },
+      {
+        "id": "t-field-presence-assets-eTADASCostCenter",
+        "category": "field-presence",
+        "entity": "assets",
+        "field": "eTADASCostCenter",
+        "runner": "node",
+        "description": "Field 'eTADASCostCenter' should be present in assets"
       },
       {
         "id": "t-field-presence-assets-etgoAmortizationStatus",
@@ -3197,6 +3253,14 @@
         "field": "description",
         "runner": "node",
         "description": "Field 'description' should have type 'string' in assets"
+      },
+      {
+        "id": "t-field-type-assets-eTADASCostCenter",
+        "category": "field-type",
+        "entity": "assets",
+        "field": "eTADASCostCenter",
+        "runner": "node",
+        "description": "Field 'eTADASCostCenter' should have type 'string' in assets"
       },
       {
         "id": "t-field-type-assets-etgoAmortizationStatus",
@@ -3546,6 +3610,14 @@
         "description": "Selector endpoint for 'currency' in assets should exist"
       },
       {
+        "id": "t-selector-endpoint-assets-eTADASCostCenter",
+        "category": "selector-endpoint",
+        "entity": "assets",
+        "field": "eTADASCostCenter",
+        "runner": "node",
+        "description": "Selector endpoint for 'eTADASCostCenter' in assets should exist"
+      },
+      {
         "id": "t-selector-endpoint-assets-product",
         "category": "selector-endpoint",
         "entity": "assets",
@@ -3890,14 +3962,6 @@
         "description": "System field 'eTADASActivity' should exist in backend but not frontend for assets"
       },
       {
-        "id": "t-system-field-assets-eTADASCostCenter",
-        "category": "system-field",
-        "entity": "assets",
-        "field": "eTADASCostCenter",
-        "runner": "node",
-        "description": "System field 'eTADASCostCenter' should exist in backend but not frontend for assets"
-      },
-      {
         "id": "t-system-field-assets-eTADASSalesCampaign",
         "category": "system-field",
         "entity": "assets",
@@ -4144,25 +4208,25 @@
       }
     ],
     "summary": {
-      "total": 231,
+      "total": 235,
       "byCategory": {
         "action-endpoint": 2,
         "crud-flags": 3,
         "default-value-type": 9,
-        "displaylogic-evaluable": 19,
-        "displaylogic-valid": 19,
-        "field-presence": 36,
-        "field-type": 36,
+        "displaylogic-evaluable": 20,
+        "displaylogic-valid": 20,
+        "field-presence": 37,
+        "field-type": 37,
         "readonlylogic-evaluable": 4,
         "readonlylogic-valid": 4,
         "rule-declared": 13,
         "searchable-filters": 4,
-        "selector-endpoint": 9,
-        "system-field": 70,
+        "selector-endpoint": 10,
+        "system-field": 69,
         "visibility": 3
       },
       "byRunner": {
-        "node": 231,
+        "node": 235,
         "junit": 0
       }
     }

--- a/artifacts/assets/contract.mcp.json
+++ b/artifacts/assets/contract.mcp.json
@@ -1,8 +1,8 @@
 {
-  "version": "0.43.0",
+  "version": "0.44.0",
   "generatedAt": "2026-04-29T19:06:30.936Z",
-  "updatedAt": "2026-07-28T13:29:08.917Z",
-  "contractChecksum": "0a9b37b0def7dd37",
+  "updatedAt": "2026-08-19T15:15:00.244Z",
+  "contractChecksum": "3a2812db53cc826c",
   "apiPrediction": {
     "specName": "assets",
     "baseUrl": "/sws/neo/assets",
@@ -78,6 +78,14 @@
         "reference": "Project",
         "inputMode": "search",
         "url": "/sws/neo/assets/assets/selectors/project"
+      },
+      {
+        "entity": "assets",
+        "field": "eTADASCostCenter",
+        "column": "EM_Etadas_Costcenter_ID",
+        "reference": "Costcenter",
+        "inputMode": "selector",
+        "url": "/sws/neo/assets/assets/selectors/eTADASCostCenter"
       },
       {
         "entity": "amortizationLine",
@@ -275,6 +283,7 @@
             "required": true,
             "defaultValue": "N"
           },
+          "eTADASCostCenter": {},
           "etgoAmortizationStatus": {
             "readOnly": true,
             "defaultValue": "0"
@@ -392,5 +401,5 @@
     "knownLimitations": [],
     "dangerousOperations": []
   },
-  "checksum": "17ac6dae0ad76be5"
+  "checksum": "6f19cd64f27b44c9"
 }

--- a/artifacts/assets/decisions.json
+++ b/artifacts/assets/decisions.json
@@ -272,8 +272,9 @@
           "reason": "ETP-4529 — accounting dimension, config-gated (raw AD: @$Element_PJ@='Y' & @IsDepreciated@='Y'). Moved from \"other\" to \"principal\" — the config-gated dimension field was rendering in the secondary/collapsed area instead of the main visible form."
         },
         "eTADASCostCenter": {
-          "visibility": "discarded",
-          "reason": "ETP-4529 — Centro de costo is 'Nunca' for Activo (Amortizaciones) per the accounting-dimension matrix."
+          "visibility": "editable",
+          "section": "principal",
+          "reason": "ETP-4914 — correction to the accounting-dimension matrix: Centro de costo is 'Por config' (not 'Nunca') for Activo (Amortizaciones) Cabecera. Config-gated, same as project (raw AD: @$Element_CC@='Y' & @IsDepreciated@='Y')."
         },
         "businessPartner": {
           "visibility": "discarded",

--- a/artifacts/assets/generated/web/assets/AssetsForm.jsx
+++ b/artifacts/assets/generated/web/assets/AssetsForm.jsx
@@ -4,6 +4,7 @@ import { EntityForm } from '@/components/contract-ui';
 const fields = [
   { key: 'product', column: 'M_Product_ID', type: 'search', label: 'Product', section: 'principal', reference: 'Product', inputMode: 'search' },
   { key: 'project', column: 'C_Project_ID', type: 'search', label: 'Project', section: 'principal', reference: 'Project', inputMode: 'search', visible: null, visibilitySource: 'server', displayLogicReason: 'accounting-dimension' },
+  { key: 'eTADASCostCenter', column: 'EM_Etadas_Costcenter_ID', type: 'selector', label: 'Cost Center', section: 'principal', reference: 'Costcenter', inputMode: 'selector', visible: null, visibilitySource: 'server', displayLogicReason: 'accounting-dimension' },
 ];
 // @sf-generated-end fields:assets
 

--- a/artifacts/assets/generated/web/assets/AssetsPage.jsx
+++ b/artifacts/assets/generated/web/assets/AssetsPage.jsx
@@ -124,6 +124,14 @@ export const api = {
       "url": "/sws/neo/assets/assets/selectors/project"
     },
     {
+      "entity": "assets",
+      "field": "eTADASCostCenter",
+      "column": "EM_Etadas_Costcenter_ID",
+      "reference": "Costcenter",
+      "inputMode": "selector",
+      "url": "/sws/neo/assets/assets/selectors/eTADASCostCenter"
+    },
+    {
       "entity": "amortizationLine",
       "field": "amortization",
       "column": "A_Amortization_ID",

--- a/artifacts/assets/generated/web/assets/mockData.js
+++ b/artifacts/assets/generated/web/assets/mockData.js
@@ -30,6 +30,7 @@ export const assets = [
     "depreciatedPlan": 38907,
     "project": "Sample project",
     "processAsset": "Sample processAsset",
+    "eTADASCostCenter": "Sample eTADASCostCenter",
     "etgoAmortizationStatus": "DR"
   },
   {
@@ -61,6 +62,7 @@ export const assets = [
     "depreciatedPlan": 9306,
     "project": "Sample project",
     "processAsset": "Sample processAsset",
+    "eTADASCostCenter": "Sample eTADASCostCenter",
     "etgoAmortizationStatus": "CO"
   },
   {
@@ -92,6 +94,7 @@ export const assets = [
     "depreciatedPlan": 11544,
     "project": "Sample project",
     "processAsset": "Sample processAsset",
+    "eTADASCostCenter": "Sample eTADASCostCenter",
     "etgoAmortizationStatus": "VO"
   },
   {
@@ -123,6 +126,7 @@ export const assets = [
     "depreciatedPlan": 11872,
     "project": "Sample project",
     "processAsset": "Sample processAsset",
+    "eTADASCostCenter": "Sample eTADASCostCenter",
     "etgoAmortizationStatus": "IP"
   },
   {
@@ -154,6 +158,7 @@ export const assets = [
     "depreciatedPlan": 48460,
     "project": "Sample project",
     "processAsset": "Sample processAsset",
+    "eTADASCostCenter": "Sample eTADASCostCenter",
     "etgoAmortizationStatus": "DR"
   },
   {
@@ -185,6 +190,7 @@ export const assets = [
     "depreciatedPlan": 45418,
     "project": "Sample project",
     "processAsset": "Sample processAsset",
+    "eTADASCostCenter": "Sample eTADASCostCenter",
     "etgoAmortizationStatus": "CO"
   },
   {
@@ -216,6 +222,7 @@ export const assets = [
     "depreciatedPlan": 33840,
     "project": "Sample project",
     "processAsset": "Sample processAsset",
+    "eTADASCostCenter": "Sample eTADASCostCenter",
     "etgoAmortizationStatus": "VO"
   },
   {
@@ -247,6 +254,7 @@ export const assets = [
     "depreciatedPlan": 25716,
     "project": "Sample project",
     "processAsset": "Sample processAsset",
+    "eTADASCostCenter": "Sample eTADASCostCenter",
     "etgoAmortizationStatus": "IP"
   },
   {
@@ -278,6 +286,7 @@ export const assets = [
     "depreciatedPlan": 44780,
     "project": "Sample project",
     "processAsset": "Sample processAsset",
+    "eTADASCostCenter": "Sample eTADASCostCenter",
     "etgoAmortizationStatus": "DR"
   },
   {
@@ -309,6 +318,7 @@ export const assets = [
     "depreciatedPlan": 12483,
     "project": "Sample project",
     "processAsset": "Sample processAsset",
+    "eTADASCostCenter": "Sample eTADASCostCenter",
     "etgoAmortizationStatus": "CO"
   },
   {
@@ -340,6 +350,7 @@ export const assets = [
     "depreciatedPlan": 46022,
     "project": "Sample project",
     "processAsset": "Sample processAsset",
+    "eTADASCostCenter": "Sample eTADASCostCenter",
     "etgoAmortizationStatus": "VO"
   },
   {
@@ -371,6 +382,7 @@ export const assets = [
     "depreciatedPlan": 38634,
     "project": "Sample project",
     "processAsset": "Sample processAsset",
+    "eTADASCostCenter": "Sample eTADASCostCenter",
     "etgoAmortizationStatus": "IP"
   }
 ];

--- a/docs/generated-custom-windows/amortization.md
+++ b/docs/generated-custom-windows/amortization.md
@@ -285,16 +285,24 @@ shape into a reusable mechanism rather than special-casing it:
   expand-panel consistently.
 - **`project`**: raw AD `displayLogic` = `@ACCT_DIMENSION_DISPLAY@` — now genuinely
   config-gated for the first time in this window's history.
-- **`costcenter` / `eTADASBpartner`**: raw AD `displayLogic` on the amortization-line tab is
-  still **empty** for both (`AD_Field.DisplayLogic` was never wired to
-  `@ACCT_DIMENSION_DISPLAY@` at the Application Dictionary level) — a separate, already-tracked
-  gap explicitly **deferred** per product direction (to be fixed by a different, already-existing
-  ticket that populates the AD_Field and regenerates the contract). Per that direction, this hook
-  is wired to *read* whatever `displayLogic.raw` the AD eventually provides rather than hardcoding
-  a value — it fails open (stays visible) for both today, exactly like
-  `NeoDisplayLogicHelper.evaluateExpression()`'s own fail-open behavior server-side. Once the AD
-  change lands and the contract is regenerated, both fields start being correctly gated with
-  **zero further changes** needed in `AmortizationLinesTable.jsx` or the hook.
+- **`costcenter` / `eTADASBpartner`** (ETP-4914 update — this section previously described both
+  fields as having an empty, deferred `AD_Field.DisplayLogic`; that is now stale): direct DB
+  verification confirms both are now correctly wired at the AD level. `Cost Center`
+  (`C_Costcenter_ID`) on the Amortización Lines tab now carries
+  `AD_Field.DisplayLogic = @ACCT_DIMENSION_DISPLAY@` — the same macro `project` uses — AND a
+  matching `AD_Dimension_Mapping` row now exists for `A_Amortizationline` (dimension `CC`,
+  docbasetype `AMZ`, level `L`, active), which is what makes the macro resolve to real,
+  non-empty JS instead of falling back to fail-open (this table did not have that mapping row
+  before). `Business Partner` (`EM_Etadas_C_Bpartner_ID`) carries `AD_Field.DisplayLogic =
+  @$Element_BP@='Y'`. Both changes were made entirely on the AD/DB side — **zero code changes**
+  were needed in `AmortizationLinesTable.jsx` or `useAccountingDimensionFields`, confirming the
+  original design note above: the hook reads whatever `displayLogic.raw` the AD provides with no
+  hardcoding, so it started respecting both fields automatically once the AD metadata landed.
+  Empirically confirmed: `make regen ONLY=amortization` produces a **zero diff** against the
+  committed artifacts — this dimension-gating fix is resolved live via the
+  `evaluate-display`/`NeoDisplayLogicHelper` server-side evaluator, not baked into
+  `contract.json`, so no regeneration step was required for this specific fix. This closes the
+  gap that was previously tracked here as deferred.
 - **`product`**: no product dimension field exists on the amortization-line tab — matrix's
   "Nunca" is already trivially satisfied.
 

--- a/docs/generated-custom-windows/assets.md
+++ b/docs/generated-custom-windows/assets.md
@@ -72,7 +72,7 @@ The Assets window should let a finance user register fixed assets, define how ea
    - percentage path shows **Annual Depreciation %** (label: `assetsAnnualDepreciationLabel`)
    - time path shows **Amortize** and usable-life inputs
 4a. **Product** is a plain, always-visible field in the first (Asset Info) section — confirm it appears next to Asset Category regardless of Depreciate state or GL Configuration, and that selecting a product, saving, and reopening the asset persists the value (see "Accounting dimension visibility per section — ETP-4529" below for why Product is not part of the dimensions group).
-4b. With **Depreciate** enabled, scroll to the last section and confirm the **Dimensiones contables** group appears **after Dates**, config-gated: it shows a single **Project** selector only when the client's accounting-dimension configuration enables the Project dimension for this org's ledger, and disappears entirely otherwise. Open the selector and confirm it returns options; select a value, save and reopen the asset — the value persists. Disable **Depreciate** and confirm the dimensions section disappears.
+4b. With **Depreciate** enabled, scroll to the last section and confirm the **Dimensiones contables** group appears **after Dates**, config-gated: it shows a **Project** and/or **Cost Center** selector, each independently, only when the client's accounting-dimension configuration enables that dimension for this org's ledger (ETP-4914 — Cost Center is now also "Por config", not "Nunca"), and disappears entirely when both resolve to not-visible. Open each visible selector and confirm it returns options; select a value, save and reopen the asset — the value persists. Disable **Depreciate** and confirm the dimensions section disappears.
 5. Save an asset with depreciation enabled and confirm the **Create Amortization** action is available.
 6. Trigger **Create Amortization** against a live backend and confirm the amortization plan tab refreshes and shows ordered schedule rows. Confirm that line status badges read "Pendiente" (not "Planificado") and "Confirmado" (not "Procesado").
 7. Review the right sidebar and confirm it shows four cards in order: Valor actual → Valor residual → Depreciación planificada → Depreciado %. Confirm that "Progreso de depreciación" is absent. Confirm that the sidebar ends above the tabs row — tabs (Plan de amortización, Adjuntos) span the full width below the form area.
@@ -574,6 +574,42 @@ does not join the "Dimensiones contables" panel at all — it is now always show
 - No backend change needed: `product`'s raw AD field already carries the
   `SL_Asset_Product` callout, so selecting a value fires the standard `/assets/callout`
   round-trip like any other field, same as before it was discarded.
+
+### Centro de costo corrected to Por config (ETP-4914)
+
+The accounting-dimension matrix was corrected again: `Activo (Amortizaciones) | Cabecera`
+now reads Contacto=**Por config** (deferred, see below), Producto=**Siempre**, Proyecto=
+**Por config**, Centro de costo=**Por config** (Centro de costo was previously, incorrectly,
+**Nunca** — the "Producto corrected to Siempre" section above and the original ETP-4529
+matrix both had it wrong). Direct DB verification confirmed `eTADASCostCenter`'s raw
+`AD_Field.DisplayLogic` on the Assets tab was already correctly wired all along
+(`@$Element_CC@='Y' & @IsDepreciated@='Y'`, the exact same pattern as `project`'s
+`@$Element_PJ@='Y' & @IsDepreciated@='Y'`) — this was a pure classification/decisions.json
+fix, no AD metadata change needed.
+
+- `decisions.json`: `assets.eTADASCostCenter.visibility` changed from `discarded` to
+  `editable` (`section: "principal"`), matching `project`'s shape.
+- `AssetsDetailPanel.jsx`: `eTADASCostCenter` added to `dimensionFieldCandidates` —
+  `{ key: 'eTADASCostCenter', column: 'EM_Etadas_Costcenter_ID', type: 'selector', section:
+  'principal', reference: 'Costcenter', inputMode: 'selector' }` — resolved through the same
+  `useAccountingDimensionFields('assets', d, dimensionFieldCandidates, { token, apiBaseUrl })`
+  call as `project`, so it is independently config-gated (visible only when the client's Cost
+  Center dimension is enabled for this org's ledger). Confirmed in the regenerated
+  `AssetsForm.jsx`: `eTADASCostCenter` now carries `visibilitySource: 'server'` and
+  `displayLogicReason: 'accounting-dimension'`, the same server-evaluated shape as `project`.
+- **Contacto remains out of scope for this pass**, even though the corrected matrix also
+  marks it "Por config": its raw `AD_Field.DisplayLogic` on the Assets tab is only
+  `@IsDepreciated@='Y'` — missing the `@$Element_BP@` dimension term that `project` and
+  `eTADASCostCenter` both carry — so fixing it properly requires an AD-level `DisplayLogic`
+  metadata edit first, tracked as a separate follow-up. `businessPartner` stays
+  `visibility: "discarded"` in `decisions.json` until that lands.
+- Regenerated via `make regen ONLY=assets`; the contract's auto-generated system-field test
+  entry for `eTADASCostCenter` (previously "should exist in backend but not frontend")
+  was replaced automatically by the standard editable-field test set (displaylogic-evaluable,
+  displaylogic-valid, field-presence, field-type, selector-endpoint) — no manual test-file
+  authoring needed for the contract itself. `AssetsDetailPanel.vitest.jsx` and
+  `AssetsDetailPanel.test.js` were updated to expect both `project` and `eTADASCostCenter`
+  as independently-gated dimension candidates.
 
 ## ETP-4542 — Generic declarative numeric validation (min + integer), applied to Usable Life
 

--- a/e2e/tests/flows/assets.integration.spec.js
+++ b/e2e/tests/flows/assets.integration.spec.js
@@ -28,6 +28,47 @@ const toastByText = (page, re) => page.locator('[data-sonner-toast]').filter({ h
 // "Crear Amortización" process button (label resolves via i18n).
 const crearAmortizacionBtn = (page) => page.getByRole('button', { name: /Crear Amortización|Create Amortization/i });
 
+/**
+ * Registers a wait for the real `POST .../assets/evaluate-display` round trip that
+ * `useAccountingDimensionFields` (via `useDisplayLogic`) fires whenever the asset
+ * form's field values change — in particular right after the "Depreciar" toggle is
+ * clicked. MUST be called BEFORE the action that triggers the change (the click),
+ * so Playwright starts listening before the response can arrive; the 300ms debounce
+ * inside `useDisplayLogic` guarantees the call hasn't already landed by then.
+ *
+ * Asserting `toBeVisible()` on "Dimensiones contables" right after the click (the
+ * previous approach) can pass purely on `useDisplayLogic`'s fail-open initial state
+ * (`{ visibility: {} }`, before the fetch resolves) even when the backend's real
+ * answer is `visibility.project: false` — exactly the boolean-serialization bug
+ * fixed under ETP-4914 in `NeoDisplayLogicHelper.buildJsObjectPreamble`. Awaiting
+ * this response before asserting makes the assertion depend on the real answer.
+ */
+function waitForDimensionEvaluateDisplay(page) {
+  return page.waitForResponse(
+    (resp) => resp.url().includes('/assets/evaluate-display') && resp.request().method() === 'POST',
+    { timeout: 5_000 },
+  );
+}
+
+/**
+ * Asserts "Dimensiones contables" is shown/hidden consistently with the REAL
+ * `evaluate-display` response body, instead of hardcoding an assumed true/false.
+ * `project` is the only accounting-dimension candidate for the Assets header
+ * (AssetsDetailPanel.jsx's `dimensionFieldCandidates`); `useAccountingDimensionFields`
+ * treats any value other than an explicit `false` as visible (fail-open, same as the
+ * server-side evaluator) — mirrored here so the test stays correct regardless of
+ * which way this tenant's GL Configuration currently has the Project dimension set.
+ */
+async function assertDimensionsSectionMatchesResponse(page, evalResponse) {
+  const body = await evalResponse.json();
+  const projectVisible = body?.visibility?.project !== false;
+  if (projectVisible) {
+    await expect(page.getByText('Dimensiones contables')).toBeVisible();
+  } else {
+    await expect(page.getByText('Dimensiones contables')).toHaveCount(0);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
@@ -333,9 +374,13 @@ async function createDepreciableAsset(page, { stamp, name }) {
   await selectGrupoActivoOtros(page);
 
   // Activate "Depreciar" → financial + accounting-dimensions sections appear.
+  // Register the evaluate-display wait BEFORE the click (see helper docblock),
+  // then assert the dimensions section against the REAL resolved answer.
+  const evalPromise = waitForDimensionEvaluateDisplay(page);
   await page.getByRole('switch').first().click();
   await expect(page.getByText('Información financiera')).toBeVisible({ timeout: 5_000 });
-  await expect(page.getByText('Dimensiones contables')).toBeVisible();
+  const evalResponse = await evalPromise;
+  await assertDimensionsSectionMatchesResponse(page, evalResponse);
 
   // Save → record created; wait for the route to settle on /assets/{id} so the
   // process has `selected.id`, then the "Crear Amortización" button is usable.
@@ -979,17 +1024,27 @@ test.describe('Assets (real backend)', () => {
     await expect(page.getByText(DISABLED_HINT, { exact: false })).toBeVisible();
     await expect(page.getByTestId('field-assetValue')).toBeVisible();
 
-    // Activate → financial + accounting-dimensions sections appear.
+    // Activate → financial + accounting-dimensions sections appear. Register the
+    // evaluate-display wait BEFORE the click (see helper docblock), then assert the
+    // dimensions section against the REAL resolved answer, not the fail-open
+    // initial state — see ETP-4914.
+    const evalPromise = waitForDimensionEvaluateDisplay(page);
     await depreciarToggle.click();
     await expect(page.getByText('Información financiera')).toBeVisible({ timeout: 5_000 });
     await expect(page.getByText('Configuración de amortización')).toBeVisible();
     await expect(page.getByText('Fechas', { exact: true })).toBeVisible();
-    await expect(page.getByText('Dimensiones contables')).toBeVisible();
+    const evalResponse = await evalPromise;
+    await assertDimensionsSectionMatchesResponse(page, evalResponse);
     await expect(page.getByTestId('field-assetValue')).toBeVisible();
     await expect(page.getByText(DISABLED_HINT, { exact: false })).toHaveCount(0);
 
     // Deactivate → all those sections hide, hint returns.
     // assetValue stays visible — it lives outside the depreciation-only sections.
+    // No evaluate-display wait needed here: AssetsDetailPanel.jsx hides this section
+    // via the coarse `depreciate && dimensionFields.length > 0` gate, which flips
+    // synchronously with the toggle — it isn't waiting on a fresh server round trip
+    // (the previously-resolved `dimensionFields` value is irrelevant once `depreciate`
+    // itself is false), so there's no race to guard against on this path.
     await depreciarToggle.click();
     await expect(page.getByText(DISABLED_HINT, { exact: false })).toBeVisible({ timeout: 5_000 });
     await expect(page.getByTestId('field-assetValue')).toBeVisible();

--- a/tools/app-shell/src/windows/custom/assets/AssetsDetailPanel.jsx
+++ b/tools/app-shell/src/windows/custom/assets/AssetsDetailPanel.jsx
@@ -253,15 +253,23 @@ export default function AssetsDetailPanel({ data, token, apiBaseUrl, catalogs, a
     return { readOnly, visibility };
   }
 
-  // ETP-4529 — per the accounting-dimension matrix, only Proyecto is "Por config"
-  // (config-gated) for Activo (Amortizaciones); Contacto and Centro de costo are
-  // "Nunca" (never applicable) and are intentionally NOT candidates here at all —
-  // see decisions.json (businessPartner/eTADASCostCenter are discarded) and
-  // docs/generated-custom-windows/assets.md. Producto is "Siempre" (always visible,
-  // rendered unconditionally in group1Fields above) — it is not a GL-config-gated
-  // dimension, so it is deliberately excluded from this candidates list too.
+  // ETP-4914 — correction to the ETP-4529 matrix: Centro de costo is also "Por
+  // config" (config-gated) for Activo (Amortizaciones) Cabecera, not "Nunca" as
+  // originally recorded — its raw AD DisplayLogic (@$Element_CC@='Y' &
+  // @IsDepreciated@='Y') is already correctly wired, same pattern as Proyecto's.
+  // So eTADASCostCenter is now a candidate here too — see decisions.json
+  // (eTADASCostCenter is now editable) and docs/generated-custom-windows/assets.md.
+  // Contacto is also "Por config" per the corrected matrix, but is deliberately
+  // deferred from this pass: its raw AD_Field.DisplayLogic is only
+  // @IsDepreciated@='Y' (missing the @$Element_BP@ dimension term), so fixing it
+  // properly requires an AD-level metadata edit first — tracked separately. It
+  // stays discarded in decisions.json until that follow-up lands. Producto is
+  // "Siempre" (always visible, rendered unconditionally in group1Fields above) —
+  // it is not a GL-config-gated dimension, so it is deliberately excluded from
+  // this candidates list too.
   const dimensionFieldCandidates = [
     { key: 'project', column: 'C_Project_ID', type: 'selector', section: 'principal', reference: 'Project', inputMode: 'selector' },
+    { key: 'eTADASCostCenter', column: 'EM_Etadas_Costcenter_ID', type: 'selector', section: 'principal', reference: 'Costcenter', inputMode: 'selector' },
   ];
   // Config-driven visibility via the shared evaluate-display evaluator (was: always
   // shown whenever depreciate === true, regardless of the client's accounting-

--- a/tools/app-shell/src/windows/custom/assets/__tests__/AssetsDetailPanel.test.js
+++ b/tools/app-shell/src/windows/custom/assets/__tests__/AssetsDetailPanel.test.js
@@ -116,16 +116,18 @@ describe('AssetsDetailPanel — field definitions', () => {
     assert.doesNotMatch(src, /key: 'currency'[\s\S]*?readOnly: true/);
   });
 
-  it('defines only Project as a dimension field candidate (ETP-4529)', () => {
-    // ETP-4529 — per the accounting-dimension matrix, only Proyecto is "Por config"
-    // for Activo (Amortizaciones); Contacto and Centro de costo are "Nunca" and were
-    // dropped as candidates entirely. Producto is "Siempre" (corrected follow-up) —
-    // it lives in group1Fields as a plain always-visible field, never a dimension
+  it('defines Project and Cost Center as dimension field candidates (ETP-4914)', () => {
+    // ETP-4914 — corrected matrix: Centro de costo is also "Por config" for Activo
+    // (Amortizaciones), not "Nunca" as ETP-4529 originally recorded — its raw AD
+    // DisplayLogic is already correctly wired, same pattern as Proyecto's. Contacto
+    // remains dropped (still "Nunca"-equivalent in this pass; its own "Por config"
+    // fix is deferred pending an AD-metadata change). Producto is "Siempre" — it
+    // lives in group1Fields as a plain always-visible field, never a dimension
     // candidate, so this array-scoped check doesn't need to mention it.
     const candidatesBlock = src.match(/dimensionFieldCandidates = \[[\s\S]*?\];/)[0];
     assert.match(candidatesBlock, /'C_Project_ID'/);
-    // The 2 previously-kept-but-now-"Nunca" dimensions are no longer candidates.
-    assert.doesNotMatch(candidatesBlock, /'EM_Etadas_Costcenter_ID'/);
+    assert.match(candidatesBlock, /'EM_Etadas_Costcenter_ID'/);
+    // Contacto is still not a candidate (deferred).
     assert.doesNotMatch(candidatesBlock, /'C_BPartner_ID'/);
     // The 5 out-of-scope dimensions were removed from the panel.
     assert.doesNotMatch(candidatesBlock, /'EM_Etadas_User1_ID'/);

--- a/tools/app-shell/src/windows/custom/assets/__tests__/AssetsDetailPanel.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/assets/__tests__/AssetsDetailPanel.vitest.jsx
@@ -80,48 +80,67 @@ describe('AssetsDetailPanel — depreciation off', () => {
 });
 
 describe('AssetsDetailPanel — depreciation on', () => {
-  it('renders the accounting dimensions form with only the Project candidate (ETP-4529)', () => {
-    // ETP-4529 — Contacto/Producto/Centro de costo are "Nunca" for Activo and are no
-    // longer candidates at all; Project is the only "Por config" dimension left, and
-    // the evaluator (mocked here as visible-by-default) lets it through.
+  it('renders the accounting dimensions form with the Project and Cost Center candidates (ETP-4914)', () => {
+    // ETP-4914 — corrected matrix: Centro de costo is also "Por config" for Activo
+    // (Amortizaciones) Cabecera, not "Nunca" as ETP-4529 originally recorded. It is
+    // now a second dimension candidate alongside Project; the evaluator (mocked here
+    // as visible-by-default) lets both through. Contacto remains "Nunca"-equivalent
+    // in this pass (deferred pending an AD-metadata fix) and Producto is still not a
+    // GL-config-gated dimension, so neither is a candidate here.
     const { container } = render(
       <AssetsDetailPanel {...BASE_PROPS} data={{ id: 'a1', depreciate: 'Y' }} />,
     );
     const dimForm = formsByFields(container).find(f => f.includes('project'));
     expect(dimForm).toBeDefined();
-    expect(dimForm.split(',')).toEqual(['project']);
-    // The 3 dropped-candidate dimensions and the 5 out-of-scope ones never appear.
+    expect(dimForm.split(',')).toEqual(['project', 'eTADASCostCenter']);
+    // Contacto/Producto and the 5 out-of-scope dimensions never appear.
     for (const key of [
-      'eTADASCostCenter', 'businessPartner', 'product',
+      'businessPartner', 'product',
       'eTADASUser1', 'eTADASUser2', 'eTADASSalesRegion', 'eTADASActivity', 'eTADASSalesCampaign',
     ]) {
       expect(dimForm).not.toContain(key);
     }
   });
 
-  it('hides the whole dimensions section when the evaluator marks Project not visible (ETP-4529)', () => {
+  it('hides the whole dimensions section when the evaluator marks both candidates not visible (ETP-4914)', () => {
     // NEW behavior under test: before ETP-4529 the dimensions section always rendered
     // whenever depreciate was on, regardless of any config. Now useAccountingDimensionFields
     // calls the same evaluate-display evaluator DetailView uses, and when it explicitly
-    // returns visibility.project === false, the candidate is filtered out — and since
-    // Project is the only candidate for Assets, the section (title + form) disappears
-    // entirely instead of rendering an empty grid.
-    useDisplayLogic.mockReturnValue({ readOnly: {}, visibility: { project: false } });
+    // returns visibility.project === false and visibility.eTADASCostCenter === false, both
+    // candidates are filtered out — and since they are the only two candidates for Assets,
+    // the section (title + form) disappears entirely instead of rendering an empty grid.
+    useDisplayLogic.mockReturnValue({ readOnly: {}, visibility: { project: false, eTADASCostCenter: false } });
     const { container } = render(
       <AssetsDetailPanel {...BASE_PROPS} data={{ id: 'a1', depreciate: 'Y' }} />,
     );
     expect(formsByFields(container).some(f => f.includes('project'))).toBe(false);
+    expect(formsByFields(container).some(f => f.includes('eTADASCostCenter'))).toBe(false);
     expect(screen.queryByText('assetsGroupDimensionsTitle')).not.toBeInTheDocument();
   });
 
-  it('shows the dimensions section when the evaluator leaves Project visible (ETP-4529)', () => {
-    // Explicit visibility.project === true (config enables the dimension for this
-    // client) — same observable result as the fail-open default, proven separately.
-    useDisplayLogic.mockReturnValue({ readOnly: {}, visibility: { project: true } });
+  it('shows the dimensions section when the evaluator leaves both candidates visible (ETP-4914)', () => {
+    // Explicit visibility.project === true / visibility.eTADASCostCenter === true (config
+    // enables both dimensions for this client) — same observable result as the fail-open
+    // default, proven separately.
+    useDisplayLogic.mockReturnValue({ readOnly: {}, visibility: { project: true, eTADASCostCenter: true } });
     const { container } = render(
       <AssetsDetailPanel {...BASE_PROPS} data={{ id: 'a1', depreciate: 'Y' }} />,
     );
     expect(formsByFields(container).some(f => f.includes('project'))).toBe(true);
+    expect(formsByFields(container).some(f => f.includes('eTADASCostCenter'))).toBe(true);
+    expect(screen.getByText('assetsGroupDimensionsTitle')).toBeInTheDocument();
+  });
+
+  it('hides only Cost Center when the evaluator marks it not visible, keeping Project (ETP-4914)', () => {
+    // The two dimensions are now independently config-gated — one can be enabled while
+    // the other is disabled for a given client.
+    useDisplayLogic.mockReturnValue({ readOnly: {}, visibility: { project: true, eTADASCostCenter: false } });
+    const { container } = render(
+      <AssetsDetailPanel {...BASE_PROPS} data={{ id: 'a1', depreciate: 'Y' }} />,
+    );
+    const dimForm = formsByFields(container).find(f => f.includes('project'));
+    expect(dimForm).toBeDefined();
+    expect(dimForm).not.toContain('eTADASCostCenter');
     expect(screen.getByText('assetsGroupDimensionsTitle')).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- **Assets Centro de costo corrected to "Por config"**: the ETP-4529 accounting-dimension matrix had `Activo (Amortizaciones) | Cabecera | Centro de costo` marked **Nunca**, but that was wrong — its raw `AD_Field.DisplayLogic` on the Assets tab was already correctly wired all along (`@$Element_CC@='Y' & @IsDepreciated@='Y'`, same pattern as `project`'s `@$Element_PJ@='Y' & @IsDepreciated@='Y'`). Valeria confirmed the corrected classification via an updated Jira matrix. Pure classification fix, no AD metadata change needed here:
  - `artifacts/assets/decisions.json`: `eTADASCostCenter.visibility` `discarded` → `editable` (`section: "principal"`)
  - `AssetsDetailPanel.jsx`: `eTADASCostCenter` added to `dimensionFieldCandidates`, independently config-gated through the same `useAccountingDimensionFields` call as `project`
  - Regenerated via `make regen ONLY=assets`, pushed to NEO and exported to XML — the NEO XML data persistence half of this same fix lands in the companion `com.etendoerp.go` PR #890 (`ETGO_ACCOUNT.xml` + sourcedata)
  - `businessPartner` (Contacto) stays **out of scope/deferred** — the corrected matrix also marks it "Por config", but its raw `AD_Field.DisplayLogic` is only `@IsDepreciated@='Y'`, missing the `@$Element_BP@` dimension term that `project`/`eTADASCostCenter` carry. Needs a separate AD `DisplayLogic` metadata fix before it can follow the same pattern.
- **E2E timing-gap fix** (`assets.integration.spec.js`): the original dimension-visibility assertions could pass against a fail-open default before the real `evaluate-display` response landed, masking the exact display-logic bug this ticket investigates. Now awaits `evaluate-display` before asserting on dimension visibility.
- **Amortización lines — docs correction only, no code change**: `docs/generated-custom-windows/amortization.md` previously described `costcenter`/`eTADASBpartner` on the Amortización Lines tab as having an empty, deferred `AD_Field.DisplayLogic`. Direct DB verification found both are now already correctly wired at the AD level (`Cost Center` carries `DisplayLogic = @ACCT_DIMENSION_DISPLAY@` with a matching `AD_Dimension_Mapping` row for `A_Amortizationline`; `Business Partner` carries `@$Element_BP@='Y'`) — zero code changes needed in `AmortizationLinesTable.jsx`, confirming the original fail-open-by-design hook worked as intended once the AD metadata landed.

## Companion PR
`com.etendoerp.go` #890 — originally scoped to only the `NeoDisplayLogicHelper` boolean-serialization fix (Problem 2); a later commit on that same branch (`482e5890`) adds the NEO XML data persistence for the Cost Center field (Problem 1's runtime half), companion to the `decisions.json`/JSX classification change in this PR.

## Test plan
- [x] `e2e/tests/flows/assets.integration.spec.js` — updated to await `evaluate-display` before dimension-visibility assertions
- [x] `AssetsDetailPanel.vitest.jsx` / `AssetsDetailPanel.test.js` — updated to expect `project` and `eTADASCostCenter` as independently-gated dimension candidates
- [x] `make regen ONLY=assets` — clean regeneration, contract's auto-generated system-field test entry for `eTADASCostCenter` replaced by the standard editable-field test set
- [x] `make regen ONLY=amortization` — zero diff (docs-only correction, no artifact change)
- [x] Full app-shell suite green after a `node_modules` resync

## Pipeline
- DEV: implemented
- REVIEW (Alex): APPROVE
- QA (Sentinel): APPROVE — full app-shell suite green

Refs: ETP-4914
