### PR TITLE
Feature ETP-5091: Hide Logistics for Expense/Resource products

### DIFF
--- a/docs/generated-custom-windows/product.md
+++ b/docs/generated-custom-windows/product.md
@@ -46,7 +46,7 @@ The image preview uses `position: absolute; inset: 0` inside a `relative flex-1 
 - **Master/child dependency:** the selected product drives price, stock, and transaction loading through `parentId=<productId>`.
 - **Gallery/detail dependency:** selecting a product card in the gallery navigates into that product's detail route.
 - **Additional Info grouping:** the `Additional Info` tab is a custom panel rendered as two-column row sections. Each row section has a left column (148 px wide) containing a section title and description, and a right column (`flex-1`) holding an `EntityForm`. The `Commercial` row groups `Tax Category`, `Sale`, and `Purchase`; an HR divider separates it from the `Logistics` row, which groups `Almacenable` ("Stocked"/`IsStocked` — relabeled from "Almacenado" in ETP-4943), `Returnable`, `Weight`, and `UOM for Weight`. The outer wrapper applies `[&_input]:bg-white` so all input fields, including `Weight`, render on a white background.
-- **Logistics hidden for Service products (ETP-4943):** the entire `Logistics` row (divider included) does not render when `productType === 'S'` — a Service product has no physical existence, so weight/UOM/stock fields do not apply. Mirrors the rule `ProductSidebar.jsx` already applies to hide the stock sidebar for Service products (ETP-4606). While editing, switching the type to Service also force-sets `stocked`/`returnable` to `false` via `onChange` (only when they were not already false), so a Service product can never be saved with either flag on. Switching back to a stockable type (e.g. Article) re-shows the row with whatever values are currently on the record.
+- **Logistics hidden for Service/Expense/Resource products (ETP-4943, extended in ETP-5091):** the entire `Logistics` row (divider included) does not render when `productType` is `'S'` (Service), `'E'` (Expense/"Gasto") or `'R'` (Resource/"Recurso") — none of these have a physical existence, so weight/UOM/stock fields do not apply. Mirrors the rule `ProductSidebar.jsx` already applies to hide the stock sidebar for the same three types (ETP-4606, extended in ETP-5091). While editing, switching the type to one of these also force-sets `stocked`/`returnable` to `false` via `onChange` (only when they were not already false), so none of these product types can ever be saved with either flag on. Switching back to a stockable type (e.g. Article) re-shows the row with whatever values are currently on the record.
 - **Selector dependencies:** the current evidence shows selector-backed maintenance for category, tax category, UOM, UOM for weight, attribute set, brand, lifecycle status, warehouse, currency, characteristic, characteristic subset, storage bin, and price-list-version references where relevant.
 - **Pricing tab states:**
   - When the product has not been saved yet, the `Price` tab shows a save-first message and blocks pricing maintenance.
@@ -103,7 +103,7 @@ The image preview uses `position: absolute; inset: 0` inside a `relative flex-1 
 - Shared shell/route behavior is documented in `docs/generated-custom-windows/app-shell-functional-flows.md`, especially the generated/custom window loading flow and the shared entity list/detail flow.
 - Product-specific behavior is grounded in current code under `tools/app-shell/src/windows/custom/product/`:
   - `ProductGallery.jsx` for gallery browsing
-  - `ProductAdditionalInfoPanel.jsx` for the two-column row layout with `Commercial` and `Logistics` sections and HR divider between them, and (ETP-4943) for hiding the `Logistics` row and force-clearing `stocked`/`returnable` when `productType === 'S'`
+  - `ProductAdditionalInfoPanel.jsx` for the two-column row layout with `Commercial` and `Logistics` sections and HR divider between them, and (ETP-4943, extended in ETP-5091) for hiding the `Logistics` row and force-clearing `stocked`/`returnable` when `productType` is `'S'`, `'E'` or `'R'`
   - `ProductPriceBar.jsx` for product pricing fetch/create/edit behavior, including the tariff-name labels, the bounded rows scroller, the per-open selector refetch and the "all tariffs already priced" hint. Amounts render through a local `CURRENCY_SYMBOLS` map plus the row's `currencySymbol`; migrating them to the canonical `formatCurrency()` util is pending the dedicated currency-format task.
   - `ImageField.jsx` was fully redesigned for ETP-4190 and extended in a follow-up: upload button inside the container, hover overlay with zoom icon and remove/replace actions, lightbox via `createPortal(document.body)` with ESC-to-close, `cursor-zoom-in` when an image exists. When no image exists (stretch mode), the area shows a full-height dashed dropzone with an upload icon button, "Selecciona o arrastra aquí tus archivos", and the constraint hint ("Hasta 30 MB y 7680 × 4320 píxeles (JPEG, JPG, PNG)"). The dropzone supports drag & drop (highlights on `isDragging`). Validation rejects non-JPEG/PNG types, files over 30 MB, and images exceeding 7680 × 4320 px — all errors surface as `toast.error()` (no inline message). The upload button at the bottom is hidden in the empty state (the entire zone is the upload target); it reappears once an image is loaded.
   - `ProductSidebar.jsx` for stock and transaction-driven sidebar summaries, including pill-style period tabs, bezier-curve SVG chart, dashed gridlines, expand link, smaller stat cards, conditional visibility of `Available`/`Reserved` cards, and divider between sections.
