### PR TITLE
Feature ETP-5028: Fix report-server deploy target and repoint core bumps

### DIFF
--- a/.github/workflows/bump-core-on-release.yml
+++ b/.github/workflows/bump-core-on-release.yml
@@ -2,7 +2,7 @@ name: Bump schema_forge_core pin on release
 
 # Fired via repository_dispatch when schema_forge_core publishes a new release
 # (see schema_forge_core .github/workflows/release.yml, "Notify functional
-# repo of new release" step). Opens a PR against the epic branch bumping the
+# repo of new release" step). Opens a PR against develop bumping the
 # lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli,
 # schema-forge-core) via `make bump-core-version`.
 #
@@ -19,7 +19,8 @@ on:
         required: true
 
 env:
-  EPIC_BRANCH: epic/ETP-3504
+  # ETP-5028: the epic is no longer an integration step; bumps go to develop.
+  TARGET_BRANCH: develop
 
 jobs:
   bump-core-version:
@@ -41,7 +42,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.EPIC_BRANCH }}
+          ref: ${{ env.TARGET_BRANCH }}
           # A PAT (not GITHUB_TOKEN) is required so the branch pushed below
           # triggers the repo's own workflows (Tests, Offline Regen Check, ...)
           # on the PR — pushes made with GITHUB_TOKEN don't trigger workflows.
@@ -98,14 +99,14 @@ jobs:
         # PR's own CI checks once opened, so skipping the local hook here is safe.
         run: git push --no-verify -u origin "chore/bump-core-${{ steps.version.outputs.version }}"
 
-      - name: Open PR against the epic branch
+      - name: Open PR against the target branch
         if: steps.diff.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.SF_BUMP_PAT }}
         run: |
           set -euo pipefail
           existing=$(gh pr list \
-            --base "${{ env.EPIC_BRANCH }}" \
+            --base "${{ env.TARGET_BRANCH }}" \
             --head "chore/bump-core-${{ steps.version.outputs.version }}" \
             --state open \
             --json url \
@@ -117,7 +118,7 @@ jobs:
           fi
 
           gh pr create \
-            --base "${{ env.EPIC_BRANCH }}" \
+            --base "${{ env.TARGET_BRANCH }}" \
             --head "chore/bump-core-${{ steps.version.outputs.version }}" \
             --title "Epic ETP-3504: Bump schema_forge_core pin to ${{ steps.version.outputs.version }}" \
             --body "Automated bump — schema_forge_core released \`${{ steps.version.outputs.version }}\`. Runs \`make bump-core-version\` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in \`package.json\` and \`tools/app-shell/package.json\`."

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -194,7 +194,9 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             TARGET="${{ inputs.environment }}"
           elif [[ "${{ github.ref_name }}" == "develop" ]]; then
-            TARGET="staging"
+            # ETP-5028: develop now feeds the experimental infrastructure, which
+            # becomes the pre-production environment (staging has been retired).
+            TARGET="experimental"
           elif [[ "${{ github.ref_name }}" == "main" ]]; then
             TARGET="production"
           else


### PR DESCRIPTION
## Qué hace

Dos ajustes de workflows para el modelo de dos ramas, en el mismo repo.

### 1. 🔴 `deploy-staging.yml` — el job del report-server apunta al cluster equivocado

El merge block de hoy (#1228) incorporó el job `deploy-report-server` de **ETP-4898**, que arregla algo real: la imagen del report-server llevaba congelada desde el **16 de abril**, así que los informes se renderizaban con la plantilla de abril mientras el catálogo del sidebar iba al día. Buen arreglo.

El problema es de sincronización, no de ese cambio: ese job se escribió el **24-08**, cuando `develop` todavía desplegaba en staging. El 27-08 se cambió el mapeo del job del SPA a experimental (#1219), y al mergear el merge block **entraron los dos bloques sin conflicto** —están en zonas distintas del fichero— dejándolo incoherente:

| Job | Destino de `develop` |
|---|---|
| SPA (línea 36) | `experimental` ✅ |
| report-server (línea 197) | `staging` 🔴 |

Con staging retirado (servicios en `desired=0` desde el 27-08), ese job desplegaría en un cluster apagado. Se corrige el `TARGET` a `experimental`; el `case` de abajo cae solo en `ECS_CLUSTER_EXPERIMENTAL`.

### 2. `bump-core-on-release.yml` — abrir los PR contra `develop`

Abría automáticamente el PR de bump del pin de `schema_forge_core` **contra `epic/ETP-3504`**. Con el epic fuera del flujo, esos PR aterrizarían en una rama que ya no alimenta ningún entorno: no fallarían, simplemente no llegarían a desplegarse.

Se sustituye `EPIC_BRANCH` por `TARGET_BRANCH: develop` y se actualizan las dos referencias, los comentarios y el nombre del step.

> Quedan **8 PR de `chore/bump-core-0.3.x`** abiertos sin mergear, desde la 0.3.23. Este cambio evita que la cola crezca, pero no resuelve los que ya están: alguien que lleve el pin de core tiene que decidir si se mergean, se redirigen o se cierran.

Ticket: ETP-5028
