### PR TITLE
Feature ETP-5070: Stabilize flaky E2E integration tests

### DIFF
--- a/e2e/tests/flows/purchase-order-to-invoice.integration.spec.js
+++ b/e2e/tests/flows/purchase-order-to-invoice.integration.spec.js
@@ -164,9 +164,11 @@ test.describe('Purchase Order → Invoice — Happy path (integration)', () => {
       await expectStatusPill(page, /completado|registrado|booked|completed/i,
         'PO status pill should show Completed after confirmation');
 
+      // After a reload the lines count badge may briefly show "0" while the
+      // lines fetch is in-flight — allow enough time for the real count to land.
       await expect(page.getByRole('button', { name: /líneas\s+2|lines\s+2/i }),
         'PO should still show 2 lines after completion',
-      ).toBeVisible({ timeout: 10_000 });
+      ).toBeVisible({ timeout: 20_000 });
 
       // [Plan 9.4] Verify the PO is not editable after confirming
       const saveAfterConfirm = page.getByRole('button', { name: /guardar|save/i });

--- a/e2e/tests/flows/sales-order-happy-path.integration.spec.js
+++ b/e2e/tests/flows/sales-order-happy-path.integration.spec.js
@@ -140,18 +140,16 @@ test.describe('Sales Order — Happy path (integration)', () => {
     await test.step('Add first line — select product', async () => {
       await waitForDetailReady(page);
 
-      // Click "+ Añadir líneas" — retry the whole click→response→render sequence
+      // Click "+ Añadir líneas" — wait for the button to appear first (the lines
+      // panel may still be loading after the draft save redirect), then retry the
+      // click→response→render sequence if the inline-add-row doesn't appear.
       const emptyStateBtn = page.getByTestId('action-add-lines-empty-state')
         .or(page.getByRole('button', { name: /añadir líneas|add lines/i }).first());
+      await expect(emptyStateBtn).toBeVisible({ timeout: 15_000 });
 
       await expect(async () => {
-        const addLinesResponse = page.waitForResponse(
-          (r) => r.url().includes('/sws/neo/') && r.status() < 400,
-          { timeout: 15_000 },
-        );
-        await emptyStateBtn.click({ timeout: 3_000 });
-        await addLinesResponse;
-        await expect(page.getByTestId('inline-add-row')).toBeVisible({ timeout: 5_000 });
+        await emptyStateBtn.click({ timeout: 5_000 });
+        await expect(page.getByTestId('inline-add-row')).toBeVisible({ timeout: 10_000 });
       }).toPass({ timeout: 30_000 });
       await slow(page);
 
@@ -173,12 +171,16 @@ test.describe('Sales Order — Happy path (integration)', () => {
         .filter({ hasText: /queso sardo/i }).first();
       await expect(productOption).toBeVisible({ timeout: 15_000 });
 
-      // Start listening for callout (price/tax fill) BEFORE clicking the product
-      const productCalloutResponse = page.waitForResponse(
-        (resp) => resp.url().includes('/sws/neo/') && resp.status() < 400,
-        { timeout: 30_000 },
-      );
-      await productOption.click();
+      // Retry click if the product element detaches mid-click (the drawer
+      // re-renders its list when waterfall fetches complete — see purchase-helpers.js).
+      let productCalloutResponse;
+      await expect(async () => {
+        productCalloutResponse = page.waitForResponse(
+          (resp) => resp.url().includes('/sws/neo/') && resp.status() < 400,
+          { timeout: 30_000 },
+        );
+        await productOption.click({ timeout: 3_000 });
+      }).toPass({ timeout: 15_000 });
       await expect(searchDrawer).toBeHidden({ timeout: 10_000 }).catch(() => {});
       await productCalloutResponse;
       await slow(page);
@@ -228,12 +230,16 @@ test.describe('Sales Order — Happy path (integration)', () => {
         .filter({ hasText: /agua/i }).first();
       await expect(secondOption).toBeVisible({ timeout: 10_000 });
 
-      // Start listening for callout BEFORE clicking the product
-      const productCalloutResponse2 = page.waitForResponse(
-        (resp) => resp.url().includes('/sws/neo/') && resp.status() < 400,
-        { timeout: 30_000 },
-      );
-      await secondOption.click();
+      // Retry click if the product element detaches mid-click (same drawer
+      // re-render issue as the first line — see purchase-helpers.js).
+      let productCalloutResponse2;
+      await expect(async () => {
+        productCalloutResponse2 = page.waitForResponse(
+          (resp) => resp.url().includes('/sws/neo/') && resp.status() < 400,
+          { timeout: 30_000 },
+        );
+        await secondOption.click({ timeout: 3_000 });
+      }).toPass({ timeout: 15_000 });
       await expect(searchDrawer2).toBeHidden({ timeout: 10_000 }).catch(() => {});
       await productCalloutResponse2;
       await slow(page);

--- a/e2e/tests/flows/sales-quotation-happy-path.integration.spec.js
+++ b/e2e/tests/flows/sales-quotation-happy-path.integration.spec.js
@@ -148,19 +148,16 @@ test.describe('Sales Quotation — Happy path (integration)', () => {
     await test.step('Add a line — select a product', async () => {
       await waitForDetailReady(page);
 
-      // Click "+ Añadir líneas" — retry the whole click→response→render sequence
-      // in case the click doesn't register (overlay, animation, React reconciliation)
+      // Click "+ Añadir líneas" — wait for the button to appear first (the lines
+      // panel may still be loading after the draft save), then retry until the
+      // inline-add-row appears.
       const emptyStateBtn = page.getByTestId('action-add-lines-empty-state')
         .or(page.getByRole('button', { name: /añadir líneas|add lines/i }).first());
+      await expect(emptyStateBtn).toBeVisible({ timeout: 15_000 });
 
       await expect(async () => {
-        const addLinesResponse = page.waitForResponse(
-          (r) => r.url().includes('/sws/neo/') && r.status() < 500,
-          { timeout: 15_000 },
-        );
-        await emptyStateBtn.click({ timeout: 3_000 });
-        await addLinesResponse;
-        await expect(page.getByTestId('inline-add-row')).toBeVisible({ timeout: 5_000 });
+        await emptyStateBtn.click({ timeout: 5_000 });
+        await expect(page.getByTestId('inline-add-row')).toBeVisible({ timeout: 10_000 });
       }).toPass({ timeout: 30_000 });
       await slow(page);
 
@@ -177,12 +174,16 @@ test.describe('Sales Quotation — Happy path (integration)', () => {
       const productOption = page.locator('[data-testid^="product-search-option-"]').first();
       await expect(productOption).toBeVisible({ timeout: 15_000 });
 
-      // Start listening for callout (price/tax fill) BEFORE clicking the product
-      const productCalloutResponse = page.waitForResponse(
-        (resp) => resp.url().includes('/sws/neo/') && resp.status() < 500,
-        { timeout: 30_000 },
-      );
-      await productOption.click();
+      // Retry click if the product element detaches mid-click (the drawer
+      // re-renders its list when waterfall fetches complete — see purchase-helpers.js).
+      let productCalloutResponse;
+      await expect(async () => {
+        productCalloutResponse = page.waitForResponse(
+          (resp) => resp.url().includes('/sws/neo/') && resp.status() < 500,
+          { timeout: 30_000 },
+        );
+        await productOption.click({ timeout: 3_000 });
+      }).toPass({ timeout: 15_000 });
       await expect(searchDrawer).toBeHidden({ timeout: 10_000 }).catch(() => {});
       await productCalloutResponse;
       await slow(page);

--- a/e2e/tests/helpers/purchase-helpers.js
+++ b/e2e/tests/helpers/purchase-helpers.js
@@ -763,8 +763,11 @@ export async function selectVendorBP(page, { name } = {}) {
 export async function saveDraft(page) {
   const saveBtn = page.getByTestId('action-save-draft')
     .or(page.getByRole('button', { name: /guardar|save/i }));
+  // Wait for the button to be enabled — it stays disabled while BP callouts
+  // (price list, payment terms, currency, address) are still propagating.
+  await expect(saveBtn.first()).toBeEnabled({ timeout: 15_000 });
   const savePromise = expectSaveResponse(page);
-  await saveBtn.click();
+  await saveBtn.first().click();
   await savePromise;
   await slow(page);
 }
@@ -813,19 +816,25 @@ export async function addProductLine(page, { productIndex = 0, quantity, isFirst
   await slow(page);
 
   // Select the product by index — fall back to first if nth doesn't exist.
-  // Retry the whole selection if the drawer loads empty (intermittent backend timing).
+  // Retry the whole click sequence if the element detaches from the DOM mid-click
+  // (the ProductSearchDrawer re-renders its entire list when waterfall/pagination
+  // fetches complete, which can replace the <button> between locator resolution
+  // and the actual pointer event — see ETP-4567 QA flaky-test investigation).
   const allProducts = page.locator('[data-testid^="product-search-option-"]');
   await expect(allProducts.first()).toBeVisible({ timeout: 20_000 });
-  const count = await allProducts.count();
-  const product = allProducts.nth(Math.min(productIndex, count - 1));
 
-  // Start listening for callout (price/tax fill) BEFORE clicking the product
-  const productCalloutResponse = page.waitForResponse(
-    (resp) => resp.url().includes('/sws/neo/') && resp.status() < 400,
-    { timeout: 30_000 },
-  );
-  await product.waitFor({ state: 'visible', timeout: 10_000 });
-  await product.click();
+  let productCalloutResponse;
+  await expect(async () => {
+    const count = await allProducts.count();
+    const product = allProducts.nth(Math.min(productIndex, count - 1));
+
+    // Start listening for callout (price/tax fill) BEFORE clicking the product
+    productCalloutResponse = page.waitForResponse(
+      (resp) => resp.url().includes('/sws/neo/') && resp.status() < 400,
+      { timeout: 30_000 },
+    );
+    await product.click({ timeout: 3_000 });
+  }).toPass({ timeout: 20_000 });
   await expect(searchDrawer).toBeHidden({ timeout: 10_000 }).catch(() => {});
   await productCalloutResponse;
   await slow(page);
@@ -843,6 +852,16 @@ export async function addProductLine(page, { productIndex = 0, quantity, isFirst
   await page.keyboard.press('Enter');
   await linePromise;
   await slow(page);
+
+  // Verify the line was saved: the inline-add-row must disappear (or be
+  // replaced by the next empty row) and the saved line must appear in the
+  // table body. Without this gate the caller can race into a second
+  // addProductLine() before the first line is committed to the DOM.
+  await expect(page.getByTestId('inline-add-row')).toBeHidden({ timeout: 15_000 })
+    .catch(() => {}); // OK if already gone or immediately replaced
+  await expect(page.locator('tbody tr').first(),
+    'Saved line should appear in the lines table',
+  ).toBeVisible({ timeout: 10_000 });
 }
 
 /**
@@ -1010,6 +1029,9 @@ export async function openDraftRow(page, { label = 'draft row' } = {}) {
 export async function clickConfirmButton(page) {
   const confirmBtn = page.getByTestId('action-save');
   await expect(confirmBtn).toBeVisible({ timeout: 10_000 });
+  // Wait for enabled — the button stays disabled while a save is in-flight
+  // or while BP callouts are still propagating derived fields.
+  await expect(confirmBtn).toBeEnabled({ timeout: 15_000 });
   await confirmBtn.click();
   // Caller is responsible for waiting on the modal/response that follows
   await slow(page);


### PR DESCRIPTION
## Summary

- Fix ProductSearchDrawer DOM detach causing intermittent test failures when clicking product options during waterfall re-renders
- Add post-save verification in `addProductLine()` to prevent race between consecutive line additions
- Wait for `saveDraft()` and `clickConfirmButton()` buttons to be enabled before clicking (BP callouts may still be propagating)

## Tests affected

- `purchase-order-full-flow.integration.spec.js`
- `purchase-order-to-invoice.integration.spec.js`
- `sales-order-happy-path.integration.spec.js`
- `sales-quotation-happy-path.integration.spec.js`

## Files changed

- `e2e/tests/helpers/purchase-helpers.js` — shared helper fixes
- `e2e/tests/flows/sales-order-happy-path.integration.spec.js` — inline product click retry
- `e2e/tests/flows/sales-quotation-happy-path.integration.spec.js` — inline product click retry
- `e2e/tests/flows/purchase-order-to-invoice.integration.spec.js` — post-reload timeout increase

## Test plan

- [x] All 5 previously flaky tests pass 2 consecutive headless runs (10/10)
- [x] Full mocked suite passes (602/602)
- [x] Full integration suite: 32 passed, 2 failed (onboarding + email sink — environment-only, unrelated)