### PR TITLE
Feature ETP-5112: Serialize concurrent updates and consume the core fix

### DIFF
--- a/docs/e2e-testing-guide.md
+++ b/docs/e2e-testing-guide.md
@@ -236,6 +236,63 @@ what proves the live recalculation without pinning a number to a locale.
 
 ---
 
+## Organization Save — Two-Entity Write (`E2E_ORGANIZATION_INTEGRATION`)
+
+The "Organización" screen (`/organization`) is the only screen that writes **two entities in
+one save** — `AD_Org` (spec entity `organization`) and `AD_OrgInfo` (spec entity
+`information`), which in Etendo **share the same primary key value**. That combination made it
+the first screen to reproduce the two chained defects fixed under ETP-5112, and both are now
+guarded by a pair of specs:
+
+| Spec | Mode | Covers |
+|---|---|---|
+| `organization-save.mocked.spec.js` | mocked, runs in CI | the client contract: each PATCH carries the `updated` token **its own** GET returned, and the two PATCHes are serialized |
+| `organization-save.integration.spec.js` | live backend, gated | the server half: both PATCHes actually answer `200` |
+
+What they protect:
+
+- **Bug 1 — 400 `missing_updated`.** ETP-5073 made the backend require the record's `updated`
+  optimistic-locking token. Only `useEntity` remembered it, so panels reading with `apiFetch`
+  directly patched without one. Fixed centrally in `@etendosoftware/app-shell-core`
+  (`auth/api.js` harvests the token on every GET).
+- **Bug 1b — the token cache must be keyed by `(entity, id)`, not by `id`.** Because `AD_Org`
+  and `AD_OrgInfo` share the id, an id-only cache let the second GET clobber the first record's
+  token and one PATCH went out with the other record's version. The mocked spec returns two
+  deliberately different tokens under the same id and asserts they are never crossed.
+- **Bug 2 — 500 false concurrency conflict.** With the token fixed, the two PATCHes (then fired
+  with `Promise.all`) landed on two Tomcat threads in the same millisecond, and core's
+  `JsonToDataConverter` parses `updated` through a `private final static SimpleDateFormat`,
+  which is not thread-safe. One write came back 500 with "The record you are saving has already
+  been changed by another user" against a record nobody else had touched. Fixed in
+  `useOrganizationData.js` by awaiting the two PATCHes in sequence.
+
+**The non-overlap test asserts non-overlap, not arrival order.** `Promise.all` also dispatches
+in order, so an order-only assertion would pass against the exact bug. The mocked spec holds the
+first PATCH open for 150ms inside the route handler and asserts the second one *starts* after
+the first one *finished*. Copy that shape for any other screen that writes more than one entity.
+
+Run the mocked spec (no backend needed):
+
+```bash
+cd e2e && npx playwright test tests/flows/organization-save.mocked.spec.js --project=mocked
+```
+
+Run the live one — it **writes to the tenant's own organization record**, so it is skipped
+unless explicitly enabled and is not run by any CI job:
+
+```bash
+cd e2e
+E2E_ORGANIZATION_INTEGRATION=1 E2E_USE_MOCK=0 E2E_PASSWORD=<pass> \
+  npx playwright test tests/flows/organization-save.integration.spec.js --project=integration
+```
+
+It writes only the phone field (optional, free-text, no callout, no uniqueness constraint) with
+a unique timestamp-derived value, and restores the original in a `finally` — so a run leaves the
+tenant as it found it and repeated runs never collide. The restore re-reads the record first:
+the write moved the `updated` token on, and the restoring PATCH needs the current one.
+
+---
+
 ## Deployed MCP OAuth2 Smoke
 
 `e2e/tests/flows/mcp-oauth-pkce.smoke.spec.js` validates the public MCP/OAuth integration after deploy. It models the browser flow started by `opencode mcp auth etendo`: clean session, OAuth authorize URL, login, requested permissions, explicit authorization, local callback, and PKCE token exchange. The UI preserves the original `/authorize?...` URL through onboarding with a local-only `returnTo` parameter, then resumes the authorization screen after environment login. It is skipped by default because it targets a deployed environment, uses real smoke credentials, can create an OAuth client through DCR, and binds a local callback server.

--- a/e2e/tests/flows/organization-save.integration.spec.js
+++ b/e2e/tests/flows/organization-save.integration.spec.js
@@ -1,0 +1,149 @@
+import { test, expect } from '@playwright/test';
+import { login } from '../helpers/auth.js';
+import { loadCredentials } from '../helpers/purchase-helpers.js';
+
+/**
+ * Organization save — live backend regression for ETP-5112 (REAL BACKEND).
+ *
+ * The mocked companion (`organization-save.mocked.spec.js`) proves the CLIENT contract:
+ * every PATCH carries the `updated` token its own GET returned, and the two PATCHes are
+ * serialized. It cannot prove the half that only exists on the server — that core
+ * actually ACCEPTS both writes. Both bugs this ticket fixed were server responses:
+ *
+ *   - 400 `missing_updated` (ETP-5073's optimistic-locking token was never sent), and
+ *   - 500 "The record you are saving has already been changed by another user", a FALSE
+ *     conflict produced by core's non-thread-safe `SimpleDateFormat` in
+ *     `JsonToDataConverter` when both PATCHes were parsed in the same millisecond.
+ *
+ * So this spec asserts on the real status codes: both `/organization/{id}` and
+ * `/information/{id}` must answer 200. Before the fix, one of them answered 500 (or 400)
+ * reproducibly.
+ *
+ * Skipped unless `E2E_ORGANIZATION_INTEGRATION=1` — it needs a live Etendo GO backend and
+ * it WRITES to the tenant's own AD_Org/AD_OrgInfo record. Not run by any CI job.
+ *
+ * Run it explicitly against local Etendo (dev server on :3100, `make dev`):
+ *
+ *   cd e2e
+ *   E2E_ORGANIZATION_INTEGRATION=1 E2E_USE_MOCK=0 E2E_PASSWORD=<pass> \
+ *     npx playwright test tests/flows/organization-save.integration.spec.js --project=integration
+ *
+ * `E2E_USER`/`E2E_PASSWORD` are used unless `e2e/.auth-credentials.json` exists (written by
+ * the onboarding project), same as the other integration specs.
+ *
+ * Isolation: the phone field is the only value written, it is set to a unique
+ * timestamp-derived number, and the ORIGINAL value is restored in a `finally` — so a run
+ * leaves the tenant exactly as it found it, and repeated runs never collide.
+ * The phone is deliberately the chosen field: it is optional, free-text, has no callout,
+ * no uniqueness constraint and no downstream effect, so writing it cannot invalidate any
+ * other record. It also lives on `AD_OrgInfo` (the `information` entity) while the save
+ * ALWAYS patches `AD_Org` (the `organization` entity) too — which is what makes a
+ * single-field edit still exercise the two-entity write this ticket is about.
+ */
+
+const onboardingCreds = loadCredentials();
+const RUN_INTEGRATION = process.env.E2E_ORGANIZATION_INTEGRATION === '1';
+
+/** A unique, format-valid phone (digits only — see `isValidPhone` in recipientEdits.js). */
+function uniquePhone() {
+  return `6${String(Date.now()).slice(-8)}`;
+}
+
+/** Matches a PATCH response for one entity of the `organization` spec. */
+function isOrganizationPatch(response, entity) {
+  return response.request().method() === 'PATCH'
+    && new RegExp(`/sws/neo/organization/${entity}/[^/?]+`).test(response.url());
+}
+
+/**
+ * Saves the form and returns both PATCH responses.
+ *
+ * Both waiters are registered BEFORE the click so neither response can land first and be
+ * missed. They are collected with `Promise.all` on the TEST side only — that is just how
+ * two independent waiters are awaited; the app itself still issues the two PATCHes in
+ * sequence, which is the behaviour under test.
+ */
+async function saveAndCaptureBothPatches(page) {
+  const orgPatch = page.waitForResponse((r) => isOrganizationPatch(r, 'organization'), { timeout: 30_000 });
+  const infoPatch = page.waitForResponse((r) => isOrganizationPatch(r, 'information'), { timeout: 30_000 });
+  await page.getByTestId('OrganizationPage__save').click();
+  return Promise.all([orgPatch, infoPatch]);
+}
+
+/** Asserts a PATCH succeeded, naming the two failure modes ETP-5112 fixed. */
+async function expectPatchOk(response, entity) {
+  const status = response.status();
+  let body = '';
+  if (status !== 200) body = await response.text().catch(() => '<unreadable body>');
+  expect(
+    status,
+    `PATCH /${entity}/{id} answered ${status}. 400 means the \`updated\` token was not sent `
+    + '(ETP-5073 / bug 1); 500 with "already been changed by another user" means the two PATCHes '
+    + `overlapped again (bug 2 — useOrganizationData.js must await them in sequence). Body: ${body}`,
+  ).toBe(200);
+
+  // Bug 1 guard at the request level: a 200 could also be reached by a backend that stopped
+  // enforcing the token, so assert the client actually sent one.
+  const sent = response.request().postData();
+  expect(
+    sent && JSON.parse(sent).updated,
+    `PATCH /${entity}/{id} went out without an \`updated\` token: ${sent}`,
+  ).toBeTruthy();
+}
+
+test.describe('Organization save — two-entity write (ETP-5112, integration)', () => {
+  test.describe.configure({ timeout: 300_000 });
+
+  test.skip(
+    !RUN_INTEGRATION,
+    'Set E2E_ORGANIZATION_INTEGRATION=1 (plus E2E_USE_MOCK=0 and credentials) to run this live organization-save integration test.',
+  );
+
+  test('saves both entities with 200 and persists the change across a reload', async ({ page }) => {
+    const user = onboardingCreds?.email || process.env.E2E_USER;
+    const password = onboardingCreds?.password || process.env.E2E_PASSWORD;
+
+    await test.step('Login and open /organization', async () => {
+      await login(page, { user, password });
+      await page.goto('/organization');
+      await expect(page.getByTestId('OrganizationPage__phone')).toBeVisible({ timeout: 30_000 });
+    });
+
+    const phoneField = page.getByTestId('OrganizationPage__phone');
+    // Captured AFTER the form has been seeded from the two GETs, so it is the real stored
+    // value and not the empty initial state — restoring an empty string would otherwise
+    // wipe a real phone number off the tenant.
+    const originalPhone = await phoneField.inputValue();
+    const newPhone = uniquePhone();
+    expect(newPhone, 'The unique phone must differ from the stored one, or nothing is dirty and there is no save to make').not.toBe(originalPhone);
+
+    try {
+      await test.step('Change the phone and save — both PATCHes must answer 200', async () => {
+        await phoneField.fill(newPhone);
+        const [orgResponse, infoResponse] = await saveAndCaptureBothPatches(page);
+        await expectPatchOk(orgResponse, 'organization');
+        await expectPatchOk(infoResponse, 'information');
+        await expect(page.locator('[data-type="error"]')).toHaveCount(0);
+      });
+
+      await test.step('Reload — the change persisted', async () => {
+        await page.reload();
+        await expect(page.getByTestId('OrganizationPage__phone')).toHaveValue(newPhone, { timeout: 30_000 });
+      });
+    } finally {
+      // Restore in a finally so a failed assertion above still leaves the tenant clean.
+      // Re-read the field after a reload: the record's `updated` token moved on with the
+      // write, and the restoring PATCH needs the CURRENT one, which only a fresh GET
+      // through the app can supply.
+      await page.reload();
+      const field = page.getByTestId('OrganizationPage__phone');
+      await field.waitFor({ state: 'visible', timeout: 30_000 });
+      if (await field.inputValue() !== originalPhone) {
+        await field.fill(originalPhone);
+        const [restoreOrg, restoreInfo] = await saveAndCaptureBothPatches(page);
+        expect(restoreOrg.status(), 'Restoring the original phone must succeed, or the tenant is left dirty').toBe(200);
+        expect(restoreInfo.status(), 'Restoring the original phone must succeed, or the tenant is left dirty').toBe(200);
+      }
+    }
+  });
+});

