### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.44

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.43",
-        "@etendosoftware/schema-forge-cli": "0.3.43",
-        "@etendosoftware/schema-forge-core": "0.3.43",
+        "@etendosoftware/app-shell-core": "0.3.44",
+        "@etendosoftware/schema-forge-cli": "0.3.44",
+        "@etendosoftware/schema-forge-core": "0.3.44",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,13 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.43",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.43/51a3a966b9ff30a108f44bd9973ce8eab2bce3c0",
-      "integrity": "sha512-hROM+bplUsJkkiNLWzrmM0n92xZTgepwh8U/YSsRyv8Wt4MNIFkkecckvQHiQOiPI84AGL9oQwveVEilONwe6g==",
+      "version": "0.3.44",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.44/1b8c964b989acf8b62fb5e5d3a1350087b3dc017",
+      "integrity": "sha512-wMJT/rPZ9X2VbWkvast0jkMn3Tx1uKaAhwpf6tYPUqJRYq+b3QFJuPFy79Up5GCnI6oy/0GHWssUTn2abts51g==",
+      "dependencies": {
+        "read-excel-file": "^9.3.10",
+        "write-excel-file": "^4.1.1"
+      },
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2572,9 +2576,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.43",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.43/80a9abc49655f8d3d38ce286fcaf894cec651cb5",
-      "integrity": "sha512-rv6GI5L/ukRABzGgZR7D2kIMd4hu/AjNn9dcgPJRcOC9yxdNbt5FPC2veFuKcLxLtz/ipUtA5uSoFSv4uCirBQ==",
+      "version": "0.3.44",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.44/a9ec87d2665bac7bbf85be36c59873467701978f",
+      "integrity": "sha512-FOCeu3C+zKTvoFDFgzK046nqSZUFXmm12GOH0MClN6vE8h3AFQNsqLq650MN6+hQu9U2UyOlBkEdABndWa5Fjw==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2584,9 +2588,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.43",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.43/0553fba76456eb3212b6690ee303bbc2f0a52388",
-      "integrity": "sha512-et8TLJHjTTyXLzKabruqY2b0LMhekyDagItkXMMrHwOABw0pT54vaGyEJc8ruAG2pi1+r7uHllKlQ1e+JXG2DQ==",
+      "version": "0.3.44",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.44/ab69c2061fa054d6b1062c87164fd91b66db8970",
+      "integrity": "sha512-bLuC816h823xfIKTlH3Uey7ba0nF+heOwdy3i3FSLB1p84gY492D5dlZ5W0OxPUppQbkN+FCyDzegk7C3ADUvA==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2631,9 +2635,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.43",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.43/ad5dcfd01548e813db8b297f0fea7a2cbc728cc1",
-      "integrity": "sha512-F4AdSotk0Esq3LTuEe0u9ofkU816rk0BzSoKhvhnVx+naEsOMhQO90Pw5JrFdokXt7LAOibnP+UHqaTjZeYurA==",
+      "version": "0.3.44",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.44/2c9b8a193f7324e16606d6f69af786f7ab23fe57",
+      "integrity": "sha512-eD4U1aSaSjQLx2/rtvw8AeG9r9rbMTUxUCKoBHCC6IFLQywkXoW1u+L3+q7rfoOLspN7uFBBIqobUHYadDdW4Q==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -7176,6 +7180,12 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/figures": {
       "version": "6.1.0",
       "dev": true,
@@ -7664,7 +7674,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphql": {
@@ -9308,6 +9317,12 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "dev": true,
@@ -10688,6 +10703,21 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/read-excel-file": {
+      "version": "9.3.10",
+      "resolved": "https://registry.npmjs.org/read-excel-file/-/read-excel-file-9.3.10.tgz",
+      "integrity": "sha512-zFcBdzunLCGBmLRT4Q3mLPJnhKPAXXfGAZ83feODlEqX2aRUbgF1h/n2oY0UF7I8tVwnJNRas6fTRD5veDUs+g==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.3",
+        "saxen": "^11.1.0",
+        "unzipper-esm": "^0.13.3",
+        "worker-f": "^0.1.12"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "dev": true,
@@ -11076,6 +11106,15 @@
       "version": "2.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/saxen": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-11.1.1.tgz",
+      "integrity": "sha512-J4BkmJFaM7VgE7pgkFGsNEcqqM3h7+Mz80vfLWFhx7uNOCOXIu6LLjQHYWNejdst3pf/3JUaBIG9+pkk1umlow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.12"
+      }
     },
     "node_modules/saxes": {
       "version": "6.0.0",
@@ -12244,6 +12283,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/kettanaito"
+      }
+    },
+    "node_modules/unzipper-esm": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/unzipper-esm/-/unzipper-esm-0.13.3.tgz",
+      "integrity": "sha512-LUO6VZ6fCzkDbdMev0/fOhoIeVGKaOkTIOoYxVLE0SQjfvmAHK+oywl7lfhloSZIsdGJ25mJ18Mtd9CyTASjrA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/upath": {
@@ -13545,6 +13597,15 @@
         "workbox-core": "7.4.0"
       }
     },
+    "node_modules/worker-f": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/worker-f/-/worker-f-0.1.20.tgz",
+      "integrity": "sha512-7z5K5z4x++FykhpDTfriT/dOu7CmSap9BBv38DVFU3CD38obopq+DoFH75yBV3butpGm+OeqR9BKdSvYJSnUfQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
       "license": "MIT",