@@ -557,3 +557,43 @@ repeated the status label. Fixed generically in app-shell-core (one `RowDataCell
 with the OK branch, plus the skip *reason* in the space the duplicated label used to occupy), so it
 applies to every window with an import, not just this one. Reasoning and coverage in the
 [Contacts guide](contacts.md#a-skipped-row-showed-no-data--etp-4997).
+
+## Logistics hidden for Expense/Resource products too — ETP-5091
+
+Twin bug of ETP-4943, reported separately: `productType` values `'E'` (Expense/"Gasto") and `'R'`
+(Resource/"Recurso")  — like `'S'` (Service) — have no physical existence in inventory, but the
+Logistics section and the stock sidebar only checked for `'S'`, so Gasto/Recurso products still
+showed and could still be saved with `Almacenable`/`Retornable` set. Same three surfaces as
+ETP-4943, all generalized from a single `'S'` check to a `NON_STOCKABLE_PRODUCT_TYPES` set/list of
+`'S'`/`'E'`/`'R'` — no new mechanism introduced:
+
+- **`ProductAdditionalInfoPanel.jsx`** — `isService` (`=== 'S'`) replaced by `isNonStockable`
+  (`NON_STOCKABLE_PRODUCT_TYPES.has(productType)`), gating both the `Logistics` row's
+  `{!isNonStockable && (...)}` wrapper and the force-false `useEffect`.
+- **`ProductSidebar.jsx`** — `data?.productType === 'S'` replaced by
+  `['S', 'E', 'R'].includes(data?.productType)`.
+- **`com.etendoerp.go`'s `ProductDefaultsHandler.java`** — `enforceServiceProductNotStockable`
+  renamed to `enforceNonStockableProductTypes`, `PRODUCT_TYPE_SERVICE` replaced by a
+  `NON_STOCKABLE_PRODUCT_TYPES` `Set.of("S", "E", "R")`. Same authoritative-server-side reasoning
+  as ETP-4943 applies unchanged: the frontend `useEffect` only fires while `Additional Info` is
+  mounted, so the server guard is what actually guarantees a Gasto/Recurso product can never
+  persist as stocked/returnable when saved straight from `General`.
+- **`'Online'` (`'O'`) was deliberately left out** — the ticket's own reported/expected cases only
+  named Gasto and Recurso; Online was not requested and is not touched by this change.
+
+**Reproduced live** with Playwright against a running instance before the fix: created a product,
+set `Tipo` to `Gasto` (then `Recurso`), confirmed the `Logistics` row and the stock sidebar both
+stayed visible/editable — matching the ticket's steps exactly. Post-fix live re-verification is
+tracked in the ticket.
+
+Coverage:
+- `e2e/tests/flows/product-logistics-nonstockable-types.mocked.spec.js` — end-to-end mocked repro
+  of the reported bug: Logistics section and stock sidebar hidden for Gasto/Recurso, control case
+  (Artículo) still shows both.
+- `tools/app-shell/src/windows/custom/product/__tests__/ProductAdditionalInfoPanel.vitest.jsx` —
+  the ETP-4943 Service cases parametrized (`describe.each`) across Service/Expense/Resource.
+- `tools/app-shell/src/windows/custom/product/__tests__/ProductSidebar.vitest.jsx` — new coverage
+  (none existed before ETP-5091) asserting the sidebar renders nothing for Service/Expense/Resource
+  and renders normally for Article.
+- `com.etendoerp.go`'s `ProductDefaultsHandlerTest.java` — the ETP-4943 Service POST/PATCH/absent-flags
+  cases mirrored for Expense and Resource.

--- a/e2e/tests/flows/product-logistics-nonstockable-types.mocked.spec.js
+++ b/e2e/tests/flows/product-logistics-nonstockable-types.mocked.spec.js
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test';
+import { login } from '../helpers/auth.js';
+
+/**
+ * ETP-5091 — Logistics section visible for Expense/Resource product types.
+ *
+ * Twin bug of ETP-4943 (Service). `ProductAdditionalInfoPanel.jsx` only hides
+ * the `Logistics` row (weight/UOM, "Almacenable"/"Retornable") when
+ * `productType === 'S'`; `ProductSidebar.jsx` only hides the stock widget
+ * under the same condition (ETP-4606). Neither treats `productType === 'E'`
+ * (Gasto) or `'R'` (Recurso) the same way, even though both have no physical
+ * existence and cannot be stocked — matching the ticket's own wording.
+ *
+ * This spec reproduces the ticket's reported steps end-to-end (real
+ * DetailView + real ProductAdditionalInfoPanel/ProductSidebar, only the
+ * network layer mocked): create/open a product of type Gasto or Recurso and
+ * confirm the Logistics section and stock sidebar are gone, the same way
+ * they already are for Service. It also pins the control case (type
+ * Artículo, 'I') so a future regression on Service/Article is caught too.
+ */
+
+function buildProduct(id, productType, productTypeLabel) {
+  return {
+    id,
+    searchKey: id,
+    name: `Product ${id}`,
+    '_identifier': `Product ${id}`,
+    productType,
+    'productType$_identifier': productTypeLabel,
+    purchase: true,
+    sale: true,
+    stocked: true,
+    returnable: true,
+    weight: 0,
+    organization: 'org-1',
+    client: 'client-1',
+  };
+}
+
+const PRODUCTS = {
+  E: buildProduct('PROD-EXPENSE-1', 'E', 'Expense type'),
+  R: buildProduct('PROD-RESOURCE-1', 'R', 'Resource'),
+  I: buildProduct('PROD-ARTICLE-1', 'I', 'Item'),
+};
+
+async function mockProductDetail(page, product) {
+  await page.route('**/sws/neo/product/product/**', async (route) => {
+    const req = route.request();
+    if (req.method() !== 'GET') return route.fallback();
+    const url = req.url();
+    if (/\/product\/product\/selectors\//.test(url)) return route.fallback();
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ response: { data: [product] } }),
+    });
+  });
+}
+
+// Deterministic, empty stock/transactions so ProductSidebar always resolves
+// to either `null` (non-stockable types) or the `StockEmptyState` fallback
+// (stockable types) — never left in a perpetually-loading state.
+async function mockStockAndTransactions(page) {
+  await page.route('**/sws/neo/product/stock**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ response: { data: [] } }),
+    });
+  });
+  await page.route('**/sws/neo/product/transactions**', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ response: { data: [] } }),
+    });
+  });
+}
+
+async function openProductAdditionalInfo(page, product) {
+  await login(page);
+  await mockProductDetail(page, product);
+  await mockStockAndTransactions(page);
+  await page.goto(`/product/${product.id}`);
+  await page.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+  await page.getByRole('button', { name: 'Información adicional' }).click();
+}
+
+for (const [code, label] of [['E', 'Gasto'], ['R', 'Recurso']]) {
+  test.describe(`Product Logistics section — hidden for ${label} (ETP-5091)`, () => {
+    test.beforeEach(async ({ page }) => {
+      await openProductAdditionalInfo(page, PRODUCTS[code]);
+    });
+
+    test(`hides the Logistics section (Almacenable/Retornable) for ${label}`, async ({ page }) => {
+      await expect(page.getByText('Logística')).not.toBeVisible();
+      await expect(page.getByTestId('field-stocked')).not.toBeVisible();
+      await expect(page.getByTestId('field-returnable')).not.toBeVisible();
+    });
+
+    test(`hides the stock movement sidebar for ${label}`, async ({ page }) => {
+      await expect(page.getByText('Sin movimientos de stock')).not.toBeVisible();
+      await expect(page.getByText('Movimiento de stock')).not.toBeVisible();
+    });
+  });
+}
+
+test.describe('Product Logistics section — control case, Artículo stays stockable', () => {
+  test.beforeEach(async ({ page }) => {
+    await openProductAdditionalInfo(page, PRODUCTS.I);
+  });
+
+  test('keeps the Logistics section visible for Artículo', async ({ page }) => {
+    await expect(page.getByText('Logística')).toBeVisible();
+    await expect(page.getByTestId('field-stocked')).toBeVisible();
+    await expect(page.getByTestId('field-returnable')).toBeVisible();
+  });
+
+  test('keeps the stock movement sidebar visible for Artículo', async ({ page }) => {
+    await expect(page.getByText('Sin movimientos de stock')).toBeVisible({ timeout: 10_000 });
+  });
+});

--- a/tools/app-shell/src/windows/custom/product/ProductAdditionalInfoPanel.jsx
+++ b/tools/app-shell/src/windows/custom/product/ProductAdditionalInfoPanel.jsx
@@ -4,7 +4,9 @@ import { EntityForm } from '@/components/contract-ui';
 import { useUI, useLabel } from '@/i18n';
 import CheckboxGroup, { isCheckedYN } from '@/windows/custom/shared/CheckboxGroup';
 
-const PRODUCT_TYPE_SERVICE = 'S';
+// ETP-5091: Expense (E, "Gasto") and Resource (R, "Recurso") have no physical
+// existence either — same rule as Service (S, ETP-4943).
+const NON_STOCKABLE_PRODUCT_TYPES = new Set(['S', 'E', 'R']);
 
 function WeightStepper({ label, value, readOnly, onChange }) {
   const [local, setLocal] = useState(String(value ?? ''));
@@ -53,18 +55,19 @@ export default function ProductAdditionalInfoPanel({ entity, data, token, apiBas
   const t = useLabel();
 
   const readOnly = !editing;
-  const isService = data?.productType === PRODUCT_TYPE_SERVICE;
+  const isNonStockable = NON_STOCKABLE_PRODUCT_TYPES.has(data?.productType);
 
-  // ETP-4943: a Service product has no physical existence, so the Logistics
-  // section (weight/UOM, "Almacenable"/Returnable) does not apply to it — force
-  // both stock-management flags off as soon as the type becomes Service, the
+  // ETP-4943 / ETP-5091: Service, Expense and Resource products have no
+  // physical existence, so the Logistics section (weight/UOM,
+  // "Almacenable"/Returnable) does not apply to them — force both
+  // stock-management flags off as soon as the type becomes one of those, the
   // same rule ProductSidebar.jsx already applies to hide the stock widget
-  // (ETP-4606: `data?.productType === 'S'` → no stock UI at all).
+  // (ETP-4606 / ETP-5091: `NON_STOCKABLE_PRODUCT_TYPES.has(data?.productType)` → no stock UI at all).
   useEffect(() => {
-    if (!editing || !isService) return;
+    if (!editing || !isNonStockable) return;
     if (isCheckedYN(data?.stocked)) onChange?.('stocked', false, 'IsStocked');
     if (isCheckedYN(data?.returnable)) onChange?.('returnable', false, 'Returnable');
-  }, [editing, isService, data?.stocked, data?.returnable, onChange]);
+  }, [editing, isNonStockable, data?.stocked, data?.returnable, onChange]);
 
   return (
     <div className="space-y-2 pb-6 [&_input]:bg-card">
@@ -102,7 +105,7 @@ export default function ProductAdditionalInfoPanel({ entity, data, token, apiBas
             data-testid="CheckboxGroup__fe05d5" />
         </div>
       </div>
-      {!isService && (
+      {!isNonStockable && (
         <>
           <hr className="border-t border-[hsl(var(--border-subtle))] mx-5" />
           <div className="flex flex-row items-start p-2 gap-5">

--- a/tools/app-shell/src/windows/custom/product/ProductSidebar.jsx
+++ b/tools/app-shell/src/windows/custom/product/ProductSidebar.jsx
@@ -586,8 +586,9 @@ export default function ProductSidebar({ recordId, data, token, apiBaseUrl }) {
     onExternalClose: () => setChartTrigger({ open: false, warehouse: null }),
   };
 
-  // Service-type products are not stockable — no stock section to show (ETP-4606).
-  if (data?.productType === 'S') return null;
+  // Service/Expense/Resource products are not stockable — no stock section to
+  // show (ETP-4606, extended to Expense/Resource in ETP-5091).
+  if (['S', 'E', 'R'].includes(data?.productType)) return null;
 
   return (
     <div className="flex flex-col gap-3">

--- a/tools/app-shell/src/windows/custom/product/__tests__/ProductAdditionalInfoPanel.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/product/__tests__/ProductAdditionalInfoPanel.vitest.jsx
@@ -28,47 +28,45 @@ const BASE_PROPS = {
   onChange: vi.fn(),
 };
 
-// ETP-4943 — a Service product has no physical existence: the Logistics section
-// (weight, UOM for weight, "Almacenable"/Returnable) does not apply to it and must
-// be hidden, and both stock-management flags must be forced to false so a Service
-// product can never be saved as stocked/returnable. Mirrors the precedent already
-// established for the stock sidebar (`ProductSidebar.jsx`, ETP-4606:
-// `if (data?.productType === 'S') return null`).
-describe('ProductAdditionalInfoPanel — Logistics section for Service-type products (ETP-4943)', () => {
-  it('hides the Logistics section when productType is Service', () => {
-    render(<ProductAdditionalInfoPanel {...BASE_PROPS} data={{ productType: 'S' }} />);
+// ETP-4943 / ETP-5091 — Service, Expense ("Gasto") and Resource ("Recurso")
+// products have no physical existence: the Logistics section (weight, UOM for
+// weight, "Almacenable"/Returnable) does not apply to them and must be
+// hidden, and both stock-management flags must be forced to false so none of
+// them can ever be saved as stocked/returnable. Mirrors the precedent already
+// established for the stock sidebar (`ProductSidebar.jsx`, ETP-4606 /
+// ETP-5091: `['S', 'E', 'R'].includes(data?.productType)` → no stock UI at all).
+describe.each([
+  ['Service', 'S'],
+  ['Expense', 'E'],
+  ['Resource', 'R'],
+])('ProductAdditionalInfoPanel — Logistics section for %s-type products (ETP-4943 / ETP-5091)', (_label, productType) => {
+  it(`hides the Logistics section when productType is ${productType}`, () => {
+    render(<ProductAdditionalInfoPanel {...BASE_PROPS} data={{ productType }} />);
     expect(screen.queryByText('logistics')).not.toBeInTheDocument();
     expect(screen.queryByTestId('field-stocked')).not.toBeInTheDocument();
     expect(screen.queryByTestId('field-returnable')).not.toBeInTheDocument();
   });
 
-  it('keeps the Logistics section visible for a stockable type (Article)', () => {
-    render(<ProductAdditionalInfoPanel {...BASE_PROPS} data={{ productType: 'I' }} />);
-    expect(screen.getByText('logistics')).toBeInTheDocument();
-    expect(screen.getByTestId('field-stocked')).toBeInTheDocument();
-    expect(screen.getByTestId('field-returnable')).toBeInTheDocument();
-  });
-
-  it('forces stocked/returnable to false as soon as the type is Service', () => {
+  it(`forces stocked/returnable to false as soon as the type is ${productType}`, () => {
     const onChange = vi.fn();
     render(
       <ProductAdditionalInfoPanel
         {...BASE_PROPS}
         onChange={onChange}
-        data={{ productType: 'S', stocked: true, returnable: true }}
+        data={{ productType, stocked: true, returnable: true }}
       />,
     );
     expect(onChange).toHaveBeenCalledWith('stocked', false, 'IsStocked');
     expect(onChange).toHaveBeenCalledWith('returnable', false, 'Returnable');
   });
 
-  it('does not call onChange when the flags are already false for a Service product', () => {
+  it(`does not call onChange when the flags are already false for a ${productType}-type product`, () => {
     const onChange = vi.fn();
     render(
       <ProductAdditionalInfoPanel
         {...BASE_PROPS}
         onChange={onChange}
-        data={{ productType: 'S', stocked: false, returnable: false }}
+        data={{ productType, stocked: false, returnable: false }}
       />,
     );
     expect(onChange).not.toHaveBeenCalled();
@@ -81,7 +79,7 @@ describe('ProductAdditionalInfoPanel — Logistics section for Service-type prod
         {...BASE_PROPS}
         editing={false}
         onChange={onChange}
-        data={{ productType: 'S', stocked: true, returnable: true }}
+        data={{ productType, stocked: true, returnable: true }}
       />,
     );
     expect(onChange).not.toHaveBeenCalled();
@@ -89,7 +87,7 @@ describe('ProductAdditionalInfoPanel — Logistics section for Service-type prod
 
   it('shows the section again with its own values when the type switches back to Article', () => {
     const { rerender } = render(
-      <ProductAdditionalInfoPanel {...BASE_PROPS} data={{ productType: 'S' }} />,
+      <ProductAdditionalInfoPanel {...BASE_PROPS} data={{ productType }} />,
     );
     expect(screen.queryByTestId('field-stocked')).not.toBeInTheDocument();
 
@@ -102,5 +100,14 @@ describe('ProductAdditionalInfoPanel — Logistics section for Service-type prod
     expect(screen.getByTestId('field-stocked')).toBeInTheDocument();
     expect(screen.getByTestId('field-stocked')).toHaveAttribute('aria-checked', 'true');
     expect(screen.getByTestId('field-returnable')).toHaveAttribute('aria-checked', 'false');
+  });
+});
+
+describe('ProductAdditionalInfoPanel — Logistics section stays visible for stockable types', () => {
+  it('keeps the Logistics section visible for a stockable type (Article)', () => {
+    render(<ProductAdditionalInfoPanel {...BASE_PROPS} data={{ productType: 'I' }} />);
+    expect(screen.getByText('logistics')).toBeInTheDocument();
+    expect(screen.getByTestId('field-stocked')).toBeInTheDocument();
+    expect(screen.getByTestId('field-returnable')).toBeInTheDocument();
   });
 });

--- a/tools/app-shell/src/windows/custom/product/__tests__/ProductSidebar.vitest.jsx
+++ b/tools/app-shell/src/windows/custom/product/__tests__/ProductSidebar.vitest.jsx
@@ -213,3 +213,30 @@ describe('ProductSidebar', () => {
     expect(screen.getByText('last3Months')).toBeInTheDocument();
   });
 });
+
+// ETP-4606 / ETP-5091 — Service, Expense ("Gasto") and Resource ("Recurso")
+// products have no physical existence, so the stock sidebar (period selector,
+// availability widget, stock movement chart) does not apply to them and must
+// not render at all. Mirrors the equivalent rule in
+// `ProductAdditionalInfoPanel.jsx` for the Logistics section.
+describe.each([
+  ['Service', 'S'],
+  ['Expense', 'E'],
+  ['Resource', 'R'],
+])('ProductSidebar — hidden for %s-type products (ETP-4606 / ETP-5091)', (_label, productType) => {
+  it(`renders nothing when productType is ${productType}`, () => {
+    mockFetchResponses();
+    const { container } = render(
+      <ProductSidebar {...defaultProps} data={{ productType }} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('ProductSidebar — stays visible for stockable types', () => {
+  it('renders normally for a stockable type (Article)', () => {
+    mockFetchResponses();
+    render(<ProductSidebar {...defaultProps} data={{ productType: 'I' }} />);
+    expect(screen.getByText('last3Months')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Twin bug of ETP-4943: the Logistics section (Almacenable/Retornable, weight, UOM) and the stock sidebar stayed visible/editable for Gasto (Expense) and Recurso (Resource) products, which have no physical existence — same rule already applied for Servicio (Service).
- `ProductAdditionalInfoPanel.jsx` and `ProductSidebar.jsx` generalized from a single `productType === 'S'` check to a `NON_STOCKABLE_PRODUCT_TYPES` set of `S`/`E`/`R`.
- Companion server-side guard in `com.etendoerp.go` PR: https://github.com/etendosoftware/com.etendoerp.go/pull/1003
- `docs/generated-custom-windows/product.md` updated per the self-documentation policy.
- Online (`O`) deliberately left out of scope — not mentioned in the ticket.

## Test plan
- [x] New mocked E2E spec `e2e/tests/flows/product-logistics-nonstockable-types.mocked.spec.js`, written RED-first against the bug, now green (6/6).
- [x] Extended `ProductAdditionalInfoPanel.vitest.jsx` and `ProductSidebar.vitest.jsx` (parametrized across Service/Expense/Resource) — 33/33 passing.
- [x] Pre-push steps 0-4 run manually (data-testid check, unit tests, SonarQube Quality Gate, coverage compare) — all green; Playwright suites run manually by the author outside the hook due to local overhead.
- [x] Live-verified in the browser: new and existing products (Gasto/Recurso) both hide the Logistics section + stock sidebar, and persist `stocked`/`returnable=false` after save, including a save from the General tab without ever opening Additional Info.