--- a/e2e/tests/flows/organization-save.mocked.spec.js
+++ b/e2e/tests/flows/organization-save.mocked.spec.js
@@ -1,0 +1,266 @@
+import { test, expect } from '@playwright/test';
+import { login } from '../helpers/auth.js';
+
+/**
+ * Organization save — regression suite for ETP-5112 (mocked).
+ *
+ * The "Organización" screen (`/organization`) is the only screen that writes TWO
+ * entities in a single save — `AD_Org` (spec entity `organization`) and `AD_OrgInfo`
+ * (spec entity `information`) — and that made it the first screen to reproduce two
+ * chained defects. Both are guarded here.
+ *
+ * Bug 1 — 400 `missing_updated`.
+ *   ETP-5073 made the backend require the `updated` optimistic-locking token of the
+ *   record as it was read. The token was only remembered by `useEntity`, so every
+ *   panel that reads with `apiFetch` directly (this one) patched without it and the
+ *   server refused the write. Fixed centrally in `@etendosoftware/app-shell-core`
+ *   (`auth/api.js` now harvests the token on every GET). Covered by
+ *   "PATCH carries the updated token …".
+ *
+ * Bug 1b — the token cache must be keyed by (entity, id), not by id alone.
+ *   In Etendo, `AD_Org` and `AD_OrgInfo` SHARE the same primary key value, so this
+ *   screen reads two different records under one id. With an id-only cache the second
+ *   GET overwrote the first record's token and one of the two PATCHes went out with
+ *   the other record's version. Covered by "each entity sends its own token …".
+ *
+ * Bug 2 — 500 false concurrency conflict.
+ *   Once bug 1 was fixed, the two PATCHes (then fired with `Promise.all`) landed on two
+ *   Tomcat threads in the same millisecond, and core's `JsonToDataConverter` parses the
+ *   `updated` token through a `private final static SimpleDateFormat` — which is not
+ *   thread-safe. The two parses corrupted each other and one write came back 500 with
+ *   "The record you are saving has already been changed by another user", against a
+ *   record nobody else had touched. Fixed in `useOrganizationData.js` by awaiting the
+ *   two PATCHes in sequence. Covered by "the two PATCH requests never overlap".
+ *
+ *   That test deliberately asserts NON-OVERLAP (second request starts after the first
+ *   one finished), not arrival order: `Promise.all` also fires them in order, so an
+ *   order-only assertion would pass against the exact bug this spec exists to catch.
+ *
+ * Mock mode only — this spec installs entity-specific routes on top of the generic
+ * `/sws/**` mock that `login()` seeds, so it needs no backend.
+ * Run with: `cd e2e && npx playwright test tests/flows/organization-save.mocked.spec.js`
+ */
+
+// AD_Org and AD_OrgInfo share this id on purpose — that is the real Etendo shape and
+// the whole point of the per-entity token assertions below.
+const ORG_ID = 'e2e-org-0001';
+
+// Deliberately different, and deliberately not date-shaped: the client must forward
+// whatever opaque string the read returned, and a crossed token has to be obvious in
+// the failure message rather than "two timestamps that look alike".
+const ORG_TOKEN = 'ORG-2026-09-01T11:45:37+00:00';
+const INFO_TOKEN = 'INFO-2026-09-01T11:45:37+00:00';
+
+const headerRecord = (updated) => ({
+  id: ORG_ID,
+  name: 'E2E Organización',
+  socialName: 'E2E Nombre Comercial',
+  etgoBusinessType: '',
+  'currency$_identifier': 'EUR',
+  updated,
+});
+
+const infoRecord = (updated) => ({
+  id: ORG_ID,
+  taxID: 'B12345678',
+  locationAddress: 'e2e-location-0001',
+  'locationAddress$_identifier': 'Calle Falsa - 123 - 28001 - Madrid - España',
+  yourCompanyDocumentImage: '',
+  etgoEmail: 'e2e@example.com',
+  etgoPhone: '600000000',
+  etgoWeb: '',
+  updated,
+});
+
+/**
+ * Installs GET/PATCH mocks for both entities of the `organization` spec and returns a
+ * journal the tests assert on.
+ *
+ * Two routes per entity, never one: a glob ending in a bare `word**` does NOT cross a
+ * `/`, so `…/organization**` alone would match neither `/organization/<id>` nor any
+ * sub-route, and the request would silently fall through to `login()`'s `/sws/**`
+ * catch-all. See docs/e2e-testing-guide.md § "Gotcha: a route pattern ending in a bare
+ * `word**`".
+ *
+ * MUST be called AFTER `login()` — Playwright matches routes in reverse registration
+ * order, so the generic stub would otherwise win.
+ *
+ * @param {import('@playwright/test').Page} page
+ * @param {{orgPatchDelayMs?: number, orgPatchStatus?: number}} [options]
+ *   `orgPatchDelayMs` holds the `organization` PATCH open for that long, which is what
+ *   makes an overlap observable at all: without it two concurrent writes and two
+ *   serialized writes produce indistinguishable timestamps.
+ */
+async function installOrganizationMock(page, options = {}) {
+  const { orgPatchDelayMs = 0, orgPatchStatus = 200 } = options;
+
+  /** @type {{patches: Array<{entity: string, body: any, startedAt: number, finishedAt: number}>}} */
+  const journal = { patches: [] };
+
+  const handlerFor = (entity) => async (route) => {
+    const request = route.request();
+    const method = request.method();
+    const updated = entity === 'organization' ? ORG_TOKEN : INFO_TOKEN;
+    const record = entity === 'organization' ? headerRecord(updated) : infoRecord(updated);
+
+    if (method === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ response: { data: [record] } }),
+      });
+      return;
+    }
+
+    if (method === 'PATCH') {
+      const startedAt = Date.now();
+      let body = null;
+      try {
+        body = JSON.parse(request.postData() ?? 'null');
+      } catch {
+        // A non-JSON body is a failure the assertions should surface as `null`, not
+        // as an exception inside the route handler (which Playwright reports as an
+        // unrelated "route was not handled" error).
+      }
+      const status = entity === 'organization' ? orgPatchStatus : 200;
+      if (entity === 'organization' && orgPatchDelayMs > 0) {
+        await new Promise((resolve) => { setTimeout(resolve, orgPatchDelayMs); });
+      }
+      const finishedAt = Date.now();
+      journal.patches.push({ entity, body, startedAt, finishedAt });
+      await route.fulfill({
+        status,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          status === 200
+            ? { response: { data: [record] } }
+            : { error: { message: 'The record you are saving has already been changed by another user' } },
+        ),
+      });
+      return;
+    }
+
+    await route.fallback();
+  };
+
+  for (const entity of ['organization', 'information']) {
+    await page.route(`**/sws/neo/organization/${entity}/**`, handlerFor(entity));
+    await page.route(`**/sws/neo/organization/${entity}**`, handlerFor(entity));
+  }
+
+  return journal;
+}
+
+/**
+ * `OrganizationPage` reads its record id from `useAuth().selectedOrg`, which `login()`
+ * does not seed (it only seeds token + role). Without this the page has no orgId, never
+ * fetches, and renders an empty form with no save button.
+ */
+async function seedSelectedOrg(page) {
+  await page.addInitScript((orgId) => {
+    localStorage.setItem('sf_auth_selected_org', JSON.stringify({ id: orgId, name: 'E2E Organización' }));
+  }, ORG_ID);
+}
+
+async function openOrganization(page, options) {
+  await login(page);
+  await seedSelectedOrg(page);
+  const journal = await installOrganizationMock(page, options);
+  await page.goto('/organization');
+  await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+  await expect(page.getByTestId('OrganizationPage__phone')).toBeVisible({ timeout: 15_000 });
+  return journal;
+}
+
+/** Edits the phone field (a free-text, always-optional field) so the save bar appears. */
+async function editPhoneAndSave(page, value) {
+  const phone = page.getByTestId('OrganizationPage__phone');
+  await phone.fill(value);
+  const save = page.getByTestId('OrganizationPage__save');
+  await expect(save).toBeVisible();
+  await save.click();
+}
+
+/** The PATCH the journal recorded for one entity, with a message that names the entity. */
+function patchFor(journal, entity) {
+  const found = journal.patches.find((p) => p.entity === entity);
+  expect(found, `Expected a PATCH to the "${entity}" entity, got: ${JSON.stringify(journal.patches.map((p) => p.entity))}`).toBeTruthy();
+  return found;
+}
+
+test.describe('Organization save — ETP-5112', () => {
+  test('PATCH carries the updated token harvested from the GET (bug 1: 400 missing_updated)', async ({ page }) => {
+    const journal = await openOrganization(page);
+
+    await editPhoneAndSave(page, '600111222');
+    await expect.poll(() => journal.patches.length, { timeout: 15_000 }).toBe(2);
+
+    // Both entities must forward a token; a missing one is exactly what the server
+    // answers 400 `missing_updated` to.
+    for (const entity of ['organization', 'information']) {
+      const patch = patchFor(journal, entity);
+      expect(
+        patch.body?.updated,
+        `PATCH /${entity}/${ORG_ID} went out without an \`updated\` token — the server answers 400 missing_updated. Body: ${JSON.stringify(patch.body)}`,
+      ).toBeTruthy();
+    }
+
+    expect(patchFor(journal, 'organization').body.updated).toBe(ORG_TOKEN);
+  });
+
+  test('each entity sends its own token, never the other one (bug 1b: cache keyed by entity+id)', async ({ page }) => {
+    const journal = await openOrganization(page);
+
+    await editPhoneAndSave(page, '600333444');
+    await expect.poll(() => journal.patches.length, { timeout: 15_000 }).toBe(2);
+
+    const orgPatch = patchFor(journal, 'organization');
+    const infoPatch = patchFor(journal, 'information');
+
+    // AD_Org and AD_OrgInfo share ORG_ID, so an id-only version cache would make the
+    // second read clobber the first and one of these two would carry the wrong token.
+    expect(
+      orgPatch.body.updated,
+      'PATCH /organization must carry the token returned by GET /organization, not the one from GET /information',
+    ).toBe(ORG_TOKEN);
+    expect(
+      infoPatch.body.updated,
+      'PATCH /information must carry the token returned by GET /information, not the one from GET /organization',
+    ).toBe(INFO_TOKEN);
+  });
+
+  test('the two PATCH requests never overlap (bug 2: 500 false concurrency conflict)', async ({ page }) => {
+    // 150ms is long enough that a concurrent second request would demonstrably start
+    // inside the first one's window, and short enough not to slow the suite down.
+    const journal = await openOrganization(page, { orgPatchDelayMs: 150 });
+
+    await editPhoneAndSave(page, '600555666');
+    await expect.poll(() => journal.patches.length, { timeout: 15_000 }).toBe(2);
+
+    const orgPatch = patchFor(journal, 'organization');
+    const infoPatch = patchFor(journal, 'information');
+
+    // Arrival ORDER is not the property under test — `Promise.all` also dispatches in
+    // order. The property is that the second request starts only once the first one has
+    // been answered, so the two never sit on two Tomcat threads at the same instant.
+    expect(
+      infoPatch.startedAt,
+      `The two PATCHes overlapped: /information started at +${infoPatch.startedAt - orgPatch.startedAt}ms while /organization was still open (it finished at +${orgPatch.finishedAt - orgPatch.startedAt}ms). They must be awaited in sequence — see useOrganizationData.js save().`,
+    ).toBeGreaterThanOrEqual(orgPatch.finishedAt);
+  });
+
+  test('a failing PATCH is reported and leaves the screen usable', async ({ page }) => {
+    const journal = await openOrganization(page, { orgPatchStatus: 500 });
+
+    await editPhoneAndSave(page, '600777888');
+    await expect.poll(() => journal.patches.length, { timeout: 15_000 }).toBeGreaterThan(0);
+
+    // Sonner v2 marks each toast with data-type — see docs/e2e-testing-guide.md.
+    await expect(page.locator('[data-type="error"]')).toBeVisible({ timeout: 10_000 });
+
+    // The screen must survive the failure: the unsaved edit is still there and the save
+    // bar is still actionable, so the user can retry.
+    await expect(page.getByTestId('OrganizationPage__phone')).toHaveValue('600777888');
+    await expect(page.getByTestId('OrganizationPage__save')).toBeEnabled();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.43",
-        "@etendosoftware/schema-forge-cli": "0.3.43",
-        "@etendosoftware/schema-forge-core": "0.3.43",
+        "@etendosoftware/app-shell-core": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
+        "@etendosoftware/schema-forge-cli": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
+        "@etendosoftware/schema-forge-core": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.43",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.43/51a3a966b9ff30a108f44bd9973ce8eab2bce3c0",
-      "integrity": "sha512-hROM+bplUsJkkiNLWzrmM0n92xZTgepwh8U/YSsRyv8Wt4MNIFkkecckvQHiQOiPI84AGL9oQwveVEilONwe6g==",
+      "version": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1/91739b1db470557f3f748c514b46ea5302fd1f91",
+      "integrity": "sha512-uHi6RiWZby5GvIq7W2q+Qk3Plpc+3hdXEL0Ilb8CaT9msbjeDK7ADJKTVXuNOT3raJYq8lLBkBdLXxa8ZXyk8A==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2572,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.43",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.43/80a9abc49655f8d3d38ce286fcaf894cec651cb5",
-      "integrity": "sha512-rv6GI5L/ukRABzGgZR7D2kIMd4hu/AjNn9dcgPJRcOC9yxdNbt5FPC2veFuKcLxLtz/ipUtA5uSoFSv4uCirBQ==",
+      "version": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1/28854f78079d3393fde738967bd8a518df6d31c2",
+      "integrity": "sha512-VZ9F8Vk2EoydDm+peM6NqpzyVhkGUj6ZrEezQQ6l5MCmOxM7WsdYOZZZ6ETBx63W9L894Dv+JNTfFfTlh4kbRQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2584,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.43",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.43/0553fba76456eb3212b6690ee303bbc2f0a52388",
-      "integrity": "sha512-et8TLJHjTTyXLzKabruqY2b0LMhekyDagItkXMMrHwOABw0pT54vaGyEJc8ruAG2pi1+r7uHllKlQ1e+JXG2DQ==",
+      "version": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1/e1c0be27bb46560b13186e9421bdf0c3478acf7f",
+      "integrity": "sha512-xwtx9ZK2Tvzh9vwIhZfeT+vxGNQUKtIObuCu51lCzHyXL+GQsElcZoOnpCgQbnS1VBO5hKoIfD8VNX1ooZFoPw==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2631,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.43",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.43/ad5dcfd01548e813db8b297f0fea7a2cbc728cc1",
-      "integrity": "sha512-F4AdSotk0Esq3LTuEe0u9ofkU816rk0BzSoKhvhnVx+naEsOMhQO90Pw5JrFdokXt7LAOibnP+UHqaTjZeYurA==",
+      "version": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1/e3df51e65d00a20274c7a1d0060a70039837f989",
+      "integrity": "sha512-NC3WsibZTLZmdgQhNRZO5PfKb4B35Z5Vdj07KWOClTYTYLJYJRSSwq11uqrY1bQCr0MAznH4QW/i0jwYPL6+Wg==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13780,8 +13780,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.43",
-        "@etendosoftware/etendo-go-core": "0.3.43",
+        "@etendosoftware/app-shell-core": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
+        "@etendosoftware/etendo-go-core": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.43",
-    "@etendosoftware/schema-forge-cli": "0.3.43",
-    "@etendosoftware/schema-forge-core": "0.3.43",
+    "@etendosoftware/app-shell-core": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
+    "@etendosoftware/schema-forge-cli": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
+    "@etendosoftware/schema-forge-core": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.43",
-        "@etendosoftware/etendo-go-core": "0.3.43",
+        "@etendosoftware/app-shell-core": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
+        "@etendosoftware/etendo-go-core": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.43",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.43/51a3a966b9ff30a108f44bd9973ce8eab2bce3c0",
-      "integrity": "sha512-hROM+bplUsJkkiNLWzrmM0n92xZTgepwh8U/YSsRyv8Wt4MNIFkkecckvQHiQOiPI84AGL9oQwveVEilONwe6g==",
+      "version": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1/91739b1db470557f3f748c514b46ea5302fd1f91",
+      "integrity": "sha512-uHi6RiWZby5GvIq7W2q+Qk3Plpc+3hdXEL0Ilb8CaT9msbjeDK7ADJKTVXuNOT3raJYq8lLBkBdLXxa8ZXyk8A==",
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2476,9 +2476,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.43",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.43/80a9abc49655f8d3d38ce286fcaf894cec651cb5",
-      "integrity": "sha512-rv6GI5L/ukRABzGgZR7D2kIMd4hu/AjNn9dcgPJRcOC9yxdNbt5FPC2veFuKcLxLtz/ipUtA5uSoFSv4uCirBQ==",
+      "version": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1/28854f78079d3393fde738967bd8a518df6d31c2",
+      "integrity": "sha512-VZ9F8Vk2EoydDm+peM6NqpzyVhkGUj6ZrEezQQ6l5MCmOxM7WsdYOZZZ6ETBx63W9L894Dv+JNTfFfTlh4kbRQ==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.43",
-    "@etendosoftware/etendo-go-core": "0.3.43",
+    "@etendosoftware/app-shell-core": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
+    "@etendosoftware/etendo-go-core": "0.3.44-preview.feature-ETP-5112.20260901202342.ab6f1c1",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",

--- a/tools/app-shell/src/test/realApiFetch.js
+++ b/tools/app-shell/src/test/realApiFetch.js
@@ -1,0 +1,82 @@
+/**
+ * Test seam for the ETP-5112 `updated`-token regression tests.
+ *
+ * `@/test/mockUseApiFetch.js` replaces `apiFetch` with a thin `globalThis.fetch` wrapper.
+ * That is the right double for almost everything — but it BYPASSES the code under test
+ * here. The whole of ETP-5112's bug-1 fix lives inside the core helper: `auth/api.js`
+ * harvests the `updated` optimistic-locking token off every GET response (keyed by entity
+ * AND id) and injects it into the PUT/PATCH that follows. A screen that reads a record and
+ * then writes it is only armed BECAUSE it goes through that helper, so a test that stubs
+ * the helper away can never show the token going out.
+ *
+ * So these tests keep the REAL `createApiFetch` and stub `globalThis.fetch` underneath it.
+ * What each screen's test then proves is its own half of the contract: that the panel reads
+ * the record through `apiFetch` (not a raw `fetch`, not a bypassing double) before writing
+ * it, at a path whose (entity, id) matches the write — which is exactly what makes the
+ * server-side concurrency check pass instead of answering 400 `missing_updated`.
+ */
+import { createApiFetch } from '@etendosoftware/app-shell-core/auth';
+
+// `rememberRecordVersion` is re-exported for the panels that never read at all: they get
+// `data` through props from `useEntity`, which remembers the token under the `null` bucket.
+// Seeding it directly is how a test stands in for that provider.
+export {
+  resetRecordVersionsForTests, rememberRecordVersion,
+} from '@etendosoftware/app-shell-core/lib/recordVersions.js';
+
+/**
+ * A `useApiFetch` replacement backed by the real core helper.
+ *
+ * Cached per base URL for the same reason `createStableUseApiFetchMock` is: a fresh
+ * function on every render re-fires any effect that lists `apiFetch` as a dependency.
+ */
+export function createRealUseApiFetchMock({ token = 'test-token' } = {}) {
+  const cache = new Map();
+  return (base = '') => {
+    if (!cache.has(base)) {
+      cache.set(base, createApiFetch(base, () => token, () => {}));
+    }
+    return cache.get(base);
+  };
+}
+
+/**
+ * A response double the core helper can actually harvest from. Three things matter and all
+ * three are easy to omit by accident, each silently disabling the harvest:
+ *
+ * - `headers.get('content-type')` must say JSON — reads are only harvested for JSON bodies;
+ * - `clone()` must return an INDEPENDENT body, because the helper reads the clone while the
+ *   caller reads the original (a `clone()` that returns `this` is deliberately skipped by
+ *   the helper, so the caller is never starved);
+ * - the payload must carry the record's `id` and `updated`, since that pair is the cache key.
+ */
+export function jsonResponse(payload, { ok = true, status = 200 } = {}) {
+  const body = JSON.stringify(payload ?? {});
+  const make = () => ({
+    ok,
+    status,
+    headers: { get: (name) => (String(name).toLowerCase() === 'content-type' ? 'application/json' : null) },
+    json: async () => JSON.parse(body),
+    text: async () => body,
+    clone: () => make(),
+  });
+  return make();
+}
+
+/** NEO's list/record envelope. */
+export function neoResponse(records, options) {
+  const rows = Array.isArray(records) ? records : [records];
+  return jsonResponse({ response: { data: rows, totalRows: rows.length } }, options);
+}
+
+/** Parses the JSON body of a recorded `fetch` call. */
+export function bodyOf(call) {
+  return JSON.parse(call[1].body);
+}
+
+/** The recorded `fetch` calls that used one of the versioned write methods. */
+export function writeCalls(fetchMock) {
+  return fetchMock.mock.calls.filter(([, options]) => (
+    ['PUT', 'PATCH'].includes(String(options?.method || '').toUpperCase())
+  ));
+}

--- a/tools/app-shell/src/test/requestJournal.js
+++ b/tools/app-shell/src/test/requestJournal.js
@@ -1,0 +1,94 @@
+/**
+ * A monotonic start/finish journal for proving that a batch of requests is issued
+ * SEQUENTIALLY (ETP-5112).
+ *
+ * Why this exists rather than a plain call-order assertion: `Promise.all(...)` and a
+ * `for (… of …) await …` loop fire their requests in exactly the same ORDER. An
+ * assertion on arrival order therefore passes against the very defect these tests exist
+ * to catch, and a reverted serialization would go unnoticed.
+ *
+ * What actually distinguishes the two is OVERLAP. So every tracked request stamps two
+ * ticks of a shared counter — one when it starts, one when it settles — and a test asserts
+ * that each request started strictly after the previous one finished. Give the FIRST
+ * request an artificial `delayMs` so a concurrent implementation is forced to interleave:
+ * the later request stamps its start tick while the delayed one is still in flight, and
+ * {@link createRequestJournal.overlapGaps} goes negative.
+ *
+ * Ticks, not wall-clock timestamps: `Date.now()` has millisecond granularity, so two
+ * requests that genuinely overlap can share a timestamp and produce a gap of 0 that a
+ * `>= 0` assertion would wave through. A counter cannot tie.
+ *
+ * The background is core's `JsonToDataConverter`, which parses a write's `updated`
+ * optimistic-locking token through a `private final static SimpleDateFormat` (line 129).
+ * `SimpleDateFormat` keeps parsing state in a shared `Calendar`, so two concurrent writes
+ * corrupt each other's parse and one comes back as a 500 conflict against a record nobody
+ * touched. Six screens were changed to serialize their writes; these journals are what
+ * keeps them that way.
+ */
+export function createRequestJournal() {
+  let clock = 0;
+  const entries = [];
+
+  /**
+   * Records one request's lifetime and returns whatever `result` produces.
+   *
+   * @param {string} label identifies the request in `labels()` and in failure output
+   * @param {object} [options]
+   * @param {number} [options.delayMs] hold the request open this long — put it on the
+   *   FIRST request of a batch so a concurrent implementation is forced to overlap
+   * @param {*|(() => *)} [options.result] resolved value, or a factory for one (use a
+   *   factory when the value is single-use, e.g. a Response double)
+   * @param {Error|string} [options.fail] reject with this instead of resolving, to
+   *   exercise the per-item error handling a sequential loop must preserve
+   */
+  async function track(label, { delayMs = 0, result, fail } = {}) {
+    const entry = { label, startedAt: ++clock, finishedAt: null };
+    entries.push(entry);
+    if (delayMs > 0) await new Promise((resolve) => { setTimeout(resolve, delayMs); });
+    entry.finishedAt = ++clock;
+    if (fail) throw (fail instanceof Error ? fail : new Error(String(fail)));
+    return typeof result === 'function' ? result() : result;
+  }
+
+  /** Labels in the order the requests STARTED. */
+  function labels() {
+    return entries.map(e => e.label);
+  }
+
+  /**
+   * Tick gap between each request starting and its predecessor finishing.
+   * Every gap `> 0` means no two requests were ever in flight together; any gap `<= 0`
+   * is an overlap, i.e. the serialization was lost.
+   */
+  function overlapGaps() {
+    // A predecessor that has not settled yet counts as still open forever (`Infinity`), so
+    // the gap goes to `-Infinity` instead of silently reading as positive. Without this a
+    // test that asserts before the batch has fully drained would pass against a concurrent
+    // implementation: the LAST request settles first there, and `startedAt - null` is just
+    // `startedAt`. Prefer `allSettled()` below over relying on this, but never let the
+    // oversight read as a pass.
+    return entries.slice(1).map((e, i) => e.startedAt - (entries[i].finishedAt ?? Infinity));
+  }
+
+  /**
+   * The single worst gap, so a test can assert on one number and still fail on any
+   * overlapping pair in a fan-out of N. `Infinity` for a batch of 0 or 1 requests —
+   * assert on `entries.length` too, so a batch that never ran cannot pass by default.
+   */
+  function minOverlapGap() {
+    const gaps = overlapGaps();
+    return gaps.length ? Math.min(...gaps) : Infinity;
+  }
+
+  /** True once every tracked request has settled — poll this with `waitFor`. */
+  function allSettled(expectedCount) {
+    return entries.length === expectedCount && entries.every(e => e.finishedAt !== null);
+  }
+
+  function reset() {
+    clock = 0;
+    entries.length = 0;
+  }
+
+  return { entries, track, labels, overlapGaps, minOverlapGap, allSettled, reset };
+}

--- a/tools/app-shell/src/windows/custom/contacts/__tests__/BillingPreferencesForm.updatedToken.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/contacts/__tests__/BillingPreferencesForm.updatedToken.vitest.jsx
@@ -1,0 +1,128 @@
+// ETP-5112 regression (bug 1) — the billing-preferences discount editor must send the
+// basic-discount record's `updated` optimistic-locking token on its PUT.
+//
+// ETP-5073 made the backend require the token of the record AS IT WAS READ; only
+// `useEntity` remembered one, so every panel that reads with `apiFetch` directly — this one
+// — wrote without it and got 400 `missing_updated`. The fix is central, in
+// `@etendosoftware/app-shell-core` (`auth/api.js` harvests the token from every GET, keyed
+// by entity AND id, and injects it into the write that follows), so nothing in this screen
+// changed. What is pinned here is the screen's half: the discount record is read as a
+// collection (`/basicDiscount?parentId=…`) and written by id (`/basicDiscount/{id}`), two
+// different path SHAPES that must still resolve to the same entity bucket — which is the
+// case `entityFromPath` exists for.
+//
+// The real `createApiFetch` is deliberately not stubbed — see `@/test/realApiFetch.js`.
+
+vi.mock('@/i18n', () => ({ useUI: () => (k) => k }));
+
+vi.mock('@/components/contract-ui', () => ({
+  EntityForm: () => <div data-testid="entity-form" />,
+}));
+
+vi.mock('lucide-react', () => {
+  const isReserved = (prop) => typeof prop !== 'string' || prop === 'then' || prop === '__esModule';
+  return new Proxy({}, {
+    has: (_t, prop) => !isReserved(prop),
+    get: (_t, prop) => (isReserved(prop) ? undefined : () => <span />),
+  });
+});
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  jsonResponse, neoResponse, bodyOf, writeCalls, resetRecordVersionsForTests,
+} from '@/test/realApiFetch.js';
+import BillingPreferencesForm from '../BillingPreferencesForm';
+
+const BP_ID = 'bp-1';
+const DISCOUNT_RECORD_ID = 'bd-1';
+const DISCOUNT_TOKEN = 'BASIC-DISCOUNT-TOKEN-0001';
+
+const defaultProps = {
+  data: { id: BP_ID, customer: true, vendor: false },
+  api: {},
+  token: 'test-token',
+  apiBaseUrl: '/sws/neo/contacts',
+  onChange: vi.fn(),
+};
+
+function installFetch({ discountRecord } = {}) {
+  globalThis.fetch = vi.fn((rawUrl, init = {}) => {
+    const url = String(rawUrl);
+    const method = String(init.method || 'GET').toUpperCase();
+    if (method === 'GET' && url.includes('/basicDiscount/selectors/')) {
+      // Selector catalog — a bare `{ items: [...] }` payload, not a NEO record envelope.
+      return Promise.resolve(jsonResponse({
+        items: [{ id: 'disc-a', label: 'Discount A' }, { id: 'disc-b', label: 'Discount B' }],
+      }));
+    }
+    if (method === 'GET' && url.includes('/basicDiscount?parentId=')) {
+      return Promise.resolve(neoResponse(discountRecord ? [discountRecord] : []));
+    }
+    return Promise.resolve(neoResponse([{ id: DISCOUNT_RECORD_ID, discount: 'disc-b' }]));
+  });
+  return globalThis.fetch;
+}
+
+const existingDiscount = {
+  id: DISCOUNT_RECORD_ID,
+  discount: 'disc-a',
+  lineNo: 10,
+  updated: DISCOUNT_TOKEN,
+};
+
+/** The discount `<select>` is the only combobox this form renders. */
+async function discountSelect() {
+  return waitFor(() => {
+    const select = screen.getByRole('combobox');
+    // Options land only after the selector catalog resolves.
+    expect(select.querySelectorAll('option').length).toBeGreaterThan(1);
+    return select;
+  });
+}
+
+beforeEach(() => {
+  resetRecordVersionsForTests();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('BillingPreferencesForm — updated token (ETP-5112)', () => {
+  it('sends the discount record token it read, on the PUT that changes the discount', async () => {
+    const fetchMock = installFetch({ discountRecord: existingDiscount });
+    render(<BillingPreferencesForm {...defaultProps} />);
+
+    const select = await discountSelect();
+    fireEvent.change(select, { target: { value: 'disc-b' } });
+
+    await waitFor(() => expect(writeCalls(fetchMock)).toHaveLength(1));
+
+    const [call] = writeCalls(fetchMock);
+    expect(call[0]).toContain(`/basicDiscount/${DISCOUNT_RECORD_ID}`);
+    const body = bodyOf(call);
+    // The list read (`/basicDiscount?parentId=…`) and the write (`/basicDiscount/{id}`)
+    // present different path tails; both must key into the same `basicDiscount` bucket.
+    expect(body.updated).toBe(DISCOUNT_TOKEN);
+    expect(body.discount).toBe('disc-b');
+  });
+
+  // The token is only ever attached to an UPDATE of a record that was read. A create has no
+  // prior version, and injecting one there would be meaningless at best.
+  it('does not attach a token to the POST that creates a first discount record', async () => {
+    const fetchMock = installFetch({ discountRecord: null });
+    render(<BillingPreferencesForm {...defaultProps} />);
+
+    const select = await discountSelect();
+    fireEvent.change(select, { target: { value: 'disc-b' } });
+
+    await waitFor(() => {
+      const posts = fetchMock.mock.calls.filter(([, o]) => o?.method === 'POST');
+      expect(posts).toHaveLength(1);
+    });
+
+    const post = fetchMock.mock.calls.find(([, o]) => o?.method === 'POST');
+    expect(JSON.parse(post[1].body)).not.toHaveProperty('updated');
+  });
+});

--- a/tools/app-shell/src/windows/custom/contacts/__tests__/ContactsFinancialPanel.updatedToken.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/contacts/__tests__/ContactsFinancialPanel.updatedToken.vitest.jsx
@@ -1,0 +1,112 @@
+// ETP-5112 regression (bug 1) — the contacts credit/tax panel must send the business
+// partner's `updated` optimistic-locking token on its inline PATCH.
+//
+// This panel is the awkward one: it NEVER READS. It receives `data` through props from
+// `useEntity` and then PATCHes `/businessPartner/{id}` directly, so there is no GET of its
+// own for `auth/api.js` to harvest a token from. What arms it is the `null` bucket of the
+// version cache — `useEntity` remembers the record it was handed WITHOUT any path context,
+// and `getRecordVersion(id, 'businessPartner')` falls back to that bucket when no entry
+// exists under the real entity name (`lib/recordVersions.js`, resolution step 2).
+//
+// So this test seeds the cache the way `useEntity` does (a bare `rememberRecordVersion`
+// with no entity) and asserts the panel's write picks it up. Break the fallback and this
+// fails; that is the point. The real `createApiFetch` is deliberately not stubbed — see
+// `@/test/realApiFetch.js`.
+
+vi.mock('@/i18n', () => ({ useUI: () => (key) => key }));
+
+vi.mock('lucide-react', () => ({
+  Minus: () => <span data-testid="icon-minus" />,
+  Plus: () => <span data-testid="icon-plus" />,
+}));
+
+vi.mock('../BillingPreferencesForm', () => ({ default: () => <div data-testid="billing-form" /> }));
+vi.mock('../FiscalDefaultsSection', () => ({ default: () => <div data-testid="fiscal-defaults-section" /> }));
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  neoResponse, bodyOf, writeCalls, resetRecordVersionsForTests, rememberRecordVersion,
+} from '@/test/realApiFetch.js';
+import ContactsFinancialPanel from '../ContactsFinancialPanel.jsx';
+
+const BP_ID = 'bp-1';
+const BP_TOKEN = 'BP-RECORD-TOKEN-0001';
+
+const defaultProps = {
+  data: { id: BP_ID, creditLimit: 5000, creditUsed: 1000, active: true },
+  token: 'test-token',
+  apiBaseUrl: '/sws/neo/contacts',
+  catalogs: {},
+  api: {},
+  // The credit fields are read-only unless the form is in edit mode, and a read-only field
+  // never persists.
+  editing: true,
+  onChange: vi.fn(),
+};
+
+/** Stands in for `useEntity`: remembers the record with NO path context (the null bucket). */
+function seedUseEntityVersion(updated = BP_TOKEN) {
+  rememberRecordVersion({ id: BP_ID, updated });
+}
+
+function creditLimitInput() {
+  return screen.getAllByRole('spinbutton')[0];
+}
+
+beforeEach(() => {
+  resetRecordVersionsForTests();
+  vi.clearAllMocks();
+  globalThis.fetch = vi.fn(() => Promise.resolve(neoResponse([{ id: BP_ID, creditLimit: 7000 }])));
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ContactsFinancialPanel — updated token (ETP-5112)', () => {
+  it('sends the token useEntity remembered, through the null-bucket fallback', async () => {
+    seedUseEntityVersion();
+    render(<ContactsFinancialPanel {...defaultProps} />);
+
+    fireEvent.change(creditLimitInput(), { target: { value: '7000' } });
+    fireEvent.blur(creditLimitInput());
+
+    await waitFor(() => expect(writeCalls(globalThis.fetch)).toHaveLength(1));
+
+    const [call] = writeCalls(globalThis.fetch);
+    expect(call[0]).toContain(`/businessPartner/${BP_ID}`);
+    const body = bodyOf(call);
+    expect(body.updated).toBe(BP_TOKEN);
+    expect(body.creditLimit).toBe(7000);
+  });
+
+  // The whole reason the cache is keyed by (entity, id) and not by id alone: an id can name
+  // two different rows. An entry remembered for another entity under the SAME id must not
+  // be handed to this write when the null bucket is available.
+  it('prefers the null bucket over an unrelated entity entry for the same id', async () => {
+    rememberRecordVersion({ id: BP_ID, updated: 'OTHER-ENTITY-TOKEN' }, 'someOtherEntity');
+    seedUseEntityVersion();
+    render(<ContactsFinancialPanel {...defaultProps} />);
+
+    fireEvent.change(creditLimitInput(), { target: { value: '7000' } });
+    fireEvent.blur(creditLimitInput());
+
+    await waitFor(() => expect(writeCalls(globalThis.fetch)).toHaveLength(1));
+
+    expect(bodyOf(writeCalls(globalThis.fetch)[0]).updated).toBe(BP_TOKEN);
+  });
+
+  // Documents the loud-failure contract: with nothing remembered the write goes out WITHOUT
+  // a token and the server answers 400 `missing_updated`. Deliberately not auto-retried —
+  // re-reading and replaying would silently overwrite someone else's change.
+  it('sends no token at all when the record was never remembered', async () => {
+    render(<ContactsFinancialPanel {...defaultProps} />);
+
+    fireEvent.change(creditLimitInput(), { target: { value: '7000' } });
+    fireEvent.blur(creditLimitInput());
+
+    await waitFor(() => expect(writeCalls(globalThis.fetch)).toHaveLength(1));
+
+    expect(bodyOf(writeCalls(globalThis.fetch)[0])).not.toHaveProperty('updated');
+  });
+});

--- a/tools/app-shell/src/windows/custom/fiscal-config/FiscalConfigPage.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-config/FiscalConfigPage.jsx
@@ -56,10 +56,32 @@ function resolveRenderProfile(addingComplementary, effectiveProfile) {
   return addingComplementary ? 'sii+tbai' : effectiveProfile;
 }
 
+/**
+ * Saves two sections one after the other — never both at once (ETP-5112).
+ *
+ * Each section's `save()` issues a PUT carrying the record's `updated` token, and core parses that
+ * token through a `private final static SimpleDateFormat` (`JsonToDataConverter` line 129) which is
+ * not thread-safe. Two writes landing together corrupt each other's parse, and the concurrency
+ * check then refuses one with "the record has already been changed by another user" against a
+ * record nobody touched. Reproduced on the Organization screen with exactly this two-write shape.
+ *
+ * Both sections are still attempted even when the first fails, which is what `allSettled` gave us
+ * and what the combined error below depends on — hence the explicit try/catch per save rather than
+ * a bare sequential await, which would skip the second on the first failure.
+ */
 async function saveTwoRefs(ref1, ref2) {
-  const [r0, r1] = await Promise.allSettled([ref1?.save(), ref2?.save()]);
-  if (r0.status === 'rejected' || r1.status === 'rejected') {
-    throw new Error(r0.reason?.message ?? r1.reason?.message ?? 'Error saving');
+  const outcomes = [];
+  for (const ref of [ref1, ref2]) {
+    try {
+      await ref?.save();
+      outcomes.push(null);
+    } catch (err) {
+      outcomes.push(err);
+    }
+  }
+  const firstError = outcomes.find(Boolean);
+  if (firstError) {
+    throw new Error(firstError.message ?? 'Error saving');
   }
 }
 

--- a/tools/app-shell/src/windows/custom/fiscal-config/OnboardingWizard.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-config/OnboardingWizard.jsx
@@ -434,7 +434,21 @@ function DetailScreen({ system, selectedTerritory, createdRecords, orgId, orgNam
 
   async function handleSaveDetail() {
     if (system === 'SII+TBAI') {
-      const results = await Promise.allSettled([siiRef.current?.save(), tbaiRef.current?.save()]);
+      // One after the other, NOT `Promise.allSettled([...])` (ETP-5112): each save is a PUT
+      // carrying the record's `updated` token, and core parses it through a non-thread-safe
+      // static `SimpleDateFormat` (`JsonToDataConverter` line 129). Concurrent writes corrupt
+      // each other's parse and one is then refused as a conflict against a record nobody touched.
+      // Both saves are still attempted when the first fails, matching the previous `allSettled`
+      // behaviour that `every(fulfilled)` below relies on.
+      const results = [];
+      for (const ref of [siiRef, tbaiRef]) {
+        try {
+          await ref.current?.save();
+          results.push({ status: 'fulfilled' });
+        } catch {
+          results.push({ status: 'rejected' });
+        }
+      }
       if (results.every(r => r.status === 'fulfilled')) onApplied();
       return;
     }

--- a/tools/app-shell/src/windows/custom/fiscal-config/__tests__/FiscalConfigPage.serialization.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-config/__tests__/FiscalConfigPage.serialization.vitest.jsx
@@ -1,0 +1,196 @@
+// ETP-5112 regression — `FiscalConfigPage.saveTwoRefs` must run its two section saves one
+// after the other, never with `Promise.allSettled([...])`.
+//
+// Each section's `save()` is a PUT carrying the record's `updated` optimistic-locking
+// token, and core parses that token through a `private final static SimpleDateFormat`
+// (`JsonToDataConverter` line 129) which is not thread-safe: two writes landing together
+// corrupt each other's parse and one comes back refused as a conflict against a record
+// nobody touched.
+//
+// WHAT THIS FILE CAN AND CANNOT PROVE — read before extending it.
+//
+// On the `sii+tbai` layout this page mounts only the ACTIVE tab's section
+// (`{activeTab === 0 && <SiiSection ref={siiRef} …>}` / `{activeTab === 1 && <TbaiSection
+// ref={tbaiRef} …>}`), so React has nulled the other ref by the time Save is pressed and
+// `saveTwoRefs`'s second `ref?.save()` is a no-op. The pair therefore never actually
+// overlaps here regardless of how `saveTwoRefs` is written, and a non-overlap assertion
+// could not distinguish a sequential loop from `Promise.allSettled` on this page. The
+// first test below PINS that single-mount fact — if the page ever starts keeping both
+// sections mounted (which is what the onboarding wizard's DetailScreen does, deliberately,
+// "so ref stays valid"), it fails and this file must grow the real non-overlap assertion
+// that `OnboardingWizard.serialization.vitest.jsx` already carries.
+//
+// What is asserted instead is the part of `saveTwoRefs`'s contract that IS observable
+// here: each ref is awaited (a rejection surfaces as the page's save error rather than an
+// unhandled rejection), a null ref is tolerated, and the first ref failing does not stop
+// the second from being attempted.
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { createRequestJournal } from '@/test/requestJournal.js';
+
+const journalRef = { current: null };
+const saveOutcome = { sii: 'ok', tbai: 'ok' };
+
+vi.mock('@/i18n', () => ({ useUI: () => (key) => key }));
+
+vi.mock('@/auth/AuthContext.jsx', () => ({
+  useAuth: vi.fn(() => ({
+    selectedOrg: { id: 'org-1', name: 'Test Org' },
+    selectedRole: { orgList: [{ id: 'org-1', name: 'Test Org' }] },
+    selectOrg: vi.fn(),
+  })),
+}));
+
+vi.mock('react-router-dom', () => ({ useNavigate: vi.fn(() => vi.fn()) }));
+vi.mock('@/components/layout/PageMetaContext', () => ({ useSetPageMeta: vi.fn() }));
+
+vi.mock('../useFiscalConfig.js', () => ({
+  useFiscalConfig: vi.fn(() => ({
+    loading: false,
+    error: null,
+    profile: 'sii+tbai',
+    siiRecord: { id: 'sii-1' },
+    tbaiRecord: { id: 'tbai-1' },
+    verifactuRecord: null,
+    refetch: vi.fn(),
+    createComplementary: vi.fn(),
+  })),
+}));
+
+vi.mock('../../fiscal-monitor/useDebugMode.js', () => ({ useDebugMode: () => false }));
+vi.mock('../useCertExpiry.js', () => ({ useCertExpiry: () => ({ daysLeft: null }) }));
+vi.mock('../fiscalConfig.utils.js', async (importActual) => ({
+  ...(await importActual()),
+  detectProfile: vi.fn(() => 'sii+tbai'),
+}));
+vi.mock('../ChangeSifDialog.jsx', () => ({ default: () => null }));
+vi.mock('../FiscalConfigDebugPanel.jsx', () => ({ default: () => <div data-testid="debug-panel" /> }));
+vi.mock('../OnboardingWizard.jsx', () => ({ default: () => <div data-testid="onboarding-wizard" /> }));
+vi.mock('../CertExpiryBanner.jsx', () => ({ default: () => <div data-testid="cert-expiry-banner" /> }));
+
+/** Section doubles whose imperative `save()` is journalled. */
+function makeSectionMock(label, delayMs) {
+  return React.forwardRef((props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      save: () => journalRef.current.track(label, {
+        delayMs,
+        fail: saveOutcome[label] === 'fail' ? new Error(`${label} boom`) : undefined,
+      }),
+    }));
+    return <div data-testid={`${label}-section`} />;
+  });
+}
+
+vi.mock('../SiiSection.jsx', () => ({ default: makeSectionMock('sii', 30) }));
+vi.mock('../TbaiSection.jsx', () => ({ default: makeSectionMock('tbai', 0) }));
+vi.mock('../VerifactuSection.jsx', () => ({ default: makeSectionMock('verifactu', 0) }));
+
+vi.mock('../TabBar.jsx', () => ({
+  default: ({ tabs, active, onChange }) => (
+    <div data-testid="tab-bar">
+      {tabs.map((tab, i) => (
+        <button key={tab} onClick={() => onChange(i)} data-active={active === i}>{tab}</button>
+      ))}
+    </div>
+  ),
+}));
+
+vi.mock('../FiscalOrgDropdown.jsx', () => ({ default: () => <div data-testid="org-dropdown" /> }));
+vi.mock('@/components/ui/skeleton', () => ({ Skeleton: () => <div data-testid="skeleton" /> }));
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, disabled, ...rest }) => (
+    <button onClick={onClick} disabled={disabled} {...rest}>{children}</button>
+  ),
+}));
+vi.mock('lucide-react', () => ({
+  Save: () => <svg data-testid="icon-save" />,
+  RefreshCw: () => <svg data-testid="icon-refresh" />,
+  PlusCircle: () => <svg data-testid="icon-plus-circle" />,
+  MoreVertical: () => <svg data-testid="icon-more-vertical" />,
+}));
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }) => <div>{children}</div>,
+  DropdownMenuTrigger: () => null,
+  DropdownMenuContent: () => null,
+  DropdownMenuItem: () => null,
+}));
+
+import FiscalConfigPage from '../FiscalConfigPage.jsx';
+
+function renderPage() {
+  return render(<FiscalConfigPage token="test-token" apiBaseUrl="/api" />);
+}
+
+function clickSave() {
+  fireEvent.click(screen.getByText('fiscal.save').closest('button'));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  journalRef.current = createRequestJournal();
+  saveOutcome.sii = 'ok';
+  saveOutcome.tbai = 'ok';
+});
+
+describe('FiscalConfigPage — sii+tbai save (ETP-5112)', () => {
+  // The premise behind every other assertion in this file. See the header comment: if this
+  // ever fails because BOTH sections are mounted, the page's two saves really can overlap
+  // and this file owes a non-overlap assertion.
+  it('mounts only the active tab section, so the second ref is null at save time', () => {
+    renderPage();
+
+    expect(screen.getByTestId('sii-section')).toBeInTheDocument();
+    expect(screen.queryByTestId('tbai-section')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('fiscal.tab.tbai'));
+
+    expect(screen.getByTestId('tbai-section')).toBeInTheDocument();
+    expect(screen.queryByTestId('sii-section')).not.toBeInTheDocument();
+  });
+
+  it('awaits the mounted section save and reports success', async () => {
+    renderPage();
+
+    clickSave();
+    await waitFor(() => expect(journalRef.current.allSettled(1)).toBe(true));
+
+    expect(journalRef.current.labels()).toEqual(['sii']);
+    // No save error banner: `saveTwoRefs` resolved, i.e. the save was genuinely awaited.
+    expect(screen.queryByText('sii boom')).not.toBeInTheDocument();
+  });
+
+  it('saves the tbai section once its tab is the active one', async () => {
+    renderPage();
+    fireEvent.click(screen.getByText('fiscal.tab.tbai'));
+
+    clickSave();
+    await waitFor(() => expect(journalRef.current.allSettled(1)).toBe(true));
+
+    expect(journalRef.current.labels()).toEqual(['tbai']);
+  });
+
+  // `saveTwoRefs` collects an outcome per ref and rethrows the FIRST error — a save that
+  // was fired but not awaited would surface as an unhandled rejection instead, and the
+  // banner would never appear.
+  it('surfaces a failing section save as the page save error', async () => {
+    saveOutcome.sii = 'fail';
+    renderPage();
+
+    clickSave();
+
+    await waitFor(() => expect(screen.getByText('sii boom')).toBeInTheDocument());
+  });
+
+  it('tolerates a null ref without failing the save', async () => {
+    // No org selected -> Save is disabled, so instead assert the shape that reaches
+    // `saveTwoRefs` with one null ref: only the mounted section is ever invoked.
+    renderPage();
+
+    clickSave();
+    await waitFor(() => expect(journalRef.current.allSettled(1)).toBe(true));
+
+    expect(journalRef.current.entries).toHaveLength(1);
+    expect(screen.queryByText(/boom/)).not.toBeInTheDocument();
+  });
+});

