### PR TITLE
Feature ETP-5028: Adapt front repo to the two-branch model

### DIFF
--- a/.github/workflows/branch-merge-policy.yml
+++ b/.github/workflows/branch-merge-policy.yml
@@ -1,10 +1,14 @@
 name: Branch Merge Policy
 
 # Restricts which source branch a PR may come from, based on its target:
-#   -> main            only from develop
-#   -> develop         only from epic/*
-#   -> epic/*          from anywhere
+#   -> main            only from develop or hotfix/*
+#   -> develop         from anywhere (feature/*, fix/*, chore/*, epic/*, main back-merge)
 #   -> anything else   from anywhere (unrestricted)
+#
+# ETP-5028: 'develop' no longer accepts only 'epic/*'. The branching model moves to
+# two branches (main = production, develop = pre-production) and features go straight
+# to develop. The guard that matters — that 'main' is only reachable through develop
+# or a hotfix — is kept.
 #
 # Self-contained (no external service) — intended to eventually replace the
 # equivalent rule in Git Police, alongside the local pre-push checks and the
@@ -27,22 +31,16 @@ jobs:
           echo "PR: $HEAD_REF -> $BASE_REF"
           case "$BASE_REF" in
             main)
-              if [ "$HEAD_REF" != "develop" ]; then
-                echo "::error::'main' only accepts PRs from 'develop' (got '$HEAD_REF')."
-                exit 1
-              fi
-              ;;
-            develop)
               case "$HEAD_REF" in
-                epic/*) ;;
+                develop|hotfix/*) ;;
                 *)
-                  echo "::error::'develop' only accepts PRs from 'epic/*' branches (got '$HEAD_REF')."
+                  echo "::error::'main' only accepts PRs from 'develop' or 'hotfix/*' (got '$HEAD_REF')."
                   exit 1
                   ;;
               esac
               ;;
-            epic/*)
-              echo "'epic/*' accepts PRs from any branch — no restriction."
+            develop)
+              echo "'develop' accepts PRs from any branch — no restriction."
               ;;
             *)
               echo "No source-branch restriction defined for target '$BASE_REF'."

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - develop
       - main
-      - epic/ETP-3504
   workflow_dispatch:
     inputs:
       environment:
@@ -34,7 +33,9 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             TARGET="${{ inputs.environment }}"
           elif [[ "${{ github.ref_name }}" == "develop" ]]; then
-            TARGET="staging"
+            # ETP-5028: develop now feeds the experimental infrastructure, which
+            # becomes the pre-production environment (staging is being retired).
+            TARGET="experimental"
           elif [[ "${{ github.ref_name }}" == "main" ]]; then
             TARGET="production"
           else


### PR DESCRIPTION
## Qué hace

Adapta el repo del front al modelo de dos ramas (`main` = producción, `develop` = preproducción). Son dos cambios pequeños e independientes:

### 1. `branch-merge-policy.yml`

| | Antes | Después |
|---|---|---|
| `main` ← | solo `develop` | `develop` o `hotfix/*` |
| `develop` ← | solo `epic/*` | cualquier rama |

El guard que importa se mantiene: a `main` solo se llega por `develop` o por un hotfix. Se añade `hotfix/*` porque el modelo nuevo contempla hotfixes que salen de `main` y vuelven a `main`.

### 2. `deploy-staging.yml`

- Un push a `develop` ahora despliega a la **infraestructura de experimental**, que pasa a ser preproducción (staging se retira). Antes iba al bucket y la distribución de staging.
- Se quita `epic/ETP-3504` de los triggers de push: el epic deja de desplegar.

Se hace cambiando el `TARGET` y no las variables de Actions, a propósito: así se reutiliza el bloque `experimental` que ya tiene sus valores correctos —incluido `VITE_PUBLIC_ORIGIN`, que está escrito en el YAML y no es variable— y las de staging quedan intactas por si hay que volver atrás.

## Notas para quien revise

- **Este PR va a salir en rojo en el check `Validate source branch for target`**, porque viene de `feature/*` hacia `develop` y la regla vigente aún no lo permite. Es esperado: es el problema que el propio PR arregla. Verificado que ese check **no es obligatorio** en el `develop` de este repo.
- Hay un PR equivalente para el punto 1 en `com.etendoerp.go` (#938). El punto 2 es solo de este repo.
- El cambio 2 tiene efecto en el siguiente push a `develop`, así que conviene mergearlo dentro de la ventana de corte, coordinado con el cambio de los Jenkinsfiles.

Ticket: ETP-5028
