### PR TITLE
Feature ETP-5128: Fix chip order, section visibility, dim-group cards

### DIFF
--- a/artifacts/inventory-stock-report/template.hbs
+++ b/artifacts/inventory-stock-report/template.hbs
@@ -12,10 +12,12 @@
    follow-up request: "no se llega a diferenciar bien"). */
 .stock-cards { display: flex; flex-direction: column; gap: 3mm; }
 .stock-card { border: 1px solid #e2e8f0; border-radius: 1.5mm; overflow: hidden; }
-/* value (left, bold) + a "Producto"/"Almacén"/"Categoría" chip (right) —
-   same layout as report-general-ledger's .dim-group-head, so the "this is
-   what we grouped by" context reads the same across reports. */
-.stock-card-head { display: flex; align-items: center; justify-content: space-between; gap: 3mm; background: var(--color-accent-highlight-muted); color: var(--color-accent-highlight-foreground); padding: 2mm 4mm; font-size: 9pt; }
+/* Chip (left, the "Producto"/"Almacén"/"Categoría" dimension type) + value
+   (right, bold) — same order/layout as report-general-ledger's own
+   .dim-group-head (ETP-5128), so "this is what we grouped by" reads the
+   same across reports. Was value-then-chip with justify-content pushing
+   the chip off to the far right, which read as the chip missing entirely. */
+.stock-card-head { display: flex; align-items: center; gap: 3mm; background: var(--color-accent-highlight-muted); color: var(--color-accent-highlight-foreground); padding: 2mm 4mm; font-size: 9pt; }
 .stock-card-head .value { font-weight: 700; font-size: 10.5pt; }
 .stock-card-head .chip { display: inline-block; line-height: 1; font-size: 8pt; font-weight: 600; color: var(--color-primary); background: var(--color-bg-stripe); border: 1px solid rgba(18,18,23,0.15); border-radius: 3mm; padding: 1mm 3mm; }
 </style>
@@ -52,7 +54,7 @@
       {{#if (isGroupBreak @root.meta.dimensionField (lookup this @root.meta.dimensionField))}}
         {{#unless @first}}</tbody></table></div>{{/unless}}
     <div class="stock-card">
-      <div class="stock-card-head"><span class="value">{{lookup this @root.meta.dimensionField}}</span><span class="chip">{{@root.meta.dimensionLabel}}</span></div>
+      <div class="stock-card-head"><span class="chip">{{@root.meta.dimensionLabel}}</span><span class="value">{{lookup this @root.meta.dimensionField}}</span></div>
       <table class="report-table">
         <thead><tr>
           <th style="width: 12%">{{@root.meta.labels.productSearchKey}}</th>

--- a/artifacts/report-general-ledger/template.hbs
+++ b/artifacts/report-general-ledger/template.hbs
@@ -7,7 +7,14 @@
    when grouping by a dimension; the flat layout below (ETP-5013 follow-up) reuses
    the same .acct-card structure, just without the outer dimension chip. */
 .dim-group { border: 1px solid #cbd5e1; border-radius: 2mm; margin-bottom: 4mm; overflow: hidden; }
-.dim-group-head { display: flex; align-items: center; justify-content: space-between; gap: 3mm; background: var(--color-accent-highlight); color: var(--color-accent-highlight-foreground); padding: 2.5mm 4mm; border-bottom: 2px solid var(--color-primary); }
+/* ETP-5128: chip (the dimension's own TYPE — "Producto"/"Contacto"/...) now
+   comes FIRST, the picked value's name second — matches the .acct-card-head
+   code+name order every report already uses for an account card, so a
+   dimension-group header reads the same way instead of value-then-chip with
+   justify-content pushing the chip off to the far right (previously easy to
+   miss entirely, reported against report-general-ledger, applies to every
+   report that groups by a dimension, not just this one). */
+.dim-group-head { display: flex; align-items: center; gap: 3mm; background: var(--color-accent-highlight); color: var(--color-accent-highlight-foreground); padding: 2.5mm 4mm; border-bottom: 2px solid var(--color-primary); }
 .dim-group-head .chip { display: inline-block; line-height: 1; font-size: 8pt; font-weight: 600; color: var(--color-primary); background: var(--color-bg-stripe); border: 1px solid rgba(18,18,23,0.15); border-radius: 3mm; padding: 1mm 3mm; }
 .dim-group-head .value { font-weight: 700; font-size: 10.5pt; }
 .dim-group-body { padding: 3mm; display: flex; flex-direction: column; gap: 3mm; }
@@ -67,7 +74,7 @@
   <div class="dim-groups">
     {{#each meta.groups}}
     <div class="dim-group">
-      <div class="dim-group-head"><span class="value">{{this.dimensionValue}}</span><span class="chip">{{@root.meta.dimensionLabel}}</span></div>
+      <div class="dim-group-head"><span class="chip">{{@root.meta.dimensionLabel}}</span><span class="value">{{this.dimensionValue}}</span></div>
       <div class="dim-group-body">
         {{#each this.accounts}}
         <div class="acct-card">

--- a/artifacts/report-trial-balance/report-contract.json
+++ b/artifacts/report-trial-balance/report-contract.json
@@ -21,7 +21,7 @@
   "sections": [
     { "id": "periodo", "label": { "en_US": "Period", "es_ES": "Periodo" } },
     { "id": "alcance", "label": { "en_US": "Scope", "es_ES": "Alcance" } },
-    { "id": "dimensiones", "label": { "en_US": "Dimensions", "es_ES": "Dimensiones" } },
+    { "id": "dimensiones", "label": { "en_US": "Dimensions", "es_ES": "Dimensiones" }, "visibleIf": { "param": "accountLevel", "equals": "S" } },
     { "id": "agrupacion", "label": { "en_US": "Grouping", "es_ES": "Agrupación" } },
     { "id": "opciones", "label": { "en_US": "Options", "es_ES": "Opciones" } }
   ],
@@ -43,7 +43,7 @@
       { "value": "C", "label": { "en_US": "Account",    "es_ES": "Cuenta"    } },
       { "value": "E", "label": { "en_US": "Heading",    "es_ES": "Epígrafe"  } }
     ] },
-    { "name": "groupBy", "label": { "en_US": "Group results by", "es_ES": "Agrupar por" }, "type": "select", "section": "agrupacion" },
+    { "name": "groupBy", "label": { "en_US": "Group results by", "es_ES": "Agrupar por" }, "type": "select", "section": "agrupacion", "visibleIf": { "param": "accountLevel", "equals": "S" } },
     { "name": "openingEntryAmount", "label": { "en_US": "Opening Entry Amount to Initial Balance", "es_ES": "Importe del asiento de apertura al saldo inicial" }, "type": "toggle", "default": true, "section": "opciones" }
   ],
   "labels": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.45",
-        "@etendosoftware/schema-forge-cli": "0.3.45",
-        "@etendosoftware/schema-forge-core": "0.3.45",
+        "@etendosoftware/app-shell-core": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
+        "@etendosoftware/schema-forge-cli": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
+        "@etendosoftware/schema-forge-core": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2543,9 +2543,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.45",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.45/66759a6ba4739b720a91f42936185b0a8c4cdc6c",
-      "integrity": "sha512-gaHi7qC5ZGNkQU1QbpgM82hp3IjQpTJWJETCpvHz2ZHvmdntmL1/m8NEsaTudQ8qXKS7h3EZZDBFsiunfRYTRA==",
+      "version": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a/1b1f68673063ddc060368a98e4394cee5a14d197",
+      "integrity": "sha512-XL+xjlKKszz3fsPX/6K/dfC8l4FAt2H8cuC4n6N9BrJGGrkbk9xLewCfWIBU3/uUKDXarhyBR/nG/tTZcJSSYg==",
       "dependencies": {
         "read-excel-file": "^9.3.10",
         "write-excel-file": "^4.1.1"
@@ -2576,9 +2576,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.45",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.45/94f56470620ceda90f66f4f09431187fe699f989",
-      "integrity": "sha512-f0WlzHwr7sDAc+f/9PQjLlk/yTjzQ5BdAEbwasFQHdSJzPECXhEcTOc6H39FlZQGlw/BRatzRoGb/IZ4IvvMZw==",
+      "version": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a/ed5ac8f250cbe884659a741d8a66190e57332411",
+      "integrity": "sha512-4vRQicGWA4JowfPVNqAVAT6KqRa6Y7cjQnaj4Vb0+Aa7VbQG+2oKPWD2dxpvxwelBX5piGMcSxV6miGCvPM34A==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2588,9 +2588,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.45",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.45/9bcee8d168e82843143db5033c27f40be0414df9",
-      "integrity": "sha512-tbaecWsOxFKGREbgLB+6JWBA0ZdNRbkg+XcqRjhY2A/kXcvk4ePb1t6Hi3VrVxzMEgsK3oQbDLvFNeHhBLOb/g==",
+      "version": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a/e28358a166669cfd041746a1e594a16910982d26",
+      "integrity": "sha512-IsTautzN0YnJ6KrVSKfCeQJlPrZuhkS7m78kGlv5nVzHmLegu0wUP8N73O8Zjl0B17acapCnkdutDdaay0n6TQ==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2635,9 +2635,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.45",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.45/a16f23077bf97ef7a11ccb414fdda3a04b24c0dc",
-      "integrity": "sha512-XajSJRBdF3m75lVNF7phENBHLjx50SpqpGZPP1mgR9oiurhXBrWpMROxXIwLL5L8D2NXNfKnmKkAuCTsYcKdRQ==",
+      "version": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a/0f81de8cb402aceece1eca80d78c7ae49ebd007b",
+      "integrity": "sha512-Hc7ho/hjU8EzH85cpFGOiNlkuAupFIBGETdlaTCSflj0OGsc2rBE2x1rMq64BKL5G/WO1CoH89l+jca9Zzuy3w==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13853,8 +13853,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.45",
-        "@etendosoftware/etendo-go-core": "0.3.45",
+        "@etendosoftware/app-shell-core": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
+        "@etendosoftware/etendo-go-core": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.45",
-    "@etendosoftware/schema-forge-cli": "0.3.45",
-    "@etendosoftware/schema-forge-core": "0.3.45",
+    "@etendosoftware/app-shell-core": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
+    "@etendosoftware/schema-forge-cli": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
+    "@etendosoftware/schema-forge-core": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/scripts/assemble-report-server-context.sh
+++ b/scripts/assemble-report-server-context.sh
@@ -66,9 +66,17 @@ CORE_FILES=(
   "tools/report-server/package.json"
   "tools/report-server/server.js"
   "tools/report-server/Dockerfile"
-  "cli/src/report-descriptor.js"
-  "cli/src/extract-from-jasper.js"
 )
+
+# cli/src goes in WHOLE, not as a per-file list — the same call the Dockerfile
+# already makes (`COPY cli/src/ ./cli/src/`) and for the same reason its own
+# comment gives: server.js imports six modules from there at load time and the
+# hand-maintained list went stale twice in one week. It had drifted again by the
+# time ETP-5128 touched this: report-i18n, report-grouping, report-sql,
+# report-filters and report-branding were all missing here while the Dockerfile
+# already copied them, so the drift guard below failed the assembly outright —
+# meaning the deploy job could not have produced an image even once the AWS
+# variables it needs are finally set.
 
 for rel in "${CORE_FILES[@]}"; do
   if [ ! -f "$CORE_DIR/$rel" ]; then
@@ -98,6 +106,10 @@ for rel in "${CORE_FILES[@]}"; do
   mkdir -p "$OUT_DIR/$(dirname "$rel")"
   cp "$CORE_DIR/$rel" "$OUT_DIR/$rel"
 done
+
+rm -rf "$OUT_DIR/cli/src"
+mkdir -p "$OUT_DIR/cli"
+cp -R "$CORE_DIR/cli/src" "$OUT_DIR/cli/src"
 
 # 2. This repo's artifacts and templates last — see TEMPLATE PRECEDENCE above.
 rm -rf "$OUT_DIR/artifacts" "$OUT_DIR/templates"

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.45-preview.feature-ETP-4956.20260902192749.3c9f45f",
-        "@etendosoftware/etendo-go-core": "0.3.45-preview.feature-ETP-4956.20260902192749.3c9f45f",
+        "@etendosoftware/app-shell-core": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
+        "@etendosoftware/etendo-go-core": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
         "@iconicapp/iconic-react": "^1.1.4",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
@@ -2447,9 +2447,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.45-preview.feature-ETP-4956.20260902192749.3c9f45f",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.45-preview.feature-ETP-4956.20260902192749.3c9f45f/84c20126aabe681eeb01bccd0b69f10904be4e1d",
-      "integrity": "sha512-xWTXuxPoTvTIBNpKy4r9RYT+H8PVLIcb/GQsZeD4nSeJUGRb9on9YYtdk+l23asGdfwV0AIewsm0RpalmScEcQ==",
+      "version": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a/1b1f68673063ddc060368a98e4394cee5a14d197",
+      "integrity": "sha512-XL+xjlKKszz3fsPX/6K/dfC8l4FAt2H8cuC4n6N9BrJGGrkbk9xLewCfWIBU3/uUKDXarhyBR/nG/tTZcJSSYg==",
       "dependencies": {
         "read-excel-file": "^9.3.10",
         "write-excel-file": "^4.1.1"
@@ -2480,9 +2480,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.45-preview.feature-ETP-4956.20260902192749.3c9f45f",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.45-preview.feature-ETP-4956.20260902192749.3c9f45f/cb2de65fd929e0e8d5dfc5adb300cea63ba13450",
-      "integrity": "sha512-VWDozt/+VETvvejxTD+C6c3iQo3odbMzZuD/T98KFzNt4QwCmElJNDp/dDKt0+xxLyZQDoker5GvMRRHR68UWw==",
+      "version": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a/ed5ac8f250cbe884659a741d8a66190e57332411",
+      "integrity": "sha512-4vRQicGWA4JowfPVNqAVAT6KqRa6Y7cjQnaj4Vb0+Aa7VbQG+2oKPWD2dxpvxwelBX5piGMcSxV6miGCvPM34A==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -18,8 +18,8 @@
   },
   "dependencies": {
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.45",
-    "@etendosoftware/etendo-go-core": "0.3.45",
+    "@etendosoftware/app-shell-core": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
+    "@etendosoftware/etendo-go-core": "0.3.46-preview.feature-ETP-5128.20260903173522.c6f4b3a",
     "@iconicapp/iconic-react": "^1.1.4",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",

--- a/tools/app-shell/src/pages/ReportViewerPage.jsx
+++ b/tools/app-shell/src/pages/ReportViewerPage.jsx
@@ -1140,10 +1140,18 @@ function ReportSidebar({ report, params, onChange, onSubmit, onReset, loading, r
       </div>
       <div className="flex-1 overflow-y-auto">
         {useAccordion ? (
-          report.sections.map(({ id, label }) => {
-            // A section with no parameters yet still renders (header + empty
-            // body) instead of disappearing — a contract may declare a
-            // section ahead of the fields that will populate it later.
+          report.sections.map(({ id, label, visibleIf }) => {
+            // A section carrying `visibleIf` (same {param, equals} shape as a
+            // field's own, ETP-5128) disappears ENTIRELY while the condition
+            // doesn't hold — e.g. Trial Balance's "Dimensions" section only
+            // makes sense at Account Level "Subaccount"; at any coarser level
+            // there is nothing to group by, so the header itself must go, not
+            // just render collapsed-and-empty. A section with no `visibleIf`
+            // keeps the pre-existing behavior below: it still renders (header
+            // + empty body) instead of disappearing when it has no visible
+            // parameters yet — a contract may declare a section ahead of the
+            // fields that will populate it later, which is a different case.
+            if (!isParamVisible({ visibleIf }, params)) return null;
             const sectionParams = grouped[id] || [];
             const isOpen = !!openSections[id];
             const sectionLabel = label?.[locale] || label?.en_US || id;
@@ -1457,6 +1465,50 @@ function ReportViewer({ report, onBack, token, selectedOrgId, selectedOrgName, r
   }, [report, selectedOrgId, selectedOrgName, searchParams]);
 
   const [params, setParams] = useState(getDefaultParams);
+
+  // A field hidden by `visibleIf` keeps its last picked value in `params` —
+  // that value must not reach the backend once the control is gone (ETP-5128):
+  // Trial Balance's "Group by" only shows at Account Level "Subaccount", but
+  // switching to any other level left the previously-picked dimension in
+  // state, and it kept being sent (and honored server-side) even though the
+  // sidebar no longer offered that control at all. `isParamVisible` already
+  // governs whether a field RENDERS; this is the same check applied to what
+  // gets SUBMITTED, so the two can never drift apart.
+  //
+  // Reset to '' rather than delete the key (ETP-5128 follow-up): report-server
+  // echoes the raw request params back as `meta.params` verbatim (no
+  // defaulting), and this SAME report's own template branches on
+  // `{{#ifCond meta.params.groupBy '!==' ''}}` — `undefined !== ''` is true,
+  // so a genuinely DELETED key flipped the template into the grouped branch
+  // with no dimension actually picked, rendering nothing at all (confirmed
+  // against a real Handlebars render: the account rows vanished entirely).
+  // '' is this codebase's existing "no value" convention throughout — every
+  // unfilled param already starts out as '' (`params[p.name] || ''`), and
+  // applyPlaceholders' own SQL-placeholder loop already treats '' and a
+  // missing key identically (stripBlankOptionalClauses removes either the
+  // same way) — so this keeps the fix's whole point (no stale value reaches
+  // the backend) while never turning "not sent" into "sent as absent".
+  //
+  // ONLY `visibleIf` (dynamic, tied to another param's current value) is in
+  // scope here — NEVER a static `hidden: true` field (ETP-5128 regression,
+  // caught immediately after landing): `orgId`/`acctSchemaId`/`glId` are
+  // `hidden: true` + `required: true` on several reports (aging, balance
+  // sheet, profit & loss), auto-populated from the session (`autoDefault`,
+  // or `getDefaultParams`'s own `selectedOrgId` seeding above) with no UI
+  // control at all — they were never part of the reported bug (a STALE
+  // user-picked value surviving a field going invisible), and blanking them
+  // broke every one of those reports outright: NEO 422
+  // "accounting_schema_unresolved" / "Could not resolve an accounting
+  // schema... for organization 0" the moment `orgId`/`glId` went to ''.
+  const submitParams = useMemo(() => {
+    const next = { ...params };
+    for (const p of report.parameters || []) {
+      if (isParamVisible(p, params)) continue;
+      next[p.name] = '';
+    }
+    return next;
+  }, [params, report.parameters]);
+
   // Lifted from ReportSidebar (ETP-4899): the top bar's PDF/Excel/CSV buttons call
   // renderReport() directly, bypassing ReportSidebar's own "Generate Report" button —
   // so validation has to live here too, shared by both entry points, or the top bar
@@ -1552,7 +1604,7 @@ function ReportViewer({ report, onBack, token, selectedOrgId, selectedOrgName, r
       const res = await apiFetch(`/api/reports/${report.id}/render`, {
         method: 'POST',
         baseUrl: '',
-        body: JSON.stringify({ format, params, locale }),
+        body: JSON.stringify({ format, params: submitParams, locale }),
       });
       if (!res.ok) {
         const data = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
@@ -1581,7 +1633,7 @@ function ReportViewer({ report, onBack, token, selectedOrgId, selectedOrgName, r
       setError(err.message);
     }
     setLoading(false);
-  }, [report.id, apiFetch, params, locale]);
+  }, [report.id, apiFetch, submitParams, locale]);
 
   // No auto-render on mount — wait for user to click Run Report... UNLESS the
   // page was opened via a deep-link that carries real filter values (e.g. the

--- a/tools/app-shell/src/pages/__tests__/ReportViewerPage.sectionVisibility.vitest.jsx
+++ b/tools/app-shell/src/pages/__tests__/ReportViewerPage.sectionVisibility.vitest.jsx
@@ -1,0 +1,230 @@
+// ETP-5128: an accordion section (`report.sections[]`) can now carry the same
+// `visibleIf: {param, equals}` shape a field already had (ETP-4899). Unlike a
+// field, a section with a false `visibleIf` disappears ENTIRELY (header gone,
+// not just collapsed-empty) — the pre-existing "always render, even with no
+// visible fields yet" rule stays true only for sections that never opted in
+// via `visibleIf`. Fixture mirrors the real Trial Balance report-contract.json
+// (artifacts/report-trial-balance/report-contract.json): the "dimensiones"
+// section and the `groupBy` field both gate on `accountLevel === 'S'`.
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+let mockSearchParams = new URLSearchParams();
+const mockSetSearchParams = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useSearchParams: () => [mockSearchParams, mockSetSearchParams],
+}));
+
+vi.mock('@/i18n', () => ({
+  useUI: () => (key) => key,
+  useMenuLabel: () => (key) => key,
+  useLocaleSwitch: () => ({ locale: 'en_US', setLocale: vi.fn() }),
+}));
+
+vi.mock('@/auth/AuthContext.jsx', () => ({
+  useAuth: () => ({
+    token: 'test-token',
+    selectedRole: { orgList: [] },
+    selectedOrg: { id: 'org1' },
+  }),
+}));
+
+vi.mock('@/components/layout/PageMetaContext', () => ({
+  useSetPageMeta: vi.fn(),
+}));
+
+vi.mock('@/components/layout/FavoritesContext', () => ({
+  useFavorites: () => ({
+    toggleFavorite: vi.fn(),
+    isFavorite: () => false,
+  }),
+}));
+
+vi.mock('@/components/contract-ui/ProductSearchDrawer.jsx', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }) => <button {...props}>{children}</button>,
+}));
+vi.mock('@/components/ui/date-field', () => ({
+  DateField: ({ value, onChange, className }) => (
+    <input
+      type="date"
+      data-testid="date-field"
+      className={className}
+      value={value || ''}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }) => (open ? <div data-testid="dialog">{children}</div> : null),
+  DialogContent: ({ children }) => <div>{children}</div>,
+  DialogHeader: ({ children }) => <div>{children}</div>,
+  DialogTitle: ({ children }) => <h2>{children}</h2>,
+}));
+
+import ReportViewerPage from '../ReportViewerPage.jsx';
+
+function makeReportsListResponse(reports) {
+  return { ok: true, json: () => Promise.resolve(reports) };
+}
+
+// Mirrors artifacts/report-trial-balance/report-contract.json's shape:
+// sections `periodo` (no visibleIf), `alcance` (no visibleIf — the sibling
+// used to protect the always-render baseline), `dimensiones` (visibleIf
+// accountLevel===S), `agrupacion` (no visibleIf, holds accountLevel itself +
+// the visibleIf-gated groupBy field), `opciones` (no visibleIf).
+const TRIAL_BALANCE_REPORT = {
+  id: 'report-trial-balance',
+  title: { en_US: 'Trial Balance' },
+  type: 'listing',
+  outputs: ['pdf'],
+  sections: [
+    { id: 'periodo', label: { en_US: 'Period' } },
+    { id: 'alcance', label: { en_US: 'Scope' } },
+    { id: 'dimensiones', label: { en_US: 'Dimensions' }, visibleIf: { param: 'accountLevel', equals: 'S' } },
+    { id: 'agrupacion', label: { en_US: 'Grouping' } },
+    { id: 'opciones', label: { en_US: 'Options' } },
+  ],
+  parameters: [
+    { name: 'dateFrom', type: 'date', label: { en_US: 'Date From' }, section: 'periodo' },
+    { name: 'orgId', type: 'text', label: { en_US: 'Organization' }, section: 'alcance' },
+    {
+      name: 'bPartnerId',
+      type: 'text',
+      label: { en_US: 'Contact' },
+      section: 'dimensiones',
+      groupByValue: 'bpartner',
+    },
+    {
+      name: 'accountLevel',
+      type: 'select',
+      label: { en_US: 'Account Level' },
+      required: true,
+      default: 'S',
+      section: 'agrupacion',
+      options: [
+        { value: 'S', label: { en_US: 'Subaccount' } },
+        { value: 'D', label: { en_US: 'Breakdown' } },
+        { value: 'C', label: { en_US: 'Account' } },
+        { value: 'E', label: { en_US: 'Heading' } },
+      ],
+    },
+    {
+      name: 'groupBy',
+      type: 'select',
+      label: { en_US: 'Group results by' },
+      section: 'agrupacion',
+      visibleIf: { param: 'accountLevel', equals: 'S' },
+    },
+    { name: 'showZero', type: 'boolean', label: { en_US: 'Show Zero Balances' }, section: 'opciones' },
+  ],
+};
+
+// `accountLevel` has a `default: 'S'`, so it renders as a pre-selected chip
+// on first render, not an empty input — the CreatableSearchSelect chip
+// re-opens the dropdown on click (same as the empty-field input does).
+async function selectAccountLevel(user, optionValue) {
+  const opener = screen.queryByTestId('field-accountLevel-chip') || screen.getByTestId('field-accountLevel');
+  await user.click(opener);
+  const option = await screen.findByTestId(`option-accountLevel-${optionValue}`);
+  await user.click(option);
+}
+
+describe('ReportViewerPage — accordion section visibleIf (ETP-5128, Trial Balance)', () => {
+  beforeEach(() => {
+    mockSearchParams = new URLSearchParams({ report: 'report-trial-balance' });
+    mockSetSearchParams.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('(a) shows the Dimensions section and the Group results by field when Account Level defaults to Subaccount', async () => {
+    globalThis.fetch = vi.fn().mockImplementation((url) => {
+      if (url === '/api/reports') return Promise.resolve(makeReportsListResponse([TRIAL_BALANCE_REPORT]));
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
+    });
+
+    render(<ReportViewerPage />);
+    await waitFor(() => expect(screen.getByText('Grouping')).toBeInTheDocument());
+
+    expect(screen.getByText('Dimensions')).toBeInTheDocument();
+
+    // Open the Grouping accordion section to reach its fields (only the
+    // first section is auto-open by default, per report.sections[0]).
+    await userEvent.setup().click(screen.getByText('Grouping'));
+    await waitFor(() => expect(screen.getByText('Group results by')).toBeInTheDocument());
+  });
+
+  it('(b) hides the Dimensions section header and Group results by entirely once Account Level is not Subaccount, while Account Level itself stays', async () => {
+    const user = userEvent.setup();
+    globalThis.fetch = vi.fn().mockImplementation((url) => {
+      if (url === '/api/reports') return Promise.resolve(makeReportsListResponse([TRIAL_BALANCE_REPORT]));
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
+    });
+
+    render(<ReportViewerPage />);
+    await waitFor(() => expect(screen.getByText('Grouping')).toBeInTheDocument());
+
+    // Open Grouping to reach the accountLevel select, and switch it away from S.
+    await user.click(screen.getByText('Grouping'));
+    await waitFor(() => expect(screen.getByTestId('field-accountLevel-chip')).toBeInTheDocument());
+    await selectAccountLevel(user, 'D');
+
+    // The Dimensions section header itself must be gone from the DOM — not
+    // just collapsed. queryByText resolves to null when truly absent.
+    await waitFor(() => expect(screen.queryByText('Dimensions')).not.toBeInTheDocument());
+    expect(screen.queryByText('Group results by')).not.toBeInTheDocument();
+
+    // Account Level (and its Grouping section, which carries no visibleIf
+    // itself) remains visible.
+    expect(screen.getByTestId('field-accountLevel-chip')).toBeInTheDocument();
+  });
+
+  it('(c) re-shows both Dimensions and Group results by after switching Account Level back to Subaccount', async () => {
+    const user = userEvent.setup();
+    globalThis.fetch = vi.fn().mockImplementation((url) => {
+      if (url === '/api/reports') return Promise.resolve(makeReportsListResponse([TRIAL_BALANCE_REPORT]));
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
+    });
+
+    render(<ReportViewerPage />);
+    await waitFor(() => expect(screen.getByText('Grouping')).toBeInTheDocument());
+
+    await user.click(screen.getByText('Grouping'));
+    await waitFor(() => expect(screen.getByTestId('field-accountLevel-chip')).toBeInTheDocument());
+
+    await selectAccountLevel(user, 'D');
+    await waitFor(() => expect(screen.queryByText('Dimensions')).not.toBeInTheDocument());
+
+    await selectAccountLevel(user, 'S');
+    await waitFor(() => expect(screen.getByText('Dimensions')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Group results by')).toBeInTheDocument());
+  });
+
+  it('(d) keeps a sibling section without visibleIf (Scope) visible regardless of Account Level', async () => {
+    const user = userEvent.setup();
+    globalThis.fetch = vi.fn().mockImplementation((url) => {
+      if (url === '/api/reports') return Promise.resolve(makeReportsListResponse([TRIAL_BALANCE_REPORT]));
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
+    });
+
+    render(<ReportViewerPage />);
+    await waitFor(() => expect(screen.getByText('Scope')).toBeInTheDocument());
+
+    await user.click(screen.getByText('Grouping'));
+    await waitFor(() => expect(screen.getByTestId('field-accountLevel-chip')).toBeInTheDocument());
+    await selectAccountLevel(user, 'D');
+
+    // Scope has no visibleIf — it must keep rendering (pre-existing baseline)
+    // regardless of the Dimensions section being hidden alongside it.
+    await waitFor(() => expect(screen.queryByText('Dimensions')).not.toBeInTheDocument());
+    expect(screen.getByText('Scope')).toBeInTheDocument();
+  });
+});

--- a/tools/app-shell/src/pages/__tests__/ReportViewerPage.submitParamsStripping.vitest.jsx
+++ b/tools/app-shell/src/pages/__tests__/ReportViewerPage.submitParamsStripping.vitest.jsx
@@ -1,0 +1,295 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+let mockSearchParams = new URLSearchParams();
+const mockSetSearchParams = vi.fn();
+
+vi.mock('react-router-dom', () => ({
+  useSearchParams: () => [mockSearchParams, mockSetSearchParams],
+}));
+
+vi.mock('@/i18n', () => ({
+  useUI: () => (key) => key,
+  useMenuLabel: () => (key) => key,
+  useLocaleSwitch: () => ({ locale: 'en_US', setLocale: vi.fn() }),
+}));
+
+vi.mock('@/auth/AuthContext.jsx', () => ({
+  useAuth: () => ({
+    token: 'test-token',
+    selectedRole: { orgList: [] },
+    selectedOrg: { id: 'org1' },
+  }),
+}));
+
+vi.mock('@/components/layout/PageMetaContext', () => ({
+  useSetPageMeta: vi.fn(),
+}));
+
+vi.mock('@/components/layout/FavoritesContext', () => ({
+  useFavorites: () => ({
+    toggleFavorite: vi.fn(),
+    isFavorite: () => false,
+  }),
+}));
+
+vi.mock('@/components/contract-ui/ProductSearchDrawer.jsx', () => ({
+  default: () => null,
+}));
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }) => <button {...props}>{children}</button>,
+}));
+vi.mock('@/components/ui/date-field', () => ({
+  DateField: ({ value, onChange, className }) => (
+    <input
+      type="date"
+      data-testid="date-field"
+      className={className}
+      value={value || ''}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  ),
+}));
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }) => (open ? <div data-testid="dialog">{children}</div> : null),
+  DialogContent: ({ children }) => <div>{children}</div>,
+  DialogHeader: ({ children }) => <div>{children}</div>,
+  DialogTitle: ({ children }) => <h2>{children}</h2>,
+}));
+
+import ReportViewerPage from '../ReportViewerPage.jsx';
+
+function makeReportsListResponse(reports) {
+  return { ok: true, json: () => Promise.resolve(reports) };
+}
+
+function makeRenderResponse() {
+  return {
+    ok: true,
+    text: () => Promise.resolve('<html></html>'),
+    blob: () => Promise.resolve(new Blob(['x'])),
+    json: () => Promise.resolve({}),
+  };
+}
+
+// Same shape as ReportViewerPage.sectionVisibility.vitest.jsx's TRIAL_BALANCE_REPORT,
+// plus a bPartnerId dimension (so the Group By select has a real option to pick — its
+// options are derived client-side from sibling params' groupByValue, see
+// renderSelectParam in ReportViewerPage.jsx) and a static hidden:true param (scenario 5).
+//
+// ETP-5128: submitParams only ever blanks a `visibleIf`-gated param whose condition
+// currently evaluates false — it never touches a static `hidden: true` param. Static
+// hidden:true fields (session-auto-populated context like org/accounting-schema) are
+// never something a user "picks then un-picks"; blanking them broke real reports in
+// production (accounting_schema_unresolved 422 on Aging Payables, zero rows on Balance
+// Sheet / P&L) because org/glId/acctSchemaId are declared hidden:true, required:true,
+// autoDefault:true with no UI control at all.
+const TRIAL_BALANCE_REPORT = {
+  id: 'report-trial-balance',
+  title: { en_US: 'Trial Balance' },
+  type: 'listing',
+  outputs: ['pdf'],
+  sections: [
+    { id: 'periodo', label: { en_US: 'Period' } },
+    { id: 'alcance', label: { en_US: 'Scope' } },
+    { id: 'dimensiones', label: { en_US: 'Dimensions' }, visibleIf: { param: 'accountLevel', equals: 'S' } },
+    { id: 'agrupacion', label: { en_US: 'Grouping' } },
+    { id: 'opciones', label: { en_US: 'Options' } },
+  ],
+  parameters: [
+    { name: 'dateFrom', type: 'date', label: { en_US: 'Date From' }, section: 'periodo' },
+    { name: 'dateTo', type: 'date', label: { en_US: 'Date To' }, section: 'periodo' },
+    { name: 'orgId', type: 'text', label: { en_US: 'Organization' }, section: 'alcance' },
+    {
+      name: 'bPartnerId',
+      type: 'text',
+      label: { en_US: 'Contact' },
+      section: 'dimensiones',
+      groupByValue: 'bpartner',
+    },
+    {
+      name: 'accountLevel',
+      type: 'select',
+      label: { en_US: 'Account Level' },
+      required: true,
+      default: 'S',
+      section: 'agrupacion',
+      options: [
+        { value: 'S', label: { en_US: 'Subaccount' } },
+        { value: 'D', label: { en_US: 'Breakdown' } },
+        { value: 'C', label: { en_US: 'Account' } },
+        { value: 'E', label: { en_US: 'Heading' } },
+      ],
+    },
+    {
+      name: 'groupBy',
+      type: 'select',
+      label: { en_US: 'Group results by' },
+      section: 'agrupacion',
+      visibleIf: { param: 'accountLevel', equals: 'S' },
+    },
+    { name: 'showZero', type: 'boolean', label: { en_US: 'Show Zero Balances' }, section: 'opciones' },
+    // Static hidden:true (not visibleIf-gated) — proves submitParams only acts on
+    // visibleIf-gated params (like groupBy above) and never on a static hidden:true one.
+    {
+      name: 'internalFlag',
+      type: 'text',
+      label: { en_US: 'Internal Flag' },
+      section: 'opciones',
+      hidden: true,
+      default: 'secret-value',
+    },
+  ],
+};
+
+async function selectAccountLevel(user, optionValue) {
+  const opener = screen.queryByTestId('field-accountLevel-chip') || screen.getByTestId('field-accountLevel');
+  await user.click(opener);
+  const option = await screen.findByTestId(`option-accountLevel-${optionValue}`);
+  await user.click(option);
+}
+
+async function pickGroupBy(user) {
+  const opener = screen.queryByTestId('field-groupBy-chip') || screen.getByTestId('field-groupBy');
+  await user.click(opener);
+  const option = await screen.findByTestId('option-groupBy-bpartner');
+  await user.click(option);
+}
+
+function installMocks() {
+  const renderCalls = [];
+  globalThis.fetch = vi.fn().mockImplementation((url, opts) => {
+    if (url === '/api/reports') return Promise.resolve(makeReportsListResponse([TRIAL_BALANCE_REPORT]));
+    if (typeof url === 'string' && url.includes('/render')) {
+      renderCalls.push({ url, body: opts?.body ? JSON.parse(opts.body) : null });
+      return Promise.resolve(makeRenderResponse());
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ items: [] }) });
+  });
+  return renderCalls;
+}
+
+describe('ReportViewerPage — submitParams blanks hidden/visibleIf-gated params to "" in the render POST body (ETP-5128)', () => {
+  let renderCalls;
+  let user;
+
+  beforeEach(() => {
+    mockSearchParams = new URLSearchParams({ report: 'report-trial-balance' });
+    mockSetSearchParams.mockClear();
+    user = userEvent.setup();
+    renderCalls = installMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('(1) sends groupBy while Account Level is Subaccount, then blanks it to "" once switched to a non-Subaccount level', async () => {
+    render(<ReportViewerPage />);
+    await waitFor(() => expect(screen.getByText('Grouping')).toBeInTheDocument());
+    await user.click(screen.getByText('Grouping'));
+    await waitFor(() => expect(screen.getByTestId('field-accountLevel-chip')).toBeInTheDocument());
+
+    await pickGroupBy(user);
+    await waitFor(() => expect(screen.getByTestId('field-groupBy-chip')).toHaveTextContent('Contact'));
+
+    await user.click(screen.getByText('runReport'));
+    await waitFor(() => expect(renderCalls).toHaveLength(1));
+    expect(renderCalls[0].body.params.groupBy).toBe('bpartner');
+
+    await selectAccountLevel(user, 'D');
+    await waitFor(() => expect(screen.queryByText('Dimensions')).not.toBeInTheDocument());
+
+    await user.click(screen.getByText('runReport'));
+    await waitFor(() => expect(renderCalls).toHaveLength(2));
+    // The key must stay present but blanked to '' — report-server echoes `params` verbatim
+    // into `meta.params` with no defaulting, and report-trial-balance/template.hbs branches
+    // on `{{#ifCond meta.params.groupBy '!==' ''}}`; a deleted key reads as `undefined`,
+    // which is `!== ''` in JS and flips the template into the (empty) grouped branch.
+    expect(renderCalls[1].body.params.groupBy).toBe('');
+  });
+
+  it('(2) switching Account Level back to Subaccount keeps the picked value in the sidebar UI and resubmits it', async () => {
+    render(<ReportViewerPage />);
+    await waitFor(() => expect(screen.getByText('Grouping')).toBeInTheDocument());
+    await user.click(screen.getByText('Grouping'));
+    await waitFor(() => expect(screen.getByTestId('field-accountLevel-chip')).toBeInTheDocument());
+
+    await pickGroupBy(user);
+    await waitFor(() => expect(screen.getByTestId('field-groupBy-chip')).toHaveTextContent('Contact'));
+
+    await selectAccountLevel(user, 'D');
+    await waitFor(() => expect(screen.queryByText('Dimensions')).not.toBeInTheDocument());
+
+    await user.click(screen.getByText('runReport'));
+    await waitFor(() => expect(renderCalls).toHaveLength(1));
+    // The key must stay present but blanked to '' — see the comment on test (1).
+    expect(renderCalls[0].body.params.groupBy).toBe('');
+
+    await selectAccountLevel(user, 'S');
+    await waitFor(() => expect(screen.getByText('Dimensions')).toBeInTheDocument());
+    // The picked value is still shown in the sidebar — the fix only strips what gets
+    // submitted while hidden, it never clears the underlying `params` state.
+    expect(screen.getByTestId('field-groupBy-chip')).toHaveTextContent('Contact');
+
+    await user.click(screen.getByText('runReport'));
+    await waitFor(() => expect(renderCalls).toHaveLength(2));
+    expect(renderCalls[1].body.params.groupBy).toBe('bpartner');
+  });
+
+  it('(3) the top-bar PDF button shares the same submitParams stripping as the sidebar submit', async () => {
+    render(<ReportViewerPage />);
+    await waitFor(() => expect(screen.getByText('Grouping')).toBeInTheDocument());
+    await user.click(screen.getByText('Grouping'));
+    await waitFor(() => expect(screen.getByTestId('field-accountLevel-chip')).toBeInTheDocument());
+
+    await pickGroupBy(user);
+    await waitFor(() => expect(screen.getByTestId('field-groupBy-chip')).toHaveTextContent('Contact'));
+
+    await selectAccountLevel(user, 'C');
+    await waitFor(() => expect(screen.queryByText('Dimensions')).not.toBeInTheDocument());
+
+    await user.click(screen.getByText('PDF'));
+    await waitFor(() => expect(renderCalls).toHaveLength(1));
+    // The key must stay present but blanked to '' — see the comment on test (1).
+    expect(renderCalls[0].body.params.groupBy).toBe('');
+  });
+
+  it('(4) an always-visible param (accountLevel) is present in the submitted body in every scenario', async () => {
+    render(<ReportViewerPage />);
+    await waitFor(() => expect(screen.getByText('Grouping')).toBeInTheDocument());
+    await user.click(screen.getByText('Grouping'));
+    await waitFor(() => expect(screen.getByTestId('field-accountLevel-chip')).toBeInTheDocument());
+
+    await user.click(screen.getByText('runReport'));
+    await waitFor(() => expect(renderCalls).toHaveLength(1));
+    expect(renderCalls[0].body.params.accountLevel).toBe('S');
+
+    await selectAccountLevel(user, 'E');
+    await user.click(screen.getByText('runReport'));
+    await waitFor(() => expect(renderCalls).toHaveLength(2));
+    expect(renderCalls[1].body.params.accountLevel).toBe('E');
+  });
+
+  it('(5) a param with the static hidden:true flag is left untouched in the submitted body regardless of Account Level', async () => {
+    render(<ReportViewerPage />);
+    await waitFor(() => expect(screen.getByText('Grouping')).toBeInTheDocument());
+    await user.click(screen.getByText('Grouping'));
+    await waitFor(() => expect(screen.getByTestId('field-accountLevel-chip')).toBeInTheDocument());
+
+    // internalFlag is hidden:true, so it never renders a control, but getDefaultParams()
+    // seeds it with its `default` value into `params`. Because it has no `visibleIf`,
+    // isParamVisible() always considers it visible for submitParams's purposes, so it is
+    // NEVER blanked — only visibleIf-gated params (like groupBy above) are. Static
+    // hidden:true fields represent session-auto-populated context (org/accounting-schema)
+    // that was never user-picked-then-hidden, so submitParams must leave them alone (ETP-5128).
+    expect(screen.queryByText('Internal Flag')).not.toBeInTheDocument();
+
+    await user.click(screen.getByText('runReport'));
+    await waitFor(() => expect(renderCalls).toHaveLength(1));
+    expect(renderCalls[0].body.params.internalFlag).toBe('secret-value');
+    // Sanity: a visible sibling param in the same section IS present with its real value.
+    expect('showZero' in renderCalls[0].body.params).toBe(true);
+  });
+});

--- a/tools/app-shell/test/report-general-ledger-open-row-and-chip-order.test.js
+++ b/tools/app-shell/test/report-general-ledger-open-row-and-chip-order.test.js
@@ -7,11 +7,21 @@
  *     `.acct-open td` now carries `font-weight: 700` alongside its existing
  *     italic style, matching `.acct-total`'s weight.
  *
- *  2. The dimension chip header ("[CONTACTO] Blanquiceleste S.A.") read
- *     backwards next to a filled table body — the dimension VALUE now comes
- *     first (bold, on the left) and the dimension LABEL chip ("Contacto")
- *     moves to the right as a light-gray pill, via `justify-content:
- *     space-between` on `.dim-group-head` plus swapping the markup order.
+ *  2. The dimension chip header ("[CONTACTO] Blanquiceleste S.A.") originally
+ *     read backwards next to a filled table body, so ETP-5013 put the
+ *     dimension VALUE first (bold, on the left) and pushed the dimension
+ *     LABEL chip ("Contacto") to the right via `justify-content:
+ *     space-between` on `.dim-group-head`.
+ *
+ * ETP-5128 follow-up — that `space-between` layout made the chip read as
+ * effectively missing/lost in the real generated report (pushed far off to
+ * the right, away from the value it labels). Reversed again: `.dim-group-head`
+ * no longer sets `justify-content: space-between` (plain flex, natural
+ * width), and the markup order is swapped back to chip-first, value-second —
+ * `<span class="chip">...</span><span class="value">...</span>`. The chip's
+ * own visual style (filled light-gray pill) is unchanged, only its position.
+ * The same reversal was applied in lockstep to inventory-stock-report's
+ * `.stock-card-head` (see report-inventory-stock-grouped-cards.test.js).
  */
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
@@ -36,17 +46,17 @@ describe('report-general-ledger — .acct-open bold, matching .acct-total (ETP-5
   });
 });
 
