### PR TITLE
Epic ETP-3504: Bump schema_forge_core pin to 0.3.46

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
         "e2e"
       ],
       "devDependencies": {
-        "@etendosoftware/app-shell-core": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
-        "@etendosoftware/schema-forge-cli": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
-        "@etendosoftware/schema-forge-core": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
+        "@etendosoftware/app-shell-core": "0.3.46",
+        "@etendosoftware/schema-forge-cli": "0.3.46",
+        "@etendosoftware/schema-forge-core": "0.3.46",
         "esbuild": "^0.28.0",
         "handlebars": "^4.7.9",
         "jscodeshift": "^17.3.0",
@@ -2624,9 +2624,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767/4b6a72f0740a9e4d0cdb1998b0d2b6d8d297fa29",
-      "integrity": "sha512-G4E6qeNNWFfqnHI2LLt+VBay+hlTV8OlPuYVeKXevA194VoyaTFdl724o7jbgJc8NneW+s5Ng5Nriekpp6jkLg==",
+      "version": "0.3.46",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.46/6255315664eb6c1e31ada6a0e6529b6aba2484c0",
+      "integrity": "sha512-8d3xrGzTQNT8LPeBTtCHJWkjBsjrpBUWM0Vsx5BQs+LbY+DZvYpLSjISunwgNcrDM7gfJOYMZ61HXdSbTAsDbA==",
       "dependencies": {
         "read-excel-file": "^9.3.10",
         "write-excel-file": "^4.1.1"
@@ -2657,9 +2657,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767/ede3c71edc5caea4c063b946863b8165196da70b",
-      "integrity": "sha512-+H+nhpji42K1mMj6utrWKYLYAo4FQuQsOqfhI5abjDUPWRcbMI8NWNc7Sgn2MOJPFC5cI/q1BkRbDDRvk26RNA==",
+      "version": "0.3.46",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.46/44f9870329686ce0e6fa4084aadefa6418fff426",
+      "integrity": "sha512-1n19O/BZnxz7Y5zYBVRw524CMqJTzDbqu6D50ZpwogDorbA+6nTx1hsnw88uqT3THJVDQ7hf0foxt5gv8P1u+w==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",
@@ -2669,9 +2669,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-cli": {
-      "version": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767/291d16bd680c0a862ba6d1935dc7c4d5fd045685",
-      "integrity": "sha512-3PhDxmlVK4jG2dQjLWQPB5+NgwYbE1uUsbmmZLjVMFmdKa8Tf9jPxAAAJJejtx6VPX1cThFnG6tdjmXJ4SxVyQ==",
+      "version": "0.3.46",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-cli/0.3.46/d21f3188dd5d065d9ff1746c1a494332ec7b9fcd",
+      "integrity": "sha512-1TEujHD032vDhsXw5JLTCEKNxd4kJtlQAy+DBlqsrYj5gXd+8LK+vx6YUqeWr96mcfDax6gP6XFmDywoRoieOQ==",
       "dev": true,
       "dependencies": {
         "@clack/prompts": "^1.5.1",
@@ -2716,9 +2716,9 @@
       }
     },
     "node_modules/@etendosoftware/schema-forge-core": {
-      "version": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767/9dfdaaf0de429896d253ab8090e1ad3d69100f09",
-      "integrity": "sha512-hmHZMcoB+DTERL40Zm56amXnDjbc7bfaiARKl5oHFNvjGQLdNWB6G+VA4fQ2lOjJXEw9adrq53YEjRdorq4Avg==",
+      "version": "0.3.46",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/schema-forge-core/0.3.46/bf781f13b81b383a536eab43f98ae7177123d80e",
+      "integrity": "sha512-w6V4EDrhEG90oug5itCsvaBCsVfSwEw9LVcOaiwoy+zDjkIVXiOLhVBsPsGwM46X1iXNyZraDwWnFev7zmR9Mg==",
       "dev": true,
       "bin": {
         "sf-domain-boundary-check": "bin/sf-domain-boundary-check.js"
@@ -13951,8 +13951,8 @@
       "dependencies": {
         "@ai-sdk/react": "^4.0.86",
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
-        "@etendosoftware/etendo-go-core": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
+        "@etendosoftware/app-shell-core": "0.3.46",
+        "@etendosoftware/etendo-go-core": "0.3.46",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
         "@openfeature/web-sdk": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "apply:data-testid": "./scripts/apply-add-data-testid.sh"
   },
   "devDependencies": {
-    "@etendosoftware/app-shell-core": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
-    "@etendosoftware/schema-forge-cli": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
-    "@etendosoftware/schema-forge-core": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
+    "@etendosoftware/app-shell-core": "0.3.46",
+    "@etendosoftware/schema-forge-cli": "0.3.46",
+    "@etendosoftware/schema-forge-core": "0.3.46",
     "esbuild": "^0.28.0",
     "handlebars": "^4.7.9",
     "jscodeshift": "^17.3.0",

--- a/tools/app-shell/package-lock.json
+++ b/tools/app-shell/package-lock.json
@@ -10,8 +10,8 @@
       "dependencies": {
         "@ai-sdk/react": "^4.0.86",
         "@configcat/sdk": "^1.1.0",
-        "@etendosoftware/app-shell-core": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
-        "@etendosoftware/etendo-go-core": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
+        "@etendosoftware/app-shell-core": "0.3.46",
+        "@etendosoftware/etendo-go-core": "0.3.46",
         "@openfeature/config-cat-web-provider": "^0.2.0",
         "@openfeature/core": "^1.11.0",
         "@openfeature/web-sdk": "^1.9.0",
@@ -2529,9 +2529,9 @@
       }
     },
     "node_modules/@etendosoftware/app-shell-core": {
-      "version": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767/4b6a72f0740a9e4d0cdb1998b0d2b6d8d297fa29",
-      "integrity": "sha512-G4E6qeNNWFfqnHI2LLt+VBay+hlTV8OlPuYVeKXevA194VoyaTFdl724o7jbgJc8NneW+s5Ng5Nriekpp6jkLg==",
+      "version": "0.3.46",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/app-shell-core/0.3.46/6255315664eb6c1e31ada6a0e6529b6aba2484c0",
+      "integrity": "sha512-8d3xrGzTQNT8LPeBTtCHJWkjBsjrpBUWM0Vsx5BQs+LbY+DZvYpLSjISunwgNcrDM7gfJOYMZ61HXdSbTAsDbA==",
       "dependencies": {
         "read-excel-file": "^9.3.10",
         "write-excel-file": "^4.1.1"
@@ -2562,9 +2562,9 @@
       }
     },
     "node_modules/@etendosoftware/etendo-go-core": {
-      "version": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
-      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767/ede3c71edc5caea4c063b946863b8165196da70b",
-      "integrity": "sha512-+H+nhpji42K1mMj6utrWKYLYAo4FQuQsOqfhI5abjDUPWRcbMI8NWNc7Sgn2MOJPFC5cI/q1BkRbDDRvk26RNA==",
+      "version": "0.3.46",
+      "resolved": "https://npm.pkg.github.com/download/@etendosoftware/etendo-go-core/0.3.46/44f9870329686ce0e6fa4084aadefa6418fff426",
+      "integrity": "sha512-1n19O/BZnxz7Y5zYBVRw524CMqJTzDbqu6D50ZpwogDorbA+6nTx1hsnw88uqT3THJVDQ7hf0foxt5gv8P1u+w==",
       "peerDependencies": {
         "@phosphor-icons/react": "^2.1.0",
         "lucide-react": "^0.400.0",

--- a/tools/app-shell/package.json
+++ b/tools/app-shell/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "@ai-sdk/react": "^4.0.86",
     "@configcat/sdk": "^1.1.0",
-    "@etendosoftware/app-shell-core": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
-    "@etendosoftware/etendo-go-core": "0.3.46-preview.mergeblock-ETP-5137.20260904000726.13b5767",
+    "@etendosoftware/app-shell-core": "0.3.46",
+    "@etendosoftware/etendo-go-core": "0.3.46",
     "@openfeature/config-cat-web-provider": "^0.2.0",
     "@openfeature/core": "^1.11.0",
     "@openfeature/web-sdk": "^1.9.0",


### PR DESCRIPTION
Automated bump — schema_forge_core released `0.3.46`. Runs `make bump-core-version` to realign the lockstep pin (@etendosoftware/app-shell-core, schema-forge-cli, schema-forge-core) in `package.json` and `tools/app-shell/package.json`.