### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.43

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.42",
-        "@etendosoftware/schema-forge-cli": "0.3.42",
-        "@etendosoftware/schema-forge-core": "0.3.42",
+        "@etendosoftware/app-shell-core": "0.3.43",
+        "@etendosoftware/schema-forge-cli": "0.3.43",
+        "@etendosoftware/schema-forge-core": "0.3.43",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.42",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.42/c12ce2f7b200b34d8500a31a591cc462775f3471",
-      "integrity": "sha512-1sTNGZ+nBfs9ACf0Io28QXUn0QjgDgaCFfuj9LkYCyDXQQ63ChyWdaohEEY7wemcveRJPwuxtrcZjIOVEdPRrQ==",
+      "version": "0.3.43",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.43/51a3a966b9ff30a108f44bd9973ce8eab2bce3c0",
+      "integrity": "sha512-hROM+bplUsJkkiNLWzrmM0n92xZTgepwh8U/YSsRyv8Wt4MNIFkkecckvQHiQOiPI84AGL9oQwveVEilONwe6g==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.42",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.42/c4a48ce6ef8627a4311bbce1fb3b5165e7f36f43",
-      "integrity": "sha512-ZDzd/97rwfyIJhiNHmkPDzc99+F3s9ErafRxiycLkvhO+KCtaT+CDK0Q8zGKPMTBQkpAmGT/nK4yaMwBeqcMcQ==",
+      "version": "0.3.43",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.43/80a9abc49655f8d3d38ce286fcaf894cec651cb5",
+      "integrity": "sha512-rv6GI5L/ukRABzGgZR7D2kIMd4hu/AjNn9dcgPJRcOC9yxdNbt5FPC2veFuKcLxLtz/ipUtA5uSoFSv4uCirBQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.42",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.42/6ce4803dafd6509de4e31d63cd99e26e4ee24236",
-      "integrity": "sha512-LM3482APojrMB975O/pGN1Smyso3rcHaIVz7HaRXnoEpaEDrpOr5CUomn8PQU8Xbo6AESC065SxIzCfqmpIb0g==",
+      "version": "0.3.43",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.43/0553fba76456eb3212b6690ee303bbc2f0a52388",
+      "integrity": "sha512-et8TLJHjTTyXLzKabruqY2b0LMhekyDagItkXMMrHwOABw0pT54vaGyEJc8ruAG2pi1+r7uHllKlQ1e+JXG2DQ==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.42",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.42/af7d52a7a4c2a1665b462f149e9fe9bdc2269685",
-      "integrity": "sha512-RTlXah4pSJ3S1WdMfvRbYqaNjd3ywswfHAouuGB1UaH0RXp65cIM2CGGk4qWZIeZamolR5v/ORGHa6fogPdpUw==",
+      "version": "0.3.43",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.43/ad5dcfd01548e813db8b297f0fea7a2cbc728cc1",
+      "integrity": "sha512-F4AdSotk0Esq3LTuEe0u9ofkU816rk0BzSoKhvhnVx+naEsOMhQO90Pw5JrFdokXt7LAOibnP+UHqaTjZeYurA==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13780,8 +13780,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.42",
-        "@etendosoftware/etendo-go-core": "0.3.42",
+        "@etendosoftware/app-shell-core": "0.3.43",
+        "@etendosoftware/etendo-go-core": "0.3.43",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.42",
-    "@etendosoftware/schema-forge-cli": "0.3.42",
-    "@etendosoftware/schema-forge-core": "0.3.42",
+    "@etendosoftware/app-shell-core": "0.3.43",
+    "@etendosoftware/schema-forge-cli": "0.3.43",
+    "@etendosoftware/schema-forge-core": "0.3.43",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.42",
-        "@etendosoftware/etendo-go-core": "0.3.42",
+        "@etendosoftware/app-shell-core": "0.3.43",
+        "@etendosoftware/etendo-go-core": "0.3.43",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.42",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.42/c12ce2f7b200b34d8500a31a591cc462775f3471",
-      "integrity": "sha512-1sTNGZ+nBfs9ACf0Io28QXUn0QjgDgaCFfuj9LkYCyDXQQ63ChyWdaohEEY7wemcveRJPwuxtrcZjIOVEdPRrQ==",
+      "version": "0.3.43",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.43/51a3a966b9ff30a108f44bd9973ce8eab2bce3c0",
+      "integrity": "sha512-hROM+bplUsJkkiNLWzrmM0n92xZTgepwh8U/YSsRyv8Wt4MNIFkkecckvQHiQOiPI84AGL9oQwveVEilONwe6g==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.42",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.42/c4a48ce6ef8627a4311bbce1fb3b5165e7f36f43",
-      "integrity": "sha512-ZDzd/97rwfyIJhiNHmkPDzc99+F3s9ErafRxiycLkvhO+KCtaT+CDK0Q8zGKPMTBQkpAmGT/nK4yaMwBeqcMcQ==",
+      "version": "0.3.43",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.43/80a9abc49655f8d3d38ce286fcaf894cec651cb5",
+      "integrity": "sha512-rv6GI5L/ukRABzGgZR7D2kIMd4hu/AjNn9dcgPJRcOC9yxdNbt5FPC2veFuKcLxLtz/ipUtA5uSoFSv4uCirBQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.42",
-    "@etendosoftware/etendo-go-core": "0.3.42",
+    "@etendosoftware/app-shell-core": "0.3.43",
+    "@etendosoftware/etendo-go-core": "0.3.43",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.43`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.