### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.42

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.41",
-        "@etendosoftware/schema-forge-cli": "0.3.41",
-        "@etendosoftware/schema-forge-core": "0.3.41",
+        "@etendosoftware/app-shell-core": "0.3.42",
+        "@etendosoftware/schema-forge-cli": "0.3.42",
+        "@etendosoftware/schema-forge-core": "0.3.42",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.41",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.41/14e36705a65901017c2e13dd909626081c0221a1",
-      "integrity": "sha512-xPo4G/6qBbgeb5BsH4mJb13nQR9MbGAH4X1RaE43CQDQ56Pxnpuip34cAwpHhYw09y0WuatYzmQJ+DVKS/du2g==",
+      "version": "0.3.42",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.42/c12ce2f7b200b34d8500a31a591cc462775f3471",
+      "integrity": "sha512-1sTNGZ+nBfs9ACf0Io28QXUn0QjgDgaCFfuj9LkYCyDXQQ63ChyWdaohEEY7wemcveRJPwuxtrcZjIOVEdPRrQ==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.41",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.41/8d127d358bbeeb091869ba98ced9370482348f6f",
-      "integrity": "sha512-4/HdhiRphgaJrU/bMRF94hkJjJeaOo/3V+07fBpLqRVU6e0CUGVPDEd+aCWLO6TxTcvVNf96yIGcwJLJJW8ENw==",
+      "version": "0.3.42",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.42/c4a48ce6ef8627a4311bbce1fb3b5165e7f36f43",
+      "integrity": "sha512-ZDzd/97rwfyIJhiNHmkPDzc99+F3s9ErafRxiycLkvhO+KCtaT+CDK0Q8zGKPMTBQkpAmGT/nK4yaMwBeqcMcQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.41",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.41/6019d80a2735dba3ab886d17a3b2ca06f6913528",
-      "integrity": "sha512-JPnv47ZOsUwjYvEqI6afYmqRBNoIAD/PSL+lDj82gNJbJ62saXvy4GZiLK2G3Unk/u1FtfmT1NPPodyLJW+QGg==",
+      "version": "0.3.42",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.42/6ce4803dafd6509de4e31d63cd99e26e4ee24236",
+      "integrity": "sha512-LM3482APojrMB975O/pGN1Smyso3rcHaIVz7HaRXnoEpaEDrpOr5CUomn8PQU8Xbo6AESC065SxIzCfqmpIb0g==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.41",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.41/a796c82216867e3717ed019cd044d4aa14c6a14c",
-      "integrity": "sha512-pe6vv6+mLMS+M7w53nsxOwIe63iokHKS8DbPLf8HCWNezDNtOH16YomZLNfLKH0H6qDEPxLw+iWZZwArC7Jwdw==",
+      "version": "0.3.42",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.42/af7d52a7a4c2a1665b462f149e9fe9bdc2269685",
+      "integrity": "sha512-RTlXah4pSJ3S1WdMfvRbYqaNjd3ywswfHAouuGB1UaH0RXp65cIM2CGGk4qWZIeZamolR5v/ORGHa6fogPdpUw==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13780,8 +13780,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.41",
-        "@etendosoftware/etendo-go-core": "0.3.41",
+        "@etendosoftware/app-shell-core": "0.3.42",
+        "@etendosoftware/etendo-go-core": "0.3.42",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.41",
-    "@etendosoftware/schema-forge-cli": "0.3.41",
-    "@etendosoftware/schema-forge-core": "0.3.41",
+    "@etendosoftware/app-shell-core": "0.3.42",
+    "@etendosoftware/schema-forge-cli": "0.3.42",
+    "@etendosoftware/schema-forge-core": "0.3.42",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.41",
-        "@etendosoftware/etendo-go-core": "0.3.41",
+        "@etendosoftware/app-shell-core": "0.3.42",
+        "@etendosoftware/etendo-go-core": "0.3.42",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.41",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.41/14e36705a65901017c2e13dd909626081c0221a1",
-      "integrity": "sha512-xPo4G/6qBbgeb5BsH4mJb13nQR9MbGAH4X1RaE43CQDQ56Pxnpuip34cAwpHhYw09y0WuatYzmQJ+DVKS/du2g==",
+      "version": "0.3.42",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.42/c12ce2f7b200b34d8500a31a591cc462775f3471",
+      "integrity": "sha512-1sTNGZ+nBfs9ACf0Io28QXUn0QjgDgaCFfuj9LkYCyDXQQ63ChyWdaohEEY7wemcveRJPwuxtrcZjIOVEdPRrQ==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.41",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.41/8d127d358bbeeb091869ba98ced9370482348f6f",
-      "integrity": "sha512-4/HdhiRphgaJrU/bMRF94hkJjJeaOo/3V+07fBpLqRVU6e0CUGVPDEd+aCWLO6TxTcvVNf96yIGcwJLJJW8ENw==",
+      "version": "0.3.42",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.42/c4a48ce6ef8627a4311bbce1fb3b5165e7f36f43",
+      "integrity": "sha512-ZDzd/97rwfyIJhiNHmkPDzc99+F3s9ErafRxiycLkvhO+KCtaT+CDK0Q8zGKPMTBQkpAmGT/nK4yaMwBeqcMcQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.41",
-    "@etendosoftware/etendo-go-core": "0.3.41",
+    "@etendosoftware/app-shell-core": "0.3.42",
+    "@etendosoftware/etendo-go-core": "0.3.42",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.42`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.