### PR TITLE
Feature ETP-4945: Fix incorrect breadcrumbs across 6 Finance windows

### DIFF
--- a/artifacts/chart-of-accounts/contract.json
+++ b/artifacts/chart-of-accounts/contract.json
@@ -1,14 +1,14 @@
 {
   "version": "0.8.0",
   "generatedAt": "2026-03-09T10:00:00.000Z",
-  "updatedAt": "2026-08-29T17:45:56.475Z",
-  "checksum": "dcf4fb7c67e38a6b",
+  "updatedAt": "2026-09-01T15:34:14.825Z",
+  "checksum": "d48c3074d69352a5",
   "frontendContract": {
     "window": {
       "id": "118",
       "name": "Chart of Accounts",
       "primaryEntity": "elementValue",
-      "category": "accounting",
+      "category": "finance",
       "hideCreate": true,
       "hideListFilters": true,
       "customComponents": {
@@ -214,7 +214,7 @@
       "id": "118",
       "name": "Chart of Accounts",
       "primaryEntity": "elementValue",
-      "category": "accounting",
+      "category": "finance",
       "hideCreate": true,
       "hideListFilters": true,
       "customComponents": {
@@ -554,7 +554,7 @@
       "parentFilter": "parentId={id} for child entities"
     },
     "window": {
-      "category": "accounting"
+      "category": "finance"
     }
   },
   "testManifest": {

--- a/artifacts/chart-of-accounts/contract.mcp.json
+++ b/artifacts/chart-of-accounts/contract.mcp.json
@@ -1,8 +1,8 @@
 {
   "version": "0.8.0",
   "generatedAt": "2026-03-09T10:00:00.000Z",
-  "updatedAt": "2026-08-29T15:53:11.114Z",
-  "contractChecksum": "dcf4fb7c67e38a6b",
+  "updatedAt": "2026-09-01T15:34:14.825Z",
+  "contractChecksum": "d48c3074d69352a5",
   "apiPrediction": {
     "specName": "chart-of-accounts",
     "baseUrl": "/sws/neo/chart-of-accounts",
@@ -35,7 +35,7 @@
       "parentFilter": "parentId={id} for child entities"
     },
     "window": {
-      "category": "accounting"
+      "category": "finance"
     }
   },
   "formState": {
@@ -69,7 +69,7 @@
     "evaluationMode": "runtime"
   },
   "agentProfile": {
-    "purpose": "Manage chart of accounts records.",
+    "purpose": "Manage chart of accounts financial records.",
     "whenToUse": [
       "Use for chart of accounts management."
     ],
@@ -86,8 +86,12 @@
     },
     "selectorContexts": [],
     "actions": [],
-    "workflow": [],
-    "edgeCases": [],
+    "workflow": [
+      "Create draft header with required fields"
+    ],
+    "edgeCases": [
+      "Required field without default value must be provided"
+    ],
     "examples": [
       {
         "operation": "createHeader",
@@ -100,9 +104,11 @@
         ]
       }
     ],
-    "warnings": [],
+    "warnings": [
+      "Transactional spec has no generated lifecycle action metadata"
+    ],
     "knownLimitations": [],
     "dangerousOperations": []
   },
-  "checksum": "7a66ab6146940c2a"
+  "checksum": "b6b30691e73242c2"
 }

--- a/artifacts/chart-of-accounts/decisions.json
+++ b/artifacts/chart-of-accounts/decisions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "decisions-v2",
   "window": {
-    "category": "accounting",
+    "category": "finance",
     "name": "Chart of Accounts",
     "hideCreate": true,
     "hideListFilters": true,

--- a/artifacts/chart-of-accounts/generated/web/chart-of-accounts/ElementValuePage.jsx
+++ b/artifacts/chart-of-accounts/generated/web/chart-of-accounts/ElementValuePage.jsx
@@ -10,7 +10,7 @@ import NewAccountModal from '../../../custom/NewAccountModal';
 import catalogs from './mockCatalogs';
 
 
-const breadcrumb = 'Accounting / Chart of Accounts';
+const breadcrumb = 'Finance / Chart of Accounts';
 
 
 // @sf-generated-start summary:elementValue
@@ -75,7 +75,7 @@ export const api = {
     "parentFilter": "parentId={id} for child entities"
   },
   "window": {
-    "category": "accounting"
+    "category": "finance"
   }
 };
 

--- a/artifacts/chart-of-accounts/generated/web/chart-of-accounts/index.jsx
+++ b/artifacts/chart-of-accounts/generated/web/chart-of-accounts/index.jsx
@@ -1,6 +1,6 @@
 import ElementValuePage, { api } from './ElementValuePage';
 
-const windowMeta = { category: 'accounting', name: 'Chart of Accounts', id: '118' };
+const windowMeta = { category: 'finance', name: 'Chart of Accounts', id: '118' };
 
 // @sf-generated-start component:App
 export default function App({ windowName, recordId, token, apiBaseUrl, window, ...rest }) {

--- a/docs/generated-custom-windows/asset-group.md
+++ b/docs/generated-custom-windows/asset-group.md
@@ -1,8 +1,8 @@
-# Asset Category
+# Asset Group
 
 ## Intent
 
-Asset Category lets finance users maintain the master records that classify fixed assets. Each category defines a named grouping (e.g. "Machinery", "Vehicles"), the depreciation policy applied to assets in that category, and the two GL accounts required to post depreciation. The window lives in the Finance section of the menu, after Assets.
+Asset Group lets finance users maintain the master records that classify fixed assets. Each group defines a named grouping (e.g. "Machinery", "Vehicles"), the depreciation policy applied to assets in that group, and the two GL accounts required to post depreciation. The window lives in the Finance section of the menu, after Assets.
 
 ## What this window should allow
 
@@ -20,7 +20,7 @@ The depreciation policy fields are shown conditionally: they only appear when **
 ## Interaction model
 
 - **Route:** `/asset-group` for the list and `/asset-group/:recordId` for record detail.
-- **Visibility:** visible in the Finance menu as **Asset Category** (after Assets).
+- **Visibility:** visible in the Finance menu as **Asset Group** (after Assets).
 - **Implementation type:** generated window loaded from `tools/app-shell/src/windows/registry.js` into the generic `/:windowName` shell route. No custom wrapper — the registry points directly to the generated `AssetCategoryPage`.
 - **Window shape:** master + inline-editable child. `assetCategory` is the header entity (table `A_Asset_Group`, AD_Window_ID 252). `accounting` is the child entity (table `A_Asset_Group_Acct`, AD_Tab_ID 800204), rendered as an inline-editable grid.
 - **List behavior:** the category list shows Name and Description. Both columns are visible in the grid.
@@ -139,19 +139,21 @@ All five flags are set in `decisions.json → window`:
 
 ## i18n notes
 
-The dictionary key for this window is `"Asset Group"` — the stable AD window name. It never changes even if the display label is updated.
+The dictionary key for this window is `"Asset Group"` — the stable AD window name (matches `AD_Menu.Name` and `decisions.json`'s `window.name`). It never changes even if the display label is updated.
 
 ```json
-// en_US.json → windows
-"Asset Group": { "label": "Asset Category", "newLabel": "New category" }
+// en_US.json → windows and menus
+"Asset Group": { "label": "Asset Group", "newLabel": "New group" }   // windows
+"Asset Group": { "label": "Asset Group" }                            // menus
 
-// es_ES.json → windows
-"Asset Group": { "label": "Categoría de Activos", "newLabel": "Nueva categoría" }
+// es_ES.json → windows and menus
+"Asset Group": { "label": "Grupo de activos", "newLabel": "Nuevo grupo" }   // windows
+"Asset Group": { "label": "Grupo de activos" }                             // menus
 ```
 
-The breadcrumb and menu title both resolve via `useMenuLabel()`. That hook searches `menus` before `windows`, so if a `menus["Asset Group"]` entry ever exists it takes precedence over the `windows` entry for the title and breadcrumb. In the current build, only the `windows` section carries this key, which is the canonical source.
+Both `windows["Asset Group"]` and `menus["Asset Group"]` carry the key, and both must be kept in sync — `tools/app-shell/src/menu.json`'s own `asset-group` entry (`label`/`favname`) is a third, separate copy that must also stay aligned (ETP-4945 fixed a case where `menu.json` still said `"Asset Category"` while `windows`/`menus` said `"Asset Group"` with the wrong label text — three disagreeing sources for the same window name).
 
-The generated page uses `entityLabel="Asset Category"` (for the detail title) and `entityLabel="Asset Group"` (for the list breadcrumb) — the list still reads the raw AD name; the detail renders the localized label from `windows[key].label`.
+The generated page uses `entityLabel="Asset Category"` (for the detail title, resolved via the `tabs["Asset Category"]` field-label key — see the `A_Asset_Group_ID` column label, a different concept from the window name) and `entityLabel="Asset Group"` (for the list breadcrumb, resolved via `tMenu('Asset Group')` against `windows`/`menus`).
 
 ## Non-obvious gotchas
 
@@ -179,7 +181,7 @@ For `depreciate`, using `defaultExpr: "N"` ensures the backend serves `IsDepreci
 
 ### No draftMode / Confirm button
 
-The Confirm/Save button seen on transactional windows (Sales Order, Internal Consumption) is a `draftMode` completion flow — it reflects a document lifecycle with an explicit Complete action. Asset Category is a master-data window and has no such lifecycle. The standard Save button is correct here. The generated `AssetCategoryPage.jsx` confirms this: `const draftMode = null`.
+The Confirm/Save button seen on transactional windows (Sales Order, Internal Consumption) is a `draftMode` completion flow — it reflects a document lifecycle with an explicit Complete action. Asset Group is a master-data window and has no such lifecycle. The standard Save button is correct here. The generated `AssetCategoryPage.jsx` confirms this: `const draftMode = null`.
 
 ## Pipeline commands
 
@@ -206,7 +208,7 @@ node cli/src/push-to-neo.js asset-group
 
 ## Automated evidence
 
-- `tools/app-shell/src/menu.json` places **Asset Category** under the Finance menu (after Assets), using `"name": "asset-group"`.
+- `tools/app-shell/src/menu.json` places **Asset Group** under the Finance menu (after Assets), using `"name": "asset-group"`.
 - `tools/app-shell/src/windows/registry.js` maps `'asset-group'` to the generated page at `@generated/asset-group/generated/web/asset-group/...`.
 - `artifacts/asset-group/generated/web/asset-group/AssetCategoryForm.jsx` defines the header form fields: `name`, `description` (`span: 2`, `rows: 1`), `depreciate` (checkbox), and the conditional depreciation-policy fields, each carrying a `displayLogic: (record) => ...` arrow function and `section: 'principal'`.
 - `artifacts/asset-group/generated/web/asset-group/AssetCategoryPage.jsx` renders `ListView` for the list route and `DetailView` with `secondaryTabs` (Accounting), `linesLayout="inlineEditable"`, `hidePrint`, `noHeaderBorder`, and `AttachmentsTab` in `customTabs`.
@@ -254,7 +256,7 @@ and `usableLifeMonths` carry `min: 1, integer: true` with their amortize-based `
 
 ### Manual verification (ETP-4542)
 
-1. Open an Asset Category with **Depreciate** enabled and **Calculate Type** = "Time" (`TI`) so
+1. Open an Asset Group record with **Depreciate** enabled and **Calculate Type** = "Time" (`TI`) so
    **Usable Life - Months** is visible.
 2. Type `0`, a negative number, or a decimal like `5.5`, then click away (blur). Confirm a toast
    error appears ("Value must be at least 1" or "Value must be a whole number", or the Spanish
@@ -289,7 +291,7 @@ Verified in `artifacts/asset-group/contract.json` and the regenerated
 
 ## Manual verification
 
-1. Open the Finance menu and confirm **Asset Category** appears after Assets.
+1. Open the Finance menu and confirm **Asset Group** appears after Assets.
 2. Open `/asset-group` and confirm the list loads with Name and Description columns.
 3. Confirm the custom Sort and Refresh icons appear in the list toolbar and that the Print and Link icons do not appear.
 4. Create a new category, confirm the **Depreciate** checkbox starts unchecked, and confirm the record saves with only Name supplied (no depreciation fields required while Depreciate is off).

--- a/docs/generated-custom-windows/chart-of-accounts.md
+++ b/docs/generated-custom-windows/chart-of-accounts.md
@@ -17,6 +17,7 @@ Maintain the account master used by finance users and provide a quick, read-only
 ## Interaction model
 - Route: `/chart-of-accounts` for the list and `/chart-of-accounts/:recordId` for record detail.
 - Visibility: visible from the Finance menu as **Chart of Accounts**.
+- Breadcrumb: `Finanzas / Plan de cuentas` — driven by `decisions.json → window.category: "finance"`, which the generated `ElementValuePage.jsx` resolves through `tMenu()` alongside the window name. ETP-4945 corrected this from `category: "accounting"`, which rendered the wrong section (`Contabilidad / Plan de cuentas`).
 - Implementation type: generated window route loaded from the app-shell window registry.
 - Window shape: single-entity window for `elementValue`, with a custom grouped tree table (`AccountTreeView.jsx`) replacing the generated list table.
 - Record detail titles use the account code (`searchKey`) rather than the internal record id.

--- a/docs/generated-custom-windows/fiscal-models.md
+++ b/docs/generated-custom-windows/fiscal-models.md
@@ -26,6 +26,13 @@ debug contracts.
 - Generate and download the submission file (`.txt`) for Modelo 303.
 - Show blocking and warning incident counts inline; a blocking count prevents file generation.
 
+## Interaction model
+
+- Route: `/fiscal-models` (list, `FmListPage`); model detail pages render inline within the same route (no separate URL) via `FmModel303Page`/`FmModel349Page`.
+- Implementation type: `layoutType: "custom"` — loaded from `customLoaders` in `tools/app-shell/src/windows/registry.js`.
+- Breadcrumb — list page: `Finanzas / Modelos Fiscales` (`` `${ui('finance')} / ${ui('fm.breadcrumb.section')}` ``, `FmListPage.jsx`).
+- Breadcrumb — Modelo 303/349 detail pages: `Finanzas / Modelos Fiscales / Modelo 303 - {periodLabel}` (`FmModel303Page.jsx`) and `Finanzas / Modelos Fiscales / Modelo 349 - {periodLabel}` (`FmModel349Page.jsx`) — 3 segments, consistent between both models. ETP-4945 replaced 3 independently hardcoded, mutually inconsistent breadcrumbs (a raw Spanish literal `Tesorería` on all three pages, with 303 at 2 segments and 349 at 3), and introduced the shared `ui('finance')` / `ui('fm.breadcrumb.section')` keys reused across all three surfaces so the "Modelos Fiscales" segment can't drift between the list and its two detail pages again.
+
 ## Auto-compute architecture (`useFiscalAutoCompute`)
 
 `FmListPage` calls `useFiscalAutoCompute` **four times** — once per (model × draft-vs-other)

--- a/docs/generated-custom-windows/fiscal-monitor.md
+++ b/docs/generated-custom-windows/fiscal-monitor.md
@@ -339,6 +339,8 @@ i18n keys: `invoicePreview.fiscalStatus.sii`, `invoicePreview.fiscalStatus.tbai`
 - Route: `/fiscal-monitor` (custom window).
 - Implementation type: `layoutType: "custom"` — loaded from `customLoaders` in `tools/app-shell/src/windows/registry.js`.
 - Entry point: `FiscalMonitorPage.jsx` — fetches profile + KPIs, renders OrgLead header, delegates to section components.
+- Breadcrumb: `Finanzas / Monitor fiscal` (`` `${ui('finance')} / ${ui('fiscal.monitor.nav')}` ``, `FiscalMonitorPage.jsx`). ETP-4945 replaced the previous 4-segment string (`Configuración / Monitor de facturas / Sistema fiscal activo / {profile}`), which put the window under the wrong section and used a third, disagreeing translation for the window name.
+- **Caveat (pre-existing, untouched by ETP-4945):** the page title and breadcrumb do not render at all when the organization has no fiscal profile configured — `useSetPageMeta` is still called with the corrected breadcrumb value, but `TopBar`'s gating on the "unconfigured" empty state (`profile === 'unconfigured'`, see `FmEmpty` above) means the header never shows it in that state. Verified live during QA for this ticket; not something ETP-4945 introduced or is expected to fix.
 - The page container uses `overflow-y: auto` so long multi-section views (e.g. `sii+tbai`) are scrollable within the fixed app shell container.
 
 ## Manual verification

--- a/docs/generated-custom-windows/general-ledger-configuration.md
+++ b/docs/generated-custom-windows/general-ledger-configuration.md
@@ -18,10 +18,10 @@ The current frontend is production-shaped but still backed by local mock data be
 
 ## Route And Layout
 
-- Menu entry: `Tesorería / Configuración contable`
+- Menu entry: `Finanzas / Esquema contable`
 - Slug: `general-ledger-configuration`
 - Window type: `layoutType: custom`
-- Top metadata: breadcrumb `Tesorería / Configuración contable`
+- Top metadata: breadcrumb `Finanzas / Esquema contable` (built from the shared `ui('finance')` key + `ui('glc.title')`, ETP-4945)
 - Right side of the tab row: dirty-state `Guardar cambios` button
 
 ## Tab Behavior

--- a/docs/generated-custom-windows/not-posted-documents.md
+++ b/docs/generated-custom-windows/not-posted-documents.md
@@ -248,7 +248,7 @@ Props: `{ token, apiBaseUrl }` — `apiBaseUrl` is already spec-scoped.
 
 - Breadcrumb: `Finanzas / Documentos no contabilizados` (`` `${ui('finance')} / ${ui('notPostedDocuments')}` ``, passed to `useSetPageMeta`). Previously this window passed no `breadcrumb` key at all — `TopBar` renders nothing when `breadcrumb` is falsy, so the window had no breadcrumb whatsoever before this fix, even though its `title` (`ui('notPostedDocuments')`) was already correctly translated.
 - The date-range filter labels now read `ui('filterFrom')` / `ui('filterTo')` (`"Desde"`/`"Hasta"` in `es_ES.json`, `"From"`/`"To"` in `en_US.json`) instead of hardcoded English `<label>From</label>` / `<label>To</label>`.
-- The document-type badge (`.npd-doc-type-badge`) now shows the translated label instead of the raw `row.documentType` string, by mapping it through the already-translated `{value, label}` pairs `filterOptions.documentTypes` returns (`documentTypeLabels` map built with `useMemo`) — no new lookup table or backend change needed, since `NoPostedDocumentDS`'s `documentType` values (e.g. `"Goods Shipment"`) already match the filter dropdown's own option values.
+- The document-type badge (`.npd-doc-type-badge`) now shows the translated label instead of the raw `row.documentType` code, by mapping it through the already-translated `{value, label}` pairs `filterOptions.documentTypes` returns (`documentTypeLabels` map built with `useMemo`, keyed by `o.value`) — no new lookup table or backend change needed, since `NoPostedDocumentDS`'s `documentType` is already the same AD_Ref_List code (e.g. `"GLJ"`, `"PI"`) used as the filter dropdown's own option `value`, not a human-readable label.
 
 ### Accounting status multi-select
 

--- a/docs/generated-custom-windows/not-posted-documents.md
+++ b/docs/generated-custom-windows/not-posted-documents.md
@@ -244,6 +244,12 @@ File: `tools/app-shell/src/windows/custom/not-posted-documents/NotPostedDocument
 
 Props: `{ token, apiBaseUrl }` — `apiBaseUrl` is already spec-scoped.
 
+### Menu entry, breadcrumb & i18n (ETP-4945)
+
+- Breadcrumb: `Finanzas / Documentos no contabilizados` (`` `${ui('finance')} / ${ui('notPostedDocuments')}` ``, passed to `useSetPageMeta`). Previously this window passed no `breadcrumb` key at all — `TopBar` renders nothing when `breadcrumb` is falsy, so the window had no breadcrumb whatsoever before this fix, even though its `title` (`ui('notPostedDocuments')`) was already correctly translated.
+- The date-range filter labels now read `ui('filterFrom')` / `ui('filterTo')` (`"Desde"`/`"Hasta"` in `es_ES.json`, `"From"`/`"To"` in `en_US.json`) instead of hardcoded English `<label>From</label>` / `<label>To</label>`.
+- The document-type badge (`.npd-doc-type-badge`) now shows the translated label instead of the raw `row.documentType` string, by mapping it through the already-translated `{value, label}` pairs `filterOptions.documentTypes` returns (`documentTypeLabels` map built with `useMemo`) — no new lookup table or backend change needed, since `NoPostedDocumentDS`'s `documentType` values (e.g. `"Goods Shipment"`) already match the filter dropdown's own option values.
+
 ### Accounting status multi-select
 
 State: `accountingStatuses: Set<string>` of selected search keys.  

--- a/tools/app-shell/src/components/contract-ui/__tests__/DetailView.titleHelpers.vitest.js
+++ b/tools/app-shell/src/components/contract-ui/__tests__/DetailView.titleHelpers.vitest.js
@@ -1,7 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { loadLocaleDictionary, makeRealTMenu } from '../../../windows/custom/shared/__tests__/testUtils/realLocaleUI.js';
 
 // Importing DetailView.jsx pulls in the whole component tree (router, i18n,
 // hooks, sub-components, lib helpers). Mirror the mocks used by
@@ -249,7 +247,8 @@ describe('getLinesContainerClassName', () => {
 // contract.json's window.category — see artifacts/<window>/generated/web/<window>/*.jsx),
 // and it is only as correct as the `menus`/`windows`/`ui` locale entries that
 // `useMenuLabel()`'s real lookup chain (ui -> menus -> windows -> tabs ->
-// genericLabels -> raw key, mirrored below) resolves each segment against.
+// genericLabels -> raw key, mirrored by makeRealTMenu below) resolves each
+// segment against.
 // Both ListView and DetailView translate that same breadcrumb string through
 // the SAME algorithm (ListView.jsx's inline `breadcrumb.split(' / ').map(tMenu)…`
 // is getFullBreadcrumb(breadcrumb, tMenu, '', label) with an empty title — see
@@ -257,24 +256,9 @@ describe('getLinesContainerClassName', () => {
 // above), so exercising getFullBreadcrumb/getWindowTitle here with a real
 // locale dictionary covers both the list and the detail page for these two
 // windows without needing to render either component tree.
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const localesDir = join(__dirname, '..', '..', '..', 'locales');
-const esES = JSON.parse(readFileSync(join(localesDir, 'es_ES.json'), 'utf8'));
-const enUS = JSON.parse(readFileSync(join(localesDir, 'en_US.json'), 'utf8'));
-const esAR = JSON.parse(readFileSync(join(localesDir, 'es_AR.json'), 'utf8'));
-
-// Mirrors useMenuLabel()'s real lookup order against a real dictionary,
-// without needing a full LocaleProvider/React tree (same helper shape as
-// windows/custom/calendar/__tests__/calendar-window-title.i18n.vitest.jsx).
-function makeTMenu(dictionary) {
-  return (key) =>
-    dictionary?.ui?.[key]?.label ??
-    dictionary?.menus?.[key]?.label ??
-    dictionary?.windows?.[key]?.label ??
-    dictionary?.tabs?.[key]?.label ??
-    dictionary?.genericLabels?.[key] ??
-    key;
-}
+const esES = loadLocaleDictionary('es_ES');
+const enUS = loadLocaleDictionary('en_US');
+const esAR = loadLocaleDictionary('es_AR');
 
 // The generated artifacts' own hardcoded breadcrumb constants — kept in sync
 // manually here since they are generator output (never hand-edited):
@@ -284,30 +268,29 @@ const CHART_OF_ACCOUNTS_BREADCRUMB = 'Finance / Chart of Accounts';
 const ASSET_GROUP_BREADCRUMB = 'Finance / Asset Group';
 
 describe.each([
-  ['es_ES', esES, 'Plan de cuentas'],
-  ['en_US', enUS, 'Chart of Accounts'],
-  ['es_AR', esAR, 'Plan de cuentas'],
-])('chart-of-accounts breadcrumb (%s)', (_locale, dictionary, expectedName) => {
-  const tMenu = makeTMenu(dictionary);
+  ['es_ES', esES, 'Plan de cuentas', 'Finanzas'],
+  ['en_US', enUS, 'Chart of Accounts', 'Finance'],
+  ['es_AR', esAR, 'Plan de cuentas', 'Finanzas'],
+])('chart-of-accounts breadcrumb (%s)', (_locale, dictionary, expectedName, expectedSection) => {
+  const tMenu = makeRealTMenu(dictionary);
 
   it(`resolves the window title to "${expectedName}"`, () => {
     expect(getWindowTitle(CHART_OF_ACCOUNTS_BREADCRUMB, tMenu, 'ignored')).toBe(expectedName);
   });
 
-  it(`resolves the full breadcrumb to "Finanzas / ${expectedName}" (not the stale "Contabilidad" section)`, () => {
+  it(`resolves the full breadcrumb to "${expectedSection} / ${expectedName}" (not the stale "Contabilidad" section)`, () => {
     const breadcrumb = getFullBreadcrumb(CHART_OF_ACCOUNTS_BREADCRUMB, tMenu, '', expectedName);
-    const expectedSection = dictionary.ui.Finance.label;
     expect(breadcrumb).toBe(`${expectedSection} / ${expectedName}`);
     expect(breadcrumb).not.toContain('Contabilidad');
   });
 });
 
 describe.each([
-  ['es_ES', esES, 'Grupo de activos'],
-  ['en_US', enUS, 'Asset Group'],
-  ['es_AR', esAR, 'Grupo de activos'],
-])('asset-group breadcrumb (%s)', (_locale, dictionary, expectedName) => {
-  const tMenu = makeTMenu(dictionary);
+  ['es_ES', esES, 'Grupo de activos', 'Finanzas'],
+  ['en_US', enUS, 'Asset Group', 'Finance'],
+  ['es_AR', esAR, 'Grupo de activos', 'Finanzas'],
+])('asset-group breadcrumb (%s)', (_locale, dictionary, expectedName, expectedSection) => {
+  const tMenu = makeRealTMenu(dictionary);
 
   it(`resolves the window title to "${expectedName}" (not the stale "Asset Category" translation)`, () => {
     const title = getWindowTitle(ASSET_GROUP_BREADCRUMB, tMenu, 'ignored');
@@ -316,9 +299,8 @@ describe.each([
     expect(title).not.toContain('Asset Category');
   });
 
-  it(`resolves the full breadcrumb to "Finanzas / ${expectedName}"`, () => {
+  it(`resolves the full breadcrumb to "${expectedSection} / ${expectedName}"`, () => {
     const breadcrumb = getFullBreadcrumb(ASSET_GROUP_BREADCRUMB, tMenu, '', expectedName);
-    const expectedSection = dictionary.ui.Finance.label;
     expect(breadcrumb).toBe(`${expectedSection} / ${expectedName}`);
     expect(breadcrumb).not.toContain('Categoría de Activos');
   });

--- a/tools/app-shell/src/components/contract-ui/__tests__/DetailView.titleHelpers.vitest.js
+++ b/tools/app-shell/src/components/contract-ui/__tests__/DetailView.titleHelpers.vitest.js
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // Importing DetailView.jsx pulls in the whole component tree (router, i18n,
 // hooks, sub-components, lib helpers). Mirror the mocks used by
@@ -231,5 +234,92 @@ describe('getLinesContainerClassName', () => {
     ['readOnly', true, 'pt-3 flex items-start gap-4 pointer-events-none'],
   ])('linesLayout=%s embedded=%s => %s', (linesLayout, embedded, expected) => {
     expect(getLinesContainerClassName(linesLayout, embedded)).toBe(expected);
+  });
+});
+
+// ── ETP-4945 — real-locale breadcrumb regression coverage ─────────────────────
+//
+// The describe blocks above exercise getWindowTitle/getFullBreadcrumb against
+// FAKE translators (upperT/identityT/falsyT) — they prove the algorithm, not
+// that any particular window's locale entries actually resolve to the right
+// Spanish text. ETP-4945 fixed exactly a real-locale-content bug for two
+// generated-pipeline windows (chart-of-accounts, asset-group): their
+// `breadcrumb` constant is a hardcoded English literal baked into the
+// generated *Page.jsx by the pipeline (from decisions.json's window.name +
+// contract.json's window.category — see artifacts/<window>/generated/web/<window>/*.jsx),
+// and it is only as correct as the `menus`/`windows`/`ui` locale entries that
+// `useMenuLabel()`'s real lookup chain (ui -> menus -> windows -> tabs ->
+// genericLabels -> raw key, mirrored below) resolves each segment against.
+// Both ListView and DetailView translate that same breadcrumb string through
+// the SAME algorithm (ListView.jsx's inline `breadcrumb.split(' / ').map(tMenu)…`
+// is getFullBreadcrumb(breadcrumb, tMenu, '', label) with an empty title — see
+// getFullBreadcrumb's "omits the trailing / title when title is empty" case
+// above), so exercising getFullBreadcrumb/getWindowTitle here with a real
+// locale dictionary covers both the list and the detail page for these two
+// windows without needing to render either component tree.
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const localesDir = join(__dirname, '..', '..', '..', 'locales');
+const esES = JSON.parse(readFileSync(join(localesDir, 'es_ES.json'), 'utf8'));
+const enUS = JSON.parse(readFileSync(join(localesDir, 'en_US.json'), 'utf8'));
+const esAR = JSON.parse(readFileSync(join(localesDir, 'es_AR.json'), 'utf8'));
+
+// Mirrors useMenuLabel()'s real lookup order against a real dictionary,
+// without needing a full LocaleProvider/React tree (same helper shape as
+// windows/custom/calendar/__tests__/calendar-window-title.i18n.vitest.jsx).
+function makeTMenu(dictionary) {
+  return (key) =>
+    dictionary?.ui?.[key]?.label ??
+    dictionary?.menus?.[key]?.label ??
+    dictionary?.windows?.[key]?.label ??
+    dictionary?.tabs?.[key]?.label ??
+    dictionary?.genericLabels?.[key] ??
+    key;
+}
+
+// The generated artifacts' own hardcoded breadcrumb constants — kept in sync
+// manually here since they are generator output (never hand-edited):
+// artifacts/chart-of-accounts/generated/web/chart-of-accounts/ElementValuePage.jsx:13
+// artifacts/asset-group/generated/web/asset-group/AssetCategoryPage.jsx:14
+const CHART_OF_ACCOUNTS_BREADCRUMB = 'Finance / Chart of Accounts';
+const ASSET_GROUP_BREADCRUMB = 'Finance / Asset Group';
+
+describe.each([
+  ['es_ES', esES, 'Plan de cuentas'],
+  ['en_US', enUS, 'Chart of Accounts'],
+  ['es_AR', esAR, 'Plan de cuentas'],
+])('chart-of-accounts breadcrumb (%s)', (_locale, dictionary, expectedName) => {
+  const tMenu = makeTMenu(dictionary);
+
+  it(`resolves the window title to "${expectedName}"`, () => {
+    expect(getWindowTitle(CHART_OF_ACCOUNTS_BREADCRUMB, tMenu, 'ignored')).toBe(expectedName);
+  });
+
+  it(`resolves the full breadcrumb to "Finanzas / ${expectedName}" (not the stale "Contabilidad" section)`, () => {
+    const breadcrumb = getFullBreadcrumb(CHART_OF_ACCOUNTS_BREADCRUMB, tMenu, '', expectedName);
+    const expectedSection = dictionary.ui.Finance.label;
+    expect(breadcrumb).toBe(`${expectedSection} / ${expectedName}`);
+    expect(breadcrumb).not.toContain('Contabilidad');
+  });
+});
+
+describe.each([
+  ['es_ES', esES, 'Grupo de activos'],
+  ['en_US', enUS, 'Asset Group'],
+  ['es_AR', esAR, 'Grupo de activos'],
+])('asset-group breadcrumb (%s)', (_locale, dictionary, expectedName) => {
+  const tMenu = makeTMenu(dictionary);
+
+  it(`resolves the window title to "${expectedName}" (not the stale "Asset Category" translation)`, () => {
+    const title = getWindowTitle(ASSET_GROUP_BREADCRUMB, tMenu, 'ignored');
+    expect(title).toBe(expectedName);
+    expect(title).not.toContain('Categoría de Activos');
+    expect(title).not.toContain('Asset Category');
+  });
+
+  it(`resolves the full breadcrumb to "Finanzas / ${expectedName}"`, () => {
+    const breadcrumb = getFullBreadcrumb(ASSET_GROUP_BREADCRUMB, tMenu, '', expectedName);
+    const expectedSection = dictionary.ui.Finance.label;
+    expect(breadcrumb).toBe(`${expectedSection} / ${expectedName}`);
+    expect(breadcrumb).not.toContain('Categoría de Activos');
   });
 });

--- a/tools/app-shell/src/locales/en_US.json
+++ b/tools/app-shell/src/locales/en_US.json
@@ -13843,8 +13843,8 @@
       "label": "Invoiceable Expenses"
     },
     "Asset Group": {
-      "label": "Asset Category",
-      "newLabel": "New category"
+      "label": "Asset Group",
+      "newLabel": "New group"
     },
     "Employee Expenses": {
       "label": "Employee Expenses"
@@ -16768,6 +16768,8 @@
     "postingFailed": "Posting failed",
     "filterDocumentType": "Document type",
     "filterAccountingStatus": "Accounting status",
+    "filterFrom": "From",
+    "filterTo": "To",
     "accountingDate": "Accounting date",
     "accountingStatus": "Accounting status",
     "postedStatus": "Posted",
@@ -20161,7 +20163,7 @@
     "customerDataSection": "Customer data",
     "vendorDataSection": "Vendor data",
     "fiscal.title": "Fiscal Configuration",
-    "fiscal.monitor.nav": "Invoice Monitor",
+    "fiscal.monitor.nav": "Fiscal Monitor",
     "fiscal.wip.badge": "Work in Progress",
     "fiscal.wip.tooltip": "This window is still under active development. Fields, design, and behaviour may change without notice and are not final.",
     "fiscal.territory.question": "What fiscal territory does this organization operate in?",
@@ -20936,6 +20938,7 @@
     "purchaseOrders": "Purchase Orders",
     "docNo": "Doc No",
     "documentNo": "Document No",
+    "finance": "Finance",
     "settings": "Settings",
     "settingsDescription": "Manage your session context. Changing role or organization will re-authenticate your session.",
     "currentSession": "Current Session",
@@ -21057,6 +21060,7 @@
     "fm.kpi.deadline_days": "days",
     "fm.kpi.deadline_blocking": "blocking",
     "fm.list.title": "Declarations",
+    "fm.breadcrumb.section": "Fiscal Models",
     "fm.list.count": "declarations",
     "fm.filter.all": "All",
     "fm.filter.model_prefix": "Form",
@@ -21734,7 +21738,6 @@
     "newSubAccountSuccess": "Sub-account created successfully",
     "newSubAccountError": "Could not create sub-account",
     "glc.title": "General Ledger Configuration",
-    "glc.breadcrumbRoot": "Treasury",
     "glc.tab.general": "General",
     "glc.tab.defaults": "Defaults",
     "glc.tab.dimensions": "Dimensions",
@@ -24574,7 +24577,7 @@
       "label": "Create AP Expense Invoices"
     },
     "Asset Group": {
-      "label": "Asset Category"
+      "label": "Asset Group"
     },
     "Create Shipments from Orders": {
       "label": "Create Shipments from Orders"

--- a/tools/app-shell/src/locales/es_AR.json
+++ b/tools/app-shell/src/locales/es_AR.json
@@ -14024,7 +14024,7 @@
       "label": "Proceso de Ejecución"
     },
     "Asset Group": {
-      "label": "Categoría de Activos"
+      "label": "Grupo de activos"
     },
     "Employee Expenses": {
       "label": "Gastos no reembolsados"
@@ -16865,6 +16865,8 @@
     "postingFailed": "Error al contabilizar",
     "filterDocumentType": "Tipo de documento",
     "filterAccountingStatus": "Estado contable",
+    "filterFrom": "Desde",
+    "filterTo": "Hasta",
     "accountingDate": "Fecha contable",
     "accountingStatus": "Estado contable",
     "postedStatus": "Contabilizado",
@@ -19552,7 +19554,7 @@
     "customerDataSection": "Datos de cliente",
     "vendorDataSection": "Datos de proveedor",
     "fiscal.title": "Configuración Fiscal",
-    "fiscal.monitor.nav": "Monitor de facturas",
+    "fiscal.monitor.nav": "Monitor fiscal",
     "fiscal.wip.badge": "Trabajo en progreso",
     "fiscal.wip.tooltip": "Esta ventana está en desarrollo activo. Los campos, el diseño y el comportamiento pueden cambiar sin previo aviso y no son definitivos.",
     "fiscal.territory.question": "¿En qué territorio fiscal opera esta organización?",
@@ -20264,6 +20266,7 @@
     "purchaseOrders": "Órdenes de compra",
     "docNo": "Nº doc.",
     "documentNo": "Nº documento",
+    "finance": "Finanzas",
     "settings": "Configuración",
     "settingsDescription": "Gestiona el contexto de tu sesión. Cambiar el rol u organización volverá a autenticar tu sesión.",
     "currentSession": "Sesión actual",
@@ -20384,6 +20387,7 @@
     "fm.kpi.deadline_days": "días",
     "fm.kpi.deadline_blocking": "bloq.",
     "fm.list.title": "Declaraciones",
+    "fm.breadcrumb.section": "Modelos Fiscales",
     "fm.list.count": "declaraciones",
     "fm.filter.all": "Todos",
     "fm.filter.model_prefix": "Modelo",
@@ -21792,7 +21796,7 @@
       "label": "Gastos para facturar"
     },
     "Asset Group": {
-      "label": "Categoría de Activos"
+      "label": "Grupo de activos"
     },
     "Employee Expenses": {
       "label": "Gastos no reembolsados"

--- a/tools/app-shell/src/locales/es_ES.json
+++ b/tools/app-shell/src/locales/es_ES.json
@@ -14062,8 +14062,8 @@
       "label": "Proceso de Ejecución"
     },
     "Asset Group": {
-      "label": "Categoría de Activos",
-      "newLabel": "Nueva categoría"
+      "label": "Grupo de activos",
+      "newLabel": "Nuevo grupo"
     },
     "Employee Expenses": {
       "label": "Gastos no reembolsados"
@@ -16995,6 +16995,8 @@
     "postingFailed": "Error al contabilizar",
     "filterDocumentType": "Tipo de documento",
     "filterAccountingStatus": "Estado contable",
+    "filterFrom": "Desde",
+    "filterTo": "Hasta",
     "accountingDate": "Fecha contable",
     "accountingStatus": "Estado contable",
     "postedStatus": "Contabilizado",
@@ -20394,7 +20396,7 @@
     "customerDataSection": "Datos de cliente",
     "vendorDataSection": "Datos de proveedor",
     "fiscal.title": "Configuración Fiscal",
-    "fiscal.monitor.nav": "Monitor de facturas",
+    "fiscal.monitor.nav": "Monitor fiscal",
     "fiscal.wip.badge": "Trabajo en progreso",
     "fiscal.wip.tooltip": "Esta ventana está en desarrollo activo. Los campos, el diseño y el comportamiento pueden cambiar sin previo aviso y no son definitivos.",
     "fiscal.territory.question": "¿En qué territorio fiscal opera esta organización?",
@@ -21169,6 +21171,7 @@
     "purchaseOrders": "Órdenes de compra",
     "docNo": "Nº doc.",
     "documentNo": "Nº documento",
+    "finance": "Finanzas",
     "settings": "Configuración",
     "settingsDescription": "Gestiona el contexto de tu sesión. Cambiar el rol u organización volverá a autenticar tu sesión.",
     "currentSession": "Sesión actual",
@@ -21290,6 +21293,7 @@
     "fm.kpi.deadline_days": "días",
     "fm.kpi.deadline_blocking": "bloq.",
     "fm.list.title": "Declaraciones",
+    "fm.breadcrumb.section": "Modelos Fiscales",
     "fm.list.count": "declaraciones",
     "fm.filter.all": "Todos",
     "fm.filter.model_prefix": "Modelo",
@@ -21968,8 +21972,7 @@
     "accountTypeRevenue": "Ingreso",
     "newSubAccountSuccess": "Subcuenta creada correctamente",
     "newSubAccountError": "No se pudo crear la subcuenta",
-    "glc.title": "Configuración contable",
-    "glc.breadcrumbRoot": "Tesorería",
+    "glc.title": "Esquema contable",
     "glc.tab.general": "General",
     "glc.tab.defaults": "Valores por defecto",
     "glc.tab.dimensions": "Dimensiones",
@@ -25448,7 +25451,7 @@
       "label": "Gastos para facturar"
     },
     "Asset Group": {
-      "label": "Categoría de Activos"
+      "label": "Grupo de activos"
     },
     "Employee Expenses": {
       "label": "Gastos no reembolsados"

--- a/tools/app-shell/src/menu.json
+++ b/tools/app-shell/src/menu.json
@@ -310,8 +310,8 @@
         },
         {
           "name": "asset-group",
-          "label": "Asset Category",
-          "favname": "Asset Category",
+          "label": "Asset Group",
+          "favname": "Asset Group",
           "windowId": "252"
         },
         {

--- a/tools/app-shell/src/windows/custom/fiscal-models/FmListPage.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/FmListPage.jsx
@@ -795,7 +795,7 @@ export default function FmListPage({ declarations: propDecls, onSelect, onComput
             data-testid="MoreOptionsMenu__cb728e" />
         </div>
         <div style={{ fontSize: 12, color: 'hsl(var(--muted-foreground))', marginTop: 2 }}>
-          Tesorería / {t('fm.list.title') ?? 'Declaraciones'}
+          {ui('finance')} / {ui('fm.breadcrumb.section')}
         </div>
       </div>
       {/* ── Toolbar ──────────────────────────────────────────────── */}

--- a/tools/app-shell/src/windows/custom/fiscal-models/__tests__/FmListPage.breadcrumb.i18n.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/__tests__/FmListPage.breadcrumb.i18n.vitest.jsx
@@ -1,0 +1,88 @@
+// Real-locale breadcrumb regression coverage (ETP-4945).
+//
+// FmListPage.jsx used to render `Tesorería / {t('fm.list.title') ?? 'Declaraciones'}` —
+// a raw hardcoded Spanish literal, never localized, never matched against the
+// menu section. The fix is `{ui('finance')} / {ui('fm.breadcrumb.section')}`.
+// The breadcrumb is inline JSX text (not a useSetPageMeta call), so this
+// asserts the rendered title-bar text directly.
+//
+// NOTE: the sibling FmListPage.vitest.jsx mocks '@etendosoftware/app-shell-core'
+// for useUI, but FmListPage.jsx actually imports useUI from '@/i18n' — that mock
+// never intercepts the real import (verified empirically), so those tests only
+// ever exercise the REAL useUI() falling back to the raw key with no
+// LocaleProvider in scope (an existing, harmless test-infra gap, not something
+// this file needs to fix). This file mocks the path FmListPage.jsx actually
+// imports ('@/i18n') so the real locale dictionary is genuinely exercised.
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { loadLocaleDictionary, makeRealUI } from '../../shared/__tests__/testUtils/realLocaleUI.js';
+
+const esES = loadLocaleDictionary('es_ES');
+const enUS = loadLocaleDictionary('en_US');
+const realUiEs = makeRealUI(esES);
+const realUiEn = makeRealUI(enUS);
+
+let activeUi = realUiEs;
+vi.mock('@/i18n', () => ({ useUI: () => activeUi }));
+
+vi.mock('../fiscal-models.css', () => ({}));
+vi.mock('../useFiscalAutoCompute.js', () => ({
+  default: vi.fn(() => ({ computedMap: {} })),
+}));
+vi.mock('../fiscalModelsUtils.js', () => ({
+  formatAmount: (n) => (n == null ? '—' : String(n)),
+  countUpcomingDeadlines: () => 0,
+  isUpcomingDeadline: () => false,
+  checkModified303: vi.fn(),
+  checkModified349: vi.fn(),
+  compute349Operators: vi.fn(),
+  fetchDeclarationIncidents: vi.fn(),
+}));
+vi.mock('../FmOverlays.jsx', () => ({
+  NewDeclModal: () => null,
+}));
+vi.mock('../FmCatalogPage.jsx', () => ({
+  default: () => null,
+}));
+vi.mock('@/components/ui/checkbox', () => ({
+  Checkbox: () => null,
+}));
+vi.mock('lucide-react', () => ({
+  LayoutGrid: () => null, Settings: () => null, ListFilter: () => null,
+  ArrowUpDown: () => null, ChevronDown: () => null, MoreHorizontal: () => null,
+  MoreVertical: () => null, Calendar: () => null, Clock: () => null,
+  TriangleAlert: () => null, OctagonAlert: () => null, ArrowUpRight: () => null,
+  Search: () => null, Play: () => null, Check: () => null,
+}));
+vi.mock('../FmCommon.jsx', () => ({
+  StatusPillMenu: () => null,
+  MoreOptionsMenu: () => null,
+  ResultPill: () => null,
+  EmptyState: () => React.createElement('div', { className: 'fm-empty-state' }, 'empty'),
+  KpiWidget: () => null,
+}));
+
+import FmListPage from '../FmListPage.jsx';
+
+const defaultProps = {
+  onSelect: vi.fn(),
+  onStatusChange: vi.fn(),
+  onComputeUpdate: vi.fn(),
+};
+
+describe('FmListPage — breadcrumb against the real locale dictionary (ETP-4945)', () => {
+  it('resolves the es_ES breadcrumb to "Finanzas / Modelos Fiscales", not the stale "Tesorería"', () => {
+    activeUi = realUiEs;
+    const { container } = render(<FmListPage declarations={[]} {...defaultProps} />);
+
+    expect(container.textContent).toContain('Finanzas / Modelos Fiscales');
+    expect(container.textContent).not.toContain('Tesorería');
+  });
+
+  it('resolves the en_US breadcrumb to "Finance / Fiscal Models"', () => {
+    activeUi = realUiEn;
+    const { container } = render(<FmListPage declarations={[]} {...defaultProps} />);
+
+    expect(container.textContent).toContain('Finance / Fiscal Models');
+  });
+});

--- a/tools/app-shell/src/windows/custom/fiscal-models/models/303/FmModel303Page.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/models/303/FmModel303Page.jsx
@@ -476,7 +476,7 @@ export default function FmModel303Page({ decl, onBack, onStatusChange, token, ap
             data-testid="MoreOptionsMenu__4f6c0d" />
         </div>
         <div style={{ fontSize: 12, color: 'hsl(var(--text-disabled))', marginTop: 1 }}>
-          Tesorería / Modelo 303 - {periodLabel}
+          {ui('finance')} / {ui('fm.breadcrumb.section')} / Modelo 303 - {periodLabel}
         </div>
       </div>
       {/* ── Action bar ───────────────────────────────────────────── */}

--- a/tools/app-shell/src/windows/custom/fiscal-models/models/303/__tests__/FmModel303Page.breadcrumb.i18n.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/models/303/__tests__/FmModel303Page.breadcrumb.i18n.vitest.jsx
@@ -1,0 +1,100 @@
+// Real-locale breadcrumb regression coverage (ETP-4945).
+//
+// FmModel303Page.jsx used to render `Tesorería / Modelo 303 - {periodLabel}` —
+// a raw hardcoded Spanish literal. The fix is
+// `${ui('finance')} / ${ui('fm.breadcrumb.section')} / Modelo 303 - {periodLabel}`,
+// 3 segments, matching the fm-list breadcrumb's root+section. Breadcrumb is
+// inline JSX text (not a useSetPageMeta call), so this asserts the rendered
+// title-bar text directly, following the sibling FmModel303Page.vitest.jsx's
+// mocking shape but with `useUI` backed by the real locale dictionary instead
+// of its identity mock.
+import { vi, describe, it, expect } from 'vitest';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { loadLocaleDictionary, makeRealUI } from '../../../../shared/__tests__/testUtils/realLocaleUI.js';
+
+const esES = loadLocaleDictionary('es_ES');
+const enUS = loadLocaleDictionary('en_US');
+const realUiEs = makeRealUI(esES);
+const realUiEn = makeRealUI(enUS);
+
+let activeUi = realUiEs;
+
+const navigateMock = vi.fn();
+
+vi.mock('@/i18n', () => ({ useUI: () => activeUi }));
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigateMock }));
+vi.mock('@/auth/AuthContext.jsx', () => ({ useAuth: () => ({ selectedOrg: { id: 'org-1' } }) }));
+vi.mock('../../../fiscalModelsUtils.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    formatAmount: (n) => (n == null ? '—' : String(n)),
+    formatPeriod: (p) => p,
+    computeBoxes303: vi.fn().mockResolvedValue(null),
+    generate303File: vi.fn().mockResolvedValue({ ok: false }),
+    checkModified303: vi.fn(),
+  };
+});
+vi.mock('@/components/related-documents/helpers.js', () => ({ neoBase: (u) => u }));
+vi.mock('../../../fiscal-models.css', () => ({}));
+vi.mock('../../../FmCommon.jsx', () => ({
+  StatusPillMenu: () => null,
+  MoreOptionsMenu: () => null,
+  ResultPill: () => null,
+  SummaryCard: () => null,
+  Tabs: () => null,
+  Banner: () => null,
+  SectionCard: () => null,
+  EmptyState: () => React.createElement('div', { className: 'fm-empty-state' }, 'empty'),
+  KpiWidget: () => null,
+}));
+vi.mock('../../../FmTabContent.jsx', () => ({
+  SourcesTab: () => null,
+  IncidentsTab: () => null,
+}));
+vi.mock('../FmBoxes303.jsx', () => ({
+  default: () => React.createElement('div', { 'data-testid': 'fm-boxes-303' }, 'boxes'),
+}));
+vi.mock('../../../FmOverlays.jsx', () => ({
+  PresentModal: () => null,
+  FileGenModal303: () => null,
+}));
+vi.mock('lucide-react', () => ({
+  Settings: () => null, Download: () => null, OctagonAlert: () => null,
+  TriangleAlert: () => null, CircleCheck: () => null, ArrowLeftRight: () => null,
+  Calculator: () => null, Loader2: () => null, MoreVertical: () => null,
+  TrendingUp: () => null, TrendingDown: () => null, Clock: () => null,
+  ClipboardCheck: () => null, ReceiptText: () => null, Folder: () => null,
+  FileCheck: () => null,
+}));
+
+import FmModel303Page from '../FmModel303Page.jsx';
+
+const BASE_DECL = {
+  id: '303-2026-T2', model: '303', year: 2026, period: 'T2', type: 'ord',
+  status: 'draft', result: null, incidents: { blocking: 0, warning: 0 },
+  _precomputed: null, boxes: null, sources: [], history: [],
+};
+
+const defaultProps = {
+  onBack: vi.fn(),
+  onStatusChange: vi.fn(),
+};
+
+describe('FmModel303Page — breadcrumb against the real locale dictionary (ETP-4945)', () => {
+  it('resolves the es_ES breadcrumb to "Finanzas / Modelos Fiscales / Modelo 303 - 2026/T2", not the stale "Tesorería"', () => {
+    activeUi = realUiEs;
+    const { container } = render(<FmModel303Page decl={BASE_DECL} {...defaultProps} />);
+
+    expect(container.textContent).toContain('Finanzas / Modelos Fiscales / Modelo 303 - 2026/T2');
+    expect(container.textContent).not.toContain('Tesorería');
+  });
+
+  it('resolves the en_US breadcrumb to "Finance / Fiscal Models / Modelo 303 - 2026/T2"', () => {
+    activeUi = realUiEn;
+    const { container } = render(<FmModel303Page decl={BASE_DECL} {...defaultProps} />);
+
+    expect(container.textContent).toContain('Finance / Fiscal Models / Modelo 303 - 2026/T2');
+  });
+});

--- a/tools/app-shell/src/windows/custom/fiscal-models/models/349/FmModel349Page.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/models/349/FmModel349Page.jsx
@@ -949,7 +949,7 @@ export default function FmModel349Page({ decl, onBack, onStatusChange, token, ap
             data-testid="MoreOptionsMenu__346dd5" />
         </div>
         <div style={{ fontSize: 12, color: 'hsl(var(--text-disabled))', marginTop: 2 }}>
-          Tesorería / Declaraciones / Modelo 349 - {periodLabel}
+          {ui('finance')} / {ui('fm.breadcrumb.section')} / Modelo 349 - {periodLabel}
         </div>
       </div>
       {/* ── Action bar ───────────────────────────────────────────── */}

--- a/tools/app-shell/src/windows/custom/fiscal-models/models/349/__tests__/FmModel349Page.breadcrumb.i18n.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-models/models/349/__tests__/FmModel349Page.breadcrumb.i18n.vitest.jsx
@@ -1,0 +1,120 @@
+// Real-locale breadcrumb regression coverage (ETP-4945).
+//
+// FmModel349Page.jsx used to render
+// `Tesorería / Declaraciones / Modelo 349 - {periodLabel}` — 3 segments,
+// inconsistent with the 303 page's 2-segment version and rooted under a raw
+// hardcoded "Tesorería" literal. The fix aligns both 303 and 349 on
+// `${ui('finance')} / ${ui('fm.breadcrumb.section')} / Modelo <n> - {periodLabel}`.
+// Breadcrumb is inline JSX text (not a useSetPageMeta call), so this asserts
+// the rendered title-bar text directly. Mirrors the sibling
+// FmModel349Page.vitest.jsx's mocking shape but with `useUI` backed by the
+// real locale dictionary instead of its identity mock.
+import { vi, describe, it, expect } from 'vitest';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { loadLocaleDictionary, makeRealUI } from '../../../../shared/__tests__/testUtils/realLocaleUI.js';
+
+const esES = loadLocaleDictionary('es_ES');
+const enUS = loadLocaleDictionary('en_US');
+const realUiEs = makeRealUI(esES);
+const realUiEn = makeRealUI(enUS);
+
+let activeUi = realUiEs;
+
+vi.mock('@/i18n', () => ({ useUI: () => activeUi }));
+
+vi.mock('../../../fiscalModelsUtils.js', () => ({
+  formatAmount: (n) => String(n),
+  compute349Operators: vi.fn(),
+  generate349File: vi.fn(),
+}));
+
+vi.mock('../use349Pdf.js', () => ({
+  use349Pdf: () => ({
+    pdfUrl: null,
+    loading: false,
+    generatePdf: vi.fn(),
+    clearPdf: vi.fn(),
+  }),
+}));
+
+vi.mock('../../../FmCommon.jsx', () => ({
+  StatusPillMenu: () => null,
+  MoreOptionsMenu: () => null,
+  KpiWidget: () => null,
+  Tabs: () => null,
+  Banner: () => null,
+}));
+
+vi.mock('../../../FmOverlays.jsx', () => ({
+  PresentModal: () => null,
+  FileGenModal: () => null,
+}));
+
+vi.mock('../../../../../../components/contract-ui/DocumentPreview.jsx', () => ({
+  DocumentPreview: () => null,
+}));
+
+vi.mock('../../../fiscal-models.css', () => ({}));
+
+vi.mock('../../../FmTabContent.jsx', () => ({
+  SourcesTab: () => null,
+  IncidentsTab: () => null,
+}));
+
+vi.mock('lucide-react', () => ({
+  ArrowLeft: () => null, Download: () => null, FileDown: () => null, Play: () => null,
+  OctagonAlert: () => null, CircleCheck: () => null, Search: () => null, RefreshCw: () => null,
+  Globe: () => null, Eye: () => null, Lock: () => null, MoreVertical: () => null,
+  ChevronDown: () => null, ChevronRight: () => null, Users: () => null, FileEdit: () => null,
+  Clock: () => null, TriangleAlert: () => null, Folder: () => null, ReceiptText: () => null,
+  Calculator: () => null, PenLine: () => null, ShieldAlert: () => null, Info: () => null,
+  Star: () => null, ArrowUpRight: () => null, Loader2: () => null, TrendingUp: () => null,
+  TrendingDown: () => null, FileText: () => null, Settings: () => null, ArrowLeftRight: () => null,
+  Pencil: () => null, X: () => null, Check: () => null, Checkbox: () => null, FileCheck: () => null,
+}));
+
+import FmModel349Page from '../FmModel349Page.jsx';
+
+// period 'T1' (not a 2-digit month code) keeps periodLabel deterministic:
+// `${decl.year} ${decl.period}` — see FmModel349Page.jsx's monthNum/monthName
+// derivation, which only kicks in for a 2-digit numeric period.
+const makeDecl = (overrides = {}) => ({
+  id: 'decl-001',
+  model: '349',
+  year: 2026,
+  period: 'T1',
+  type: 'ord',
+  status: 'pending',
+  nif: 'B12345678',
+  operators: [],
+  invoices: [],
+  rectifications: 0,
+  incidents: { blocking: 0 },
+  _precomputed: null,
+  ...overrides,
+});
+
+const defaultProps = {
+  onBack: vi.fn(),
+  onStatusChange: vi.fn(),
+  token: 'test-token',
+  apiBaseUrl: '/api/fiscal-models',
+};
+
+describe('FmModel349Page — breadcrumb against the real locale dictionary (ETP-4945)', () => {
+  it('resolves the es_ES breadcrumb to "Finanzas / Modelos Fiscales / Modelo 349 - 2026 T1", not the stale "Tesorería / Declaraciones"', () => {
+    activeUi = realUiEs;
+    const { container } = render(<FmModel349Page decl={makeDecl()} {...defaultProps} />);
+
+    expect(container.textContent).toContain('Finanzas / Modelos Fiscales / Modelo 349 - 2026 T1');
+    expect(container.textContent).not.toContain('Tesorería');
+  });
+
+  it('resolves the en_US breadcrumb to "Finance / Fiscal Models / Modelo 349 - 2026 T1"', () => {
+    activeUi = realUiEn;
+    const { container } = render(<FmModel349Page decl={makeDecl()} {...defaultProps} />);
+
+    expect(container.textContent).toContain('Finance / Fiscal Models / Modelo 349 - 2026 T1');
+  });
+});

--- a/tools/app-shell/src/windows/custom/fiscal-monitor/FiscalMonitorPage.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-monitor/FiscalMonitorPage.jsx
@@ -176,7 +176,7 @@ export default function FiscalMonitorPage({ token, apiBaseUrl }) {
 
   useSetPageMeta({
     title: PROFILE_LABELS[profile] ?? '',
-    breadcrumb: `${ui('settings')} / ${ui('fiscal.monitor.nav')} / ${ui('fiscalMonitor.systemFiscal')} / ${PROFILE_LABELS[profile] ?? ''}`,
+    breadcrumb: `${ui('finance')} / ${ui('fiscal.monitor.nav')}`,
     recordCount: _totalCountMeta,
   });
 

--- a/tools/app-shell/src/windows/custom/fiscal-monitor/__tests__/FiscalMonitorPage.breadcrumb.i18n.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-monitor/__tests__/FiscalMonitorPage.breadcrumb.i18n.vitest.jsx
@@ -1,0 +1,141 @@
+// Real-locale breadcrumb regression coverage (ETP-4945).
+//
+// FiscalMonitorPage.jsx used to build a 4-segment breadcrumb
+// (`${ui('settings')} / ${ui('fiscal.monitor.nav')} / ${ui('fiscalMonitor.systemFiscal')} / ${PROFILE_LABELS[profile]}`)
+// rooted under "Configuración" instead of "Finanzas". The fix collapsed it to
+// `${ui('finance')} / ${ui('fiscal.monitor.nav')}`. Since this is a template
+// literal (not a pure exported helper), the sibling
+// FiscalMonitorPage.vitest.jsx's identity `useUI` mock (`(key) => key`) can't
+// catch a real-locale regression — this file renders with `useUI` backed by
+// the real dictionary and captures the useSetPageMeta call, same pattern as
+// windows/custom/financial-account/__tests__/index.vitest.jsx.
+import { render, waitFor, screen } from '@testing-library/react';
+import { loadLocaleDictionary, makeRealUI } from '../../shared/__tests__/testUtils/realLocaleUI.js';
+
+const esES = loadLocaleDictionary('es_ES');
+const enUS = loadLocaleDictionary('en_US');
+const realUiEs = makeRealUI(esES);
+const realUiEn = makeRealUI(enUS);
+
+let activeUi = realUiEs;
+
+const stableApiFetch = vi.fn(() => Promise.resolve({ ok: true, json: async () => ({ response: { data: [] } }) }));
+
+vi.mock('@/i18n', () => ({ useUI: () => activeUi }));
+vi.mock('@/auth/AuthContext.jsx', () => ({
+  useAuth: () => ({ selectedOrg: { id: 'org-1', name: 'TestOrg' } }),
+}));
+vi.mock('@/auth/useApiFetch.js', () => ({ useApiFetch: () => stableApiFetch }));
+vi.mock('@/components/related-documents/helpers.js', () => ({ neoBase: (u) => u }));
+
+const setMetaMock = vi.fn();
+vi.mock('@/components/layout/PageMetaContext', () => ({
+  useSetPageMeta: (meta) => setMetaMock(meta),
+}));
+
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }));
+vi.mock('../../fiscal-config/useCertExpiry.js', () => ({
+  useCertExpiry: () => ({ daysLeft: null }),
+}));
+vi.mock('../../fiscal-config/CertExpiryBanner.jsx', () => ({
+  default: () => null,
+}));
+vi.mock('../useFiscalMonitor.js', () => ({
+  useFiscalMonitor: () => ({
+    loading: false,
+    error: null,
+    profile: 'sii',
+    kpis: { sii: { issued: 2, received: 1, issuedPrevious: 0, receivedPrevious: 0 } },
+    siiParentId: 'parent-1',
+    tbaiValidationResults: [],
+    refetch: vi.fn(),
+  }),
+  SII_SPEC: 'sii-monitor',
+  SII_EMITIDAS_ENTITY: 'a',
+  SII_RECIBIDAS_ENTITY: 'b',
+  SII_EMITIDAS_ANT_ENTITY: 'c',
+  SII_RECIBIDAS_ANT_ENTITY: 'd',
+  VF_SPEC: 'vf',
+  VF_ACEPTADAS_ENTITY: 'e',
+  VF_PARCIAL_ENTITY: 'f',
+  VF_RECHAZADAS_ENTITY: 'g',
+  VF_INVALIDAS_ENTITY: 'h',
+  TBAI_SPEC: 'tbai',
+  TBAI_ENTITY: 'i',
+}));
+vi.mock('../useDebugMode.js', () => ({
+  useDebugMode: () => false,
+}));
+vi.mock('../fiscalMonitor.utils.js', () => ({
+  computeKpis: () => ({}),
+}));
+vi.mock('../fiscalMonitorMockData.js', () => ({
+  MOCK_MONITOR_DATA: {},
+  MOCK_SII_ROWS: [],
+  MOCK_TBAI_ROWS: [],
+  MOCK_VF_ROWS: [],
+  MOCK_TBAI_VALIDATION_RESULTS: [],
+}));
+vi.mock('../SiiMonitorSection.jsx', () => ({
+  default: (props) => <div data-testid="sii-section" data-parent={props.parentId} />,
+}));
+vi.mock('../TbaiMonitorSection.jsx', () => ({
+  default: () => <div data-testid="tbai-section" />,
+}));
+vi.mock('../VerifactuMonitorSection.jsx', () => ({
+  default: () => <div data-testid="verifactu-section" />,
+}));
+vi.mock('../FiscalMonitorDebugPanel.jsx', () => ({
+  default: () => <div data-testid="debug-panel" />,
+}));
+vi.mock('../../shared/InvoicePreviewModal.jsx', () => ({
+  default: () => <div data-testid="invoice-preview" />,
+}));
+vi.mock('../../shared/PdfViewer.jsx', () => ({
+  default: () => <div data-testid="pdf-viewer" />,
+}));
+vi.mock('react-pdf', () => ({
+  Document: () => null,
+  Page: () => null,
+  pdfjs: { GlobalWorkerOptions: {} },
+}));
+vi.mock('../ContactDetailModal.jsx', () => ({
+  default: () => <div data-testid="contact-detail" />,
+}));
+vi.mock('../fiscal-monitor.css', () => ({}));
+
+import FiscalMonitorPage from '../FiscalMonitorPage.jsx';
+
+const baseProps = {
+  token: 'test-token',
+  apiBaseUrl: '/sws/neo/fiscal-monitor',
+};
+
+beforeEach(() => {
+  setMetaMock.mockClear();
+});
+
+describe('FiscalMonitorPage — breadcrumb against the real locale dictionary (ETP-4945)', () => {
+  it('resolves the es_ES breadcrumb to the 2-segment "Finanzas / Monitor fiscal" (not the stale 4-level "Configuración / Monitor de facturas / Sistema fiscal activo / SII")', async () => {
+    activeUi = realUiEs;
+    render(<FiscalMonitorPage {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('sii-section')).toBeInTheDocument();
+    });
+
+    const lastCall = setMetaMock.mock.calls.at(-1)[0];
+    expect(lastCall.breadcrumb).toBe('Finanzas / Monitor fiscal');
+    expect(lastCall.breadcrumb.split(' / ')).toHaveLength(2);
+  });
+
+  it('resolves the en_US breadcrumb to "Finance / Fiscal Monitor"', async () => {
+    activeUi = realUiEn;
+    render(<FiscalMonitorPage {...baseProps} />);
+    await waitFor(() => {
+      expect(screen.getByTestId('sii-section')).toBeInTheDocument();
+    });
+
+    const lastCall = setMetaMock.mock.calls.at(-1)[0];
+    expect(lastCall.breadcrumb).toBe('Finance / Fiscal Monitor');
+  });
+});

--- a/tools/app-shell/src/windows/custom/general-ledger-configuration/GeneralLedgerConfigPage.jsx
+++ b/tools/app-shell/src/windows/custom/general-ledger-configuration/GeneralLedgerConfigPage.jsx
@@ -16,7 +16,7 @@ const REQUIRED_GENERAL = ['name', 'currency'];
 const REQUIRED_DEFAULTS = DEFAULTS_GROUPS.flatMap((g) => g.fields.filter((f) => f.required).map((f) => f.key));
 
 /**
- * General Ledger Configuration (AD window 125, "Configuración contable").
+ * General Ledger Configuration (AD window 125, "Esquema contable").
  * layoutType: custom — fiscal-config pattern. 4 tabs: General · Valores por
  * defecto · Dimensiones · Cuentas generales.
  *
@@ -41,7 +41,7 @@ export default function GeneralLedgerConfigPage({ apiBaseUrl }) {
 
   useSetPageMeta({
     title: ui('glc.title'),
-    breadcrumb: `${ui('glc.breadcrumbRoot')} / ${ui('glc.title')}`,
+    breadcrumb: `${ui('finance')} / ${ui('glc.title')}`,
   });
 
   function validate() {

--- a/tools/app-shell/src/windows/custom/general-ledger-configuration/__tests__/GeneralLedgerConfigPage.breadcrumb.i18n.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/general-ledger-configuration/__tests__/GeneralLedgerConfigPage.breadcrumb.i18n.vitest.jsx
@@ -1,0 +1,99 @@
+// Real-locale breadcrumb regression coverage (ETP-4945).
+//
+// GeneralLedgerConfigPage.jsx builds its breadcrumb as
+// `${ui('finance')} / ${ui('glc.title')}` — a template literal, not a pure
+// exported helper, so the only way to catch a real regression (a locale key
+// reverting to the pre-fix "Tesorería" root, or "glc.title" reverting to the
+// stale "Configuración contable") is to render the page with `useUI` backed
+// by the REAL locale dictionary instead of the sibling
+// GeneralLedgerConfigPage.vitest.jsx's identity mock (`(key) => key`), and
+// capture what it actually passes to useSetPageMeta — same capture pattern as
+// windows/custom/financial-account/__tests__/index.vitest.jsx
+// ("calls useSetPageMeta with the account name in the breadcrumb").
+import { render } from '@testing-library/react';
+import { loadLocaleDictionary, makeRealUI } from '../../shared/__tests__/testUtils/realLocaleUI.js';
+
+const esES = loadLocaleDictionary('es_ES');
+const enUS = loadLocaleDictionary('en_US');
+const realUiEs = makeRealUI(esES);
+const realUiEn = makeRealUI(enUS);
+
+let activeUi = realUiEs;
+vi.mock('@/i18n', () => ({
+  useUI: () => activeUi,
+}));
+
+vi.mock('@/auth/AuthContext.jsx', () => ({
+  useAuth: vi.fn(() => ({ selectedOrg: { id: 'org-1', name: 'Test Org' } })),
+}));
+
+const setMetaMock = vi.fn();
+vi.mock('@/components/layout/PageMetaContext', () => ({
+  useSetPageMeta: (meta) => setMetaMock(meta),
+}));
+
+vi.mock('../useGeneralLedgerConfig.js', () => ({
+  useGeneralLedgerConfig: vi.fn(() => ({
+    general: { name: 'GL', currency: 'EUR' },
+    defaults: { bankAsset: 'acct-1' },
+    dimensions: [],
+    orgInfo: {},
+    meta: { source: 'mock' },
+    catalogs: { currencies: [], accounts: [] },
+    generalAccounts: { active: true },
+    setGeneralField: vi.fn(),
+    setDefaultField: vi.fn(),
+    setDimensionField: vi.fn(),
+    setGeneralAccountsField: vi.fn(),
+    isDirty: false,
+    save: vi.fn(),
+    loading: false,
+  })),
+}));
+
+vi.mock('../mockCatalogs.js', () => ({
+  DEFAULTS_GROUPS: [
+    { fields: [{ key: 'bankAsset', required: true }, { key: 'optional', required: false }] },
+  ],
+}));
+
+vi.mock('../TabBar.jsx', () => ({ default: () => <div data-testid="tab-bar" /> }));
+vi.mock('../GeneralTab.jsx', () => ({ default: () => <div data-testid="general-tab" /> }));
+vi.mock('../DefaultsTab.jsx', () => ({ default: () => <div data-testid="defaults-tab" /> }));
+vi.mock('../DimensionsTab.jsx', () => ({ default: () => <div data-testid="dimensions-tab" /> }));
+vi.mock('../GeneralAccountsTab.jsx', () => ({ default: () => <div data-testid="general-accounts-tab" /> }));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...rest }) => <button {...rest}>{children}</button>,
+}));
+
+vi.mock('lucide-react', () => ({
+  Check: (props) => <svg data-testid="icon-check" {...props} />,
+}));
+
+import GeneralLedgerConfigPage from '../GeneralLedgerConfigPage.jsx';
+
+beforeEach(() => {
+  setMetaMock.mockClear();
+});
+
+describe('GeneralLedgerConfigPage — breadcrumb against the real locale dictionary (ETP-4945)', () => {
+  it('resolves the es_ES breadcrumb to "Finanzas / Esquema contable", not the stale "Tesorería / Configuración contable"', () => {
+    activeUi = realUiEs;
+    render(<GeneralLedgerConfigPage apiBaseUrl="/api" />);
+
+    const lastCall = setMetaMock.mock.calls.at(-1)[0];
+    expect(lastCall.breadcrumb).toBe('Finanzas / Esquema contable');
+    expect(lastCall.breadcrumb).not.toContain('Tesorería');
+    expect(lastCall.breadcrumb).not.toContain('Configuración contable');
+    expect(lastCall.title).toBe('Esquema contable');
+  });
+
+  it('resolves the en_US breadcrumb to "Finance / General Ledger Configuration"', () => {
+    activeUi = realUiEn;
+    render(<GeneralLedgerConfigPage apiBaseUrl="/api" />);
+
+    const lastCall = setMetaMock.mock.calls.at(-1)[0];
+    expect(lastCall.breadcrumb).toBe('Finance / General Ledger Configuration');
+  });
+});

--- a/tools/app-shell/src/windows/custom/not-posted-documents/NotPostedDocumentsPage.jsx
+++ b/tools/app-shell/src/windows/custom/not-posted-documents/NotPostedDocumentsPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { toast } from 'sonner';
 import { useUI } from '@/i18n';
 import { useSetPageMeta } from '@/components/layout/PageMetaContext';
@@ -59,6 +59,14 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
 
   // ── Filter options (fetched once) ────────────────────────────────────────────
   const [filterOptions, setFilterOptions] = useState({ documentTypes: [], accountingStatuses: [] });
+
+  // row.documentType is the raw AD_Ref_List code (e.g. "GLJ", "PI") that backs
+  // filterOptions.documentTypes — reuse those already-translated {value,label}
+  // pairs to render the badge instead of the raw code (ETP-4945).
+  const documentTypeLabels = useMemo(
+    () => new Map(filterOptions.documentTypes.map(o => [o.value, o.label])),
+    [filterOptions.documentTypes]
+  );
 
   useEffect(() => {
     const ctrl = new AbortController();
@@ -225,7 +233,11 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
     }
   }
 
-  useSetPageMeta({ title: ui('notPostedDocuments'), recordCount: rows.length });
+  useSetPageMeta({
+    title: ui('notPostedDocuments'),
+    breadcrumb: `${ui('finance')} / ${ui('notPostedDocuments')}`,
+    recordCount: rows.length,
+  });
 
   const allChecked = rows.length > 0 && selected.size === rows.length;
   const someChecked = selected.size > 0 && selected.size < rows.length;
@@ -280,7 +292,9 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
                     />
                   </td>
                   <td>
-                    <span className="npd-doc-type-badge">{row.documentType}</span>
+                    <span className="npd-doc-type-badge">
+                      {documentTypeLabels.get(row.documentType) ?? row.documentType}
+                    </span>
                   </td>
                   <td>{row.description}</td>
                   <td className="npd-date">{formatDate(row.accountingDate)}</td>
@@ -328,12 +342,12 @@ export default function NotPostedDocumentsPage({ token, apiBaseUrl }) {
         </div>
 
         <div className="npd-filter-field">
-          <label>From</label>
+          <label>{ui('filterFrom')}</label>
           <input type="date" value={dateFrom} onChange={e => setDateFrom(e.target.value)} />
         </div>
 
         <div className="npd-filter-field">
-          <label>To</label>
+          <label>{ui('filterTo')}</label>
           <input type="date" value={dateTo} onChange={e => setDateTo(e.target.value)} />
         </div>
 

--- a/tools/app-shell/src/windows/custom/not-posted-documents/__tests__/NotPostedDocumentsPage.breadcrumb.i18n.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/not-posted-documents/__tests__/NotPostedDocumentsPage.breadcrumb.i18n.vitest.jsx
@@ -1,0 +1,150 @@
+// Real-locale breadcrumb + i18n regression coverage (ETP-4945).
+//
+// Three separate bugs fixed in NotPostedDocumentsPage.jsx, all invisible to
+// the sibling NotPostedDocumentsPage.vitest.jsx's identity `useUI` mock
+// (`(key) => key`) — this file renders with `useUI` backed by the REAL locale
+// dictionary so each fix's actual text is verified, not just that some key
+// was looked up:
+//   1. useSetPageMeta never received a `breadcrumb` key at all — TopBar
+//      rendered nothing. Fix: `breadcrumb: `${ui('finance')} / ${ui('notPostedDocuments')}``.
+//   2. The date-range filter labels were hardcoded English `<label>From</label>`
+//      / `<label>To</label>`. Fix: `ui('filterFrom')` / `ui('filterTo')`.
+//   3. The document-type badge rendered the raw backend code
+//      (`row.documentType`, e.g. "GLJ") untranslated. Fix: look it up in
+//      `filterOptions.documentTypes` (already {value,label} pairs from the
+//      API) via `documentTypeLabels`, falling back to the raw code only if
+//      unmapped.
+// Capture pattern for useSetPageMeta mirrors
+// windows/custom/financial-account/__tests__/index.vitest.jsx.
+import { render, screen, waitFor } from '@testing-library/react';
+import { loadLocaleDictionary, makeRealUI } from '../../shared/__tests__/testUtils/realLocaleUI.js';
+
+import NotPostedDocumentsPage from '../NotPostedDocumentsPage.jsx';
+
+const esES = loadLocaleDictionary('es_ES');
+const enUS = loadLocaleDictionary('en_US');
+const realUiEs = makeRealUI(esES);
+const realUiEn = makeRealUI(enUS);
+
+let activeUi = realUiEs;
+vi.mock('@/i18n', () => ({ useUI: () => activeUi }));
+
+const setMetaMock = vi.fn();
+vi.mock('@/components/layout/PageMetaContext', () => ({
+  useSetPageMeta: (meta) => setMetaMock(meta),
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const BASE_URL = '/swebsf/not-posted-documents';
+const TOKEN = 'test-token';
+
+// GLJ ("General Ledger Journal") is a real AD_Ref_List document-type code —
+// mirrors what the backend's `/header?_mode=filter-options` response actually
+// carries (a {value,label} pair per document type), matching the comment
+// in NotPostedDocumentsPage.jsx:63-65.
+const ROWS = [
+  {
+    documentId: 'doc-1',
+    documentType: 'GLJ',
+    description: 'GL-001',
+    accountingDate: '2024-03-15T00:00:00',
+    organization: 'Main Org',
+    tableId: 'tbl-1',
+  },
+  {
+    documentId: 'doc-2',
+    documentType: 'UNKNOWN_CODE',
+    description: 'UNK-002',
+    accountingDate: '2024-04-20',
+    organization: 'Branch',
+    tableId: 'tbl-2',
+  },
+];
+
+function mkFetch(rows = []) {
+  return vi.fn((url) => {
+    if (String(url).includes('_mode=filter-options')) {
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({
+          documentTypes: [{ value: 'GLJ', label: 'Asiento contable' }],
+          accountingStatuses: [],
+        }),
+      });
+    }
+    return Promise.resolve({ ok: true, json: async () => ({ rows, total: rows.length }) });
+  });
+}
+
+beforeEach(() => {
+  setMetaMock.mockClear();
+});
+
+describe('NotPostedDocumentsPage — breadcrumb against the real locale dictionary (ETP-4945)', () => {
+  it('resolves the es_ES breadcrumb to "Finanzas / Documentos no contabilizados" (previously missing entirely)', async () => {
+    activeUi = realUiEs;
+    globalThis.fetch = mkFetch(ROWS);
+    render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
+
+    await waitFor(() => expect(setMetaMock).toHaveBeenCalled());
+    const lastCall = setMetaMock.mock.calls.at(-1)[0];
+    expect(lastCall.breadcrumb).toBe('Finanzas / Documentos no contabilizados');
+    expect(lastCall.title).toBe('Documentos no contabilizados');
+  });
+
+  it('resolves the en_US breadcrumb to "Finance / Unposted Documents"', async () => {
+    activeUi = realUiEn;
+    globalThis.fetch = mkFetch(ROWS);
+    render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
+
+    await waitFor(() => expect(setMetaMock).toHaveBeenCalled());
+    const lastCall = setMetaMock.mock.calls.at(-1)[0];
+    expect(lastCall.breadcrumb).toBe(`Finance / ${enUS.genericLabels.notPostedDocuments}`);
+  });
+});
+
+describe('NotPostedDocumentsPage — filter labels against the real locale dictionary (ETP-4945)', () => {
+  it('renders "Desde"/"Hasta" for the date-range filters in es_ES, not the hardcoded English "From"/"To"', async () => {
+    activeUi = realUiEs;
+    globalThis.fetch = mkFetch([]);
+    render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
+
+    await waitFor(() => expect(screen.getByTestId('npd-filter-apply')).toBeInTheDocument());
+    expect(screen.getByText('Desde')).toBeInTheDocument();
+    expect(screen.getByText('Hasta')).toBeInTheDocument();
+    expect(screen.queryByText('From')).not.toBeInTheDocument();
+    expect(screen.queryByText('To')).not.toBeInTheDocument();
+  });
+
+  it('renders "From"/"To" in en_US', async () => {
+    activeUi = realUiEn;
+    globalThis.fetch = mkFetch([]);
+    render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
+
+    await waitFor(() => expect(screen.getByTestId('npd-filter-apply')).toBeInTheDocument());
+    expect(screen.getByText('From')).toBeInTheDocument();
+    expect(screen.getByText('To')).toBeInTheDocument();
+  });
+});
+
+describe('NotPostedDocumentsPage — document-type badge translation (ETP-4945)', () => {
+  it('renders the mapped label for a known document-type code, not the raw code', async () => {
+    activeUi = realUiEs;
+    globalThis.fetch = mkFetch(ROWS);
+    render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
+
+    const row = await screen.findByTestId('npd-row-doc-1');
+    expect(row.textContent).toContain('Asiento contable');
+    expect(row.textContent).not.toContain('GLJ');
+  });
+
+  it('falls back to the raw code for a document type absent from the filter-options catalog', async () => {
+    activeUi = realUiEs;
+    globalThis.fetch = mkFetch(ROWS);
+    render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
+
+    const row = await screen.findByTestId('npd-row-doc-2');
+    expect(row.textContent).toContain('UNKNOWN_CODE');
+  });
+});

--- a/tools/app-shell/src/windows/custom/not-posted-documents/__tests__/NotPostedDocumentsPage.breadcrumb.i18n.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/not-posted-documents/__tests__/NotPostedDocumentsPage.breadcrumb.i18n.vitest.jsx
@@ -81,10 +81,14 @@ beforeEach(() => {
   setMetaMock.mockClear();
 });
 
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
 describe('NotPostedDocumentsPage — breadcrumb against the real locale dictionary (ETP-4945)', () => {
   it('resolves the es_ES breadcrumb to "Finanzas / Documentos no contabilizados" (previously missing entirely)', async () => {
     activeUi = realUiEs;
-    globalThis.fetch = mkFetch(ROWS);
+    vi.stubGlobal('fetch', mkFetch(ROWS));
     render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
 
     await waitFor(() => expect(setMetaMock).toHaveBeenCalled());
@@ -93,21 +97,21 @@ describe('NotPostedDocumentsPage — breadcrumb against the real locale dictiona
     expect(lastCall.title).toBe('Documentos no contabilizados');
   });
 
-  it('resolves the en_US breadcrumb to "Finance / Unposted Documents"', async () => {
+  it('resolves the en_US breadcrumb to "Finance / Not Posted Documents"', async () => {
     activeUi = realUiEn;
-    globalThis.fetch = mkFetch(ROWS);
+    vi.stubGlobal('fetch', mkFetch(ROWS));
     render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
 
     await waitFor(() => expect(setMetaMock).toHaveBeenCalled());
     const lastCall = setMetaMock.mock.calls.at(-1)[0];
-    expect(lastCall.breadcrumb).toBe(`Finance / ${enUS.genericLabels.notPostedDocuments}`);
+    expect(lastCall.breadcrumb).toBe('Finance / Not Posted Documents');
   });
 });
 
 describe('NotPostedDocumentsPage — filter labels against the real locale dictionary (ETP-4945)', () => {
   it('renders "Desde"/"Hasta" for the date-range filters in es_ES, not the hardcoded English "From"/"To"', async () => {
     activeUi = realUiEs;
-    globalThis.fetch = mkFetch([]);
+    vi.stubGlobal('fetch', mkFetch([]));
     render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
 
     await waitFor(() => expect(screen.getByTestId('npd-filter-apply')).toBeInTheDocument());
@@ -119,7 +123,7 @@ describe('NotPostedDocumentsPage — filter labels against the real locale dicti
 
   it('renders "From"/"To" in en_US', async () => {
     activeUi = realUiEn;
-    globalThis.fetch = mkFetch([]);
+    vi.stubGlobal('fetch', mkFetch([]));
     render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
 
     await waitFor(() => expect(screen.getByTestId('npd-filter-apply')).toBeInTheDocument());
@@ -131,7 +135,7 @@ describe('NotPostedDocumentsPage — filter labels against the real locale dicti
 describe('NotPostedDocumentsPage — document-type badge translation (ETP-4945)', () => {
   it('renders the mapped label for a known document-type code, not the raw code', async () => {
     activeUi = realUiEs;
-    globalThis.fetch = mkFetch(ROWS);
+    vi.stubGlobal('fetch', mkFetch(ROWS));
     render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
 
     const row = await screen.findByTestId('npd-row-doc-1');
@@ -141,7 +145,7 @@ describe('NotPostedDocumentsPage — document-type badge translation (ETP-4945)'
 
   it('falls back to the raw code for a document type absent from the filter-options catalog', async () => {
     activeUi = realUiEs;
-    globalThis.fetch = mkFetch(ROWS);
+    vi.stubGlobal('fetch', mkFetch(ROWS));
     render(<NotPostedDocumentsPage token={TOKEN} apiBaseUrl={BASE_URL} />);
 
     const row = await screen.findByTestId('npd-row-doc-2');

--- a/tools/app-shell/src/windows/custom/shared/__tests__/testUtils/realLocaleUI.js
+++ b/tools/app-shell/src/windows/custom/shared/__tests__/testUtils/realLocaleUI.js
@@ -1,0 +1,80 @@
+// Real-locale i18n test helpers (ETP-4945 breadcrumb regression coverage).
+//
+// A mocked `useUI: () => (key) => key` (the default across custom-window test
+// files) is fine for structural tests, but it silently hides a real translation
+// regression — e.g. a breadcrumb key that resolves to the wrong text, or a
+// stale locale entry that never got updated when a menu label changed. ETP-4945
+// fixed exactly that bug class across 6 Finance-section windows; these helpers
+// let a test assert the EXACT string a real user sees, sourced from the real
+// locale JSON files, without needing a full LocaleProvider/React tree.
+//
+// Usage in a test file (mirrors the pattern already used by
+// windows/custom/calendar/__tests__/calendar-window-title.i18n.vitest.jsx and
+// components/contract-ui/__tests__/ListView.importLabels.vitest.jsx — a plain
+// top-level `const` referenced inside a `vi.mock(...)` factory in the SAME
+// file is hoist-safe in this codebase's Vitest setup):
+//
+//   import { loadLocaleDictionary, makeRealUI } from '../../shared/__tests__/testUtils/realLocaleUI.js';
+//   const esES = loadLocaleDictionary('es_ES');
+//   const realUI = makeRealUI(esES);
+//   vi.mock('@/i18n', () => ({ useUI: () => realUI }));
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+// This file lives at windows/custom/shared/__tests__/testUtils/ — locales/ is
+// 5 levels up, at tools/app-shell/src/locales/.
+const LOCALES_DIR = join(__dirname, '..', '..', '..', '..', '..', 'locales');
+
+const cache = new Map();
+
+/**
+ * Reads and parses a real locale JSON file (es_ES, en_US, es_AR, ...).
+ * Cached per file so multiple test files sharing this helper in the same
+ * Vitest worker don't re-read/re-parse the (large) locale files repeatedly.
+ */
+export function loadLocaleDictionary(locale) {
+  if (!cache.has(locale)) {
+    cache.set(locale, JSON.parse(readFileSync(join(LOCALES_DIR, `${locale}.json`), 'utf8')));
+  }
+  return cache.get(locale);
+}
+
+/**
+ * Mirrors useUI()'s real resolution exactly (see
+ * @etendosoftware/app-shell-core/src/i18n/useUI.js): resolves `genericLabels`,
+ * falls back to the raw key, then substitutes any `{param}` placeholders.
+ */
+export function makeRealUI(dictionary) {
+  return (key, params = {}) => {
+    let text = dictionary?.genericLabels?.[key] ?? key;
+    if (params && typeof params === 'object') {
+      Object.keys(params).forEach((p) => {
+        text = text.replace(`{${p}}`, params[p]);
+      });
+    }
+    return text;
+  };
+}
+
+/**
+ * Mirrors useMenuLabel()'s real resolution chain exactly (see
+ * @etendosoftware/app-shell-core/src/i18n/useMenuLabel.js):
+ * ui -> menus -> windows -> tabs -> genericLabels -> raw key.
+ */
+export function makeRealTMenu(dictionary) {
+  return (key, { field } = {}) => {
+    if (field) {
+      return dictionary?.windows?.[key]?.[field] ?? null;
+    }
+    return (
+      dictionary?.ui?.[key]?.label ??
+      dictionary?.menus?.[key]?.label ??
+      dictionary?.windows?.[key]?.label ??
+      dictionary?.tabs?.[key]?.label ??
+      dictionary?.genericLabels?.[key] ??
+      key
+    );
+  };
+}


### PR DESCRIPTION
## Summary

Fixes incorrect breadcrumbs across 6 Finance windows. Went through the full DEV -> REVIEW -> QA -> DOCS pipeline; all phases approved.

## Test plan

- Full unit suite: 746 files / 13905 tests passed
- Playwright mocked suite: 609 passed
- Playwright integration suite: 39 passed / 12 skipped
- Regenerate + drift-check: clean

## Known pre-existing bugs found along the way (not fixed, out of scope, worth follow-up tickets)

1. `general-ledger-configuration` renders the literal string "glc.title" in the es_AR locale (that locale has zero glc.* keys - pre-existing i18n gap).
2. `fiscal-monitor`'s title/breadcrumb don't render at all when an org has no fiscal profile configured (pre-existing TopBar gating).
3. `FmModel349Page.jsx`'s period-label fallback has no null-guard (theoretical only, decl.period is always populated in practice).

Refs ETP-4945