### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.38

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.37",
-        "@etendosoftware/schema-forge-cli": "0.3.37",
-        "@etendosoftware/schema-forge-core": "0.3.37",
+        "@etendosoftware/app-shell-core": "0.3.38",
+        "@etendosoftware/schema-forge-cli": "0.3.38",
+        "@etendosoftware/schema-forge-core": "0.3.38",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.37",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.37/171681d0bbdce1255d5223ca17d15f94cc53861f",
-      "integrity": "sha512-UGsjYA9Ax0pI8ikRXAawB7KCDZxX6hPZENKuihd3d/0hXG+IdlIUj/bIGW54CLhEKI6Wlfe/93vZg3HwMt/SHA==",
+      "version": "0.3.38",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.38/5432346cf322f2df7dc18266cca5286cfe03ac0d",
+      "integrity": "sha512-GdZDOYrjWIh65EF1Y4utJEssZ9TulPyo1Bbt12vMeWykxzLgr6pUIpUcOIM5vLshhKLxI39tpJEYFZKDyd+m5Q==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.37",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.37/80a279ea6b7e443ac69b57262f55fa726dfbb08a",
-      "integrity": "sha512-2Sq6PTMI05I3Fgvi1H7Cv1FwRGvY+2Emz9O5vF2iEuTql5MM/XguQbRSkTgkpKAegwIfkkw+rscHRsxYSmREnA==",
+      "version": "0.3.38",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.38/3b560c33ffb011a8b9a22471a9e3e8f338d413ba",
+      "integrity": "sha512-S1Z/mtTB+XVA1cM8LxCeQ3hpY63Teo47a5MIMdLtPABg+l36s/pfuuL7QzEh+/hvhaD4brTmxPiz7LJNW5fJtw==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.37",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.37/3afd55301d55eef24dd47a8601a38121d5dbd434",
-      "integrity": "sha512-a0YQjuhOnTntKk/wyzc3MiorZ41BhBhKNCqPInxq78SQ/RRaUfZEPkH0jWskwSxx6nz390gexQE5CfPJg1EAdg==",
+      "version": "0.3.38",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.38/42607e7188290514dcea555107eabab42fd0bbc8",
+      "integrity": "sha512-nWPH5w0ZoLRVFVuQbIbdGQFnegA5keMQwBccijv9B8+ut6IwjQaDDu31dyDPKYAEiwCs+ao7Gsvvpy7dvbqSSQ==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.37",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.37/7fc7251bf9fff885f9cc5b01d8d6d770487371f2",
-      "integrity": "sha512-B7evtR3298KVVEctUhGxVcqaExoj/37LGrxizidrHvEN0xsIiFJ9ZjP2ulKucqfo5R9UcFqxogNqyIrrJYt4kw==",
+      "version": "0.3.38",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.38/7a54e9a49d587a06bff965d3feda4fbb48b13c23",
+      "integrity": "sha512-WIhWnmdbwoY91e9ZVCPL34pV7ZSIkZ8sXB42ylgVnnMmZ0AfaIc9v/yl9mygvlSeFGhKjzgP8vhjlTOoTWhBwg==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13780,8 +13780,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.37",
-        "@etendosoftware/etendo-go-core": "0.3.37",
+        "@etendosoftware/app-shell-core": "0.3.38",
+        "@etendosoftware/etendo-go-core": "0.3.38",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.37",
-    "@etendosoftware/schema-forge-cli": "0.3.37",
-    "@etendosoftware/schema-forge-core": "0.3.37",
+    "@etendosoftware/app-shell-core": "0.3.38",
+    "@etendosoftware/schema-forge-cli": "0.3.38",
+    "@etendosoftware/schema-forge-core": "0.3.38",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.37",
-        "@etendosoftware/etendo-go-core": "0.3.37",
+        "@etendosoftware/app-shell-core": "0.3.38",
+        "@etendosoftware/etendo-go-core": "0.3.38",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.37",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.37/171681d0bbdce1255d5223ca17d15f94cc53861f",
-      "integrity": "sha512-UGsjYA9Ax0pI8ikRXAawB7KCDZxX6hPZENKuihd3d/0hXG+IdlIUj/bIGW54CLhEKI6Wlfe/93vZg3HwMt/SHA==",
+      "version": "0.3.38",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.38/5432346cf322f2df7dc18266cca5286cfe03ac0d",
+      "integrity": "sha512-GdZDOYrjWIh65EF1Y4utJEssZ9TulPyo1Bbt12vMeWykxzLgr6pUIpUcOIM5vLshhKLxI39tpJEYFZKDyd+m5Q==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.37",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.37/80a279ea6b7e443ac69b57262f55fa726dfbb08a",
-      "integrity": "sha512-2Sq6PTMI05I3Fgvi1H7Cv1FwRGvY+2Emz9O5vF2iEuTql5MM/XguQbRSkTgkpKAegwIfkkw+rscHRsxYSmREnA==",
+      "version": "0.3.38",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.38/3b560c33ffb011a8b9a22471a9e3e8f338d413ba",
+      "integrity": "sha512-S1Z/mtTB+XVA1cM8LxCeQ3hpY63Teo47a5MIMdLtPABg+l36s/pfuuL7QzEh+/hvhaD4brTmxPiz7LJNW5fJtw==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.37",
-    "@etendosoftware/etendo-go-core": "0.3.37",
+    "@etendosoftware/app-shell-core": "0.3.38",
+    "@etendosoftware/etendo-go-core": "0.3.38",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.38`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.