### PR TITLE
Feature ETP-4907: Restore roles-overview matrix page

### DIFF
--- a/e2e/tests/flows/roles-overview.mocked.spec.js
+++ b/e2e/tests/flows/roles-overview.mocked.spec.js
@@ -2,85 +2,182 @@ import { test, expect } from '@playwright/test';
 import { login } from '../helpers/auth.js';
 
 /**
- * Roles Overview — Configuración > Roles (ETP-4513, mocked).
+ * Roles Overview — Configuración > Roles (ETP-4907 redesign, mocked).
  *
- * Validates the read-only "Configuración > Roles" page: the menu entry is
- * gated by the `isAdminOrClientAdmin` capability from `SFWindowAccessMap`
- * (see registry.js's `filterMenuGroupsByAccess` capability axis and
- * AppLayout.jsx's `useCapabilitiesSafe()` wiring), the page lists all 5 fixed
- * GOClient roles from `GET /sws/neo/rolesoverview` (ETP-4513 — moved off the
- * Webhooks module's `/webhooks/SFRolesOverview`, which required a per-role
- * grant row wiped by `update.database`, onto NEO Headless's own
- * JWT-authenticated bridge), and Edit only ever
- * opens a "coming soon" notice — no create/delete UI anywhere.
+ * ETP-4907 redesigned this screen from a plain role list (ETP-4513) into:
+ * 5 role summary cards (`RoleSummaryCard.jsx` — icon, name, user-count badge,
+ * window count) followed by a full category-grouped window x role access
+ * matrix (`RolesAccessMatrix.jsx`), each cell tri-state (full / read-only /
+ * none) via `AccessTierPill.jsx`. Data comes from `useRolesOverviewData()`
+ * (`tools/app-shell/src/pages/roles/useRolesOverviewData.js`), which still
+ * calls the real `GET /sws/neo/rolesoverview` (`lib/rolesApi.js`'s
+ * `fetchRolesOverview()`, unchanged since ETP-4513 — NEO Headless's own
+ * JWT-authenticated bridge, not the Webhooks module's `/webhooks/*` grant
+ * table wiped by `update.database`) but adapts the ETP-4907-extended response
+ * (`roles[].windowCount`/`roleSource`, plus a brand-new top-level `matrix`)
+ * into this page's card/matrix shape.
+ *
+ * The menu-gating layer (`isAdminOrClientAdmin` capability from
+ * `SFWindowAccessMap`, `menu-item-roles` testid, `/roles` route) was NOT
+ * touched by ETP-4907 — only the page's internal content changed — so those
+ * tests are carried over unchanged from the ETP-4513 spec.
  *
  * Mock mode only: this spec installs its own route/fetch overrides on top of
- * what `login()` seeds, so it does not need a backend. It follows the
- * `role-filtered-sidebar.mocked.spec.js` precedent for gating a menu entry
- * via a webhook-backed signal, and `row-quick-actions.mocked.spec.js` for the
- * overall list/dialog interaction shape.
- *
- * `login()`'s own addInitScript already stubs `/sws/neo/windowaccessmap`
- * with a Proxy that resolves every capability key to `true` (full access) —
- * see `e2e/tests/helpers/auth.js`. That covers the admin/client-admin
- * scenario below for free. The non-admin scenario needs to downgrade that
- * flag to `false`, which requires layering a SECOND `addInitScript` (see
- * `installNonAdminCapabilities()` below) rather than a `page.route()`
- * override — `SFWindowAccessMap` is short-circuited entirely inside
- * `window.fetch` before any request reaches the network layer that
- * `page.route()` operates on.
+ * what `login()` seeds, so it does not need a backend. It follows
+ * `row-quick-actions.mocked.spec.js` for the overall mocked list/detail shape
+ * and keeps its own inline `page.route()` fixture (rather than delegating to
+ * `lib/mockFetch.js`'s `handleRolesOverviewRequest()`) for full control over
+ * exact test data — matching this spec's own pre-existing convention, and
+ * consistent with the guide's `VITE_MOCK=true` gotcha (that mock-mode wiring
+ * bypasses `page.route()` entirely, so it's not a substitute here).
  */
+
+// Deliberately NOT already in the canonical display order (Admin, Sales,
+// Purchasing, Finance, Inventory — see `ROLE_ORDER` in
+// `useRolesOverviewData.js`). The backend's own fixed-name order is
+// Finance/Sales/Purchasing/Inventory (Admin wherever it naturally falls) per
+// that module's `sortByRoleOrder` JSDoc, so scrambling it here actually
+// exercises the client-side re-sort instead of passing by coincidence.
+const ROLE_IDS = {
+  finance: 'e2e-role-finance',
+  purchasing: 'e2e-role-purchasing',
+  admin: 'e2e-role-admin',
+  inventory: 'e2e-role-inventory',
+  sales: 'e2e-role-sales',
+};
+
+const ROLE_BOILERPLATE_DESCRIPTION = '*** Please, do not edit this role. Use Copy Record instead ***';
 
 const ROLES_FIXTURE = [
   {
-    id: '9B8D736190724807AB256DC95F20EC5E',
+    id: ROLE_IDS.finance,
+    name: 'Finance',
+    rawDescription: ROLE_BOILERPLATE_DESCRIPTION,
+    isClientAdmin: false,
+    roleSource: 'tenant',
+    userCount: 2,
+    windowCount: 27,
+    windows: [],
+  },
+  {
+    id: ROLE_IDS.purchasing,
+    name: 'Purchasing',
+    rawDescription: ROLE_BOILERPLATE_DESCRIPTION,
+    isClientAdmin: false,
+    roleSource: 'systemTemplate',
+    userCount: 1,
+    windowCount: 11,
+    windows: [],
+  },
+  {
+    id: ROLE_IDS.admin,
     name: 'GOClient Admin',
     rawDescription: 'GOClient Admin',
+    isClientAdmin: true,
+    roleSource: 'tenant',
     userCount: 2,
-    windows: [
-      { id: '108', name: 'User', tier: 'full' },
-      { id: '146', name: 'Price List', tier: 'full' },
-    ],
+    windowCount: 48,
+    windows: [],
   },
   {
-    id: '127AE77FE2994067B7FE6495FC21D51E',
-    name: 'Finance',
-    rawDescription: '*** Please, do not edit this role. Use Copy Record instead ***',
-    userCount: 2,
-    windows: [
-      { id: 'w-fin-1', name: 'Financial Account', tier: 'full' },
-      { id: 'w-fin-2', name: 'Sales Invoice', tier: 'read-only' },
-    ],
-  },
-  {
-    id: '2A159DF4F4B944A6AA903202AD35B545',
-    name: 'Sales',
-    rawDescription: '*** Please, do not edit this role. Use Copy Record instead ***',
-    userCount: 1,
-    windows: [{ id: 'w-sales-1', name: 'Sales Order', tier: 'full' }],
-  },
-  {
-    id: 'A826430F723E4C1B9A53EBB0746A98C0',
-    name: 'Purchasing',
-    rawDescription: '*** Please, do not edit this role. Use Copy Record instead ***',
-    userCount: 0,
-    windows: [{ id: 'w-pur-1', name: 'Purchase Order', tier: 'full' }],
-  },
-  {
-    id: '55E05A4B43514A029D6FB6B8D94B49D4',
+    id: ROLE_IDS.inventory,
     name: 'Inventory',
-    rawDescription: '*** Please, do not edit this role. Use Copy Record instead ***',
+    rawDescription: ROLE_BOILERPLATE_DESCRIPTION,
+    isClientAdmin: false,
+    roleSource: 'tenant',
     userCount: 0,
-    windows: [{ id: 'w-inv-1', name: 'Warehouse and Storage Bins', tier: 'read-only' }],
+    windowCount: 13,
+    windows: [],
+  },
+  {
+    id: ROLE_IDS.sales,
+    name: 'Sales',
+    rawDescription: ROLE_BOILERPLATE_DESCRIPTION,
+    isClientAdmin: false,
+    roleSource: 'tenant',
+    userCount: 3,
+    windowCount: 13,
+    windows: [],
   },
 ];
 