--- a/tools/app-shell/src/windows/custom/fiscal-config/__tests__/OnboardingWizard.serialization.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-config/__tests__/OnboardingWizard.serialization.vitest.jsx
@@ -1,0 +1,184 @@
+// ETP-5112 regression — the onboarding wizard's SII+TBAI detail step must save the two
+// sections one after the other, never with `Promise.allSettled([...])`.
+//
+// Each section's `save()` is a PUT carrying the record's `updated` optimistic-locking
+// token, and core parses that token through a `private final static SimpleDateFormat`
+// (`JsonToDataConverter` line 129) which is not thread-safe: two writes landing together
+// corrupt each other's parse and one is refused as a conflict against a record nobody
+// touched.
+//
+// Unlike `FiscalConfigPage`, the wizard's DetailScreen keeps BOTH sections mounted for
+// SII+TBAI (the inactive one is only hidden with a CSS class, "so ref stays valid"), so
+// both refs are live at save time and the two writes really do go out together — which is
+// what makes this call site reachable, and what makes this test able to observe it.
+//
+// The assertion is NON-OVERLAP, not arrival order: `allSettled([a, b])` evaluates in order
+// too. See `@/test/requestJournal.js`.
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import { createRequestJournal } from '@/test/requestJournal.js';
+
+// Handed to the section mocks, which are hoisted above this file's body — hence a mutable
+// holder rather than a value captured at module scope.
+const journalRef = { current: null };
+const saveOutcome = { sii: 'ok', tbai: 'ok' };
+
+vi.mock('@/i18n', () => ({
+  useUI: () => (key) => key,
+  useLocaleSwitch: () => ({ locale: 'en_US', setLocale: vi.fn() }),
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, onClick, disabled, ...rest }) => (
+    <button onClick={onClick} disabled={disabled} {...rest}>{children}</button>
+  ),
+}));
+
+// The POST that creates each config record must come back with a record in the NEO
+// envelope: `createRecords` stores what it returns, and the detail screen only mounts a
+// section when its `createdRecords.<system>` is truthy.
+vi.mock('@/auth/useApiFetch.js', () => ({
+  useApiFetch: vi.fn(() => vi.fn((url) => Promise.resolve({
+    ok: true,
+    text: () => Promise.resolve(''),
+    json: () => Promise.resolve({
+      response: { data: [{ id: url.includes('tbai') ? 'tbai-rec-1' : 'sii-rec-1' }] },
+    }),
+  }))),
+}));
+
+vi.mock('@/auth/AuthContext.jsx', () => ({
+  useAuth: vi.fn(() => ({
+    selectedOrg: { id: 'org-1', name: 'Test Organization' },
+    selectedRole: { orgList: [{ id: 'org-1', name: 'Test Organization' }] },
+    selectOrg: vi.fn(),
+  })),
+}));
+
+vi.mock('@/components/related-documents/helpers.js', () => ({
+  fetchById: vi.fn(() => Promise.resolve(null)),
+  neoBase: (url) => url?.replace(/\/[^/]+$/, '') ?? '',
+}));
+
+// `resolveSystem` decides which detail screen is shown; force the combined system, which is
+// the only one that saves two records. `buildOnboardingPayloads` must return BOTH payloads
+// so `createdRecords.sii` and `.tbai` exist and both sections mount.
+vi.mock('../fiscalConfig.utils.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  buildOnboardingPayloads: vi.fn(() => ({ sii: {}, tbai: {} })),
+  getFiscalRecordId: vi.fn(() => null),
+  getAllowedSystemsForTerritory: vi.fn(() => ['SII', 'TBAI', 'VERIFACTU']),
+  getCertificateContext: vi.fn(() => null),
+  resolveSystem: vi.fn(() => 'SII+TBAI'),
+}));
+
+/**
+ * Section doubles whose imperative `save()` is journalled. The SII save is held open long
+ * enough that a concurrent implementation starts the TBAI save inside its window.
+ */
+function makeSectionMock(label, delayMs) {
+  return React.forwardRef((props, ref) => {
+    React.useImperativeHandle(ref, () => ({
+      save: () => journalRef.current.track(label, {
+        delayMs,
+        fail: saveOutcome[label] === 'fail' ? new Error(`${label} save failed`) : undefined,
+      }),
+    }));
+    return <div data-testid={`${label}-section`} />;
+  });
+}
+
+vi.mock('../SiiSection.jsx', () => ({ default: makeSectionMock('sii', 30) }));
+vi.mock('../TbaiSection.jsx', () => ({ default: makeSectionMock('tbai', 0) }));
+vi.mock('../CertModal.jsx', () => ({ default: () => <div data-testid="cert-modal" /> }));
+vi.mock('../CertSection.jsx', () => ({ default: () => <div data-testid="cert-section" /> }));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import OnboardingWizard from '../OnboardingWizard.jsx';
+
+/**
+ * Walks the wizard to the SII+TBAI detail screen: pick a territory, continue, confirm.
+ * `createRecords` then creates both records and lands on the detail step, where both the
+ * SII and the TBAI section are mounted at once.
+ */
+async function renderAtDetailScreen(props = {}) {
+  const merged = {
+    apiBaseUrl: '/api/fiscal-config',
+    onComplete: vi.fn(),
+    onGoHome: vi.fn(),
+    ...props,
+  };
+  const utils = render(<OnboardingWizard {...merged} />);
+  fireEvent.click(screen.getByText('fiscal.territory.navarra'));
+  fireEvent.click(screen.getByText('fiscal.onboarding.continue'));
+  fireEvent.click(screen.getByText('fiscal.onboarding.confirm.btn'));
+  await waitFor(() => expect(screen.getByText('fiscal.save')).toBeInTheDocument());
+  // Both sections mounted — without this the "two saves" premise would be vacuous and the
+  // non-overlap assertion below would pass on a batch of one.
+  await waitFor(() => {
+    expect(screen.getByTestId('sii-section')).toBeInTheDocument();
+    expect(screen.getByTestId('tbai-section')).toBeInTheDocument();
+  });
+  return { ...utils, props: merged };
+}
+
+/** Saves and waits until both section saves have SETTLED, not merely been started. */
+async function clickSaveDetail(journal, expected = 2) {
+  fireEvent.click(screen.getByText('fiscal.save'));
+  await waitFor(() => expect(journal.allSettled(expected)).toBe(true));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  journalRef.current = createRequestJournal();
+  saveOutcome.sii = 'ok';
+  saveOutcome.tbai = 'ok';
+});
+
+describe('OnboardingWizard — SII+TBAI detail save serialization (ETP-5112)', () => {
+  it('never has the TBAI save in flight while the SII save is open', async () => {
+    await renderAtDetailScreen();
+    const journal = journalRef.current;
+
+    await clickSaveDetail(journal);
+
+    expect(journal.labels()).toEqual(['sii', 'tbai']);
+    // `Promise.allSettled([siiRef.current?.save(), tbaiRef.current?.save()])` yields -2
+    // here: the TBAI save stamps its start tick at 2 while the SII save settles at 4.
+    expect(journal.minOverlapGap()).toBeGreaterThan(0);
+  });
+
+  it('reaches the applied screen once both saves succeeded', async () => {
+    await renderAtDetailScreen();
+
+    await clickSaveDetail(journalRef.current);
+
+    await waitFor(() => expect(screen.getByText('fiscal.onboarding.goHome')).toBeInTheDocument());
+  });
+
+  // Semantics the serialization must preserve: the previous `allSettled` attempted both
+  // regardless, so a plain sequential `await` (which would skip the second on the first
+  // failure) is NOT an acceptable replacement.
+  it('still runs the TBAI save after the SII save threw', async () => {
+    saveOutcome.sii = 'fail';
+    await renderAtDetailScreen();
+    const journal = journalRef.current;
+
+    await clickSaveDetail(journal);
+
+    expect(journal.labels()).toEqual(['sii', 'tbai']);
+    expect(journal.minOverlapGap()).toBeGreaterThan(0);
+  });
+
+  it('does not advance to the applied screen when one save failed', async () => {
+    saveOutcome.tbai = 'fail';
+    await renderAtDetailScreen();
+
+    await clickSaveDetail(journalRef.current);
+
+    expect(screen.queryByText('fiscal.onboarding.goHome')).not.toBeInTheDocument();
+    expect(screen.getByText('fiscal.save')).toBeInTheDocument();
+  });
+});

