### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.45

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.44",
-        "@etendosoftware/schema-forge-cli": "0.3.44",
-        "@etendosoftware/schema-forge-core": "0.3.44",
+        "@etendosoftware/app-shell-core": "0.3.45",
+        "@etendosoftware/schema-forge-cli": "0.3.45",
+        "@etendosoftware/schema-forge-core": "0.3.45",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.44",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.44/1b8c964b989acf8b62fb5e5d3a1350087b3dc017",
-      "integrity": "sha512-wMJT/rPZ9X2VbWkvast0jkMn3Tx1uKaAhwpf6tYPUqJRYq+b3QFJuPFy79Up5GCnI6oy/0GHWssUTn2abts51g==",
+      "version": "0.3.45",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.45/66759a6ba4739b720a91f42936185b0a8c4cdc6c",
+      "integrity": "sha512-gaHi7qC5ZGNkQU1QbpgM82hp3IjQpTJWJETCpvHz2ZHvmdntmL1/m8NEsaTudQ8qXKS7h3EZZDBFsiunfRYTRA==",
       "dependencies": {
         "read-excel-file": "^9.3.10",
         "write-excel-file": "^4.1.1"
@@ -2576,9 +2576,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.44",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.44/a9ec87d2665bac7bbf85be36c59873467701978f",
-      "integrity": "sha512-FOCeu3C+zKTvoFDFgzK046nqSZUFXmm12GOH0MClN6vE8h3AFQNsqLq650MN6+hQu9U2UyOlBkEdABndWa5Fjw==",
+      "version": "0.3.45",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.45/94f56470620ceda90f66f4f09431187fe699f989",
+      "integrity": "sha512-f0WlzHwr7sDAc+f/9PQjLlk/yTjzQ5BdAEbwasFQHdSJzPECXhEcTOc6H39FlZQGlw/BRatzRoGb/IZ4IvvMZw==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2588,9 +2588,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.44",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.44/ab69c2061fa054d6b1062c87164fd91b66db8970",
-      "integrity": "sha512-bLuC816h823xfIKTlH3Uey7ba0nF+heOwdy3i3FSLB1p84gY492D5dlZ5W0OxPUppQbkN+FCyDzegk7C3ADUvA==",
+      "version": "0.3.45",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.45/9bcee8d168e82843143db5033c27f40be0414df9",
+      "integrity": "sha512-tbaecWsOxFKGREbgLB+6JWBA0ZdNRbkg+XcqRjhY2A/kXcvk4ePb1t6Hi3VrVxzMEgsK3oQbDLvFNeHhBLOb/g==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2635,9 +2635,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.44",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.44/2c9b8a193f7324e16606d6f69af786f7ab23fe57",
-      "integrity": "sha512-eD4U1aSaSjQLx2/rtvw8AeG9r9rbMTUxUCKoBHCC6IFLQywkXoW1u+L3+q7rfoOLspN7uFBBIqobUHYadDdW4Q==",
+      "version": "0.3.45",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.45/a16f23077bf97ef7a11ccb414fdda3a04b24c0dc",
+      "integrity": "sha512-XajSJRBdF3m75lVNF7phENBHLjx50SpqpGZPP1mgR9oiurhXBrWpMROxXIwLL5L8D2NXNfKnmKkAuCTsYcKdRQ==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13853,8 +13853,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.44",
-        "@etendosoftware/etendo-go-core": "0.3.44",
+        "@etendosoftware/app-shell-core": "0.3.45",
+        "@etendosoftware/etendo-go-core": "0.3.45",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.44",
-    "@etendosoftware/schema-forge-cli": "0.3.44",
-    "@etendosoftware/schema-forge-core": "0.3.44",
+    "@etendosoftware/app-shell-core": "0.3.45",
+    "@etendosoftware/schema-forge-cli": "0.3.45",
+    "@etendosoftware/schema-forge-core": "0.3.45",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.44",
-        "@etendosoftware/etendo-go-core": "0.3.44",
+        "@etendosoftware/app-shell-core": "0.3.45",
+        "@etendosoftware/etendo-go-core": "0.3.45",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.44",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.44/1b8c964b989acf8b62fb5e5d3a1350087b3dc017",
-      "integrity": "sha512-wMJT/rPZ9X2VbWkvast0jkMn3Tx1uKaAhwpf6tYPUqJRYq+b3QFJuPFy79Up5GCnI6oy/0GHWssUTn2abts51g==",
+      "version": "0.3.45",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.45/66759a6ba4739b720a91f42936185b0a8c4cdc6c",
+      "integrity": "sha512-gaHi7qC5ZGNkQU1QbpgM82hp3IjQpTJWJETCpvHz2ZHvmdntmL1/m8NEsaTudQ8qXKS7h3EZZDBFsiunfRYTRA==",
       "dependencies": {
         "read-excel-file": "^9.3.10",
         "write-excel-file": "^4.1.1"
@@ -2480,9 +2480,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.44",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.44/a9ec87d2665bac7bbf85be36c59873467701978f",
-      "integrity": "sha512-FOCeu3C+zKTvoFDFgzK046nqSZUFXmm12GOH0MClN6vE8h3AFQNsqLq650MN6+hQu9U2UyOlBkEdABndWa5Fjw==",
+      "version": "0.3.45",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.45/94f56470620ceda90f66f4f09431187fe699f989",
+      "integrity": "sha512-f0WlzHwr7sDAc+f/9PQjLlk/yTjzQ5BdAEbwasFQHdSJzPECXhEcTOc6H39FlZQGlw/BRatzRoGb/IZ4IvvMZw==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.44",
-    "@etendosoftware/etendo-go-core": "0.3.44",
+    "@etendosoftware/app-shell-core": "0.3.45",
+    "@etendosoftware/etendo-go-core": "0.3.45",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.45`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.