@@ -13594,6 +13655,18 @@
       "version": "1.0.2",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/write-excel-file": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/write-excel-file/-/write-excel-file-4.1.1.tgz",
+      "integrity": "sha512-MUnCnNtQrcZek832ZcU24uU0rSphFmKPD1DvIjXOlygVb93CV7Tme6H3jUTkxsMmjB2W7HIzERzjqTi5kui71A==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/write-file-atomic": {
       "version": "5.0.1",
@@ -13780,8 +13853,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.43",
-        "@etendosoftware/etendo-go-core": "0.3.43",
+        "@etendosoftware/app-shell-core": "0.3.44",
+        "@etendosoftware/etendo-go-core": "0.3.44",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.43",
-    "@etendosoftware/schema-forge-cli": "0.3.43",
-    "@etendosoftware/schema-forge-core": "0.3.43",
+    "@etendosoftware/app-shell-core": "0.3.44",
+    "@etendosoftware/schema-forge-cli": "0.3.44",
+    "@etendosoftware/schema-forge-core": "0.3.44",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.43",
-        "@etendosoftware/etendo-go-core": "0.3.43",
+        "@etendosoftware/app-shell-core": "0.3.44",
+        "@etendosoftware/etendo-go-core": "0.3.44",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,13 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.43",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.43/51a3a966b9ff30a108f44bd9973ce8eab2bce3c0",
-      "integrity": "sha512-hROM+bplUsJkkiNLWzrmM0n92xZTgepwh8U/YSsRyv8Wt4MNIFkkecckvQHiQOiPI84AGL9oQwveVEilONwe6g==",
+      "version": "0.3.44",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.44/1b8c964b989acf8b62fb5e5d3a1350087b3dc017",
+      "integrity": "sha512-wMJT/rPZ9X2VbWkvast0jkMn3Tx1uKaAhwpf6tYPUqJRYq+b3QFJuPFy79Up5GCnI6oy/0GHWssUTn2abts51g==",
+      "dependencies": {
+        "read-excel-file": "^9.3.10",
+        "write-excel-file": "^4.1.1"
+      },
       "peerDependencies": {
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2476,9 +2480,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.43",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.43/80a9abc49655f8d3d38ce286fcaf894cec651cb5",
-      "integrity": "sha512-rv6GI5L/ukRABzGgZR7D2kIMd4hu/AjNn9dcgPJRcOC9yxdNbt5FPC2veFuKcLxLtz/ipUtA5uSoFSv4uCirBQ==",
+      "version": "0.3.44",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.44/a9ec87d2665bac7bbf85be36c59873467701978f",
+      "integrity": "sha512-FOCeu3C+zKTvoFDFgzK046nqSZUFXmm12GOH0MClN6vE8h3AFQNsqLq650MN6+hQu9U2UyOlBkEdABndWa5Fjw==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -6684,6 +6688,12 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/filelist": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
@@ -7043,7 +7053,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/handlebars": {
@@ -8304,6 +8313,12 @@
         "webidl-conversions": "^3.0.0"
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.51",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
@@ -9077,6 +9092,21 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/read-excel-file": {
+      "version": "9.3.10",
+      "resolved": "https://registry.npmjs.org/read-excel-file/-/read-excel-file-9.3.10.tgz",
+      "integrity": "sha512-zFcBdzunLCGBmLRT4Q3mLPJnhKPAXXfGAZ83feODlEqX2aRUbgF1h/n2oY0UF7I8tVwnJNRas6fTRD5veDUs+g==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.3",
+        "saxen": "^11.1.0",
+        "unzipper-esm": "^0.13.3",
+        "worker-f": "^0.1.12"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -9386,6 +9416,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxen": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-11.1.1.tgz",
+      "integrity": "sha512-J4BkmJFaM7VgE7pgkFGsNEcqqM3h7+Mz80vfLWFhx7uNOCOXIu6LLjQHYWNejdst3pf/3JUaBIG9+pkk1umlow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.12"
       }
     },
     "node_modules/saxes": {
@@ -10398,6 +10437,19 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unzipper-esm": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/unzipper-esm/-/unzipper-esm-0.13.3.tgz",
+      "integrity": "sha512-LUO6VZ6fCzkDbdMev0/fOhoIeVGKaOkTIOoYxVLE0SQjfvmAHK+oywl7lfhloSZIsdGJ25mJ18Mtd9CyTASjrA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/upath": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
@@ -11178,6 +11230,15 @@
         "workbox-core": "7.4.1"
       }
     },
+    "node_modules/worker-f": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/worker-f/-/worker-f-0.1.20.tgz",
+      "integrity": "sha512-7z5K5z4x++FykhpDTfriT/dOu7CmSap9BBv38DVFU3CD38obopq+DoFH75yBV3butpGm+OeqR9BKdSvYJSnUfQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
@@ -11205,6 +11266,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/write-excel-file": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/write-excel-file/-/write-excel-file-4.1.1.tgz",
+      "integrity": "sha512-MUnCnNtQrcZek832ZcU24uU0rSphFmKPD1DvIjXOlygVb93CV7Tme6H3jUTkxsMmjB2W7HIzERzjqTi5kui71A==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/xml-name-validator": {

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.43",
-    "@etendosoftware/etendo-go-core": "0.3.43",
+    "@etendosoftware/app-shell-core": "0.3.44",
+    "@etendosoftware/etendo-go-core": "0.3.44",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.44`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.