### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.36

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.35",
-        "@etendosoftware/schema-forge-cli": "0.3.35",
-        "@etendosoftware/schema-forge-core": "0.3.35",
+        "@etendosoftware/app-shell-core": "0.3.36",
+        "@etendosoftware/schema-forge-cli": "0.3.36",
+        "@etendosoftware/schema-forge-core": "0.3.36",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.35",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.35/b8ecdbdf2d19582cb6e2e9b3694493396574853f",
-      "integrity": "sha512-2hmXrvx3xVyvio6hHJbPF8uPfPbgp2gMz1PhcollsEGVkl5UwP0rVhkb97IhpwFYqip3Z7CfUHQF8RP0YvwAYg==",
+      "version": "0.3.36",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.36/9eb4baa5a9f8c94df677d78d920e2b6c5d613c29",
+      "integrity": "sha512-/6UcK4CfC69wgksKxoD1cgXzb51Wbb3Tcgp/f9NGQGY9R6jnyOW0rJeNhrLbakU5VZDf1vhp4x0twS+Atgpoew==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.35",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.35/bdb10d1a4e22fba3d4ca61267c040a1f98d68e8b",
-      "integrity": "sha512-EZwVCXRAlKNIe+TYj1l5urpBHjxn9ZxPwiBS4pRhmuON41hYSqu+f639WOWE3BfJhjVmF1Vu8S1Sp0XLMouh8g==",
+      "version": "0.3.36",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.36/b940b11aaf7219fdaeed9605fc2316f4d3c6377e",
+      "integrity": "sha512-jExwalcFetppNXg3ka16AzG6dU35B1tICgOKmIrPTnc8E/qhlSD0oicJu4QU4igGAmMdOz3V1EfKfD5VjuVv+A==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.35",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.35/6bbd30c2e6665213c7a5a476eba1802033d13641",
-      "integrity": "sha512-cLGSuN+Q11aSKCn1wTdeYzq210c+Oa6qBF80kWTFXvU1BeX4NVhSOvsvpZrY7OYXwt8EF8FxP9ZsXhLuj/F+AQ==",
+      "version": "0.3.36",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.36/ddba517e4e940dc65b22419094bda94490e6f326",
+      "integrity": "sha512-r7L7kMQxD9ObZ5E4NK6gS0l4Yg1ap7Xhrf2vp9n0ZfpGIDTBkFjmSW4SUCzzMNHLHHneX9EOI6svAetAYmP4Bg==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.35",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.35/f01c764204e38ce49a9e91323f97b4de2f2551e6",
-      "integrity": "sha512-p6nRSntkehC/qORFn53mOR7dN72pO999ZRNDCNqs4GYI9wkl6EvNOcN8Ty0z20IL/cAy8X6DvmiU904+SAQOFw==",
+      "version": "0.3.36",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.36/91c0164c2dfb7659403a841ade691c0e9beb548a",
+      "integrity": "sha512-ENgQmBEtqJ6a2c5GFUgdOb3suw1RI79MGWTQ8dwSRqopFXk0HvH4h2HRAQNEG6Tr9es99kn6fPadpfqPclUsRQ==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13780,8 +13780,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.35",
-        "@etendosoftware/etendo-go-core": "0.3.35",
+        "@etendosoftware/app-shell-core": "0.3.36",
+        "@etendosoftware/etendo-go-core": "0.3.36",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.35",
-    "@etendosoftware/schema-forge-cli": "0.3.35",
-    "@etendosoftware/schema-forge-core": "0.3.35",
+    "@etendosoftware/app-shell-core": "0.3.36",
+    "@etendosoftware/schema-forge-cli": "0.3.36",
+    "@etendosoftware/schema-forge-core": "0.3.36",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.35",
-        "@etendosoftware/etendo-go-core": "0.3.35",
+        "@etendosoftware/app-shell-core": "0.3.36",
+        "@etendosoftware/etendo-go-core": "0.3.36",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.35",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.35/b8ecdbdf2d19582cb6e2e9b3694493396574853f",
-      "integrity": "sha512-2hmXrvx3xVyvio6hHJbPF8uPfPbgp2gMz1PhcollsEGVkl5UwP0rVhkb97IhpwFYqip3Z7CfUHQF8RP0YvwAYg==",
+      "version": "0.3.36",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.36/9eb4baa5a9f8c94df677d78d920e2b6c5d613c29",
+      "integrity": "sha512-/6UcK4CfC69wgksKxoD1cgXzb51Wbb3Tcgp/f9NGQGY9R6jnyOW0rJeNhrLbakU5VZDf1vhp4x0twS+Atgpoew==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.35",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.35/bdb10d1a4e22fba3d4ca61267c040a1f98d68e8b",
-      "integrity": "sha512-EZwVCXRAlKNIe+TYj1l5urpBHjxn9ZxPwiBS4pRhmuON41hYSqu+f639WOWE3BfJhjVmF1Vu8S1Sp0XLMouh8g==",
+      "version": "0.3.36",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.36/b940b11aaf7219fdaeed9605fc2316f4d3c6377e",
+      "integrity": "sha512-jExwalcFetppNXg3ka16AzG6dU35B1tICgOKmIrPTnc8E/qhlSD0oicJu4QU4igGAmMdOz3V1EfKfD5VjuVv+A==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.35",
-    "@etendosoftware/etendo-go-core": "0.3.35",
+    "@etendosoftware/app-shell-core": "0.3.36",
+    "@etendosoftware/etendo-go-core": "0.3.36",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.36`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.