### PR TITLE
Feature ETP-4968: Document GOClient webhook-role grant leak

### DIFF
--- a/cli/src/data-fixes/sql/20260727T114306Z__R16-tenant-roles-and-webhook-access.sql
+++ b/cli/src/data-fixes/sql/20260727T114306Z__R16-tenant-roles-and-webhook-access.sql
@@ -16,6 +16,15 @@
 -- file's old Step 3 are harmless leftovers (the Webhooks module dispatch path still exists and still
 -- honors them), not cleaned up retroactively.
 
+-- FOLLOW-UP (2026-08-21, ETP-4968): those "harmless leftover" grant rows had a second-order effect
+-- for GOClient specifically -- 12 SMFWHE_DEFINEDWEBHOOK_ROLE rows for SFWindowAccessMap/
+-- SFRolesOverview leaked from referencedata/sampledata/GOClient/SMFWHE_DEFINEDWEBHOOK_ROLE.xml into
+-- com.etendoerp.go/src-db/database/sourcedata/SMFWHE_DEFINEDWEBHOOK_ROLE.xml (the module's universal
+-- baseline, loaded on every fresh install) via an unrelated commit's `export.database` run against a
+-- dev DB that had GOClient's sample tenant loaded. That broke CI's from-scratch `update.database`
+-- with an AD_CLIENT FK violation. Both copies were cleaned directly under ETP-4968 -- a source-file
+-- edit, not a data-fix, since this was contaminated reference data rather than live-tenant state.
+
 -- Background
 -- --------------------------------------------------------------------------------------------
 -- This closes two layered gaps together, both surfaced 2026-07-27 manually testing ETP-4513/

--- a/docs/etendo-ad/onboarding-gaps.md
+++ b/docs/etendo-ad/onboarding-gaps.md
@@ -893,6 +893,13 @@ WHERE au.ad_client_id = '<NEW_CLIENT_ID>';
 > `neo-headless.md` §4.10–4.11) instead of the Webhooks module, so no grant is needed at all — this
 > whole gap class cannot recur for these 3 webhooks. Left below for historical context; the
 > corrective/preventive code this section describes has since been removed as dead weight.
+>
+> **Related leak (2026-08-21, ETP-4968):** stale `SMFWHE_DEFINEDWEBHOOK_ROLE` rows from this
+> already-superseded flow leaked from GOClient's sample data into the module's universal baseline
+> via an `export.database` run, breaking CI — see the "FOLLOW-UP" note at the top of
+> `cli/src/data-fixes/sql/20260727T114306Z__R16-tenant-roles-and-webhook-access.sql`. General risk:
+> `export.database` dumps a module-owned table's full live state regardless of client scope, so any
+> table with client-scoped rows plus a dev DB carrying sample-tenant data can leak the same way.
 
 **Symptom:** any authenticated role other than System Administrator (`AD_Role_ID = '0'`) gets a flat `404` from every Schema Forge webhook that requires a `SMFWHE_DEFINEDWEBHOOK_ROLE` grant — `SFListMenu`, `SFWindowAccessMap`, `SFRolesOverview`. Observable symptoms compound in a confusing way because the two callers fail in opposite directions: the sidebar shows the **full, unfiltered** menu (`useRoleMenu()`'s fetch fails → `AppLayout` fails **open** on a fetch error) while **every window** is denied (`fetchWindowAccess`'s fetch fails → `AuthContext`'s `windowAccess` map stays at its fail-**closed** `{}` default → `WindowAccessGuard` blocks everything).
 


### PR DESCRIPTION
## Summary
Documentation-only companion to `etendosoftware/com.etendoerp.go#911` (ETP-4968).

Adds a short follow-up note to `cli/src/data-fixes/sql/20260727T114306Z__R16-tenant-roles-and-webhook-access.sql` explaining that 12 GOClient rows leaked from `referencedata/sampledata/GOClient/SMFWHE_DEFINEDWEBHOOK_ROLE.xml` into `com.etendoerp.go`'s universal baseline sourcedata via an unrelated `export.database` run, broke CI with an `AD_CLIENT` FK violation, and were cleaned in both places directly (not a data-fix — contaminated reference data, not live-tenant remediation).

Also adds a one-line pointer in `docs/etendo-ad/onboarding-gaps.md` flagging the general risk pattern: `export.database` dumps full module-table state regardless of client scope, so any module-owned table with client-scoped rows can leak the same way in the future.

Jira: ETP-4968 (epic ETP-3504)