### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.35

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.34",
-        "@etendosoftware/schema-forge-cli": "0.3.34",
-        "@etendosoftware/schema-forge-core": "0.3.34",
+        "@etendosoftware/app-shell-core": "0.3.35",
+        "@etendosoftware/schema-forge-cli": "0.3.35",
+        "@etendosoftware/schema-forge-core": "0.3.35",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.34",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.34/4185c89c8c44003fba0ad633a09b88dcdf85ec35",
-      "integrity": "sha512-RgDKaOnJfmZtnkwUCx49xDSZkoyo9QSFgaeWioFyYJ79peqIecthC6xaq+lyXheA1+4z6TrVi78PLtlQkWzeZQ==",
+      "version": "0.3.35",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.35/b8ecdbdf2d19582cb6e2e9b3694493396574853f",
+      "integrity": "sha512-2hmXrvx3xVyvio6hHJbPF8uPfPbgp2gMz1PhcollsEGVkl5UwP0rVhkb97IhpwFYqip3Z7CfUHQF8RP0YvwAYg==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.34",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.34/98d886dbc50bb88a5d9a1b3c88d9570178513586",
-      "integrity": "sha512-yopgFiTBQ/jt0i5yGu7GEQxHXynCVekRwe94ydVJu5mrrKAaJ3zIYdNx79lkZG9OBB8Ql1KXr6Fok8+ntd1RMg==",
+      "version": "0.3.35",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.35/bdb10d1a4e22fba3d4ca61267c040a1f98d68e8b",
+      "integrity": "sha512-EZwVCXRAlKNIe+TYj1l5urpBHjxn9ZxPwiBS4pRhmuON41hYSqu+f639WOWE3BfJhjVmF1Vu8S1Sp0XLMouh8g==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.34",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.34/08c9369b9c401c80e03b7ab219ce79eefc491fa1",
-      "integrity": "sha512-gCa9nKro6ZMfLFyKM2rcDurS+DCJBPd6Z48dLtzCvvVaWo3QT0IVlOB3o2KkwFcIw1w2U+TTVkX/+nXCMOCuzQ==",
+      "version": "0.3.35",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.35/6bbd30c2e6665213c7a5a476eba1802033d13641",
+      "integrity": "sha512-cLGSuN+Q11aSKCn1wTdeYzq210c+Oa6qBF80kWTFXvU1BeX4NVhSOvsvpZrY7OYXwt8EF8FxP9ZsXhLuj/F+AQ==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.34",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.34/bfec042183f3da7b26d974a5e0549ee5a2426ece",
-      "integrity": "sha512-JNpxbqaB6uVGihXiivu3HxCGTH0mMTO0Jax/eXIJh+07WpHrTD7Gp3YPKYQv5R345gPTrHSE3B6Wb3fgQT4pXw==",
+      "version": "0.3.35",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.35/f01c764204e38ce49a9e91323f97b4de2f2551e6",
+      "integrity": "sha512-p6nRSntkehC/qORFn53mOR7dN72pO999ZRNDCNqs4GYI9wkl6EvNOcN8Ty0z20IL/cAy8X6DvmiU904+SAQOFw==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13780,8 +13780,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.34",
-        "@etendosoftware/etendo-go-core": "0.3.34",
+        "@etendosoftware/app-shell-core": "0.3.35",
+        "@etendosoftware/etendo-go-core": "0.3.35",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.34",
-    "@etendosoftware/schema-forge-cli": "0.3.34",
-    "@etendosoftware/schema-forge-core": "0.3.34",
+    "@etendosoftware/app-shell-core": "0.3.35",
+    "@etendosoftware/schema-forge-cli": "0.3.35",
+    "@etendosoftware/schema-forge-core": "0.3.35",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.34",
-        "@etendosoftware/etendo-go-core": "0.3.34",
+        "@etendosoftware/app-shell-core": "0.3.35",
+        "@etendosoftware/etendo-go-core": "0.3.35",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.34",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.34/4185c89c8c44003fba0ad633a09b88dcdf85ec35",
-      "integrity": "sha512-RgDKaOnJfmZtnkwUCx49xDSZkoyo9QSFgaeWioFyYJ79peqIecthC6xaq+lyXheA1+4z6TrVi78PLtlQkWzeZQ==",
+      "version": "0.3.35",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.35/b8ecdbdf2d19582cb6e2e9b3694493396574853f",
+      "integrity": "sha512-2hmXrvx3xVyvio6hHJbPF8uPfPbgp2gMz1PhcollsEGVkl5UwP0rVhkb97IhpwFYqip3Z7CfUHQF8RP0YvwAYg==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.34",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.34/98d886dbc50bb88a5d9a1b3c88d9570178513586",
-      "integrity": "sha512-yopgFiTBQ/jt0i5yGu7GEQxHXynCVekRwe94ydVJu5mrrKAaJ3zIYdNx79lkZG9OBB8Ql1KXr6Fok8+ntd1RMg==",
+      "version": "0.3.35",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.35/bdb10d1a4e22fba3d4ca61267c040a1f98d68e8b",
+      "integrity": "sha512-EZwVCXRAlKNIe+TYj1l5urpBHjxn9ZxPwiBS4pRhmuON41hYSqu+f639WOWE3BfJhjVmF1Vu8S1Sp0XLMouh8g==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.34",
-    "@etendosoftware/etendo-go-core": "0.3.34",
+    "@etendosoftware/app-shell-core": "0.3.35",
+    "@etendosoftware/etendo-go-core": "0.3.35",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.35`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.