--- a/tools/app-shell/src/windows/custom/fiscal-monitor/ContactDetailModal.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-monitor/ContactDetailModal.jsx
@@ -254,15 +254,24 @@ async function saveContactData({
   }
   setSaving(true);
   try {
+    // Thunks, not promises, and awaited one at a time (ETP-5112). Both are PUTs carrying their
+    // record's `updated` token, and core parses that token through a non-thread-safe static
+    // `SimpleDateFormat` (`JsonToDataConverter` line 129) — two writes arriving together corrupt
+    // each other's parse and one is refused as a conflict against a record nobody touched. This is
+    // the same two-write shape that reproduced it on the Organization screen.
+    //
+    // The request must NOT be started while building this list: calling `apiFetch` here would put
+    // both in flight immediately and awaiting them in order afterwards would serialise only the
+    // reading of the results, not the requests themselves — leaving the race exactly as it was.
     const saves = [
-      apiFetch(`/businessPartner/${bpId}`, {
+      () => apiFetch(`/businessPartner/${bpId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: name || null, taxID: taxID || null, oBTIKTaxIDKey: taxIDKey || null }),
       }),
     ];
     if (hasInvoice) {
-      saves.push(invoiceApiFetch(`/${invoiceSpec}/header/${invoiceId}`, {
+      saves.push(() => invoiceApiFetch(`/${invoiceSpec}/header/${invoiceId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -271,7 +280,10 @@ async function saveContactData({
         }),
       }));
     }
-    const results = await Promise.all(saves);
+    const results = [];
+    for (const save of saves) {
+      results.push(await save());
+    }
     if (results.every(r => r.ok)) {
       toast.success(ui('contactDetail.saved'));
       onClose();

--- a/tools/app-shell/src/windows/custom/fiscal-monitor/VfSolveErrorModal.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-monitor/VfSolveErrorModal.jsx
@@ -65,17 +65,36 @@ export default function VfSolveErrorModal({ open, onClose, rows, neoApiBase, onR
     if (saving || !canResolve) return;
     setSaving(true);
     try {
-      const results = await Promise.allSettled(
-        rows.map(r => {
-          if (isInvalid) {
+      // One row at a time, NOT `Promise.allSettled(rows.map(...))` (ETP-5112).
+      //
+      // Core parses the `updated` token of a write through a `private final static
+      // SimpleDateFormat` (`JsonToDataConverter` line 129), and `SimpleDateFormat` is not
+      // thread-safe — concurrent writes corrupt each other's parse and the concurrency check then
+      // refuses one of them with "the record has already been changed by another user", against a
+      // record nobody touched. Reproduced on the Organization screen, which fired just two
+      // concurrent PATCHes; this modal fans out one write PER SELECTED ROW, so it had more room to
+      // hit it, not less.
+      //
+      // Note this only became reachable here WITH ETP-5112: before it, these PUTs carried no
+      // `updated` at all, and core skips the parse entirely when the key is absent. Making every
+      // read remember its token is what brought this path into the race.
+      //
+      // `allSettled` semantics are preserved deliberately: each row is settled on its own and one
+      // failure must not skip the rows after it, which is what the per-row result list below and
+      // the partial-failure toast depend on. Sequential means N round trips for N invoices; that
+      // is the price of not corrupting the parse, and this is an operator action on a handful of
+      // rows, not a hot path.
+      const results = [];
+      for (const r of rows) {
+        try {
+          const value = isInvalid
             // Correct_Invoice is a Button-type process — must call the NEO action endpoint,
             // not a regular PUT (the backing table is a VIEW; PUT returns 200 but writes nothing).
-            return apiFetch(
+            ? await apiFetch(
               `/${VF_SPEC}/${encodeURIComponent(VF_INVALIDAS_ENTITY)}/${r.id}/action/Correct_Invoice`,
               { method: 'POST' },
-            );
-          } else {
-            return apiFetch(
+            )
+            : await apiFetch(
               `/${VF_SPEC}/${encodeURIComponent(VF_PARCIAL_ENTITY)}/${r.id}`,
               {
                 method: 'PUT',
@@ -83,9 +102,11 @@ export default function VfSolveErrorModal({ open, onClose, rows, neoApiBase, onR
                 body: JSON.stringify({ isSubsanation: true }),
               },
             );
-          }
-        })
-      );
+          results.push({ status: 'fulfilled', value });
+        } catch (err) {
+          results.push({ status: 'rejected', reason: err });
+        }
+      }
       const failed = results.filter(r => r.status === 'rejected' || (r.value && !r.value.ok));
       if (failed.length === 0) {
         toast.success(ui('vfSolveError.success'));

--- a/tools/app-shell/src/windows/custom/fiscal-monitor/__tests__/ContactDetailModal.serialization.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-monitor/__tests__/ContactDetailModal.serialization.vitest.jsx
@@ -1,0 +1,183 @@
+// ETP-5112 regression — `ContactDetailModal`'s save must issue its two PUTs one after the
+// other: the business partner record first, then the invoice record.
+//
+// Core parses a write's `updated` optimistic-locking token through a `private final static
+// SimpleDateFormat` (`JsonToDataConverter` line 129), which is not thread-safe. Two writes
+// landing on two Tomcat threads at once corrupt each other's parse and one comes back as a
+// 500 conflict against a record nobody touched — the same two-write shape that reproduced
+// it on the Organización screen.
+//
+// THE SPECIFIC REGRESSION THIS FILE EXISTS FOR: `saves` is a list of THUNKS
+// (`() => apiFetch(...)`), not of promises. Building the list as promises —
+// `const saves = [apiFetch(...), apiFetch(...)]` — puts BOTH requests in flight while the
+// array is being constructed, and the `for (const save of saves) results.push(await save)`
+// loop underneath then serializes only the READING of the results, leaving the race
+// exactly as it was. That variant passes any order-only assertion, and it passes any
+// assertion that only counts requests. It does not pass a non-overlap assertion, which is
+// why that is what this file checks. See `@/test/requestJournal.js`.
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createRequestJournal } from '@/test/requestJournal.js';
+
+const apiFetchMock = vi.fn();
+
+vi.mock('@/i18n', () => ({ useUI: () => (key) => key }));
+// One shared double for both bases (`contactsApiBase` and `neoApiBase`): the two writes are
+// told apart by their PATH, which is what the journal labels on.
+vi.mock('@/auth/useApiFetch.js', () => ({ useApiFetch: () => apiFetchMock }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('lucide-react', () => ({
+  X: () => <span data-testid="icon-x" />,
+  Loader2: () => <span data-testid="icon-loader" />,
+  MapPin: () => <span data-testid="icon-map" />,
+  ChevronDown: () => <span data-testid="icon-chevron" />,
+  Check: () => <span data-testid="icon-check" />,
+}));
+vi.mock('@/windows/custom/shared/LocationEditorModal.jsx', () => ({
+  default: () => <div data-testid="location-editor-modal" />,
+}));
+
+import ContactDetailModal from '../ContactDetailModal.jsx';
+import { toast } from 'sonner';
+
+const BP_ID = 'bp-1';
+const INVOICE_ID = 'inv-1';
+const INVOICE_SPEC = 'sales-invoice';
+
+const BP_LABEL = 'businessPartner';
+const INVOICE_LABEL = 'invoice';
+
+const baseProps = {
+  open: true,
+  onClose: vi.fn(),
+  bpId: BP_ID,
+  contactsApiBase: '/sws/neo/contacts',
+  invoiceId: INVOICE_ID,
+  invoiceSpec: INVOICE_SPEC,
+  neoApiBase: '/sws/neo',
+};
+
+function okJson(body) {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+/** The reads the modal performs on mount, none of which are journalled. */
+function readResponse(url) {
+  if (url.includes('/businessPartner/selectors')) {
+    return okJson({ items: [{ id: 'key1', label: 'NIF' }] });
+  }
+  if (url.includes('/locationAddress')) {
+    return okJson({ response: { data: [{ id: 'loc1', address: '1 St', city: 'Madrid' }] } });
+  }
+  if (url.includes(`/${INVOICE_SPEC}/header/`)) {
+    // `aeatsiiDescripcionSii` must be non-empty: the save handler refuses to write at all
+    // (and jumps to the invoice tab) when the SII description is blank.
+    return okJson({ response: { data: [{ id: INVOICE_ID, aeatsiiClaveTipo: '01', aeatsiiDescripcionSii: 'Operación interior' }] } });
+  }
+  if (url.includes('/businessPartner/')) {
+    return okJson({ response: { data: [{ id: BP_ID, name: 'Test BP', taxID: 'B1', oBTIKTaxIDKey: 'key1' }] } });
+  }
+  return okJson({});
+}
+
+function labelFor(url) {
+  return url.includes(`/${INVOICE_SPEC}/header/`) ? INVOICE_LABEL : BP_LABEL;
+}
+
+/**
+ * Journals the two PUTs and leaves every read untouched.
+ *
+ * The delay is on the business partner write — the FIRST of the two — because that is what
+ * forces a pre-launched (promise-built) `saves` array to stamp the invoice write's start
+ * tick while the BP write is still open.
+ */
+function installJournalledApiFetch({ bpDelayMs = 30, invoiceDelayMs = 0, failing = null } = {}) {
+  const journal = createRequestJournal();
+  apiFetchMock.mockImplementation((url, options) => {
+    if (options?.method !== 'PUT') return Promise.resolve(readResponse(url));
+    const label = labelFor(url);
+    return journal.track(label, {
+      delayMs: label === BP_LABEL ? bpDelayMs : invoiceDelayMs,
+      result: () => (failing === label ? { ok: false, status: 500 } : okJson({})),
+    });
+  });
+  return journal;
+}
+
+async function renderLoadedModal(props = {}) {
+  const merged = { ...baseProps, onClose: vi.fn(), ...props };
+  const utils = render(<ContactDetailModal {...merged} />);
+  await waitFor(() => expect(screen.getByText('save')).toBeInTheDocument());
+  return { ...utils, props: merged };
+}
+
+/** Saves and waits until both writes have SETTLED, not merely been issued. */
+async function clickSave(journal, expected = 2) {
+  fireEvent.click(screen.getByText('save'));
+  await waitFor(() => expect(journal.allSettled(expected)).toBe(true));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ContactDetailModal — save serialization (ETP-5112)', () => {
+  it('never has the invoice PUT in flight while the business partner PUT is open', async () => {
+    const journal = installJournalledApiFetch();
+    await renderLoadedModal();
+
+    await clickSave(journal);
+
+    expect(journal.labels()).toEqual([BP_LABEL, INVOICE_LABEL]);
+    // A `saves` array built from already-launched promises yields -2 here: the invoice
+    // write stamps its start tick at 2 while the BP write only settles at 4.
+    expect(journal.minOverlapGap()).toBeGreaterThan(0);
+  });
+
+  it('never overlaps when both writes are equally slow', async () => {
+    const journal = installJournalledApiFetch({ bpDelayMs: 20, invoiceDelayMs: 20 });
+    await renderLoadedModal();
+
+    await clickSave(journal);
+
+    expect(journal.entries).toHaveLength(2);
+    expect(journal.minOverlapGap()).toBeGreaterThan(0);
+  });
+
+  // A pre-launched list would fire the invoice write even for the branch that must not
+  // build one at all, so this pins the other half of the thunk contract.
+  it('issues only the business partner PUT when there is no invoice in context', async () => {
+    const journal = installJournalledApiFetch();
+    await renderLoadedModal({ invoiceId: null, invoiceSpec: null });
+
+    fireEvent.click(screen.getByText('save'));
+    await waitFor(() => expect(journal.allSettled(1)).toBe(true));
+
+    expect(journal.labels()).toEqual([BP_LABEL]);
+  });
+
+  it('reports success and closes only when both writes succeeded', async () => {
+    const journal = installJournalledApiFetch();
+    const { props } = await renderLoadedModal();
+
+    await clickSave(journal);
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('contactDetail.saved'));
+
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  // Semantics the serialization must preserve: the loop never breaks, so a failing first
+  // write must not skip the second one, and the modal must stay open on the error.
+  it('still issues the invoice PUT after the business partner PUT failed', async () => {
+    const journal = installJournalledApiFetch({ failing: BP_LABEL });
+    const { props } = await renderLoadedModal();
+
+    await clickSave(journal);
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('contactDetail.saveError'));
+
+    expect(journal.labels()).toEqual([BP_LABEL, INVOICE_LABEL]);
+    expect(journal.minOverlapGap()).toBeGreaterThan(0);
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+});

--- a/tools/app-shell/src/windows/custom/fiscal-monitor/__tests__/VfSolveErrorModal.serialization.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/fiscal-monitor/__tests__/VfSolveErrorModal.serialization.vitest.jsx
@@ -1,0 +1,202 @@
+// ETP-5112 regression — `VfSolveErrorModal.handleResolve` must write one selected row at a
+// time, never with `Promise.allSettled(rows.map(...))`.
+//
+// Core parses a write's `updated` optimistic-locking token through a `private final static
+// SimpleDateFormat` (`JsonToDataConverter` line 129), which is not thread-safe: two
+// concurrent writes corrupt each other's parse and one is refused as a conflict against a
+// record nobody touched. This modal fans out one write PER SELECTED INVOICE, so an
+// operator resolving a multi-row selection had more room to hit it, not less.
+//
+// Note this path only became reachable WITH ETP-5112: before it these PUTs carried no
+// `updated` at all, and core skips the parse entirely when the key is absent. Making every
+// read arm the write that follows is what brought this modal into the race.
+//
+// The assertion is NON-OVERLAP, not arrival order — `allSettled` maps in order too. See
+// `@/test/requestJournal.js`.
+//
+// `allSettled`'s per-row semantics are asserted alongside: one failing invoice must not
+// skip the invoices after it, and a partial failure must still surface as an error toast
+// rather than a success + close.
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createRequestJournal } from '@/test/requestJournal.js';
+
+const apiFetchMock = vi.fn();
+
+vi.mock('@/i18n', () => ({ useUI: () => (key) => key }));
+vi.mock('@/auth/useApiFetch.js', () => ({ useApiFetch: () => apiFetchMock }));
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('lucide-react', () => ({
+  X: () => <span data-testid="icon-x" />,
+  Loader2: () => <span data-testid="icon-loader" />,
+  AlertTriangle: () => <span data-testid="icon-alert" />,
+  ChevronDown: () => <span data-testid="icon-chevron-down" />,
+  ChevronUp: () => <span data-testid="icon-chevron-up" />,
+}));
+vi.mock('../FmPrimitives.jsx', () => ({
+  StatusPill: ({ estado }) => <span data-testid="status-pill">{estado}</span>,
+}));
+
+import VfSolveErrorModal from '../VfSolveErrorModal.jsx';
+import { toast } from 'sonner';
+
+// 'AE' = partially accepted → the PUT branch (`isSubsanation: true`), which is the write
+// shape the serialization protects. 'IN' would take the POST /action/Correct_Invoice
+// branch instead.
+const STATUS_PARTIAL = 'AE';
+const ROW_IDS = ['vf-1', 'vf-2', 'vf-3'];
+
+const rows = ROW_IDS.map(id => ({
+  id,
+  verifactuSendingStatus: STATUS_PARTIAL,
+  'invoice$documentNo': `DOC-${id}`,
+}));
+
+function okResponse() {
+  return { ok: true, status: 200, json: async () => ({ response: { data: [] } }) };
+}
+
+function idFromUrl(url) {
+  return ROW_IDS.find(id => url.includes(`/${id}`)) ?? url;
+}
+
+/**
+ * Journalling `apiFetch`. `delayedId` is held open long enough that a concurrent
+ * implementation starts the next PUT inside its window.
+ */
+function installJournalledApiFetch({ delayedId = ROW_IDS[0], failingIds = [] } = {}) {
+  const journal = createRequestJournal();
+  apiFetchMock.mockImplementation((url) => {
+    const id = idFromUrl(url);
+    return journal.track(id, {
+      delayMs: id === delayedId ? 30 : 0,
+      result: () => okResponse(),
+      fail: failingIds.includes(id) ? new Error(`network failure on ${id}`) : undefined,
+    });
+  });
+  return journal;
+}
+
+function renderModal(props = {}) {
+  const defaults = {
+    open: true,
+    onClose: vi.fn(),
+    rows,
+    neoApiBase: '/sws/neo',
+    onResolved: vi.fn(),
+  };
+  const merged = { ...defaults, ...props };
+  return { ...render(<VfSolveErrorModal {...merged} />), props: merged };
+}
+
+/**
+ * Clicks the modal's resolve button and waits until every tracked write has SETTLED — not
+ * merely been issued. Under a concurrent implementation the last request settles first, so
+ * asserting on call count alone would read a still-open first request as a clean gap.
+ */
+async function clickResolve(journal, expectedCalls = ROW_IDS.length) {
+  fireEvent.click(screen.getByText('vfSolveError.partial.action'));
+  await waitFor(() => expect(apiFetchMock).toHaveBeenCalledTimes(expectedCalls));
+  if (journal) await waitFor(() => expect(journal.allSettled(expectedCalls)).toBe(true));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('VfSolveErrorModal — resolve serialization (ETP-5112)', () => {
+  it('never has two invoice writes in flight at the same time', async () => {
+    const journal = installJournalledApiFetch();
+    renderModal();
+
+    await clickResolve(journal);
+
+    expect(journal.labels()).toEqual(ROW_IDS);
+    // `Promise.allSettled(rows.map(...))` yields -3 here: rows 2 and 3 stamp their start
+    // ticks while row 1 is still open.
+    expect(journal.minOverlapGap()).toBeGreaterThan(0);
+  });
+
+  it('never overlaps when every invoice is equally slow', async () => {
+    const journal = createRequestJournal();
+    apiFetchMock.mockImplementation((url) => journal.track(idFromUrl(url), {
+      delayMs: 15,
+      result: () => okResponse(),
+    }));
+    renderModal();
+
+    await clickResolve(journal);
+
+    expect(journal.entries).toHaveLength(ROW_IDS.length);
+    expect(journal.minOverlapGap()).toBeGreaterThan(0);
+  });
+
+  it('sends one PUT per selected invoice, carrying the subsanation flag', async () => {
+    const journal = installJournalledApiFetch();
+    renderModal();
+
+    await clickResolve(journal);
+
+    const calls = apiFetchMock.mock.calls;
+    expect(calls).toHaveLength(ROW_IDS.length);
+    calls.forEach(([url, options], i) => {
+      expect(url).toContain(`/${ROW_IDS[i]}`);
+      expect(options.method).toBe('PUT');
+      expect(JSON.parse(options.body)).toEqual({ isSubsanation: true });
+    });
+  });
+
+  it('reports success and closes only when every invoice succeeded', async () => {
+    const journal = installJournalledApiFetch();
+    const { props } = renderModal();
+
+    await clickResolve(journal);
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('vfSolveError.success'));
+
+    expect(props.onResolved).toHaveBeenCalled();
+    expect(props.onClose).toHaveBeenCalled();
+  });
+
+  // Semantics the serialization must preserve — the previous `allSettled` settled each row
+  // on its own, and a `break` on the first failure would silently drop the rest.
+  it('still writes the invoices after one that threw', async () => {
+    const journal = installJournalledApiFetch({ failingIds: [ROW_IDS[0]] });
+    renderModal();
+
+    await clickResolve(journal);
+
+    expect(journal.labels()).toEqual(ROW_IDS);
+    expect(journal.minOverlapGap()).toBeGreaterThan(0);
+  });
+
+  it('still writes the invoices after one that failed mid fan-out', async () => {
+    const journal = installJournalledApiFetch({ failingIds: [ROW_IDS[1]] });
+    renderModal();
+
+    await clickResolve(journal);
+
+    expect(journal.labels()).toContain(ROW_IDS[2]);
+  });
+
+  it('surfaces a partial failure as an error, without resolving or closing', async () => {
+    const journal = installJournalledApiFetch({ failingIds: [ROW_IDS[1]] });
+    const { props } = renderModal();
+
+    await clickResolve(journal);
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('vfSolveError.saveError'));
+
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(props.onResolved).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it('treats a non-ok response like a failure, not a success', async () => {
+    apiFetchMock.mockImplementation(async (url) => (
+      url.includes(ROW_IDS[2]) ? { ok: false, status: 500 } : okResponse()
+    ));
+    renderModal();
+
+    await clickResolve(null);
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('vfSolveError.saveError'));
+  });
+});

--- a/tools/app-shell/src/windows/custom/organization/__tests__/useActividadesIae.serialization.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/organization/__tests__/useActividadesIae.serialization.vitest.jsx
@@ -1,0 +1,183 @@
+// ETP-5112 regression — `enforceSingleDefault` must sweep its sibling rows one PATCH at a
+// time, never with `Promise.all(others.map(...))`.
+//
+// This is the worst shape for core's non-thread-safe `updated` parser
+// (`JsonToDataConverter` line 129, a `private final static SimpleDateFormat`): the sweep
+// fans out one write PER SIBLING ROW, so an organization with several IAE activities fires
+// N concurrent PATCHes and any two of them can corrupt each other's parse — the loser
+// coming back as a 500 conflict against a row nobody touched.
+//
+// The assertion is NON-OVERLAP, not arrival order: `Promise.all` maps in order too. See
+// `@/test/requestJournal.js`.
+//
+// The sweep's ORIGINAL semantics are asserted alongside, because the obvious "fix" —
+// breaking the loop on the first failure — would serialize correctly while silently
+// dropping the guarantee the hook's docstring makes: a failed sweep on one sibling must
+// not stop the others from being corrected.
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { createStableUseApiFetchMock } from '@/test/mockUseApiFetch.js';
+import { createRequestJournal } from '@/test/requestJournal.js';
+
+vi.mock('@/auth/useApiFetch.js', () => ({
+  useApiFetch: createStableUseApiFetchMock(),
+}));
+
+import { useActividadesIae } from '../useActividadesIae.js';
+
+const API_BASE_URL = '/sws/neo/organization';
+const ORG_ID = 'org-1';
+
+const KEEP_ID = 'row-keep';
+// Three siblings, not one: a single sweep target cannot expose an overlap, and the whole
+// point of this call site is that it fans out.
+const SIBLING_IDS = ['row-a', 'row-b', 'row-c'];
+
+const ALL_ROWS = [
+  { id: KEEP_ID, default: false, epiaeCode: 'K' },
+  ...SIBLING_IDS.map((id, i) => ({ id, default: true, epiaeCode: `S${i}` })),
+];
+
+function okJson(body) {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+function rowIdFromUrl(url) {
+  return url.split('/actividadesDelIae/')[1]?.split('?')[0] ?? null;
+}
+
+/** Mounts the hook with `ALL_ROWS` already loaded. */
+async function mountLoaded() {
+  globalThis.fetch = vi.fn(async () => okJson({ response: { data: ALL_ROWS } }));
+  const { result } = renderHook(() => useActividadesIae(ORG_ID, API_BASE_URL));
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  expect(result.current.rows).toHaveLength(ALL_ROWS.length);
+  return result;
+}
+
+/**
+ * Journalling `fetch` for the sweep. `delayedId` is held open long enough that a
+ * concurrent sweep would start the next PATCH inside its window; `failingIds` reject so
+ * the per-row `catch` and the loop's refusal to break can be asserted.
+ */
+function installJournalledFetch({ delayedId = SIBLING_IDS[0], failingIds = [] } = {}) {
+  const journal = createRequestJournal();
+  globalThis.fetch = vi.fn((url, options) => {
+    if (options?.method !== 'PATCH') return Promise.resolve(okJson({ response: { data: [] } }));
+    const id = rowIdFromUrl(url);
+    return journal.track(id, {
+      delayMs: id === delayedId ? 30 : 0,
+      result: () => (failingIds.includes(id)
+        ? { ok: false, status: 500, json: async () => ({}) }
+        : okJson({ response: { data: [{ id, default: false }] } })),
+    });
+  });
+  return journal;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useActividadesIae — enforceSingleDefault serialization (ETP-5112)', () => {
+  it('never has two sweep PATCHes in flight at the same time', async () => {
+    const result = await mountLoaded();
+    const journal = installJournalledFetch();
+
+    await act(async () => {
+      await result.current.enforceSingleDefault(KEEP_ID);
+    });
+
+    expect(journal.labels()).toEqual(SIBLING_IDS);
+    // `Promise.all(others.map(...))` yields -3 here: rows b and c stamp their start ticks
+    // while row a is still open.
+    expect(journal.minOverlapGap()).toBeGreaterThan(0);
+  });
+
+  it('never overlaps when every sibling is equally slow', async () => {
+    const result = await mountLoaded();
+    const journal = createRequestJournal();
+    globalThis.fetch = vi.fn((url, options) => {
+      if (options?.method !== 'PATCH') return Promise.resolve(okJson({ response: { data: [] } }));
+      return journal.track(rowIdFromUrl(url), {
+        delayMs: 15,
+        result: () => okJson({ response: { data: [] } }),
+      });
+    });
+
+    await act(async () => {
+      await result.current.enforceSingleDefault(KEEP_ID);
+    });
+
+    expect(journal.entries).toHaveLength(SIBLING_IDS.length);
+    expect(journal.minOverlapGap()).toBeGreaterThan(0);
+  });
+
+  it('does not touch the row being kept', async () => {
+    const result = await mountLoaded();
+    const journal = installJournalledFetch();
+
+    await act(async () => {
+      await result.current.enforceSingleDefault(KEEP_ID);
+    });
+
+    expect(journal.labels()).not.toContain(KEEP_ID);
+  });
+
+  it('clears every sibling with default:false, one body per row', async () => {
+    const result = await mountLoaded();
+    installJournalledFetch();
+
+    await act(async () => {
+      await result.current.enforceSingleDefault(KEEP_ID);
+    });
+
+    const patches = globalThis.fetch.mock.calls.filter(([, o]) => o?.method === 'PATCH');
+    expect(patches).toHaveLength(SIBLING_IDS.length);
+    patches.forEach(([, options]) => {
+      expect(JSON.parse(options.body)).toEqual({ default: false });
+    });
+  });
+
+  // Semantics the serialization must preserve — see the hook's docstring.
+  it('keeps sweeping the remaining siblings after one of them fails', async () => {
+    const result = await mountLoaded();
+    const journal = installJournalledFetch({ failingIds: [SIBLING_IDS[0]] });
+
+    await act(async () => {
+      // Swallowed per row: the caller must not see the failed sibling as a rejection.
+      await expect(result.current.enforceSingleDefault(KEEP_ID)).resolves.toBeUndefined();
+    });
+
+    expect(journal.labels()).toEqual(SIBLING_IDS);
+    expect(journal.minOverlapGap()).toBeGreaterThan(0);
+  });
+
+  it('keeps sweeping when the failure is in the middle of the fan-out', async () => {
+    const result = await mountLoaded();
+    const journal = installJournalledFetch({ failingIds: [SIBLING_IDS[1]] });
+
+    await act(async () => {
+      await result.current.enforceSingleDefault(KEEP_ID);
+    });
+
+    // The row AFTER the failing one was still attempted — a `break` would stop here.
+    expect(journal.labels()).toContain(SIBLING_IDS[2]);
+    expect(journal.labels()).toEqual(SIBLING_IDS);
+  });
+
+  it('issues no request at all when there is no other default row', async () => {
+    globalThis.fetch = vi.fn(async () => okJson({
+      response: { data: [{ id: KEEP_ID, default: false }, { id: 'other', default: false }] },
+    }));
+    const { result } = renderHook(() => useActividadesIae(ORG_ID, API_BASE_URL));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const journal = installJournalledFetch();
+    await act(async () => {
+      await result.current.enforceSingleDefault(KEEP_ID);
+    });
+
+    expect(journal.entries).toHaveLength(0);
+  });
+});

--- a/tools/app-shell/src/windows/custom/organization/__tests__/useOrganizationData.serialization.vitest.js
+++ b/tools/app-shell/src/windows/custom/organization/__tests__/useOrganizationData.serialization.vitest.js
@@ -1,0 +1,129 @@
+// ETP-5112 regression — `useOrganizationData.save()` must issue its two PATCHes one
+// AFTER the other, never concurrently.
+//
+// The Organización screen is the only one that writes two entities in a single save
+// (`AD_Org` as entity `organization`, `AD_OrgInfo` as entity `information`). Fired with
+// `Promise.all`, both PATCHes landed on two Tomcat threads in the same millisecond and
+// both parsed their `updated` token through core's `private final static
+// SimpleDateFormat` (`JsonToDataConverter` line 129) — which is not thread-safe. The
+// loser of the race got a corrupted `Date`, the concurrency check found a difference, and
+// the write came back 500 "the record has already been changed by another user" against a
+// record nobody had touched.
+//
+// The assertion is NON-OVERLAP, not arrival order: `Promise.all` also fires the two in
+// order, so an order-only test would pass against the exact defect this file guards.
+// See `@/test/requestJournal.js`.
+
+import { createStableUseApiFetchMock } from '@/test/mockUseApiFetch.js';
+
+vi.mock('@/auth/useApiFetch.js', () => ({
+  useApiFetch: createStableUseApiFetchMock(),
+}));
+
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { createRequestJournal } from '@/test/requestJournal.js';
+import { useOrganizationData } from '../useOrganizationData.js';
+
+const API_BASE_URL = '/sws/neo/organization';
+const ORG_ID = 'org-1';
+
+// AD_Org and AD_OrgInfo share the same primary key in Etendo, so the entity segment is
+// the only thing that tells the two requests apart.
+const HEADER_PATH = `/organization/organization/${ORG_ID}`;
+
+function okResponse(record = {}) {
+  return { ok: true, status: 200, json: async () => ({ response: { data: [record] } }) };
+}
+
+/** Mounts the hook and lets its initial load settle, so `save` starts from a clean slate. */
+async function mountLoaded() {
+  globalThis.fetch = vi.fn(async () => okResponse({ id: ORG_ID }));
+  const { result } = renderHook(() => useOrganizationData(ORG_ID, API_BASE_URL));
+  await waitFor(() => expect(result.current.loading).toBe(false));
+  return result;
+}
+
+/**
+ * Replaces `fetch` with a journalling double. Only PATCHes are tracked — the hook issues
+ * nothing else during a save, and tracking a stray GET would add a phantom entry.
+ *
+ * The delay goes on the FIRST of the two writes: that is what forces a concurrent
+ * implementation to stamp the second request's start tick while the first is still open.
+ */
+function installJournalledFetch({ headerDelayMs = 30, infoDelayMs = 0, failing = null } = {}) {
+  const journal = createRequestJournal();
+  globalThis.fetch = vi.fn((url, options) => {
+    if (options?.method !== 'PATCH') return Promise.resolve(okResponse());
+    const isHeader = url.includes(HEADER_PATH);
+    const label = isHeader ? 'organization' : 'information';
+    return journal.track(label, {
+      delayMs: isHeader ? headerDelayMs : infoDelayMs,
+      result: () => (failing === label
+        ? { ok: false, status: 500, json: async () => ({}) }
+        : okResponse()),
+    });
+  });
+  return journal;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useOrganizationData — save serialization (ETP-5112)', () => {
+  it('never has the information PATCH in flight while the organization PATCH is open', async () => {
+    const result = await mountLoaded();
+    const journal = installJournalledFetch();
+
+    await act(async () => {
+      await result.current.save({ header: { name: 'New name' }, info: { taxID: 'B999' } });
+    });
+
+    expect(journal.labels()).toEqual(['organization', 'information']);
+    // Strictly greater than zero: the second write started after the first one settled.
+    // `Promise.all` yields -2 here (second starts at tick 2, first settles at tick 4).
+    expect(journal.minOverlapGap()).toBeGreaterThan(0);
+  });
+
+  // Same guarantee with both writes held open for the same time, so the result does not
+  // depend on the first one being the slow one — under `Promise.all` the second still
+  // stamps its start tick inside the first one's window and the gap goes negative.
+  it('never overlaps when both writes are equally slow', async () => {
+    const result = await mountLoaded();
+    const journal = installJournalledFetch({ headerDelayMs: 20, infoDelayMs: 20 });
+
+    await act(async () => {
+      await result.current.save({ header: { name: 'x' }, info: { taxID: 'y' } });
+    });
+
+    expect(journal.entries).toHaveLength(2);
+    expect(journal.minOverlapGap()).toBeGreaterThan(0);
+  });
+
+  it('issues only the entity that was passed, and still awaits it', async () => {
+    const result = await mountLoaded();
+    const journal = installJournalledFetch();
+
+    await act(async () => {
+      await result.current.save({ header: null, info: { taxID: 'only-info' } });
+    });
+
+    expect(journal.labels()).toEqual(['information']);
+    const [entry] = journal.entries;
+    expect(entry.finishedAt).not.toBeNull();
+  });
+
+  it('still surfaces a failing write as a throw after serializing', async () => {
+    const result = await mountLoaded();
+    const journal = installJournalledFetch({ failing: 'organization' });
+
+    await expect(
+      result.current.save({ header: { name: 'x' }, info: { taxID: 'y' } }),
+    ).rejects.toThrow(/500/);
+
+    // Both writes are still attempted — the first one failing must not swallow the second,
+    // which is the behaviour the pre-ETP-5112 `Promise.all` had and the loop preserves.
+    expect(journal.labels()).toEqual(['organization', 'information']);
+    expect(journal.minOverlapGap()).toBeGreaterThan(0);
+  });
+});

--- a/tools/app-shell/src/windows/custom/organization/useActividadesIae.js
+++ b/tools/app-shell/src/windows/custom/organization/useActividadesIae.js
@@ -130,7 +130,19 @@ export function useActividadesIae(orgId, apiBaseUrl) {
     // a row this call already swept.
     rowsRef.current = rowsRef.current.map(r =>
       (others.some(o => o.id === r.id) ? { ...r, default: false } : r));
-    await Promise.all(others.map(r => patchRow(r.id, { default: false }).catch(() => null)));
+    // Swept one at a time, NOT `Promise.all(others.map(...))` (ETP-5112). Each `patchRow` is a
+    // PATCH carrying the row's `updated` token, and core parses that token through a
+    // non-thread-safe static `SimpleDateFormat` (`JsonToDataConverter` line 129); concurrent
+    // writes corrupt each other's parse and one comes back refused as a conflict against a row
+    // nobody touched. A sweep is the worst shape for it — it fans out one write per sibling row.
+    //
+    // The per-row `catch` stays and the loop never breaks: a failed sweep on one sibling must not
+    // stop the others from being corrected, which is what the docstring above promises. The
+    // optimistic marks in `rowsRef` are already written by the synchronous prefix, so overlapping
+    // callers still see them regardless of how long this loop takes.
+    for (const r of others) {
+      await patchRow(r.id, { default: false }).catch(() => null);
+    }
   }, [patchRow]);
 
   return {

--- a/tools/app-shell/src/windows/custom/organization/useOrganizationData.js
+++ b/tools/app-shell/src/windows/custom/organization/useOrganizationData.js
@@ -58,22 +58,46 @@ export function useOrganizationData(orgId, apiBaseUrl) {
 
   useEffect(() => { load(); }, [load]);
 
+  /**
+   * Saves both tabs, one request AFTER the other — never with `Promise.all` (ETP-5112).
+   *
+   * This screen is the only one that writes two entities in a single save, and running the two
+   * PATCHes concurrently made one of them fail with a 500 carrying core's "the record has already
+   * been changed by another user" message, against a record nobody else had touched.
+   *
+   * The cause is in core, not here: `JsonToDataConverter` holds its date parser in a
+   * `private final static SimpleDateFormat` (line 129 of that file), and `SimpleDateFormat` is not
+   * thread-safe — it keeps parsing state in a shared `Calendar` between calls. Both PATCHes
+   * arrived in the same millisecond on two Tomcat threads, both parsed their `updated` token
+   * through that one shared instance, and whichever lost the race got a corrupted `Date`. The
+   * concurrency check (`areDatesEqual`) then compared that garbage against the stored value, found
+   * a difference, and threw `OBStaleObjectException`. Verified in the Tomcat log: two `body
+   * recibido` lines stamped 21:07:38,375 on `exec-2` and `exec-3`, identical `updated` tokens, one
+   * 200 and one 500.
+   *
+   * Awaiting them in sequence removes the overlap, so the shared parser is only ever used by one
+   * thread at a time on this path. It costs one extra round trip on a screen that is saved rarely.
+   *
+   * This does NOT fix core's race — any other concurrent writer can still hit it, and the real
+   * repair is a `ThreadLocal` or a `DateTimeFormatter` in `JsonToDataConverter`. That lives in
+   * `modules_core` and affects all of Etendo, so it is deliberately out of scope here; this only
+   * stops the one screen that reproduces it 100% of the time.
+   */
   const save = useCallback(async ({ header, info }) => {
-    const requests = [];
+    const responses = [];
     if (header) {
-      requests.push(organizationApiFetch(`/organization/${orgId}`, {
+      responses.push(await organizationApiFetch(`/organization/${orgId}`, {
         method: 'PATCH',
         body: JSON.stringify(header),
       }));
     }
     if (info) {
-      requests.push(organizationApiFetch(`/information/${orgId}`, {
+      responses.push(await organizationApiFetch(`/information/${orgId}`, {
         method: 'PATCH',
         body: JSON.stringify(info),
       }));
     }
-    const results = await Promise.all(requests);
-    const failed = results.find(r => !r.ok);
+    const failed = responses.find(r => !r.ok);
     if (failed) throw new Error(`HTTP ${failed.status}`);
   }, [orgId, organizationApiFetch]);
 

--- a/tools/app-shell/src/windows/custom/price-list/__tests__/PriceListProductPrices.updatedToken.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/price-list/__tests__/PriceListProductPrices.updatedToken.vitest.jsx
@@ -1,0 +1,107 @@
+// ETP-5112 regression (bug 1) — the price-list product-price inline edit must send the
+// row's `updated` optimistic-locking token.
+//
+// ETP-5073 made the backend require the token of the record AS IT WAS READ; only
+// `useEntity` remembered one, so every panel that reads with `apiFetch` directly — this one
+// — patched without it and got 400 `missing_updated`. The fix is central, in
+// `@etendosoftware/app-shell-core` (`auth/api.js` harvests the token from every GET, keyed
+// by entity AND id, and injects it into the write that follows), so nothing in this screen
+// changed. What is pinned here is the screen's half of the contract: it reads its lines
+// through `apiFetch` at a path whose (entity, id) matches the write.
+//
+// ALL rows of the list read are harvested, not just row 0 — the row a user edits in a grid
+// is rarely the first one, which is what the second test covers.
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  neoResponse, bodyOf, writeCalls, resetRecordVersionsForTests,
+} from '@/test/realApiFetch.js';
+
+vi.mock('@/i18n', () => ({
+  useUI: () => (key) => key,
+  useLabel: () => (key) => key,
+}));
+
+// Same stub as the neighbouring suite: exposes one "edit" button per row that calls the
+// component's real `onUpdateRow` handler.
+vi.mock('@/components/contract-ui', () => ({
+  InlineLinesPanel: (props) => (
+    <div data-testid="inline-lines-panel">
+      {props.data?.map((row) => (
+        <button
+          key={row.id}
+          data-testid={`edit-listPrice-${row.id}`}
+          onClick={() => props.onUpdateRow(row, 'listPrice', '99')}>
+          edit
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+import PriceListProductPrices from '../PriceListProductPrices.jsx';
+
+const VERSION_ID = 'ver-1';
+const ROW_1 = { id: 'pp-1', product: 'prod-1', standardPrice: 10, listPrice: 12, updated: 'PP1-TOKEN' };
+const ROW_2 = { id: 'pp-2', product: 'prod-2', standardPrice: 20, listPrice: 25, updated: 'PP2-TOKEN' };
+
+const defaultProps = {
+  recordId: 'rec-1',
+  data: { id: 'rec-1', priceListVersion: VERSION_ID },
+  token: 'test-token',
+  apiBaseUrl: 'http://localhost/sws/neo/price-list',
+  editing: true,
+};
+
+function installFetch(rows) {
+  globalThis.fetch = vi.fn((url, init = {}) => {
+    const method = String(init.method || 'GET').toUpperCase();
+    if (method === 'GET' && url.includes('/productPrice?parentId=')) return Promise.resolve(neoResponse(rows));
+    return Promise.resolve(neoResponse([]));
+  });
+  return globalThis.fetch;
+}
+
+beforeEach(() => {
+  resetRecordVersionsForTests();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('PriceListProductPrices — updated token (ETP-5112)', () => {
+  it('sends the line updated token it read, on the inline price PATCH', async () => {
+    const fetchMock = installFetch([ROW_1, ROW_2]);
+    const user = userEvent.setup();
+    render(<PriceListProductPrices {...defaultProps} />);
+
+    await screen.findByTestId('edit-listPrice-pp-1');
+    await user.click(screen.getByTestId('edit-listPrice-pp-1'));
+
+    await waitFor(() => expect(writeCalls(fetchMock)).toHaveLength(1));
+
+    const [call] = writeCalls(fetchMock);
+    expect(call[0]).toContain('/productPrice/pp-1');
+    const body = bodyOf(call);
+    expect(body.updated).toBe(ROW_1.updated);
+    expect(body.listPrice).toBe(99);
+  });
+
+  it('sends the SECOND row token when the second row is the one edited', async () => {
+    const fetchMock = installFetch([ROW_1, ROW_2]);
+    const user = userEvent.setup();
+    render(<PriceListProductPrices {...defaultProps} />);
+
+    await screen.findByTestId('edit-listPrice-pp-2');
+    await user.click(screen.getByTestId('edit-listPrice-pp-2'));
+
+    await waitFor(() => expect(writeCalls(fetchMock)).toHaveLength(1));
+
+    const [call] = writeCalls(fetchMock);
+    expect(call[0]).toContain('/productPrice/pp-2');
+    expect(bodyOf(call).updated).toBe(ROW_2.updated);
+  });
+});

--- a/tools/app-shell/src/windows/custom/product/__tests__/ProductPriceBar.updatedToken.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/product/__tests__/ProductPriceBar.updatedToken.vitest.jsx
@@ -1,0 +1,142 @@
+// ETP-5112 regression (bug 1) — ProductPriceBar's inline price edit must send the row's
+// `updated` optimistic-locking token.
+//
+// ETP-5073 made the backend require the token of the record AS IT WAS READ; only
+// `useEntity` remembered one, so every panel that reads with `apiFetch` directly — this one
+// — patched without it and the server answered 400 `missing_updated`. The fix is central,
+// in `@etendosoftware/app-shell-core` (`auth/api.js` harvests the token from every GET,
+// keyed by entity AND id, and injects it into the PUT/PATCH that follows), so NOTHING in
+// this screen changed. What this test pins is the screen's half of that contract: it reads
+// its rows through `apiFetch` at a path whose (entity, id) matches the write, which is the
+// only reason the injection has anything to inject.
+//
+// The real `createApiFetch` is deliberately NOT stubbed here — see `@/test/realApiFetch.js`
+// for why a `useApiFetch` double would make this test vacuous.
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+  neoResponse, bodyOf, writeCalls, resetRecordVersionsForTests,
+} from '@/test/realApiFetch.js';
+
+vi.mock('@/i18n', () => ({
+  useUI: () => (key) => key,
+  useLabel: () => (key) => key,
+  useMenuLabel: () => (key) => key,
+}));
+
+vi.mock('@/lib/selectorCatalog.js', () => ({ getCatalogOptions: () => [] }));
+
+// Stub every icon the tree pulls in (shared Dialog, CreatableSearchSelect, the steppers).
+vi.mock('lucide-react', () => {
+  const isReserved = (prop) => typeof prop !== 'string' || prop === 'then' || prop === '__esModule';
+  return new Proxy({}, {
+    has: (_t, prop) => !isReserved(prop),
+    get: (_t, prop) => (isReserved(prop) ? undefined : (props) => <span {...props} />),
+  });
+});
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+
+import ProductPriceBar from '../ProductPriceBar.jsx';
+
+const ROW_ID = 'price-s1';
+// Deliberately not date-shaped: the client must forward whatever opaque string the read
+// returned, and a crossed or invented token has to be obvious in the failure output.
+const ROW_TOKEN = 'PRICE-ROW-TOKEN-0001';
+
+function salesRow(overrides = {}) {
+  return {
+    id: ROW_ID,
+    standardPrice: 23,
+    listPrice: 25,
+    priceListVersion: 'plv-sales-1',
+    'priceListVersion$_identifier': 'Sales List v1',
+    'priceListVersion$salesPriceList': true,
+    updated: ROW_TOKEN,
+    ...overrides,
+  };
+}
+
+function installFetch(rows) {
+  globalThis.fetch = vi.fn((url, init = {}) => {
+    const method = String(init.method || 'GET').toUpperCase();
+    if (method === 'GET' && url.includes('/price?parentId=')) return Promise.resolve(neoResponse(rows));
+    if (method === 'PATCH' && url.includes(`/price/${ROW_ID}`)) return Promise.resolve(neoResponse([]));
+    return Promise.resolve(neoResponse([]));
+  });
+  return globalThis.fetch;
+}
+
+function renderBar(overrides = {}) {
+  return render(
+    <ProductPriceBar
+      data={{ id: 'prod-1' }}
+      token="tok"
+      apiBaseUrl="/api/product"
+      catalogs={{}}
+      api={{ selectors: [] }}
+      onCountChange={vi.fn()}
+      {...overrides} />,
+  );
+}
+
+beforeEach(() => {
+  // The version cache is module-global in the core helper; without this a token remembered
+  // by one test could make the next one pass for the wrong reason.
+  resetRecordVersionsForTests();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ProductPriceBar — updated token (ETP-5112)', () => {
+  it('sends the row updated token it read, on the inline price PATCH', async () => {
+    const fetchMock = installFetch([salesRow({ standardPrice: 10 })]);
+    const user = userEvent.setup();
+    renderBar();
+
+    await screen.findByDisplayValue('Sales List v1');
+
+    const spinbuttons = screen.getAllByRole('spinbutton');
+    await user.clear(spinbuttons[0]);
+    await user.type(spinbuttons[0], '99');
+    await user.tab();
+
+    await waitFor(() => expect(writeCalls(fetchMock)).toHaveLength(1));
+
+    const body = bodyOf(writeCalls(fetchMock)[0]);
+    expect(body.updated).toBe(ROW_TOKEN);
+    // The field being edited still goes out — the injection adds to the body, never replaces it.
+    expect(body).toHaveProperty('standardPrice');
+  });
+
+  it('picks the token of the row actually edited, not of the first row in the list', async () => {
+    const otherRow = salesRow({
+      id: 'price-s0',
+      updated: 'OTHER-ROW-TOKEN',
+      'priceListVersion$_identifier': 'Sales List v0',
+      priceListVersion: 'plv-sales-0',
+    });
+    const fetchMock = installFetch([otherRow, salesRow({ standardPrice: 10 })]);
+    const user = userEvent.setup();
+    renderBar();
+
+    await screen.findByDisplayValue('Sales List v1');
+
+    // Rows render in list order, and each row contributes two spinbuttons (unit, list
+    // price) — index 2 is the SECOND row's unit price.
+    const spinbuttons = screen.getAllByRole('spinbutton');
+    await user.clear(spinbuttons[2]);
+    await user.type(spinbuttons[2], '77');
+    await user.tab();
+
+    await waitFor(() => expect(writeCalls(fetchMock)).toHaveLength(1));
+
+    const [call] = writeCalls(fetchMock);
+    expect(call[0]).toContain(`/price/${ROW_ID}`);
+    expect(bodyOf(call).updated).toBe(ROW_TOKEN);
+  });
+});

--- a/tools/app-shell/src/windows/custom/sales-invoice/__tests__/ReversedInvoicesPanel.updatedToken.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/sales-invoice/__tests__/ReversedInvoicesPanel.updatedToken.vitest.jsx
@@ -1,0 +1,126 @@
+// ETP-5112 regression (bug 1) — the Rectificaciones panel must send the line's `updated`
+// optimistic-locking token on its PATCH.
+//
+// ETP-5073 made the backend require the token of the record AS IT WAS READ; only
+// `useEntity` remembered one, so every panel that reads with `apiFetch` directly — this one
+// — patched without it and got 400 `missing_updated`. The fix is central, in
+// `@etendosoftware/app-shell-core` (`auth/api.js` harvests the token from every GET, keyed
+// by entity AND id, and injects it into the write that follows), so nothing in this screen
+// changed. What is pinned here is the screen's half: it lists its lines through `apiFetch`
+// at a path whose entity (`reversedInvoices`) matches the one it writes to.
+//
+// The real `createApiFetch` is deliberately not stubbed — see `@/test/realApiFetch.js`.
+
+vi.mock('@/i18n', () => ({
+  useUI: () => (key) => key,
+  useLabel: () => (key) => key,
+  useLocaleSwitch: () => ({ locale: 'es_ES', setLocale: () => {} }),
+}));
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn(), message: vi.fn() } }));
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  jsonResponse, neoResponse, bodyOf, writeCalls, resetRecordVersionsForTests,
+} from '@/test/realApiFetch.js';
+import ReversedInvoicesPanel from '../ReversedInvoicesPanel.jsx';
+
+const RECORD_ID = 'rec-1';
+const API_BASE = '/sws/neo/sales-invoice';
+const LINE_ID = 'line-1';
+const LINE_TOKEN = 'RECT-LINE-TOKEN-0001';
+
+const YEARS = [{ id: 'y2026', fiscalYear: '2026' }];
+
+/** A rectification line that is already corrective, so unchecking PATCHes immediately. */
+const correctiveLine = (overrides = {}) => ({
+  id: LINE_ID,
+  invoice: RECORD_ID,
+  'reversedInvoice$_identifier': '10000067 - 05-06-2026 - 2854.20',
+  reversedInvoice: 'inv-orig-1',
+  aEAT349IsCorrective: 'Y',
+  aEAT349CYear: 'y2026',
+  'aEAT349CYear$_identifier': '2026',
+  aEAT349Period: '1T',
+  updated: LINE_TOKEN,
+  ...overrides,
+});
+
+function installFetch({ lines = [] } = {}) {
+  globalThis.fetch = vi.fn((rawUrl, init = {}) => {
+    const url = String(rawUrl);
+    const method = String(init.method || 'GET').toUpperCase();
+    if (method === 'GET' && url.includes('/fiscal-models-catalog')) {
+      // Not a NEO record envelope — the panel reads this catalog as a bare object.
+      return Promise.resolve(jsonResponse({ 349: true }));
+    }
+    if (method === 'GET' && url.includes('/fiscal-calendar/year')) return Promise.resolve(neoResponse(YEARS));
+    if (method === 'GET' && url.includes('/reversedInvoices')) return Promise.resolve(neoResponse(lines));
+    if (method === 'GET' && url.includes('/header')) return Promise.resolve(neoResponse([]));
+    return Promise.resolve(neoResponse([]));
+  });
+  return globalThis.fetch;
+}
+
+function renderPanel(fetchOptions) {
+  installFetch(fetchOptions);
+  return render(
+    <ReversedInvoicesPanel
+      recordId={RECORD_ID}
+      data={{ id: RECORD_ID, isRectificative: true, processed: false, documentStatus: 'DR' }}
+      token="tkn"
+      apiBaseUrl={API_BASE}
+      api={{}}
+      catalogs={{}}
+      isActive />,
+  );
+}
+
+async function expandFirstRow() {
+  fireEvent.click(await screen.findByRole('button', { name: 'rectExpand' }));
+}
+
+beforeEach(() => {
+  resetRecordVersionsForTests();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('ReversedInvoicesPanel — updated token (ETP-5112)', () => {
+  it('sends the line updated token it read, on the corrective PATCH', async () => {
+    renderPanel({ lines: [correctiveLine()] });
+    const fetchMock = globalThis.fetch;
+    await expandFirstRow();
+
+    // Unchecking a fully-configured corrective line PATCHes immediately.
+    fireEvent.click(screen.getByTestId('checkbox__isCorrective'));
+
+    await waitFor(() => expect(writeCalls(fetchMock)).toHaveLength(1));
+
+    const [call] = writeCalls(fetchMock);
+    expect(call[0]).toContain(`/reversedInvoices/${LINE_ID}`);
+    const body = bodyOf(call);
+    expect(body.updated).toBe(LINE_TOKEN);
+    expect(body.aEAT349IsCorrective).toBe('N');
+  });
+
+  it('sends the token of the row actually edited, not of the first row listed', async () => {
+    const other = correctiveLine({ id: 'line-0', updated: 'OTHER-LINE-TOKEN' });
+    renderPanel({ lines: [other, correctiveLine()] });
+    const fetchMock = globalThis.fetch;
+
+    const chevrons = await screen.findAllByRole('button', { name: 'rectExpand' });
+    fireEvent.click(chevrons[1]);
+
+    fireEvent.click(screen.getByTestId('checkbox__isCorrective'));
+
+    await waitFor(() => expect(writeCalls(fetchMock)).toHaveLength(1));
+
+    const [call] = writeCalls(fetchMock);
+    expect(call[0]).toContain(`/reversedInvoices/${LINE_ID}`);
+    expect(bodyOf(call).updated).toBe(LINE_TOKEN);
+  });
+});


### PR DESCRIPTION
## Problem

Two bugs, the second uncovered by fixing the first.

**1 — Saving failed with `400 missing_updated`.** ETP-5073 made the backend require the `updated` token of a record as it was read. On the client that token was only remembered by `useEntity`, so every screen that loads its data with a direct `apiFetch` GET sent its PATCH without one and the server refused the write. Around 15 screens were affected, including the generic `ListModalWindow`.

**2 — Saving then failed with a false `500` concurrency conflict.** With the token finally being sent, the Organization screen started answering "The record you are saving has already been changed by another user or process" against a record nobody had touched. Core parses that token through a `private final static SimpleDateFormat` (`JsonToDataConverter` line 129), and `SimpleDateFormat` is not thread-safe: the screen fired both of its PATCHes with `Promise.all`, they landed in the same millisecond on two Tomcat threads, and whichever lost the race got a corrupted date.

Tomcat log, before the fix — same millisecond, identical token, one 200 and one 500:

```
21:07:38,375 [exec-3] body recibido: {"name":"Valetinendo",...,"updated":"2026-09-01T11:45:37+00:00"}
21:07:38,375 [exec-2] body recibido: {"taxID":"?",...,"updated":"2026-09-01T11:45:37+00:00"}
21:07:38,552 [exec-2] entity=information,  status=success, httpStatus=200
21:07:38,631 [exec-3] entity=organization, status=failed,  httpStatus=500
```

## Changes

**Bug 1 — no screen was touched.** The fix is central, in `schema_forge_core` (PR #168): `apiFetch` now harvests record versions from successful GETs, keyed by `(entity, id)`. This PR only consumes it. The absence of per-screen patches is deliberate, not an oversight.

**Bug 2 — six write paths serialized.** Every one fired concurrent updates that each carry an `updated` token:

| File | Shape |
|---|---|
| `organization/useOrganizationData.js` | two fixed PATCHes |
| `organization/useActividadesIae.js` | one PATCH per sibling row in the default sweep |
| `fiscal-monitor/VfSolveErrorModal.jsx` | one PUT per selected row |
| `fiscal-monitor/ContactDetailModal.jsx` | two PUTs |
| `fiscal-config/FiscalConfigPage.jsx` | two section saves |
| `fiscal-config/OnboardingWizard.jsx` | two section saves |

`allSettled` semantics are preserved where they existed: a failure on one row still lets the rest proceed, and per-row results still drive the partial-failure toasts.

Note `ContactDetailModal` needed thunks rather than promises. Its list was built by calling `apiFetch` up front, so both requests were already in flight and awaiting them in order would have serialized only the reading of results, not the requests.

## Tests

- **44 new Vitest tests** across the six screens plus five token-injection screens. Full app-shell suite: 14403 passed.
- **Mutation-tested.** Reverting each serialization to `Promise.all` makes the matching tests fail, with the overlap gap going negative by the full delay window. The assertion is absence of overlap, not arrival order — an order assertion would pass with the bug present.
- **2 E2E specs** for the Organization save: a mocked one (4 tests, always runs) and a gated integration one, both verified passing. The mocked spec asserts each entity sends its own token, which is what fails if the version cache ever goes back to being keyed by id alone.

## Notes

- **This PR must not merge before `schema_forge_core` #168.** `package.json` currently pins a preview build (`0.3.44-preview.feature-ETP-5112…`); it needs bumping to the published version once #168 lands.
- Core's race is not fixed by this, only avoided on these paths. Any other concurrent writer still hits it — reported as etendosoftware/etendo_core#1145.
- `FiscalConfigPage` turned out unable to issue two saves at all (only the active tab's section is mounted), so its change is defensive. The committed test pins that fact so it fails the day it changes.
- The backend-side logging for these refusals is in com.etendoerp.go PR #991.
- The pre-push integration suite was red on unrelated specs (assets, cash-close, user-invitation) while the local Tomcat was OOM-ing and the machine was under load average 74; those specs have prior flakiness history and touch none of the files here. Flagged rather than hidden.