-describe('report-general-ledger — dim-group-head value/chip order (ETP-5013 follow-up)', () => {
-  it('.dim-group-head uses justify-content: space-between', () => {
+describe('report-general-ledger — dim-group-head value/chip order (ETP-5128 follow-up, reverses ETP-5013)', () => {
+  it('.dim-group-head does NOT use justify-content: space-between', () => {
     const body = ruleBody(src, '.dim-group-head');
     assert.ok(body, 'expected a .dim-group-head rule');
-    assert.match(body, /justify-content:\s*space-between/);
+    assert.doesNotMatch(body, /justify-content:\s*space-between/);
   });
 
-  it('the dimension VALUE renders BEFORE the chip in markup (value on the left, chip on the right)', () => {
+  it('the chip renders BEFORE the dimension VALUE in markup (chip on the left, value on the right)', () => {
     assert.match(
       src,
-      /<div class="dim-group-head"><span class="value">\{\{this\.dimensionValue\}\}<\/span><span class="chip">\{\{@root\.meta\.dimensionLabel\}\}<\/span><\/div>/
+      /<div class="dim-group-head"><span class="chip">\{\{@root\.meta\.dimensionLabel\}\}<\/span><span class="value">\{\{this\.dimensionValue\}\}<\/span><\/div>/
     );
   });
 

--- a/tools/app-shell/test/report-inventory-stock-grouped-cards.test.js
+++ b/tools/app-shell/test/report-inventory-stock-grouped-cards.test.js
@@ -69,11 +69,11 @@ describe('inventory-stock-report — grouped layout renders one card per group (
     assert.equal(theadOccurrences.length, 3, 'expected one <thead> per group, not one shared thead');
   });
 
-  it('the group name renders as the value, with a dimensionLabel chip alongside (matching report-general-ledger)', () => {
+  it('the group name renders as the value, with a dimensionLabel chip appearing FIRST (matching report-general-ledger, ETP-5128)', () => {
     const html = render({ dimensionField: 'product', dimensionLabel: 'Producto' }, rows);
-    assert.match(html, /<span class="value">Agua<\/span><span class="chip">Producto<\/span>/);
-    assert.match(html, /<span class="value">Cerveza<\/span><span class="chip">Producto<\/span>/);
-    assert.match(html, /<span class="value">Queso Sardo<\/span><span class="chip">Producto<\/span>/);
+    assert.match(html, /<span class="chip">Producto<\/span><span class="value">Agua<\/span>/);
+    assert.match(html, /<span class="chip">Producto<\/span><span class="value">Cerveza<\/span>/);
+    assert.match(html, /<span class="chip">Producto<\/span><span class="value">Queso Sardo<\/span>/);
   });
 
   it('no longer renders the old flat group-header row', () => {


### PR DESCRIPTION
Balance de Sumas y Saldos:
- Dimensions section and "Group by" field now hide entirely (not just render empty) unless Account Level is Subaccount, via a new section-level visibleIf on report.sections[] (mirrors the existing field-level one).
- submitParams: a field hidden by visibleIf is blanked to '' rather than removed before the render request is sent, so a stale picked value (e.g. a leftover "Group by" dimension) can no longer leak into — and get honored by — the backend once its control is gone. Blanked, not deleted: report-server echoes params verbatim into meta.params with no defaulting, and this report's own template branches on `!== ''`, so a genuinely missing key flipped it into the grouped-with-no-dimension branch and rendered nothing at all.
- Fixed a real regression from the above, caught before it shipped: the first version also blanked any STATIC hidden:true param, which broke Antigüedad de Pagos/Cobros, Balance de Situación and Perdidas y Ganancias outright (orgId/acctSchemaId/glId are session-auto-populated, never user-picked-then-hidden). submitParams now only ever touches visibleIf fields.
- Documents ungrouped now sort oldest-to-newest by invoice date (companion Java fix, com.etendoerp.go).

Libro Mayor / Informe de Stock: the grouped-by-dimension card header showed the picked value first and the dimension type as a chip pushed to the far right via justify-content: space-between — easy to lose entirely in the real generated report. Chip now renders first, value second, in both templates (kept byte-consistent per inventory-stock-report's own doc comment).

scripts/assemble-report-server-context.sh: copies cli/src/ as a whole directory instead of a stale per-file list — it had drifted again (5 of 6 server.js imports missing), which made the build-context assembly abort outright regardless of the AWS deploy variables ever getting set.

Bumped @etendosoftware/{app-shell-core,schema-forge-cli,schema-forge-core} to the schema_forge_core preview build carrying the per-format Excel/CSV template fix for the report server.

Checks: npm, testid, tests, regen, xml, pw-mocked, pw-integration
Hooks-Verified: v2 8ee3cd90 3d72a9d1f72e 087e6ec730a5