### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.40

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.39",
-        "@etendosoftware/schema-forge-cli": "0.3.39",
-        "@etendosoftware/schema-forge-core": "0.3.39",
+        "@etendosoftware/app-shell-core": "0.3.40",
+        "@etendosoftware/schema-forge-cli": "0.3.40",
+        "@etendosoftware/schema-forge-core": "0.3.40",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.39",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.39/780c1af652a237550b40ef811ea030c1d677fab5",
-      "integrity": "sha512-joH6n1G6ZyP5PySmtqtfJi4wXlmaj9AEb8sewJbfqFFB7QUc46hd2NMdPvgl72nIDwbzmrhJ7XKZwJED5vRG5w==",
+      "version": "0.3.40",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.40/8aa9aca069468de36a3e7a6d9ed5b9a2ef898c8e",
+      "integrity": "sha512-RpcM6G/j2yPoLVqOZndsTm+3nITI0pVdO8Tx/D2j4RRvCXN2gibDTTv/SpD9rKYm5AteRknrFGCl0qnL76KcyQ==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.39",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.39/5f16f5eb2a6ba7a2a982c8676bfe1beec59fcc97",
-      "integrity": "sha512-FPM7TWhISMOvANp/S6gz7b/4Lr2Jxisxi6NxIrfHqyY210/Q42DoTW3a4oC/z+YHXHd7QqgllSr64hWn0llFrA==",
+      "version": "0.3.40",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.40/7dcf31f49a99aaf98a71939f581408a96a701dc0",
+      "integrity": "sha512-xgm7D7qq4ZaxocXjBT9SuZHMC+XtHaMpCbltb870JXa0LUlB8nZItpfiPtGC5Y5lYT7Z4W1V3TnwKjeChEnFDw==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.39",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.39/7ff54179af6872ee59ef84006b097907b62c84ec",
-      "integrity": "sha512-SFlkAB58RFul0WB3BeqGiQdtm3l4RWmKlaEm0HIOCdlIYUyq5Vj+JqcNoax/w7Ufs7tPkk+f1YSXwEBcdR7Chg==",
+      "version": "0.3.40",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.40/5dea4ef2d99ac7ae68b2b0a625ddb10c166a121c",
+      "integrity": "sha512-tG+3eZLd3GzpKCkfNP8oXp6uu8iubd2lNEZ38SUl9dBm5aZPmB40TvNSrsPwjbr8BpoEbmR4qm4P4IZP2Ewi4w==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.39",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.39/b65c3212201208a05d542ac1d0da61c66ff098f7",
-      "integrity": "sha512-6flFiQBk3nodAxng9N9nk+0mN6cbxMKZ82YXi45I13Oe5sDaNsrI6C5JW8u7JhH6+Lmy7mToUmowQgPyk4txKw==",
+      "version": "0.3.40",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.40/46504f8fdc18a071aca888c6381dd7fa0f71607e",
+      "integrity": "sha512-bXLBnq0eNESVZJlCLXLzckFip042+cGAWllrEPbmeWpnucLd7b87aG/nx7u11HLUi784j2VjowzkI4s5tMMsHQ==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13780,8 +13780,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.39",
-        "@etendosoftware/etendo-go-core": "0.3.39",
+        "@etendosoftware/app-shell-core": "0.3.40",
+        "@etendosoftware/etendo-go-core": "0.3.40",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.39",
-    "@etendosoftware/schema-forge-cli": "0.3.39",
-    "@etendosoftware/schema-forge-core": "0.3.39",
+    "@etendosoftware/app-shell-core": "0.3.40",
+    "@etendosoftware/schema-forge-cli": "0.3.40",
+    "@etendosoftware/schema-forge-core": "0.3.40",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.39",
-        "@etendosoftware/etendo-go-core": "0.3.39",
+        "@etendosoftware/app-shell-core": "0.3.40",
+        "@etendosoftware/etendo-go-core": "0.3.40",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.39",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.39/780c1af652a237550b40ef811ea030c1d677fab5",
-      "integrity": "sha512-joH6n1G6ZyP5PySmtqtfJi4wXlmaj9AEb8sewJbfqFFB7QUc46hd2NMdPvgl72nIDwbzmrhJ7XKZwJED5vRG5w==",
+      "version": "0.3.40",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.40/8aa9aca069468de36a3e7a6d9ed5b9a2ef898c8e",
+      "integrity": "sha512-RpcM6G/j2yPoLVqOZndsTm+3nITI0pVdO8Tx/D2j4RRvCXN2gibDTTv/SpD9rKYm5AteRknrFGCl0qnL76KcyQ==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.39",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.39/5f16f5eb2a6ba7a2a982c8676bfe1beec59fcc97",
-      "integrity": "sha512-FPM7TWhISMOvANp/S6gz7b/4Lr2Jxisxi6NxIrfHqyY210/Q42DoTW3a4oC/z+YHXHd7QqgllSr64hWn0llFrA==",
+      "version": "0.3.40",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.40/7dcf31f49a99aaf98a71939f581408a96a701dc0",
+      "integrity": "sha512-xgm7D7qq4ZaxocXjBT9SuZHMC+XtHaMpCbltb870JXa0LUlB8nZItpfiPtGC5Y5lYT7Z4W1V3TnwKjeChEnFDw==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.39",
-    "@etendosoftware/etendo-go-core": "0.3.39",
+    "@etendosoftware/app-shell-core": "0.3.40",
+    "@etendosoftware/etendo-go-core": "0.3.40",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.40`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.