+// The canonical ETP-4907 display order — see `ROLE_ORDER`/`sortByRoleOrder`
+// in `useRolesOverviewData.js`. `RoleSummaryCard.jsx` prefixes its root
+// `Card`'s data-testid with `RoleSummaryCard__`, so the DOM order of these
+// ids is a direct, un-guessable proxy for the sort the frontend applied.
+const EXPECTED_CARD_ORDER = [
+  `RoleSummaryCard__${ROLE_IDS.admin}`,
+  `RoleSummaryCard__${ROLE_IDS.sales}`,
+  `RoleSummaryCard__${ROLE_IDS.purchasing}`,
+  `RoleSummaryCard__${ROLE_IDS.finance}`,
+  `RoleSummaryCard__${ROLE_IDS.inventory}`,
+];
+
+// `matrix.categories[].windows[].access` is keyed by the SAME role ids as
+// `roles[].id` (see `useRolesOverviewData.js`'s file-level JSDoc) — real
+// tier values are hyphenated (`'read-only'`), normalized client-side to
+// `'readOnly'` by `normalizeTier()`. One row below deliberately exercises all
+// 3 states across its 5 role columns (full / full / none / read-only / none)
+// so the tri-state cell rendering is proven, not just the happy path.
+const MATRIX_FIXTURE = {
+  categories: [
+    {
+      name: 'Sales',
+      windows: [
+        {
+          id: 'e2e-window-sales-order',
+          name: 'Sales Order',
+          access: {
+            [ROLE_IDS.admin]: 'full',
+            [ROLE_IDS.sales]: 'full',
+            [ROLE_IDS.purchasing]: 'none',
+            [ROLE_IDS.finance]: 'read-only',
+            [ROLE_IDS.inventory]: 'none',
+          },
+        },
+      ],
+    },
+    {
+      name: 'Inventory',
+      windows: [
+        {
+          id: 'e2e-window-warehouse',
+          name: 'Warehouse and Storage Bins',
+          access: {
+            [ROLE_IDS.admin]: 'full',
+            [ROLE_IDS.sales]: 'none',
+            [ROLE_IDS.purchasing]: 'none',
+            [ROLE_IDS.finance]: 'none',
+            [ROLE_IDS.inventory]: 'read-only',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+// `GENERAL_ROWS` in `RolesAccessMatrix.jsx` — 3 hardcoded rows (Inicio/
+// Favoritos/Copilot) always overlaid ahead of the real `matrix.categories`,
+// always full access for every role. Never present in a real backend
+// response — this is a pure client-side constant, asserted against directly.
+const GENERAL_ROW_IDS = ['dashboard', 'favorites', 'copilot'];
+
+/**
+ * `fetchRolesOverview()` (`lib/rolesApi.js`) does: parse JSON, then if
+ * `Array.isArray(data.roles)` return `data` as-is — so a plain
+ * `{ roles, matrix }` body (no `{ result: "<json-string>" }` wrapping) is a
+ * valid, real code path, not a test-only shortcut.
+ */
 async function installRolesOverviewMock(page) {
-  await page.route('**/sws/neo/rolesoverview{/**,}**', async (route) => {
+  // The real endpoint (`NEO_BASE + '/rolesoverview'`) never receives a
+  // sub-path or query string, so a single glued `**` is sufficient — no
+  // brace-alternation needed here (see the e2e guide's gotcha on `{/**,}**`
+  // silently degrading for multi-segment sub-paths; this endpoint has none).
+  await page.route('**/sws/neo/rolesoverview**', async (route) => {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ roles: ROLES_FIXTURE }),
+      body: JSON.stringify({ roles: ROLES_FIXTURE, matrix: MATRIX_FIXTURE }),
     });
   });
 }
@@ -137,40 +234,106 @@ test.describe('Roles overview — admin/client-admin', () => {
     await expect(page.getByTestId('RolesOverviewPage')).toBeVisible();
   });
 
-  test('renders all 5 roles with real data-testid selectors (no hardcoded label-string assertions)', async ({ page }) => {
+  test('renders all 5 role summary cards in the canonical Admin/Sales/Purchasing/Finance/Inventory order', async ({ page }) => {
     await page.goto('/roles');
     await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+    await expect(page.getByTestId('RolesOverviewPage__content')).toBeVisible();
 
     for (const role of ROLES_FIXTURE) {
-      const card = page.getByTestId(`RolesOverviewPage__role-${role.id}`);
+      const card = page.getByTestId(`RoleSummaryCard__${role.id}`);
       await expect(card).toBeVisible();
-      await expect(page.getByTestId(`RolesOverviewPage__userCount-${role.id}`)).toContainText(String(role.userCount));
-      for (const w of role.windows) {
-        await expect(page.getByTestId(`RolesOverviewPage__window-${role.id}-${w.id}`)).toBeVisible();
-      }
+      await expect(page.getByTestId(`RoleSummaryCard__content-${role.id}`)).toBeVisible();
+      await expect(page.getByTestId(`RoleSummaryCard__userCount-${role.id}`)).toContainText(String(role.userCount));
+      await expect(page.getByTestId(`RoleSummaryCard__usersIcon-${role.id}`)).toBeVisible();
+      // `rolesWindowCount` is i18n'd ("{count} Windows"/"{count} Ventanas") —
+      // assert the interpolated count is present rather than hardcoding the
+      // rendered locale string.
+      await expect(page.getByTestId(`RoleSummaryCard__windowCount-${role.id}`)).toContainText(String(role.windowCount));
     }
 
+    // Real DOM order of the card grid's direct children — a direct proxy for
+    // `sortByRoleOrder()` having actually run, since the fixture above is
+    // deliberately scrambled.
+    const renderedOrder = await page
+      .locator('[data-testid="RolesOverviewPage__cards"] > [data-testid^="RoleSummaryCard__"]')
+      .evaluateAll((nodes) => nodes.map((n) => n.getAttribute('data-testid')));
+    expect(renderedOrder).toEqual(EXPECTED_CARD_ORDER);
+
     // The raw AD_Role boilerplate text must never surface as display copy —
-    // only the curated i18n descriptions render.
+    // only the curated i18n role names render.
     await expect(page.locator('body')).not.toContainText('Please, do not edit this role');
   });
 
   test('exposes no edit/create/delete affordance anywhere on the page', async ({ page }) => {
-    // These 5 roles are product-defined, not editable by any tenant user (2026-07-27 decision —
-    // only future user-created roles, out of scope for now, will ever be editable here). The
-    // "coming soon" Edit dialog this test used to click through was removed entirely, not just
-    // disabled — there is no `RolesOverviewPage__edit-*` testid anywhere on the page anymore.
+    // These 5 roles are product-defined, not editable by any tenant user
+    // (2026-07-27 decision — only future user-created roles, out of scope
+    // for now, will ever be editable here). ETP-4907's redesign carries this
+    // forward: neither the cards nor the matrix expose any edit/create/
+    // delete affordance — scope the search to the page's own content so a
+    // false positive from unrelated global chrome (topbar, user menu) can't
+    // slip through.
     await page.goto('/roles');
     await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
 
-    const firstRole = ROLES_FIXTURE[0];
-    await expect(page.getByTestId(`RolesOverviewPage__role-${firstRole.id}`)).toBeVisible();
+    const content = page.getByTestId('RolesOverviewPage__content');
+    await expect(content).toBeVisible();
 
-    await expect(page.getByTestId('RolesOverviewPage__editDialog')).toHaveCount(0);
-    await expect(page.getByTestId(/^RolesOverviewPage__edit/i)).toHaveCount(0);
-    await expect(page.getByTestId(/delete/i)).toHaveCount(0);
-    await expect(page.getByTestId(/create/i)).toHaveCount(0);
-    await expect(page.getByTestId(/^RolesOverviewPage__new/i)).toHaveCount(0);
+    await expect(content.locator('[data-testid*="edit" i]')).toHaveCount(0);
+    await expect(content.locator('[data-testid*="delete" i]')).toHaveCount(0);
+    await expect(content.locator('[data-testid*="create" i]')).toHaveCount(0);
+    await expect(content.getByRole('button', { name: /new|nuevo/i })).toHaveCount(0);
+  });
+
+  test('matrix General section always shows full access for every role', async ({ page }) => {
+    await page.goto('/roles');
+    await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+
+    await expect(page.getByTestId('RolesAccessMatrix')).toBeVisible();
+    await expect(page.getByTestId('RolesAccessMatrix__category-General')).toBeVisible();
+
+    for (const rowId of GENERAL_ROW_IDS) {
+      const rowKey = `General::${rowId}`;
+      await expect(page.getByTestId(`RolesAccessMatrix__row-${rowKey}`)).toBeVisible();
+      for (const role of ROLES_FIXTURE) {
+        const cell = page.getByTestId(`RolesAccessMatrix__cell-${rowKey}-${role.id}`);
+        // AccessTierPill renders the literal '✓' glyph for 'full' — not an
+        // i18n string, so safe to assert exactly across both locales.
+        await expect(cell).toHaveText('✓');
+      }
+    }
+  });
+
+  test('matrix renders real categories with correct per-role tri-state access cells', async ({ page }) => {
+    await page.goto('/roles');
+    await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+
+    await expect(page.getByTestId('RolesAccessMatrix__headerIcon-' + ROLE_IDS.admin)).toBeVisible();
+
+    const salesCategory = MATRIX_FIXTURE.categories[0];
+    const salesWindow = salesCategory.windows[0];
+    const salesRowKey = `${salesCategory.name}::${salesWindow.id}`;
+
+    await expect(page.getByTestId(`RolesAccessMatrix__category-${salesCategory.name}`)).toBeVisible();
+    await expect(page.getByTestId(`RolesAccessMatrix__row-${salesRowKey}`)).toBeVisible();
+
+    // full → literal '✓' glyph
+    await expect(page.getByTestId(`RolesAccessMatrix__cell-${salesRowKey}-${ROLE_IDS.admin}`)).toHaveText('✓');
+    await expect(page.getByTestId(`RolesAccessMatrix__cell-${salesRowKey}-${ROLE_IDS.sales}`)).toHaveText('✓');
+
+    // none → literal '—' glyph
+    await expect(page.getByTestId(`RolesAccessMatrix__cell-${salesRowKey}-${ROLE_IDS.purchasing}`)).toHaveText('—');
+    await expect(page.getByTestId(`RolesAccessMatrix__cell-${salesRowKey}-${ROLE_IDS.inventory}`)).toHaveText('—');
+
+    // read-only (normalized from the backend's hyphenated 'read-only' to
+    // 'readOnly') → an i18n string, neither of the other two glyphs and
+    // non-empty. Avoids hardcoding the locale-specific rendered text while
+    // still proving the tri-state (not just full/none) actually renders.
+    const readOnlyCell = page.getByTestId(`RolesAccessMatrix__cell-${salesRowKey}-${ROLE_IDS.finance}`);
+    await expect(readOnlyCell).toBeVisible();
+    const readOnlyText = (await readOnlyCell.textContent())?.trim();
+    expect(readOnlyText).not.toBe('✓');
+    expect(readOnlyText).not.toBe('—');
+    expect(readOnlyText).toBeTruthy();
   });
 });
 
@@ -191,20 +354,25 @@ test.describe('Roles overview — non-admin', () => {
     await expect(page.getByTestId('menu-item-roles')).toHaveCount(0);
   });
 
-  // NOTE (QA, ETP-4513): a "direct navigation to /roles as a denied non-admin" deep-link test
-  // was attempted here and deliberately removed — see the QA report for why. In short:
-  // `mockFetch.js`'s `handleRolesOverviewRequest()` is checked unconditionally, ahead of any
-  // capability logic (unlike the real `SFRolesOverview.java`, which does branch on the caller's
-  // admin status), so it always serves the fixed 5-role fixture no matter what a test overrides
-  // via `page.route()` or an `addInitScript`-wrapped `window.fetch` — neither technique can win
-  // against it once `App.jsx`'s async mock-install effect has replaced `window.fetch` (which, for
-  // a fetch fired well after page load like `RolesOverviewPage`'s mount-time call, it reliably
-  // has by then). The real backend enforcement is proven instead by
-  // `SFRolesOverviewTest#testCallerIsAGoClientRoleButNotAdminIsStillDenied` (JUnit), and the
-  // frontend's handling of an empty `roles` array is proven by
-  // `RolesOverviewPage.vitest.jsx`'s "shows the no-access card when roles resolves to an empty
-  // array" test — both already cover this scenario's two halves individually. Wiring them
-  // together in a mocked E2E spec would need `handleRolesOverviewRequest()` to gain the same
-  // kind of admin-gate `handleWindowAccessMapRequest()` already has (a follow-up for whoever
+  // NOTE (QA, ETP-4513, carried over unchanged by ETP-4907): a "direct
+  // navigation to /roles as a denied non-admin" deep-link test was attempted
+  // here and deliberately removed — see the original QA report for why. In
+  // short: `mockFetch.js`'s `handleRolesOverviewRequest()` is checked
+  // unconditionally, ahead of any capability logic (unlike the real
+  // `SFRolesOverview.java`, which does branch on the caller's admin status),
+  // so it always serves the fixed 5-role fixture no matter what a test
+  // overrides via `page.route()` or an `addInitScript`-wrapped
+  // `window.fetch` — neither technique can win against it once `App.jsx`'s
+  // async mock-install effect has replaced `window.fetch` (which, for a
+  // fetch fired well after page load like `RolesOverviewPage`'s mount-time
+  // call, it reliably has by then). The real backend enforcement is proven
+  // instead by
+  // `SFRolesOverviewTest#testCallerIsAGoClientRoleButNotAdminIsStillDenied`
+  // (JUnit), and the frontend's handling of an empty `roles` array is proven
+  // by `RolesOverviewPage.vitest.jsx`'s "shows the no-access card when cards
+  // resolves to an empty array" test — both already cover this scenario's
+  // two halves individually. Wiring them together in a mocked E2E spec would
+  // need `handleRolesOverviewRequest()` to gain the same kind of admin-gate
+  // `handleWindowAccessMapRequest()` already has (a follow-up for whoever
   // owns `mockFetch.js`, not a QA fix).
 });

--- a/tools/app-shell/src/lib/mockFetch.js
+++ b/tools/app-shell/src/lib/mockFetch.js
@@ -110,53 +110,144 @@ function isRolesOverviewRequest(url) {
 // SFRolesOverview.java's class javadoc) — hoisted once instead of repeated per role literal.
 const ROLE_BOILERPLATE_DESCRIPTION = '*** Please, do not edit this role. Use Copy Record instead ***';
 
+// ETP-4907 follow-up: the real fixed role ids, reused below both for `roles[]` and as the
+// `matrix.categories[].windows[].access` keys — these must be THE SAME id values (the real
+// backend keys `access` by `roles[].id`), not a second synthetic id scheme.
+const ROLE_IDS = {
+  admin: '9B8D736190724807AB256DC95F20EC5E',
+  finance: '127AE77FE2994067B7FE6495FC21D51E',
+  sales: '2A159DF4F4B944A6AA903202AD35B545',
+  purchasing: 'A826430F723E4C1B9A53EBB0746A98C0',
+  inventory: '55E05A4B43514A029D6FB6B8D94B49D4',
+};
+
 // Builds one mock role entry. `windows` is a list of `[id, name, tier]` tuples rather than
 // object literals so the 5 roles below read as data, not 5 near-identical object shapes —
 // keeps this file's mock fixture from tripping SonarQube's copy-paste detector on structurally
-// repeated `{ id, name, tier }` / `{ id, name, rawDescription, userCount, windows }` blocks.
-function mockRole(id, name, rawDescription, userCount, windows) {
+// repeated `{ id, name, tier }` / `{ id, name, rawDescription, ... }` blocks.
+function mockRole({ id, name, rawDescription, isClientAdmin, roleSource, windowCount, userCount, windows }) {
   return {
     id,
     name,
     rawDescription,
+    isClientAdmin,
+    roleSource,
+    windowCount,
     userCount,
     windows: windows.map(([winId, winName, tier]) => ({ id: winId, name: winName, tier })),
   };
 }
 
-// Mirrors the real SFRolesOverview.java response shape for the 5 fixed GOClient roles, so
-// mock/demo mode and E2E tests can exercise the "Configuración > Roles" page without a live
-// Etendo backend. `rawDescription` intentionally mirrors the real boilerplate AD_Role text
-// (see SFRolesOverview.java's class javadoc) — the frontend never displays it directly.
+// ETP-4907 follow-up: builds one `matrix.categories[]` entry. `windows` is a list of
+// `[id, name, accessByRoleKind]` tuples — `accessByRoleKind` keyed by the SAME short kinds as
+// `ROLE_IDS` above (translated to real role ids below), not by role id directly, so this
+// fixture reads as data rather than a wall of UUIDs.
+function mockCategory(name, windows) {
+  return {
+    name,
+    windows: windows.map(([id, winName, accessByKind]) => ({
+      id,
+      name: winName,
+      access: Object.fromEntries(Object.entries(accessByKind).map(([kind, tier]) => [ROLE_IDS[kind], tier])),
+    })),
+  };
+}
+
+// Mirrors the real (ETP-4907-extended) SFRolesOverview.java response shape for the 5 fixed
+// GOClient roles, so mock/demo mode and E2E tests can exercise the redesigned
+// "Configuración > Roles" page without a live Etendo backend. `rawDescription` intentionally
+// mirrors the real boilerplate AD_Role text (see SFRolesOverview.java's class javadoc) — the
+// frontend never displays it directly. `windowCount` figures mirror the LIVE GOClient numbers
+// confirmed by the backend developer while building this (Admin 48, Finance 27, Sales 13,
+// Purchasing 11, Inventory 13) — NOT the earlier Figma reference screenshot's placeholder
+// numbers (17/17/17/18), which do not match production data. `userCount` figures are small,
+// plausible values consistent with GOClient's real total of 9 active users, not independently
+// verified per-role.
 function handleRolesOverviewRequest() {
   return makeResponse(200, {
     roles: [
-      mockRole('9B8D736190724807AB256DC95F20EC5E', 'GOClient Admin', 'GOClient Admin', 2, [
-        ['108', 'User', 'full'],
-        ['146', 'Price List', 'full'],
-        ['137', 'Tax', 'full'],
-      ]),
-      mockRole('127AE77FE2994067B7FE6495FC21D51E', 'Finance', ROLE_BOILERPLATE_DESCRIPTION, 2, [
-        ['mock-financial-account', 'Financial Account', 'full'],
-        ['mock-payment-in', 'Payment In', 'full'],
-        ['mock-payment-out', 'Payment Out', 'full'],
-        ['mock-sales-invoice', 'Sales Invoice', 'read-only'],
-      ]),
-      mockRole('2A159DF4F4B944A6AA903202AD35B545', 'Sales', ROLE_BOILERPLATE_DESCRIPTION, 1, [
-        ['mock-business-partner', 'Business Partner', 'full'],
-        ['mock-sales-order', 'Sales Order', 'full'],
-        ['mock-sales-quotation', 'Sales Quotation', 'full'],
-      ]),
-      mockRole('A826430F723E4C1B9A53EBB0746A98C0', 'Purchasing', ROLE_BOILERPLATE_DESCRIPTION, 0, [
-        ['mock-purchase-order', 'Purchase Order', 'full'],
-        ['mock-purchase-invoice', 'Purchase Invoice', 'full'],
-      ]),
-      mockRole('55E05A4B43514A029D6FB6B8D94B49D4', 'Inventory', ROLE_BOILERPLATE_DESCRIPTION, 0, [
-        ['mock-goods-receipt', 'Goods Receipt', 'full'],
-        ['mock-goods-shipment', 'Goods Shipment', 'full'],
-        ['mock-warehouse', 'Warehouse and Storage Bins', 'read-only'],
-      ]),
+      mockRole({
+        id: ROLE_IDS.admin, name: 'GOClient Admin', rawDescription: 'GOClient Admin',
+        isClientAdmin: true, roleSource: 'tenant', windowCount: 48, userCount: 2,
+        windows: [
+          ['108', 'User', 'full'],
+          ['146', 'Price List', 'full'],
+          ['137', 'Tax', 'full'],
+        ],
+      }),
+      mockRole({
+        id: ROLE_IDS.finance, name: 'Finance', rawDescription: ROLE_BOILERPLATE_DESCRIPTION,
+        isClientAdmin: false, roleSource: 'tenant', windowCount: 27, userCount: 2,
+        windows: [
+          ['mock-financial-account', 'Financial Account', 'full'],
+          ['mock-payment-in', 'Payment In', 'full'],
+          ['mock-payment-out', 'Payment Out', 'full'],
+          ['mock-sales-invoice', 'Sales Invoice', 'read-only'],
+        ],
+      }),
+      mockRole({
+        id: ROLE_IDS.sales, name: 'Sales', rawDescription: ROLE_BOILERPLATE_DESCRIPTION,
+        isClientAdmin: false, roleSource: 'tenant', windowCount: 13, userCount: 3,
+        windows: [
+          ['mock-business-partner', 'Business Partner', 'full'],
+          ['mock-sales-order', 'Sales Order', 'full'],
+          ['mock-sales-quotation', 'Sales Quotation', 'full'],
+        ],
+      }),
+      mockRole({
+        id: ROLE_IDS.purchasing, name: 'Purchasing', rawDescription: ROLE_BOILERPLATE_DESCRIPTION,
+        isClientAdmin: false, roleSource: 'systemTemplate', windowCount: 11, userCount: 1,
+        windows: [
+          ['mock-purchase-order', 'Purchase Order', 'full'],
+          ['mock-purchase-invoice', 'Purchase Invoice', 'full'],
+        ],
+      }),
+      mockRole({
+        id: ROLE_IDS.inventory, name: 'Inventory', rawDescription: ROLE_BOILERPLATE_DESCRIPTION,
+        isClientAdmin: false, roleSource: 'tenant', windowCount: 13, userCount: 1,
+        windows: [
+          ['mock-goods-receipt', 'Goods Receipt', 'full'],
+          ['mock-goods-shipment', 'Goods Shipment', 'full'],
+          ['mock-warehouse', 'Warehouse and Storage Bins', 'read-only'],
+        ],
+      }),
     ],
+    // ETP-4907 follow-up: illustrative only — a small representative slice, NOT verified
+    // against the live category/window breakdown (this session has no DB access). In
+    // particular this does NOT include General/Inicio/Favoritos/Copilot-style windowless
+    // rows (see `UserRolesTab.jsx`'s ETP-4906 `GENERAL_ROWS` precedent on the sibling,
+    // unmerged `feature/ETP-4906` branch) — open question for the backend dev on whether the
+    // real matrix includes those or the frontend must still overlay them itself.
+    matrix: {
+      categories: [
+        mockCategory('Commercial', [
+          [
+            'mock-contacts-commercial',
+            'Business Partner',
+            { admin: 'full', sales: 'full', purchasing: 'full', finance: 'full', inventory: 'read-only' },
+          ],
+        ]),
+        mockCategory('Sales', [
+          [
+            'mock-sales-quotation-row',
+            'Sales Quotation',
+            { admin: 'full', sales: 'full', purchasing: 'none', finance: 'read-only', inventory: 'none' },
+          ],
+          [
+            'mock-sales-order-row',
+            'Sales Order',
+            { admin: 'full', sales: 'full', purchasing: 'none', finance: 'read-only', inventory: 'read-only' },
+          ],
+        ]),
+        mockCategory('Inventory', [
+          [
+            'mock-contacts-inventory',
+            'Business Partner',
+            { admin: 'full', sales: 'full', purchasing: 'full', finance: 'full', inventory: 'full' },
+          ],
+        ]),
+      ],
+    },
   });
 }
 

--- a/tools/app-shell/src/pages/RolesOverviewPage.jsx
+++ b/tools/app-shell/src/pages/RolesOverviewPage.jsx
@@ -1,12 +1,12 @@
-import { useState, useEffect, useCallback } from 'react';
-import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Users, RefreshCw, ShieldAlert } from 'lucide-react';
+import { ShieldAlert } from 'lucide-react';
 import { useUI, useMenuLabel } from '@/i18n';
-import { fetchRolesOverview } from '@/lib/rolesApi.js';
-import { ROLE_NAME_I18N_KEYS, ADMIN_NAME_I18N_KEY } from '@/lib/roleNameI18n.js';
+import { useSetPageMeta } from '@/components/layout/PageMetaContext';
+import { useRolesOverviewData, ROLE_ICONS, resolveRoleKind } from './roles/useRolesOverviewData.js';
+import RoleSummaryCard from './roles/RoleSummaryCard.jsx';
+import RolesAccessMatrix from './roles/RolesAccessMatrix.jsx';
 
 /**
  * Shared centered "status" card wrapper for the error and no-access states below — both were
@@ -29,92 +29,34 @@ function StatusCard({ testId, className, children }) {
 }
 
 /**
- * ETP-4513 — the tenant's 4 fixed non-admin roles: NAME -> {nameKey, descKey}. Matched by the
- * role's own NAME (consistent across every tenant, since `OnboardingRoleProvisioningService` /
- * `R16-tenant-roles-and-webhook-access.sql` clone these 4 names verbatim onto every client), NOT
- * by a hardcoded per-client role id — a hardcoded-GOClient-id map is exactly the bug fixed
- * 2026-07-27 (see `SFRolesOverview.java`'s class javadoc for the live RolesPresa symptom: every
- * OTHER tenant's admin saw GOClient's role names with empty user counts/windows). The 5th role
- * (client-admin) is NOT in this map — its NAME varies per tenant ("RolesPresa Admin" vs
- * "GOClient Admin" vs any future tenant's own), so it's identified by the backend's
- * `isClientAdmin` flag instead and always rendered with the generic `roleNameAdmin`/
- * `roleDescAdmin` copy, never its literal AD_Role.name.
+ * "Configuración > Roles" overview page (ETP-4513, redesigned by ETP-4907 to match
+ * a new reference layout): 5 role summary cards (icon, name, user-count badge, window
+ * count) followed by a full window x role access matrix grouped by category, each cell
+ * tri-state (full access / read-only / no access). Data comes from
+ * `useRolesOverviewData()` (`./roles/useRolesOverviewData.js`), which calls the real
+ * `GET /sws/neo/rolesoverview` (`lib/rolesApi.js`'s `fetchRolesOverview()`, unchanged
+ * since ETP-4513) and adapts its response into this page's card/matrix shape. This is a
+ * hand-built standalone page (no `decisions.json`/pipeline artifact), routed via
+ * `runtime-routes.jsx`'s `lazyRoute('roles', RolesOverviewPage)` and gated in `menu.json`
+ * by the `isAdminOrClientAdmin` capability — see `registry.js`'s `filterMenuGroupsByAccess`.
  *
- * The backend's `rawDescription` (raw `AD_Role.description`) is explicitly NOT display copy
- * (boilerplate "do not edit this role" text for 4 of the 5 roles today — see
- * `SFRolesOverview.java`'s class javadoc). These curated, i18n-keyed descriptions are what
- * actually renders; `rawDescription` is only used as a last-resort fallback for a role this map
- * doesn't recognize (a name Etendo Go doesn't know about, which should never happen for the 4
- * fixed roles, but keeps the page from showing a blank description if that ever changes).
- */
-const ROLE_DESC_I18N_KEYS = {
-  Finance: 'roleDescFinance',
-  Sales: 'roleDescSales',
-  Purchasing: 'roleDescPurchasing',
-  Inventory: 'roleDescInventory',
-};
-
-const ROLE_NAME_I18N = Object.fromEntries(
-  Object.entries(ROLE_NAME_I18N_KEYS).map(([name, nameKey]) => (
-    [name, { nameKey, descKey: ROLE_DESC_I18N_KEYS[name] }]
-  ))
-);
-
-/** Generic copy for the client-admin role, identified by `role.isClientAdmin`, never its name. */
-const ADMIN_I18N = { nameKey: ADMIN_NAME_I18N_KEY, descKey: 'roleDescAdmin' };
-
-/**
- * Read-only "Configuración > Roles" page (ETP-4513). Lists the tenant's 5 fixed roles with a
- * curated description, assigned-user count, and the Etendo GO windows each role can reach
- * (from `GET /sws/neo/rolesoverview`). No create/edit/delete actions anywhere — these 5
- * roles are product-defined and not editable by any tenant user; only future user-created
- * roles (out of scope for now) will ever be editable here.
- *
- * The menu entry that routes here is itself gated by the `isAdminOrClientAdmin` capability
- * (`SFWindowAccessMap`, see `menu.json`'s `roles` entry and `registry.js`'s
- * `filterMenuGroupsByAccess`) — a non-admin role should never reach this route through normal
- * navigation. The empty-state handling below (`roles.length === 0`) is a defense-in-depth
- * fallback for direct navigation / a stale menu, not the primary access control: the backend
- * (`SFRolesOverview.java`) is the actual enforcement point and always returns `{ roles: [] }`
- * for a non-admin/no-role caller regardless of how the request reached it.
+ * The empty-state handling below (`cards.length === 0`) is a defense-in-depth fallback for
+ * direct navigation / a stale menu, not the primary access control — `SFRolesOverview.java`
+ * is the actual enforcement point and always returns an empty `roles`/`matrix` payload for a
+ * non-admin/no-role caller regardless of how the request reached it.
  */
 export default function RolesOverviewPage() {
   const ui = useUI();
   const tMenu = useMenuLabel();
-  const [roles, setRoles] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(null);
+  const { loading, error, cards, matrix, reload } = useRolesOverviewData();
 
-  const load = useCallback(() => {
-    setLoading(true);
-    setError(null);
-    fetchRolesOverview()
-      .then((data) => setRoles(Array.isArray(data?.roles) ? data.roles : []))
-      .catch((err) => setError(err?.message || String(err)))
-      .finally(() => setLoading(false));
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+  useSetPageMeta({
+    title: ui('rolesPageTitle'),
+    breadcrumb: `${tMenu('Settings')} / ${ui('rolesPageTitle')}`,
+  });
 
   return (
     <div className="h-full overflow-y-auto space-y-6 p-6" data-testid="RolesOverviewPage">
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-2xl font-bold tracking-tight">{ui('rolesPageTitle')}</h2>
-          <p className="text-muted-foreground">{ui('rolesPageSubtitle')}</p>
-        </div>
-        <Button
-          variant="outline"
-          size="icon"
-          onClick={load}
-          disabled={loading}
-          data-testid="RolesOverviewPage__refresh"
-        >
-          <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} data-testid="RefreshCw__rolesOverview" />
-        </Button>
-      </div>
       {(() => {
         if (loading) {
           return (
@@ -133,14 +75,14 @@ export default function RolesOverviewPage() {
               className="gap-3 py-12"
               data-testid="StatusCard__67e3bc">
               <p className="text-sm text-muted-foreground">{ui('rolesLoadError')}</p>
-              <Button variant="outline" onClick={load} data-testid="RolesOverviewPage__retry">
+              <Button variant="outline" onClick={reload} data-testid="RolesOverviewPage__retry">
                 {ui('retry')}
               </Button>
             </StatusCard>
           );
         }
 
-        if (roles.length === 0) {
+        if (cards.length === 0) {
           return (
             <StatusCard
               testId="RolesOverviewPage__noAccess"
@@ -154,53 +96,24 @@ export default function RolesOverviewPage() {
         }
 
         return (
-          <div className="space-y-4" data-testid="RolesOverviewPage__list">
-            {roles.map((role) => {
-              const i18nKeys = role.isClientAdmin ? ADMIN_I18N : ROLE_NAME_I18N[role.name];
-              const displayName = i18nKeys ? ui(i18nKeys.nameKey) : role.name;
-              const displayDescription = i18nKeys ? ui(i18nKeys.descKey) : role.rawDescription;
-              const windows = Array.isArray(role.windows) ? role.windows : [];
-
-              return (
-                <Card key={role.id} data-testid={`RolesOverviewPage__role-${role.id}`}>
-                  <CardHeader
-                    className="flex flex-row items-start justify-between gap-4 space-y-0"
-                    data-testid="CardHeader__67e3bc">
-                    <div>
-                      <CardTitle data-testid="CardTitle__67e3bc">{displayName}</CardTitle>
-                      <CardDescription data-testid="CardDescription__67e3bc">{displayDescription}</CardDescription>
-                    </div>
-                    <div className="flex shrink-0 items-center gap-3">
-                      <Badge
-                        variant="secondary"
-                        title={ui('rolesColUsers')}
-                        data-testid={`RolesOverviewPage__userCount-${role.id}`}>
-                        <Users className="mr-1 h-3 w-3" data-testid="Users__rolesOverview" />
-                        {role.userCount}
-                      </Badge>
-                    </div>
-                  </CardHeader>
-                  <CardContent data-testid="CardContent__67e3bc">
-                    <p className="mb-2 text-xs font-medium text-muted-foreground">{ui('rolesColWindows')}</p>
-                    <div className="flex flex-wrap gap-1.5" data-testid={`RolesOverviewPage__windows-${role.id}`}>
-                      {windows.length === 0 && (
-                        <span className="text-xs text-muted-foreground">{'—'}</span>
-                      )}
-                      {windows.map((w) => (
-                        <Badge
-                          key={w.id}
-                          variant={w.tier === 'full' ? 'default' : 'outline'}
-                          title={w.tier === 'full' ? ui('accessTierFull') : ui('accessTierReadOnly')}
-                          data-testid={`RolesOverviewPage__window-${role.id}-${w.id}`}
-                        >
-                          {tMenu(w.name)}
-                        </Badge>
-                      ))}
-                    </div>
-                  </CardContent>
-                </Card>
-              );
-            })}
+          <div className="space-y-6" data-testid="RolesOverviewPage__content">
+            <div
+              className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5"
+              data-testid="RolesOverviewPage__cards"
+            >
+              {cards.map((role) => (
+                <RoleSummaryCard
+                  key={role.id}
+                  role={role}
+                  Icon={ROLE_ICONS[resolveRoleKind(role)]}
+                  data-testid={`RoleSummaryCard__wrapper-${role.id}`} />
+              ))}
+            </div>
+            <RolesAccessMatrix
+              cards={cards}
+              matrix={matrix}
+              iconFor={(role) => ROLE_ICONS[resolveRoleKind(role)]}
+              data-testid="RolesAccessMatrix__67e3bc" />
           </div>
         );
       })()}

--- a/tools/app-shell/src/pages/__tests__/RolesOverviewPage.vitest.jsx
+++ b/tools/app-shell/src/pages/__tests__/RolesOverviewPage.vitest.jsx
@@ -1,55 +1,44 @@
-// Vitest render tests for RolesOverviewPage.jsx (ETP-4513 — read-only
-// "Configuración > Roles" view). Mirrors OAuth2ClientsPage.vitest.jsx's
-// mocking style: real i18n keys surface as-is (useUI mock returns the key),
-// UI primitives are stubbed to plain elements that preserve data-testid/props
-// so we can assert on the page's own contract instead of shadcn/Radix
-// internals.
-import { vi, describe, it, expect, beforeEach } from 'vitest';
+// Vitest render tests for RolesOverviewPage.jsx, redesigned by ETP-4907 to
+// match a new reference layout: 5 role summary cards + a window x role
+// access matrix grouped by category (replacing ETP-4513's per-role card
+// list with window "tier" chips). Sub-component internals (RoleSummaryCard,
+// RolesAccessMatrix, AccessTierPill) have their own dedicated test files —
+// this file only verifies the page's own orchestration: loading/error/
+// no-access states, and that both sub-components receive the right data.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import React from 'react';
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
-// ETP-4513 window-name i18n fix: RolesOverviewPage now also calls
-// useMenuLabel() to translate each assigned-window badge (previously
-// rendered the raw AD_Window English `name` untranslated, e.g. "Business
-// Partner" / "Sales Invoice" instead of "Terceros" / "Factura (Cliente)").
-// This mock mirrors useMenuLabel's REAL contract (see
-// `node_modules/@etendosoftware/app-shell-core/src/i18n/useMenuLabel.js`):
-// a lookup keyed by the raw name, falling back to the raw name unchanged
-// when no dictionary entry exists — NOT a different/invented contract.
-const MENU_LABELS = {
-  'Business Partner': 'Terceros',
-  'Sales Invoice': 'Factura (Cliente)',
-};
-
 vi.mock('@/i18n', () => ({
-  useUI: () => (key) => key,
-  useMenuLabel: () => (key) => MENU_LABELS[key] ?? key,
+  useUI: () => (key, params = {}) => {
+    let text = key;
+    Object.keys(params).forEach((p) => { text = `${text} {${p}=${params[p]}}`; });
+    return text;
+  },
+  useMenuLabel: () => (key) => key,
 }));
 
-vi.mock('@/lib/rolesApi.js', () => ({
-  fetchRolesOverview: vi.fn(),
+vi.mock('@/components/layout/PageMetaContext', () => ({
+  useSetPageMeta: vi.fn(),
+}));
+
+const mockUseRolesOverviewData = vi.fn();
+vi.mock('../roles/useRolesOverviewData.js', () => ({
+  useRolesOverviewData: () => mockUseRolesOverviewData(),
+  ROLE_ICONS: {},
+  resolveRoleKind: () => null,
+  buildRowKey: (category, windowId) => `${category}::${windowId}`,
 }));
 
 vi.mock('lucide-react', () => ({
-  Users: (p) => <span data-testid={p['data-testid']} {...p} />,
-  Pencil: (p) => <span data-testid={p['data-testid']} {...p} />,
-  RefreshCw: (p) => <span data-testid={p['data-testid']} className={p.className} />,
   ShieldAlert: (p) => <span data-testid={p['data-testid']} {...p} />,
+  Users: (p) => <span data-testid={p['data-testid']} {...p} />,
 }));
 
 vi.mock('@/components/ui/card', () => ({
   Card: ({ children, ...props }) => <div {...props}>{children}</div>,
-  CardHeader: ({ children, className }) => <div className={className}>{children}</div>,
-  CardTitle: ({ children }) => <h3>{children}</h3>,
-  CardDescription: ({ children }) => <p>{children}</p>,
   CardContent: ({ children, className }) => <div className={className}>{children}</div>,
-}));
-
-vi.mock('@/components/ui/badge', () => ({
-  Badge: ({ children, variant, title, ...props }) => (
-    <span data-variant={variant} title={title} {...props}>{children}</span>
-  ),
 }));
 
 vi.mock('@/components/ui/button', () => ({
@@ -67,61 +56,20 @@ vi.mock('@/components/ui/skeleton', () => ({
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import RolesOverviewPage from '../RolesOverviewPage.jsx';
-import { fetchRolesOverview } from '@/lib/rolesApi.js';
 
-// Real backend shape (mirrors SFRolesOverview.java / mockFetch.js's fixture):
-// `rawDescription` is deliberately junk AD_Role boilerplate text that must
-// NEVER be what the page renders — the page must use the curated i18n
-// descKey instead (ROLE_I18N map in RolesOverviewPage.jsx).
-const RAW_JUNK_DESCRIPTION = '*** Please, do not edit this role. Use Copy Record instead ***';
-
-const FIVE_ROLES = [
-  {
-    // Deliberately a tenant-specific admin name (not "GOClient Admin") with
-    // isClientAdmin: true — proves the page identifies the admin role via
-    // the flag, never via role.name, and always renders the generic
-    // roleNameAdmin/roleDescAdmin copy regardless of the literal name.
-    id: 'tenant-admin-role',
-    name: 'RolesPresa Admin',
-    isClientAdmin: true,
-    rawDescription: 'RolesPresa Admin',
-    userCount: 2,
-    windows: [
-      { id: '108', name: 'User', tier: 'full' },
-      { id: '146', name: 'Price List', tier: 'full' },
-    ],
-  },
-  {
-    id: '127AE77FE2994067B7FE6495FC21D51E',
-    name: 'Finance',
-    rawDescription: RAW_JUNK_DESCRIPTION,
-    userCount: 2,
-    windows: [
-      { id: 'w-fin-1', name: 'Financial Account', tier: 'full' },
-      { id: 'w-fin-2', name: 'Sales Invoice', tier: 'read-only' },
-    ],
-  },
-  {
-    id: '2A159DF4F4B944A6AA903202AD35B545',
-    name: 'Sales',
-    rawDescription: RAW_JUNK_DESCRIPTION,
-    userCount: 1,
-    windows: [{ id: 'w-sales-1', name: 'Sales Order', tier: 'full' }],
-  },
-  {
-    id: 'A826430F723E4C1B9A53EBB0746A98C0',
-    name: 'Purchasing',
-    rawDescription: RAW_JUNK_DESCRIPTION,
-    userCount: 0,
-    windows: [{ id: 'w-pur-1', name: 'Purchase Order', tier: 'full' }],
-  },
-  {
-    id: '55E05A4B43514A029D6FB6B8D94B49D4',
-    name: 'Inventory',
-    rawDescription: RAW_JUNK_DESCRIPTION,
-    userCount: 0,
-    windows: [{ id: 'w-inv-1', name: 'Warehouse and Storage Bins', tier: 'read-only' }],
-  },
+// Realistic-but-arbitrary figures (NOT the earlier Figma reference
+// screenshot's placeholder numbers, which the backend developer confirmed
+// don't match live GOClient data — Admin's 48/2 is the one figure that does).
+const SAMPLE_CARDS = [
+  { id: 'admin', name: 'GOClient Admin', isClientAdmin: true, windowCount: 48, userCount: 2 },
+  { id: 'sales', name: 'Sales', windowCount: 13, userCount: 3 },
+];
+// Uses a category other than "General" — RolesAccessMatrix always overlays a
+// hardcoded "General" section (Inicio/Favoritos/Copilot) of its own ahead of
+// whatever `matrix` prop it receives, so a same-named fixture category here
+// would collide on data-testid="RolesAccessMatrix__category-General".
+const SAMPLE_MATRIX = [
+  { category: 'Commercial', rows: [{ windowId: 'w-contacts', windowName: 'Business Partner', access: { admin: 'full', sales: 'full' } }] },
 ];
 
 describe('RolesOverviewPage', () => {
@@ -129,250 +77,82 @@ describe('RolesOverviewPage', () => {
     vi.clearAllMocks();
   });
 
-  // Regression for ETP-4513's scroll bug: the page's root sits inside
-  // AppLayout's `overflow-hidden` content wrapper, so it must own its own
-  // scroll container (`h-full overflow-y-auto`, the same pattern used by
-  // DashboardPage/ContactsPage) or content taller than the viewport (5 role
-  // cards) gets silently clipped instead of scrolling.
-  it('makes its own root container scrollable (h-full overflow-y-auto)', async () => {
-    fetchRolesOverview.mockResolvedValue({ roles: FIVE_ROLES });
-    render(<RolesOverviewPage />);
-    await waitFor(() => {
-      expect(screen.getByTestId(`RolesOverviewPage__role-${FIVE_ROLES[0].id}`)).toBeTruthy();
-    });
-
-    const root = screen.getByTestId('RolesOverviewPage');
-    expect(root.className).toContain('overflow-y-auto');
-    expect(root.className).toContain('h-full');
-  });
-
-  describe('rendering all 5 roles', () => {
-    it('renders one card per role, keyed by role id', async () => {
-      fetchRolesOverview.mockResolvedValue({ roles: FIVE_ROLES });
-      render(<RolesOverviewPage />);
-      await waitFor(() => {
-        for (const role of FIVE_ROLES) {
-          expect(screen.getByTestId(`RolesOverviewPage__role-${role.id}`)).toBeTruthy();
-        }
-      });
-    });
-
-    it('renders the curated i18n name/description keys (not raw role.name/rawDescription)', async () => {
-      fetchRolesOverview.mockResolvedValue({ roles: FIVE_ROLES });
-      render(<RolesOverviewPage />);
-      await waitFor(() => {
-        expect(document.body.textContent).toContain('roleNameAdmin');
-        expect(document.body.textContent).toContain('roleDescAdmin');
-        expect(document.body.textContent).toContain('roleNameFinance');
-        expect(document.body.textContent).toContain('roleDescFinance');
-      });
-    });
-
-    it('identifies the admin role via isClientAdmin, never via its literal name', async () => {
-      fetchRolesOverview.mockResolvedValue({ roles: FIVE_ROLES });
-      render(<RolesOverviewPage />);
-      await waitFor(() => {
-        expect(screen.getByTestId(`RolesOverviewPage__role-${FIVE_ROLES[0].id}`)).toBeTruthy();
-      });
-      // The fixture's literal role.name ("RolesPresa Admin") must never leak into the page —
-      // only the generic roleNameAdmin/roleDescAdmin i18n keys represent the admin role.
-      expect(document.body.textContent).not.toContain('RolesPresa Admin');
-    });
-
-    // This is the central "no raw junk text" assertion the task calls out
-    // explicitly: the backend's rawDescription field is boilerplate AD_Role
-    // text ("*** Please, do not edit this role...") and must never leak into
-    // the rendered page — only the curated roleDesc* i18n keys should appear.
-    it('never renders the raw AD_Role.description-shaped junk text', async () => {
-      fetchRolesOverview.mockResolvedValue({ roles: FIVE_ROLES });
-      render(<RolesOverviewPage />);
-      await waitFor(() => {
-        expect(screen.getByTestId(`RolesOverviewPage__role-${FIVE_ROLES[1].id}`)).toBeTruthy();
-      });
-      expect(document.body.textContent).not.toContain(RAW_JUNK_DESCRIPTION);
-      expect(document.body.textContent).not.toContain('Please, do not edit this role');
-    });
-
-    it('renders the userCount badge for each role', async () => {
-      fetchRolesOverview.mockResolvedValue({ roles: FIVE_ROLES });
-      render(<RolesOverviewPage />);
-      await waitFor(() => {
-        expect(screen.getByTestId(`RolesOverviewPage__userCount-${FIVE_ROLES[0].id}`).textContent).toContain('2');
-        expect(screen.getByTestId(`RolesOverviewPage__userCount-${FIVE_ROLES[3].id}`).textContent).toContain('0');
-      });
-    });
-
-    it('renders a window chip for every window in role.windows, per role', async () => {
-      fetchRolesOverview.mockResolvedValue({ roles: FIVE_ROLES });
-      render(<RolesOverviewPage />);
-      await waitFor(() => {
-        for (const role of FIVE_ROLES) {
-          for (const w of role.windows) {
-            const chip = screen.getByTestId(`RolesOverviewPage__window-${role.id}-${w.id}`);
-            expect(chip.textContent).toBe(MENU_LABELS[w.name] ?? w.name);
-          }
-        }
-      });
-    });
-
-    it('gives a "full" tier window chip the default badge variant and a "read-only" one the outline variant', async () => {
-      fetchRolesOverview.mockResolvedValue({ roles: FIVE_ROLES });
-      render(<RolesOverviewPage />);
-      await waitFor(() => {
-        const fullChip = screen.getByTestId(`RolesOverviewPage__window-${FIVE_ROLES[0].id}-108`);
-        expect(fullChip.getAttribute('data-variant')).toBe('default');
-        const readOnlyChip = screen.getByTestId(`RolesOverviewPage__window-${FIVE_ROLES[1].id}-w-fin-2`);
-        expect(readOnlyChip.getAttribute('data-variant')).toBe('outline');
-      });
-    });
-
-    it('renders a placeholder dash when a role has no windows', async () => {
-      const roleWithNoWindows = { ...FIVE_ROLES[3], windows: [] };
-      fetchRolesOverview.mockResolvedValue({ roles: [roleWithNoWindows] });
-      render(<RolesOverviewPage />);
-      await waitFor(() => {
-        expect(screen.getByTestId(`RolesOverviewPage__windows-${roleWithNoWindows.id}`).textContent).toContain('—');
-      });
-    });
-  });
-
-  describe('window badge i18n (ETP-4513)', () => {
-    // Regression: the "Ventanas asignadas" badges used to render the raw
-    // AD_Window English `name` verbatim (untranslated even in Spanish
-    // locale). The page must now pass every window name through
-    // useMenuLabel() before rendering it.
-    const roleWithTranslatableWindows = {
-      ...FIVE_ROLES[1],
-      id: 'role-i18n-windows',
-      windows: [
-        { id: 'w-bp', name: 'Business Partner', tier: 'full' },
-        { id: 'w-si', name: 'Sales Invoice', tier: 'read-only' },
-      ],
-    };
-
-    it('renders the translated (mapped) window name, not the raw AD_Window name', async () => {
-      fetchRolesOverview.mockResolvedValue({ roles: [roleWithTranslatableWindows] });
-      render(<RolesOverviewPage />);
-      await waitFor(() => {
-        const bpChip = screen.getByTestId(`RolesOverviewPage__window-${roleWithTranslatableWindows.id}-w-bp`);
-        expect(bpChip.textContent).toBe('Terceros');
-        expect(bpChip.textContent).not.toBe('Business Partner');
-      });
-      const siChip = screen.getByTestId(`RolesOverviewPage__window-${roleWithTranslatableWindows.id}-w-si`);
-      expect(siChip.textContent).toBe('Factura (Cliente)');
-      expect(siChip.textContent).not.toBe('Sales Invoice');
-    });
-
-    it('falls back to the raw window name when no dictionary entry exists (matches useMenuLabel default)', async () => {
-      const roleWithUnknownWindow = {
-        ...FIVE_ROLES[2],
-        id: 'role-i18n-unknown-window',
-        windows: [{ id: 'w-unknown', name: 'Some Untranslated Window', tier: 'full' }],
-      };
-      fetchRolesOverview.mockResolvedValue({ roles: [roleWithUnknownWindow] });
-      render(<RolesOverviewPage />);
-      await waitFor(() => {
-        const chip = screen.getByTestId(`RolesOverviewPage__window-${roleWithUnknownWindow.id}-w-unknown`);
-        expect(chip.textContent).toBe('Some Untranslated Window');
-      });
-    });
-  });
-
-  describe('no create/edit/delete affordance', () => {
-    // These 5 roles are product-defined, not editable by any tenant user — only future
-    // user-created roles (out of scope for now) will ever be editable here. There is no
-    // Edit button, no dialog, and no create/delete affordance anywhere on the page.
-    it('exposes no edit/create/delete affordance anywhere on the page', async () => {
-      fetchRolesOverview.mockResolvedValue({ roles: FIVE_ROLES });
-      render(<RolesOverviewPage />);
-      await waitFor(() => {
-        expect(screen.getByTestId(`RolesOverviewPage__role-${FIVE_ROLES[0].id}`)).toBeTruthy();
-      });
-
-      const allTestIds = Array.from(document.querySelectorAll('[data-testid]')).map(
-        (el) => el.getAttribute('data-testid')
-      );
-      expect(allTestIds.some((id) => /delete/i.test(id))).toBe(false);
-      expect(allTestIds.some((id) => /create/i.test(id))).toBe(false);
-      expect(allTestIds.some((id) => /^RolesOverviewPage__new/i.test(id))).toBe(false);
-      expect(allTestIds.some((id) => /^RolesOverviewPage__edit/i.test(id))).toBe(false);
-      expect(document.querySelector('form')).toBeNull();
-    });
-  });
-
   describe('loading state', () => {
-    it('shows 3 skeleton placeholders while the fetch is in flight', () => {
-      fetchRolesOverview.mockReturnValue(new Promise(() => {})); // never resolves
+    it('shows 3 skeleton placeholders while loading', () => {
+      mockUseRolesOverviewData.mockReturnValue({ loading: true, error: null, cards: [], matrix: [], reload: vi.fn() });
       render(<RolesOverviewPage />);
       expect(screen.getByTestId('RolesOverviewPage__loading')).toBeTruthy();
       expect(screen.getAllByTestId('Skeleton__rolesOverview')).toHaveLength(3);
     });
 
-    it('does not show the role list or error/empty states while loading', () => {
-      fetchRolesOverview.mockReturnValue(new Promise(() => {}));
+    it('does not render the cards/matrix content or error/empty states while loading', () => {
+      mockUseRolesOverviewData.mockReturnValue({ loading: true, error: null, cards: [], matrix: [], reload: vi.fn() });
       render(<RolesOverviewPage />);
-      expect(screen.queryByTestId('RolesOverviewPage__list')).toBeNull();
+      expect(screen.queryByTestId('RolesOverviewPage__content')).toBeNull();
       expect(screen.queryByTestId('RolesOverviewPage__error')).toBeNull();
       expect(screen.queryByTestId('RolesOverviewPage__noAccess')).toBeNull();
     });
   });
 
   describe('error state', () => {
-    it('shows the error card with a retry action when the API rejects', async () => {
-      fetchRolesOverview.mockRejectedValue(new Error('network down'));
-      render(<RolesOverviewPage />);
-      await waitFor(() => {
-        expect(screen.getByTestId('RolesOverviewPage__error')).toBeTruthy();
+    it('shows the error card with a retry action', () => {
+      mockUseRolesOverviewData.mockReturnValue({
+        loading: false, error: 'network down', cards: [], matrix: [], reload: vi.fn(),
       });
+      render(<RolesOverviewPage />);
+      expect(screen.getByTestId('RolesOverviewPage__error')).toBeTruthy();
       expect(document.body.textContent).toContain('rolesLoadError');
       expect(screen.getByTestId('RolesOverviewPage__retry')).toBeTruthy();
     });
 
-    it('retry re-invokes fetchRolesOverview and can recover into the success state', async () => {
-      fetchRolesOverview.mockRejectedValueOnce(new Error('network down'));
-      fetchRolesOverview.mockResolvedValueOnce({ roles: FIVE_ROLES });
+    it('retry invokes reload()', async () => {
+      const reload = vi.fn();
+      mockUseRolesOverviewData.mockReturnValue({ loading: false, error: 'boom', cards: [], matrix: [], reload });
       const user = userEvent.setup();
       render(<RolesOverviewPage />);
-
-      await waitFor(() => expect(screen.getByTestId('RolesOverviewPage__error')).toBeTruthy());
       await user.click(screen.getByTestId('RolesOverviewPage__retry'));
-
-      await waitFor(() => {
-        expect(screen.getByTestId(`RolesOverviewPage__role-${FIVE_ROLES[0].id}`)).toBeTruthy();
-      });
-      expect(fetchRolesOverview).toHaveBeenCalledTimes(2);
+      expect(reload).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('empty / denied state', () => {
-    it('shows the no-access card when roles resolves to an empty array', async () => {
-      fetchRolesOverview.mockResolvedValue({ roles: [] });
+  describe('no-access / empty state', () => {
+    it('shows the no-access card when cards resolves to an empty array', () => {
+      mockUseRolesOverviewData.mockReturnValue({ loading: false, error: null, cards: [], matrix: [], reload: vi.fn() });
       render(<RolesOverviewPage />);
-      await waitFor(() => {
-        expect(screen.getByTestId('RolesOverviewPage__noAccess')).toBeTruthy();
-      });
+      expect(screen.getByTestId('RolesOverviewPage__noAccess')).toBeTruthy();
       expect(document.body.textContent).toContain('rolesNoAccessTitle');
       expect(document.body.textContent).toContain('rolesNoAccessMessage');
     });
-
-    it('treats a missing/non-array roles field as empty rather than crashing', async () => {
-      fetchRolesOverview.mockResolvedValue({});
-      render(<RolesOverviewPage />);
-      await waitFor(() => {
-        expect(screen.getByTestId('RolesOverviewPage__noAccess')).toBeTruthy();
-      });
-    });
   });
 
-  describe('refresh action', () => {
-    it('refetches when the refresh button is clicked', async () => {
-      fetchRolesOverview.mockResolvedValue({ roles: FIVE_ROLES });
-      const user = userEvent.setup();
-      render(<RolesOverviewPage />);
-      await waitFor(() => expect(fetchRolesOverview).toHaveBeenCalledTimes(1));
+  describe('content — cards + matrix', () => {
+    beforeEach(() => {
+      mockUseRolesOverviewData.mockReturnValue({
+        loading: false, error: null, cards: SAMPLE_CARDS, matrix: SAMPLE_MATRIX, reload: vi.fn(),
+      });
+    });
 
-      await user.click(screen.getByTestId('RolesOverviewPage__refresh'));
-      await waitFor(() => expect(fetchRolesOverview).toHaveBeenCalledTimes(2));
+    it('renders one summary card per role', () => {
+      render(<RolesOverviewPage />);
+      expect(screen.getByTestId('RoleSummaryCard__admin')).toBeTruthy();
+      expect(screen.getByTestId('RoleSummaryCard__sales')).toBeTruthy();
+    });
+
+    it('renders the access matrix below the cards', () => {
+      render(<RolesOverviewPage />);
+      expect(screen.getByTestId('RolesAccessMatrix')).toBeTruthy();
+      expect(screen.getByTestId('RolesAccessMatrix__category-General')).toBeTruthy();
+    });
+
+    it('exposes no create/edit/delete affordance anywhere on the page', () => {
+      render(<RolesOverviewPage />);
+      const allTestIds = Array.from(document.querySelectorAll('[data-testid]')).map((el) =>
+        el.getAttribute('data-testid')
+      );
+      expect(allTestIds.some((id) => /delete/i.test(id))).toBe(false);
+      expect(allTestIds.some((id) => /create/i.test(id))).toBe(false);
+      expect(allTestIds.some((id) => /^RolesOverviewPage__edit/i.test(id))).toBe(false);
+      expect(document.querySelector('form')).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary

This branch was reset to a clean, single-commit fix after discovering the original ETP-4907 work (permission-matrix page for Roles overview, previously delivered and merged via PR #1153) had been silently reverted by a bad merge-conflict resolution during an unrelated merge-block test (`mergeblock/userroles` → epic via PR #1160).

During that conflict resolution, 4 files were reverted to their pre-ETP-4907 content:
- `tools/app-shell/src/pages/RolesOverviewPage.jsx` — the permission-matrix page
- `tools/app-shell/src/lib/mockFetch.js`
- `tools/app-shell/src/pages/__tests__/RolesOverviewPage.vitest.jsx`
- `e2e/tests/flows/roles-overview.mocked.spec.js`

The revert was verified via `git diff` against the original feature branch tip. This PR restores all 4 files to the correct, tested state (tests passing 47/47).

## Test plan
- [x] Vitest suite for `RolesOverviewPage` passing (47/47)
- [x] Playwright mocked spec (`roles-overview.mocked.spec.js`) restored and passing
- [x] Diff verified as exactly these 4 files, no unrelated changes